### PR TITLE
feat: add DELETE /api/endpoints/:name management API route

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -224,6 +224,7 @@ async fn main() {
                 registry: registry.clone(),
                 config: Arc::new(tokio::sync::RwLock::new(cfg.clone())),
                 start_time: std::time::Instant::now(),
+                config_path: Some(config_path.clone()),
             };
             let router = build_router(state).merge(management::management_routes(mgmt_state));
             let addr: SocketAddr = ([0, 0, 0, 0], port).into();

--- a/src/management.rs
+++ b/src/management.rs
@@ -2,11 +2,12 @@ use axum::{
     extract::{Path, State},
     http::StatusCode,
     response::IntoResponse,
-    routing::{get, post},
+    routing::{delete, get, post},
     Json, Router,
 };
 use serde::Serialize;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::RwLock;
@@ -26,6 +27,8 @@ pub struct ManagementState {
     pub registry: Arc<AdapterRegistry>,
     pub config: Arc<RwLock<Config>>,
     pub start_time: Instant,
+    /// Path to the TOML config file on disk (used by DELETE endpoint).
+    pub config_path: Option<PathBuf>,
 }
 
 // ---------------------------------------------------------------------------
@@ -278,6 +281,107 @@ async fn reload_config() -> Json<ActionResponse> {
     })
 }
 
+/// DELETE /api/endpoints/:name
+///
+/// Removes the named endpoint from the config file on disk. The config file
+/// watcher (hot-reload) will automatically pick up the change and unload the
+/// endpoint from the running registry.
+async fn delete_endpoint(
+    State(state): State<ManagementState>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    let Some(config_path) = &state.config_path else {
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "config_path not configured",
+            Some("The management API was not initialised with a config file path."),
+        )
+        .into_response();
+    };
+
+    let resolved = crate::config::expand_tilde(config_path);
+
+    // Read the raw TOML from disk so we can do a targeted edit.
+    let contents = match std::fs::read_to_string(&resolved) {
+        Ok(c) => c,
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to read config file",
+                Some(&e.to_string()),
+            )
+            .into_response();
+        }
+    };
+
+    let mut parsed: toml::Table = match contents.parse() {
+        Ok(t) => t,
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to parse config file",
+                Some(&e.to_string()),
+            )
+            .into_response();
+        }
+    };
+
+    // Remove the matching endpoint from the [[endpoints]] array.
+    let found = if let Some(toml::Value::Array(endpoints)) = parsed.get_mut("endpoints") {
+        let original_len = endpoints.len();
+        endpoints.retain(|ep| {
+            ep.get("name")
+                .and_then(|v| v.as_str())
+                .map(|n| n != name)
+                .unwrap_or(true)
+        });
+        endpoints.len() < original_len
+    } else {
+        false
+    };
+
+    if !found {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: format!("Endpoint not found: {}", name),
+                detail: None,
+            }),
+        )
+            .into_response();
+    }
+
+    // Serialize and write back.
+    let new_contents = match toml::to_string_pretty(&parsed) {
+        Ok(s) => s,
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to serialize config",
+                Some(&e.to_string()),
+            )
+            .into_response();
+        }
+    };
+
+    if let Err(e) = std::fs::write(&resolved, &new_contents) {
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to write config file",
+            Some(&e.to_string()),
+        )
+        .into_response();
+    }
+
+    // Return success — the config watcher will pick up the file change and
+    // unload the endpoint from the registry automatically.
+    Json(serde_json::json!({
+        "status": "removed",
+        "name": name,
+    }))
+    .into_response()
+}
+
 // ---------------------------------------------------------------------------
 // Router builder
 // ---------------------------------------------------------------------------
@@ -287,6 +391,7 @@ pub fn management_routes(state: ManagementState) -> Router {
     Router::new()
         .route("/api/status", get(get_status))
         .route("/api/endpoints", get(get_endpoints))
+        .route("/api/endpoints/{name}", delete(delete_endpoint))
         .route("/api/endpoints/{name}/tools", get(get_endpoint_tools))
         .route("/api/endpoints/{name}/restart", post(restart_endpoint))
         .route("/api/endpoints/{name}/refresh", post(refresh_endpoint))
@@ -409,6 +514,7 @@ mod tests {
             registry: Arc::new(registry),
             config: Arc::new(RwLock::new(test_config())),
             start_time: Instant::now(),
+            config_path: None,
         }
     }
 
@@ -626,5 +732,111 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn management_delete_endpoint_success() {
+        // Write a temp config file with two endpoints
+        let dir = std::env::temp_dir().join(format!("relay-test-delete-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let config_file = dir.join("config.toml");
+        let toml_content = r#"[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "echo"
+transport = "stdio"
+command = "echo"
+
+[[endpoints]]
+name = "keep-me"
+transport = "stdio"
+command = "cat"
+"#;
+        std::fs::write(&config_file, toml_content).unwrap();
+
+        let mut state = test_state(vec![("echo", MockAdapter::healthy_with_tools(vec![]))]).await;
+        state.config_path = Some(config_file.clone());
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::delete("/api/endpoints/echo")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["status"], "removed");
+        assert_eq!(body["name"], "echo");
+
+        // Verify the config file was updated
+        let updated = std::fs::read_to_string(&config_file).unwrap();
+        assert!(!updated.contains("\"echo\""));
+        assert!(updated.contains("keep-me"));
+
+        // Clean up
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn management_delete_endpoint_not_found() {
+        let dir = std::env::temp_dir().join(format!("relay-test-delete-nf-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let config_file = dir.join("config.toml");
+        let toml_content = r#"[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "echo"
+transport = "stdio"
+command = "echo"
+"#;
+        std::fs::write(&config_file, toml_content).unwrap();
+
+        let mut state = test_state(vec![]).await;
+        state.config_path = Some(config_file.clone());
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::delete("/api/endpoints/nonexistent")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = body_json(resp).await;
+        assert!(body["error"]
+            .as_str()
+            .unwrap()
+            .contains("Endpoint not found"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn management_delete_endpoint_no_config_path() {
+        let state = test_state(vec![]).await;
+        // config_path is None
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::delete("/api/endpoints/echo")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = body_json(resp).await;
+        assert!(body["error"]
+            .as_str()
+            .unwrap()
+            .contains("config_path not configured"));
     }
 }

--- a/tests/management_api_integration.rs
+++ b/tests/management_api_integration.rs
@@ -10,7 +10,6 @@ use endara_relay::config::{Config, EndpointConfig, RelayConfig, Transport};
 use endara_relay::management::{management_routes, ManagementState};
 use endara_relay::registry::AdapterRegistry;
 use serde_json::{json, Value};
-use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Instant;
@@ -90,6 +89,7 @@ async fn start_management_server(
         registry,
         config: Arc::new(tokio::sync::RwLock::new(test_config())),
         start_time: Instant::now(),
+        config_path: None,
     };
 
     let app = management_routes(state);
@@ -243,4 +243,100 @@ async fn test_management_api_config() {
     assert_eq!(endpoints.len(), 1);
     assert_eq!(endpoints[0]["name"], "echo");
     assert_eq!(endpoints[0]["transport"], "stdio");
+}
+
+async fn start_management_server_with_config(
+    adapters: Vec<(&str, MockAdapter)>,
+    config_path: std::path::PathBuf,
+) -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let registry = AdapterRegistry::new("test-machine".into());
+    for (name, adapter) in adapters {
+        registry
+            .register(name.to_string(), Box::new(adapter), "stdio".to_string())
+            .await;
+    }
+    let registry = Arc::new(registry);
+    let state = ManagementState {
+        registry,
+        config: Arc::new(tokio::sync::RwLock::new(test_config())),
+        start_time: Instant::now(),
+        config_path: Some(config_path),
+    };
+
+    let app = management_routes(state);
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.ok();
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    (addr, handle)
+}
+
+#[tokio::test]
+async fn test_management_api_delete_endpoint() {
+    // Write a temp config file
+    let dir = std::env::temp_dir().join(format!("relay-integ-delete-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let config_file = dir.join("config.toml");
+    let toml_content = r#"[relay]
+machine_name = "test-machine"
+
+[[endpoints]]
+name = "echo-ep"
+transport = "stdio"
+command = "echo"
+args = ["hello"]
+
+[[endpoints]]
+name = "other-ep"
+transport = "stdio"
+command = "cat"
+"#;
+    std::fs::write(&config_file, toml_content).unwrap();
+
+    let tools = vec![ToolInfo {
+        name: "echo".into(),
+        description: Some("Echoes input".into()),
+        input_schema: json!({"type": "object"}),
+    }];
+    let (addr, _handle) = start_management_server_with_config(
+        vec![("echo-ep", MockAdapter::healthy_with_tools(tools))],
+        config_file.clone(),
+    )
+    .await;
+    let client = reqwest::Client::new();
+
+    // Delete the endpoint
+    let resp = client
+        .delete(format!("http://{}/api/endpoints/echo-ep", addr))
+        .send()
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["status"], "removed");
+    assert_eq!(body["name"], "echo-ep");
+
+    // Verify config file no longer contains echo-ep
+    let updated = std::fs::read_to_string(&config_file).unwrap();
+    assert!(!updated.contains("echo-ep"));
+    assert!(updated.contains("other-ep"));
+
+    // Try deleting a non-existent endpoint
+    let resp = client
+        .delete(format!("http://{}/api/endpoints/nonexistent", addr))
+        .send()
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status(), 404);
+    let body: Value = resp.json().await.unwrap();
+    assert!(body["error"]
+        .as_str()
+        .unwrap()
+        .contains("Endpoint not found"));
+
+    let _ = std::fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
Adds a DELETE route to the management API that removes an endpoint from config.toml. The config watcher automatically unloads the removed endpoint via hot-reload.