### PR TITLE
feat: freeform endpoint names, tool_prefix, single-server no-prefix, SIGHUP handling

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use crate::prefix;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
@@ -44,6 +45,8 @@ pub struct EndpointConfig {
     pub name: String,
     #[serde(default)]
     pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_prefix: Option<String>,
     pub transport: Transport,
     pub command: Option<String>,
     pub args: Option<Vec<String>>,
@@ -58,18 +61,49 @@ pub struct EndpointConfig {
     pub disabled_tools: Vec<String>,
 }
 
+impl EndpointConfig {
+    /// Returns the tool prefix to use for this endpoint.
+    ///
+    /// Priority: explicit `tool_prefix` field → `sanitize_name(name)`.
+    /// Returns `None` if both fail (e.g. unicode-only name with no tool_prefix).
+    pub fn resolved_tool_prefix(&self) -> Option<String> {
+        if let Some(ref tp) = self.tool_prefix {
+            Some(tp.clone())
+        } else {
+            prefix::sanitize_name(&self.name)
+        }
+    }
+}
+
 /// Custom PartialEq that ignores `disabled` and `disabled_tools` so that
 /// `diff_configs` treats an endpoint as "unchanged" when only these fields differ.
 /// Note: `headers` IS included — changing headers should trigger adapter restart.
 impl PartialEq for EndpointConfig {
     fn eq(&self, other: &Self) -> bool {
         self.name == other.name
+            && self.tool_prefix == other.tool_prefix
             && self.transport == other.transport
             && self.command == other.command
             && self.args == other.args
             && self.url == other.url
             && self.env == other.env
             && self.headers == other.headers
+    }
+}
+
+/// A per-endpoint validation warning. These do NOT prevent the relay from starting;
+/// instead the endpoint is registered as a `FailedAdapter`.
+#[derive(Debug, Clone)]
+pub struct EndpointValidationWarning {
+    /// The endpoint name (as written in the config).
+    pub endpoint_name: String,
+    /// Human-readable description of the problem.
+    pub message: String,
+}
+
+impl fmt::Display for EndpointValidationWarning {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Endpoint '{}': {}", self.endpoint_name, self.message)
     }
 }
 
@@ -155,6 +189,7 @@ pub fn create_default_config_file(path: &Path) -> Result<Config, ConfigError> {
 }
 
 /// Load, parse, resolve env vars, and validate a config file.
+#[allow(dead_code)]
 pub fn load_config(path: &Path) -> Result<Config, ConfigError> {
     let resolved = expand_tilde(path);
     let contents = std::fs::read_to_string(&resolved)?;
@@ -162,6 +197,7 @@ pub fn load_config(path: &Path) -> Result<Config, ConfigError> {
 }
 
 /// Parse TOML string, resolve env vars, and validate.
+#[allow(dead_code)]
 pub fn parse_and_validate(contents: &str) -> Result<Config, ConfigError> {
     let mut config: Config = toml::from_str(contents)?;
     resolve_env_vars(&mut config)?;
@@ -169,7 +205,41 @@ pub fn parse_and_validate(contents: &str) -> Result<Config, ConfigError> {
     Ok(config)
 }
 
+/// Parse TOML string, resolve env vars, and validate **gracefully**.
+///
+/// Fatal errors (TOML syntax, missing `[relay]`) still return `Err`.
+/// Per-endpoint issues (invalid name, missing command/url, duplicate names,
+/// env var resolution failures) are collected as warnings. The returned
+/// `Config` contains **all** endpoints (valid and invalid). The caller is
+/// expected to register invalid endpoints as `FailedAdapter`.
+pub fn parse_and_validate_graceful(
+    contents: &str,
+) -> Result<(Config, Vec<EndpointValidationWarning>), ConfigError> {
+    let mut config: Config = toml::from_str(contents)?;
+    let mut warnings = Vec::new();
+
+    // Resolve env vars per-endpoint, collecting failures as warnings
+    resolve_env_vars_graceful(&mut config, &mut warnings);
+
+    // Validate per-endpoint, collecting failures as warnings
+    validate_graceful(&config, &mut warnings);
+
+    Ok((config, warnings))
+}
+
+/// Load, parse, resolve env vars, and validate a config file **gracefully**.
+///
+/// Same semantics as [`parse_and_validate_graceful`] but reads from a file path.
+pub fn load_config_graceful(
+    path: &Path,
+) -> Result<(Config, Vec<EndpointValidationWarning>), ConfigError> {
+    let resolved = expand_tilde(path);
+    let contents = std::fs::read_to_string(&resolved)?;
+    parse_and_validate_graceful(&contents)
+}
+
 /// Resolve environment variables in endpoint env maps and header values.
+#[allow(dead_code)]
 fn resolve_env_vars(config: &mut Config) -> Result<(), ConfigError> {
     for endpoint in &mut config.endpoints {
         if let Some(ref mut env_map) = endpoint.env {
@@ -190,6 +260,62 @@ fn resolve_env_vars(config: &mut Config) -> Result<(), ConfigError> {
         }
     }
     Ok(())
+}
+
+/// Like [`resolve_env_vars`] but collects failures as warnings instead of
+/// returning an error. Endpoints with env resolution failures are left with
+/// their original (unresolved) values.
+fn resolve_env_vars_graceful(
+    config: &mut Config,
+    warnings: &mut Vec<EndpointValidationWarning>,
+) {
+    for endpoint in &mut config.endpoints {
+        let mut env_failed = false;
+        if let Some(ref mut env_map) = endpoint.env {
+            let mut resolved = HashMap::new();
+            for (key, value) in env_map.iter() {
+                match resolve_env_value(value, &endpoint.name) {
+                    Ok(v) => {
+                        resolved.insert(key.clone(), v);
+                    }
+                    Err(e) => {
+                        env_failed = true;
+                        warnings.push(EndpointValidationWarning {
+                            endpoint_name: endpoint.name.clone(),
+                            message: e.to_string(),
+                        });
+                        break;
+                    }
+                }
+            }
+            if !env_failed {
+                *env_map = resolved;
+            }
+        }
+
+        if !env_failed {
+            if let Some(ref mut headers_map) = endpoint.headers {
+                let mut resolved = HashMap::new();
+                for (key, value) in headers_map.iter() {
+                    match resolve_header_value(value, &endpoint.name) {
+                        Ok(v) => {
+                            resolved.insert(key.clone(), v);
+                        }
+                        Err(e) => {
+                            warnings.push(EndpointValidationWarning {
+                                endpoint_name: endpoint.name.clone(),
+                                message: e.to_string(),
+                            });
+                            break;
+                        }
+                    }
+                }
+                if warnings.iter().all(|w| w.endpoint_name != endpoint.name) {
+                    *headers_map = resolved;
+                }
+            }
+        }
+    }
 }
 
 /// Resolve a single env value string.
@@ -288,28 +414,44 @@ fn is_valid_endpoint_name(name: &str) -> bool {
 impl Config {
     /// Validate the config, collecting **all** errors instead of stopping at the first.
     ///
-    /// Each endpoint `name` must:
-    /// - match `^[a-z0-9][a-z0-9_-]*$`
-    /// - be unique across all endpoints
+    /// Each endpoint must have a resolvable tool_prefix (either explicitly set or
+    /// auto-sanitized from the name) that matches `^[a-z0-9][a-z0-9_-]*$` and is
+    /// unique across all endpoints.
     ///
     /// Returns `Ok(())` when valid, or `Err(Vec<String>)` with every validation
     /// error found.
+    #[allow(dead_code)]
     pub fn validate(&self) -> Result<(), Vec<String>> {
         let mut errors: Vec<String> = Vec::new();
-        let mut seen_names = std::collections::HashSet::new();
+        let mut seen_prefixes = std::collections::HashSet::new();
 
         for ep in &self.endpoints {
             if ep.name.is_empty() {
                 errors.push("Endpoint name must not be empty".to_string());
-            } else if !is_valid_endpoint_name(&ep.name) {
-                errors.push(format!(
-                    "Invalid endpoint name '{}': must match ^[a-z0-9][a-z0-9_-]*$ (lowercase alphanumeric, hyphens, underscores; must start with letter or digit)",
-                    ep.name
-                ));
             }
 
-            if !ep.name.is_empty() && !seen_names.insert(&ep.name) {
-                errors.push(format!("Duplicate endpoint name: '{}'", ep.name));
+            // Validate resolved tool_prefix
+            match ep.resolved_tool_prefix() {
+                None => {
+                    errors.push(format!(
+                        "Endpoint '{}': name cannot be sanitized into a valid tool prefix. Set 'tool_prefix' explicitly.",
+                        ep.name
+                    ));
+                }
+                Some(ref tp) if !is_valid_endpoint_name(tp) => {
+                    errors.push(format!(
+                        "Endpoint '{}': tool_prefix '{}' must match ^[a-z0-9][a-z0-9_-]*$ (lowercase alphanumeric, hyphens, underscores; must start with letter or digit)",
+                        ep.name, tp
+                    ));
+                }
+                Some(ref tp) => {
+                    if !seen_prefixes.insert(tp.clone()) {
+                        errors.push(format!(
+                            "Duplicate tool_prefix '{}' (from endpoint '{}')",
+                            tp, ep.name
+                        ));
+                    }
+                }
             }
 
             match ep.transport {
@@ -347,10 +489,99 @@ impl Config {
 }
 
 /// Validate the parsed config (internal wrapper for backward compatibility).
+#[allow(dead_code)]
 fn validate(config: &Config) -> Result<(), ConfigError> {
     config.validate().map_err(|errors| {
         ConfigError::ValidationError(errors.join("; "))
     })
+}
+
+/// Per-endpoint validation that collects warnings instead of erroring.
+///
+/// Checks: resolved tool_prefix validity, missing command/url, duplicate prefixes.
+/// First occurrence of a duplicate wins; subsequent duplicates are warned.
+fn validate_graceful(
+    config: &Config,
+    warnings: &mut Vec<EndpointValidationWarning>,
+) {
+    let mut seen_prefixes = std::collections::HashSet::new();
+
+    for ep in &config.endpoints {
+        // Check if this endpoint already has an env-var warning (skip further checks)
+        let already_warned = warnings.iter().any(|w| w.endpoint_name == ep.name);
+
+        if ep.name.is_empty() {
+            warnings.push(EndpointValidationWarning {
+                endpoint_name: ep.name.clone(),
+                message: "Endpoint name must not be empty".to_string(),
+            });
+        }
+
+        // Validate resolved tool_prefix
+        match ep.resolved_tool_prefix() {
+            None => {
+                warnings.push(EndpointValidationWarning {
+                    endpoint_name: ep.name.clone(),
+                    message: format!(
+                        "Endpoint '{}': name cannot be sanitized into a valid tool prefix. Set 'tool_prefix' explicitly.",
+                        ep.name
+                    ),
+                });
+            }
+            Some(ref tp) if !is_valid_endpoint_name(tp) => {
+                warnings.push(EndpointValidationWarning {
+                    endpoint_name: ep.name.clone(),
+                    message: format!(
+                        "Endpoint '{}': tool_prefix '{}' is invalid: must match ^[a-z0-9][a-z0-9_-]*$",
+                        ep.name, tp
+                    ),
+                });
+            }
+            Some(ref tp) => {
+                if !seen_prefixes.insert(tp.clone()) {
+                    warnings.push(EndpointValidationWarning {
+                        endpoint_name: ep.name.clone(),
+                        message: format!(
+                            "Duplicate tool_prefix '{}' (from endpoint '{}')",
+                            tp, ep.name
+                        ),
+                    });
+                }
+            }
+        }
+
+        // Only check transport requirements if not already warned (env var issue)
+        if !already_warned {
+            match ep.transport {
+                Transport::Stdio => {
+                    if ep.command.is_none() || ep.command.as_deref() == Some("") {
+                        warnings.push(EndpointValidationWarning {
+                            endpoint_name: ep.name.clone(),
+                            message: "stdio transport requires a 'command' field".to_string(),
+                        });
+                    }
+                }
+                Transport::Sse | Transport::Http => {
+                    if ep.url.is_none() || ep.url.as_deref() == Some("") {
+                        warnings.push(EndpointValidationWarning {
+                            endpoint_name: ep.name.clone(),
+                            message: format!(
+                                "{} transport requires a 'url' field",
+                                ep.transport
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Helper: get the set of endpoint names that have validation warnings.
+pub fn warned_endpoint_names(
+    warnings: &[EndpointValidationWarning],
+) -> std::collections::HashSet<String> {
+    warnings.iter().map(|w| w.endpoint_name.clone()).collect()
 }
 
 /// Result of comparing two configs to determine what changed.
@@ -606,6 +837,7 @@ machine_name = "test"
 
     #[test]
     fn valid_endpoint_names() {
+        // These names are all directly valid tool_prefix values
         for name in &["echo", "my-server", "test_ep", "a", "0day", "abc-123", "a-b_c"] {
             let toml_str = format!(
                 r#"
@@ -628,7 +860,8 @@ command = "echo"
     }
 
     #[test]
-    fn invalid_endpoint_name_uppercase() {
+    fn freeform_name_uppercase_is_valid() {
+        // Freeform names: "MyServer" sanitizes to "myserver" which is valid
         let toml_str = r#"
 [relay]
 machine_name = "test"
@@ -638,17 +871,27 @@ name = "MyServer"
 transport = "stdio"
 command = "echo"
 "#;
-        let err = parse_and_validate(toml_str).unwrap_err();
-        match err {
-            ConfigError::ValidationError(msg) => {
-                assert!(msg.contains("MyServer"), "Error should mention the name: {}", msg);
-            }
-            other => panic!("Expected ValidationError, got: {:?}", other),
-        }
+        assert!(parse_and_validate(toml_str).is_ok());
+    }
+
+    #[test]
+    fn freeform_name_with_spaces_is_valid() {
+        // "my server" sanitizes to "my_server" which is valid
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "my server"
+transport = "stdio"
+command = "echo"
+"#;
+        assert!(parse_and_validate(toml_str).is_ok());
     }
 
     #[test]
     fn invalid_endpoint_name_starts_with_hyphen() {
+        // "-bad" sanitizes to "-bad" which starts with hyphen → invalid
         let toml_str = r#"
 [relay]
 machine_name = "test"
@@ -661,42 +904,59 @@ command = "echo"
         let err = parse_and_validate(toml_str).unwrap_err();
         match err {
             ConfigError::ValidationError(msg) => {
-                assert!(msg.contains("-bad"), "Error should mention the name: {}", msg);
+                assert!(msg.contains("-bad"), "Error should mention the prefix: {}", msg);
             }
             other => panic!("Expected ValidationError, got: {:?}", other),
         }
     }
 
     #[test]
-    fn invalid_endpoint_name_special_chars() {
+    fn unicode_only_name_fails() {
+        // Unicode-only name with no sanitizable ASCII chars → tool_prefix is None
         let toml_str = r#"
 [relay]
 machine_name = "test"
 
 [[endpoints]]
-name = "my server"
+name = "日本語"
 transport = "stdio"
 command = "echo"
 "#;
         let err = parse_and_validate(toml_str).unwrap_err();
         match err {
             ConfigError::ValidationError(msg) => {
-                assert!(msg.contains("my server"), "Error should mention the name: {}", msg);
+                assert!(msg.contains("cannot be sanitized"), "Error should mention sanitization: {}", msg);
             }
             other => panic!("Expected ValidationError, got: {:?}", other),
         }
     }
 
     #[test]
+    fn explicit_tool_prefix_overrides_name() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "日本語サーバー"
+tool_prefix = "japanese_server"
+transport = "stdio"
+command = "echo"
+"#;
+        assert!(parse_and_validate(toml_str).is_ok());
+    }
+
+    #[test]
     fn validate_collects_multiple_errors() {
+        // "_also_bad" sanitizes to "_also_bad" which starts with underscore → invalid
         let config = make_config(vec![
-            stdio_ep("Bad-Name", "echo"),
-            stdio_ep("_also_bad", "cat"),
+            stdio_ep("_also_bad", "echo"),
+            stdio_ep("-starts-with-hyphen", "cat"),
         ]);
         let errors = config.validate().unwrap_err();
         assert_eq!(errors.len(), 2, "Should have 2 errors: {:?}", errors);
-        assert!(errors[0].contains("Bad-Name"));
-        assert!(errors[1].contains("_also_bad"));
+        assert!(errors[0].contains("_also_bad"));
+        assert!(errors[1].contains("-starts-with-hyphen"));
     }
 
     #[test]
@@ -706,13 +966,24 @@ command = "echo"
     }
 
     #[test]
-    fn validate_reports_duplicates_and_invalid_names() {
+    fn validate_reports_duplicates() {
         let config = make_config(vec![
             stdio_ep("good", "echo"),
             stdio_ep("good", "cat"),
         ]);
         let errors = config.validate().unwrap_err();
         assert!(errors.iter().any(|e| e.contains("Duplicate")));
+    }
+
+    #[test]
+    fn validate_duplicate_resolved_prefix() {
+        // "My Server" and "my_server" both resolve to "my_server"
+        let config = make_config(vec![
+            stdio_ep("My Server", "echo"),
+            stdio_ep("my_server", "cat"),
+        ]);
+        let errors = config.validate().unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("Duplicate tool_prefix")));
     }
 
     // --- Config diff tests ---
@@ -731,6 +1002,7 @@ command = "echo"
         EndpointConfig {
             name: name.to_string(),
             description: None,
+            tool_prefix: None,
             transport: Transport::Stdio,
             command: Some(cmd.to_string()),
             args: None,
@@ -746,6 +1018,7 @@ command = "echo"
         EndpointConfig {
             name: name.to_string(),
             description: None,
+            tool_prefix: None,
             transport: Transport::Sse,
             command: None,
             args: None,
@@ -854,5 +1127,156 @@ headers = { Authorization = "Bearer $TEST_HEADER_TOKEN_12345" }
         let diff = diff_configs(&old, &new);
         assert_eq!(diff.changed.len(), 1);
         assert!(diff.unchanged.is_empty());
+    }
+
+    // --- Graceful validation tests ---
+
+    #[test]
+    fn graceful_freeform_name_is_valid() {
+        // "Sequential Thinking" sanitizes to "sequential_thinking" — now valid
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "Sequential Thinking"
+transport = "stdio"
+command = "echo"
+"#;
+        let (config, warnings) = parse_and_validate_graceful(toml_str).unwrap();
+        assert_eq!(config.endpoints.len(), 1);
+        assert!(warnings.is_empty(), "Expected no warnings, got: {:?}", warnings);
+    }
+
+    #[test]
+    fn graceful_unicode_only_name_returns_warning() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "日本語"
+transport = "stdio"
+command = "echo"
+"#;
+        let (config, warnings) = parse_and_validate_graceful(toml_str).unwrap();
+        assert_eq!(config.endpoints.len(), 1);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].message.contains("cannot be sanitized"));
+    }
+
+    #[test]
+    fn graceful_mixed_valid_and_invalid_endpoints() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "good-endpoint"
+transport = "stdio"
+command = "echo"
+
+[[endpoints]]
+name = "日本語"
+transport = "stdio"
+command = "cat"
+
+[[endpoints]]
+name = "another-good"
+transport = "stdio"
+command = "ls"
+"#;
+        let (config, warnings) = parse_and_validate_graceful(toml_str).unwrap();
+        assert_eq!(config.endpoints.len(), 3);
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].endpoint_name, "日本語");
+        let warned = warned_endpoint_names(&warnings);
+        assert!(warned.contains("日本語"));
+        assert!(!warned.contains("good-endpoint"));
+        assert!(!warned.contains("another-good"));
+    }
+
+    #[test]
+    fn graceful_missing_command_returns_warning() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "no-cmd"
+transport = "stdio"
+"#;
+        let (_, warnings) = parse_and_validate_graceful(toml_str).unwrap();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].message.contains("command"));
+    }
+
+    #[test]
+    fn graceful_missing_url_returns_warning() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "no-url"
+transport = "sse"
+"#;
+        let (_, warnings) = parse_and_validate_graceful(toml_str).unwrap();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].message.contains("url"));
+    }
+
+    #[test]
+    fn graceful_duplicate_names_warned() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "dup"
+transport = "stdio"
+command = "echo"
+
+[[endpoints]]
+name = "dup"
+transport = "stdio"
+command = "cat"
+"#;
+        let (config, warnings) = parse_and_validate_graceful(toml_str).unwrap();
+        assert_eq!(config.endpoints.len(), 2);
+        assert!(warnings.iter().any(|w| w.message.contains("Duplicate")));
+    }
+
+    #[test]
+    fn graceful_toml_syntax_error_still_fatal() {
+        let toml_str = "this is not valid toml [[[";
+        assert!(parse_and_validate_graceful(toml_str).is_err());
+    }
+
+    #[test]
+    fn graceful_missing_relay_section_still_fatal() {
+        let toml_str = r#"
+[[endpoints]]
+name = "test"
+transport = "stdio"
+command = "echo"
+"#;
+        assert!(parse_and_validate_graceful(toml_str).is_err());
+    }
+
+    #[test]
+    fn graceful_no_warnings_for_valid_config() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "echo"
+transport = "stdio"
+command = "echo"
+"#;
+        let (config, warnings) = parse_and_validate_graceful(toml_str).unwrap();
+        assert_eq!(config.endpoints.len(), 1);
+        assert!(warnings.is_empty());
     }
 }

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -447,6 +447,7 @@ mod tests {
                 ])),
                 "stdio".into(),
                 None,
+                Some("ep".into()),
             )
             .await;
         Arc::new(registry)
@@ -552,7 +553,7 @@ mod tests {
         let reg = make_registry().await;
         let sandbox = JsSandbox::new(reg, Duration::from_secs(5));
         let result = sandbox
-            .execute(r#"const r = await tools.ep__echo({text: "hi"}); return r;"#)
+            .execute(r#"const r = await tools.echo({text: "hi"}); return r;"#)
             .await
             .unwrap();
         assert_eq!(result["called"], "echo");
@@ -565,7 +566,7 @@ mod tests {
         let sandbox = JsSandbox::new(reg, Duration::from_secs(5));
         // Without await — should also work since tool calls are synchronous
         let result = sandbox
-            .execute(r#"const r = tools.ep__echo({msg: "sync"}); return r;"#)
+            .execute(r#"const r = tools.echo({msg: "sync"}); return r;"#)
             .await
             .unwrap();
         assert_eq!(result["called"], "echo");
@@ -628,8 +629,8 @@ mod tests {
         let reg = make_registry().await;
         let sandbox = JsSandbox::new(reg, Duration::from_secs(10));
         let script = r#"
-            const r1 = await tools.ep__echo({text: "first"});
-            const r2 = await tools.ep__add({a: 1, b: 2});
+            const r1 = await tools.echo({text: "first"});
+            const r2 = await tools.add({a: 1, b: 2});
             return { echo_result: r1, add_result: r2 };
         "#;
         let result = sandbox.execute(script).await.unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,14 +96,18 @@ async fn main() {
             init_tracing(&log_format);
             info!(config = %config_path.display(), "Starting endara-relay");
 
-            let cfg = match config::load_config(&config_path) {
-                Ok(cfg) => {
+            let (cfg, validation_warnings) = match config::load_config_graceful(&config_path) {
+                Ok((cfg, warnings)) => {
                     info!(
                         machine_name = %cfg.relay.machine_name,
                         endpoints = cfg.endpoints.len(),
+                        warnings = warnings.len(),
                         "Configuration loaded successfully"
                     );
-                    cfg
+                    for w in &warnings {
+                        warn!("{}", w);
+                    }
+                    (cfg, warnings)
                 }
                 Err(config::ConfigError::IoError(ref io_err))
                     if io_err.kind() == std::io::ErrorKind::NotFound =>
@@ -119,7 +123,7 @@ async fn main() {
                                 path = %config_path.display(),
                                 "Created default configuration"
                             );
-                            cfg
+                            (cfg, Vec::new())
                         }
                         Err(e) => {
                             error!(error = %e, "Failed to create default configuration");
@@ -133,11 +137,49 @@ async fn main() {
                 }
             };
 
+            // Collect endpoint names that have validation warnings
+            let warned_names = config::warned_endpoint_names(&validation_warnings);
+            // Build a map from endpoint name to its warning message(s)
+            let warning_messages: std::collections::HashMap<String, String> = {
+                let mut map = std::collections::HashMap::new();
+                for w in &validation_warnings {
+                    map.entry(w.endpoint_name.clone())
+                        .and_modify(|msg: &mut String| {
+                            msg.push_str("; ");
+                            msg.push_str(&w.message);
+                        })
+                        .or_insert_with(|| w.message.clone());
+                }
+                map
+            };
+
             // Create adapter registry
             let registry = AdapterRegistry::new();
 
+            // Track duplicate endpoint names: first occurrence wins
+            let mut registered_names = std::collections::HashSet::new();
+
             // Register and initialize adapters for each endpoint
             for ep in &cfg.endpoints {
+                // Handle duplicate endpoint names: first wins, rest become FailedAdapter
+                if !ep.name.is_empty() && !registered_names.insert(ep.name.clone()) {
+                    let msg = format!("Duplicate endpoint name: '{}'", ep.name);
+                    warn!(endpoint = %ep.name, "{}", msg);
+                    // Skip duplicate — already registered above
+                    continue;
+                }
+
+                // If this endpoint has validation warnings, register as FailedAdapter
+                if warned_names.contains(&ep.name) {
+                    let msg = warning_messages.get(&ep.name).cloned().unwrap_or_default();
+                    warn!(endpoint = %ep.name, "Registering as failed due to validation error: {}", msg);
+                    let adapter: Box<dyn McpAdapter> = Box::new(FailedAdapter::new(msg));
+                    registry
+                        .register(ep.name.clone(), adapter, ep.transport.to_string(), ep.description.clone(), ep.resolved_tool_prefix())
+                        .await;
+                    continue;
+                }
+
                 info!(name = %ep.name, transport = %ep.transport, "Configuring endpoint");
                 let adapter: Box<dyn McpAdapter> = match ep.transport {
                     config::Transport::Stdio => {
@@ -192,7 +234,7 @@ async fn main() {
                     }
                 };
                 registry
-                    .register(ep.name.clone(), adapter, ep.transport.to_string(), ep.description.clone())
+                    .register(ep.name.clone(), adapter, ep.transport.to_string(), ep.description.clone(), ep.resolved_tool_prefix())
                     .await;
             }
 

--- a/src/management.rs
+++ b/src/management.rs
@@ -59,6 +59,8 @@ pub struct EndpointInfo {
     pub disabled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_prefix: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -193,6 +195,7 @@ async fn get_endpoints(State(state): State<ManagementState>) -> Json<Vec<Endpoin
             last_activity: entry.last_activity.map(|t| now.duration_since(t).as_secs()),
             disabled: entry.disabled,
             error,
+            tool_prefix: entry.tool_prefix.clone(),
         });
     }
     endpoints.sort_by(|a, b| a.name.cmp(&b.name));
@@ -860,6 +863,7 @@ mod tests {
             endpoints: vec![EndpointConfig {
                 name: "echo".to_string(),
                 description: None,
+                tool_prefix: None,
                 transport: Transport::Stdio,
                 command: Some("echo".to_string()),
                 args: Some(vec!["hello".to_string()]),
@@ -879,7 +883,7 @@ mod tests {
         let registry = AdapterRegistry::new();
         for (name, adapter) in adapters {
             registry
-                .register(name.to_string(), Box::new(adapter), "stdio".to_string(), None)
+                .register(name.to_string(), Box::new(adapter), "stdio".to_string(), None, Some(name.to_string()))
                 .await;
         }
         ManagementState {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -11,6 +11,7 @@ pub struct RegisteredAdapter {
     pub adapter: Box<dyn McpAdapter>,
     pub transport: String,
     pub description: Option<String>,
+    pub tool_prefix: Option<String>,
     pub last_activity: Option<Instant>,
     pub disabled: bool,
     pub disabled_tools: HashSet<String>,
@@ -44,14 +45,16 @@ impl AdapterRegistry {
         adapter: Box<dyn McpAdapter>,
         transport: String,
         description: Option<String>,
+        tool_prefix: Option<String>,
     ) {
-        debug!(endpoint = %name, "Registering adapter");
+        debug!(endpoint = %name, ?tool_prefix, "Registering adapter");
         self.adapters.write().await.insert(
             name,
             RegisteredAdapter {
                 adapter,
                 transport,
                 description,
+                tool_prefix,
                 last_activity: None,
                 disabled: false,
                 disabled_tools: HashSet::new(),
@@ -80,15 +83,13 @@ impl AdapterRegistry {
         &self.adapters
     }
 
-    /// Build merged tool catalog from all adapters, with collision-aware prefixed names.
+    /// Build merged tool catalog from all adapters, with prefix-aware names.
     ///
     /// Naming strategy:
-    /// 1. Each adapter reports a `server_type()` (sanitized `serverInfo.name`).
-    ///    If unavailable, the endpoint name is used as fallback.
-    /// 2. If only one endpoint has a given server_type, tools are named
-    ///    `{server_type}__{tool}`.
-    /// 3. If multiple endpoints share a server_type (collision), tools are named
-    ///    `{server_type}__{endpoint_name}__{tool}`.
+    /// 1. Each adapter has a `tool_prefix` (from config's `resolved_tool_prefix`).
+    /// 2. **Single-server no-prefix mode**: if only one non-disabled adapter is
+    ///    registered, tool names are passed through without any prefix.
+    /// 3. Otherwise, tools are named `{tool_prefix}__{tool}`.
     ///
     /// Also builds and returns a reverse lookup map for use by `route_tool_call`.
     ///
@@ -112,23 +113,10 @@ impl AdapterRegistry {
     ) -> (Vec<ToolInfo>, HashMap<String, (String, String)>) {
         let adapters = self.adapters.read().await;
 
-        // First pass: determine server_type for each endpoint and detect collisions
-        let mut server_type_map: HashMap<String, String> = HashMap::new(); // endpoint -> server_type
-        let mut type_counts: HashMap<String, usize> = HashMap::new();
+        // Count non-disabled adapters for single-server no-prefix mode
+        let active_count = adapters.values().filter(|e| !e.disabled).count();
+        let skip_prefix = active_count <= 1;
 
-        for (endpoint_name, entry) in adapters.iter() {
-            if entry.disabled {
-                continue;
-            }
-            let st = entry
-                .adapter
-                .server_type()
-                .unwrap_or_else(|| endpoint_name.clone());
-            *type_counts.entry(st.clone()).or_insert(0) += 1;
-            server_type_map.insert(endpoint_name.clone(), st);
-        }
-
-        // Second pass: build catalog with collision-aware names
         let mut catalog = Vec::new();
         let mut lookup: HashMap<String, (String, String)> = HashMap::new();
 
@@ -144,11 +132,12 @@ impl AdapterRegistry {
                 .as_deref()
                 .unwrap_or(endpoint_name.as_str());
 
-            let server_type = server_type_map
-                .get(endpoint_name)
-                .cloned()
-                .unwrap_or_else(|| endpoint_name.clone());
-            let has_collision = type_counts.get(&server_type).copied().unwrap_or(0) > 1;
+            // Determine the prefix to use (if any)
+            let effective_prefix = if skip_prefix {
+                None
+            } else {
+                entry.tool_prefix.clone()
+            };
 
             match entry.adapter.list_tools().await {
                 Ok(tools) => {
@@ -156,13 +145,10 @@ impl AdapterRegistry {
                         if entry.disabled_tools.contains(&tool.name) {
                             continue;
                         }
-                        let instance = if has_collision {
-                            Some(endpoint_name.as_str())
-                        } else {
-                            None
+                        let final_name = match &effective_prefix {
+                            Some(pfx) => prefix::encode_tool_name(pfx, None, &tool.name),
+                            None => tool.name.clone(),
                         };
-                        let prefixed_name =
-                            prefix::encode_tool_name(&server_type, instance, &tool.name);
                         let enriched_description = if is_healthy {
                             match tool.description {
                                 Some(desc) => Some(format!("[{}] {}", label, desc)),
@@ -177,11 +163,11 @@ impl AdapterRegistry {
                             }
                         };
                         lookup.insert(
-                            prefixed_name.clone(),
+                            final_name.clone(),
                             (endpoint_name.clone(), tool.name.clone()),
                         );
                         catalog.push(ToolInfo {
-                            name: prefixed_name,
+                            name: final_name,
                             description: enriched_description,
                             input_schema: tool.input_schema,
                             annotations: tool.annotations,
@@ -327,10 +313,10 @@ mod tests {
         }
     }
 
-    // --- No collision: each endpoint has unique server_type (falls back to endpoint name) ---
+    // --- Single-server no-prefix mode ---
 
     #[tokio::test]
-    async fn test_merged_catalog_no_collision() {
+    async fn test_single_server_no_prefix() {
         let registry = AdapterRegistry::new();
         registry
             .register(
@@ -338,6 +324,28 @@ mod tests {
                 Box::new(MockAdapter::healthy(vec![make_tool("read")])),
                 "stdio".into(),
                 None,
+                Some("ep1".into()),
+            )
+            .await;
+
+        let catalog = registry.merged_catalog().await;
+        assert_eq!(catalog.len(), 1);
+        // Single adapter → no prefix
+        assert_eq!(catalog[0].name, "read");
+    }
+
+    // --- Multi-server with tool_prefix ---
+
+    #[tokio::test]
+    async fn test_multi_server_uses_tool_prefix() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "ep1".into(),
+                Box::new(MockAdapter::healthy(vec![make_tool("read")])),
+                "stdio".into(),
+                None,
+                Some("ep1".into()),
             )
             .await;
         registry
@@ -346,6 +354,7 @@ mod tests {
                 Box::new(MockAdapter::healthy(vec![make_tool("write")])),
                 "stdio".into(),
                 None,
+                Some("ep2".into()),
             )
             .await;
 
@@ -353,59 +362,8 @@ mod tests {
         assert_eq!(catalog.len(), 2);
 
         let names: Vec<&str> = catalog.iter().map(|t| t.name.as_str()).collect();
-        // No collision: server_type == endpoint_name, so format is {ep}__{tool}
         assert!(names.contains(&"ep1__read"));
         assert!(names.contains(&"ep2__write"));
-    }
-
-    // --- With server_type: no collision ---
-
-    #[tokio::test]
-    async fn test_merged_catalog_with_server_type_no_collision() {
-        let registry = AdapterRegistry::new();
-        registry
-            .register(
-                "echo-ep".into(),
-                Box::new(MockAdapter::healthy_with_type(vec![make_tool("echo")], "echo_mcp")),
-                "stdio".into(),
-                None,
-            )
-            .await;
-
-        let catalog = registry.merged_catalog().await;
-        assert_eq!(catalog.len(), 1);
-        assert_eq!(catalog[0].name, "echo_mcp__echo");
-    }
-
-    // --- With server_type: collision (same type, different endpoints) ---
-
-    #[tokio::test]
-    async fn test_merged_catalog_collision_adds_instance() {
-        let registry = AdapterRegistry::new();
-        registry
-            .register(
-                "fs-local".into(),
-                Box::new(MockAdapter::healthy_with_type(vec![make_tool("read")], "filesystem")),
-                "stdio".into(),
-                None,
-            )
-            .await;
-        registry
-            .register(
-                "fs-remote".into(),
-                Box::new(MockAdapter::healthy_with_type(vec![make_tool("read")], "filesystem")),
-                "stdio".into(),
-                None,
-            )
-            .await;
-
-        let catalog = registry.merged_catalog().await;
-        assert_eq!(catalog.len(), 2);
-
-        let names: Vec<&str> = catalog.iter().map(|t| t.name.as_str()).collect();
-        // Collision: both have server_type "filesystem", so instance prefix added
-        assert!(names.contains(&"filesystem__fs-local__read"));
-        assert!(names.contains(&"filesystem__fs-remote__read"));
     }
 
     // --- Unhealthy endpoints still show in catalog ---
@@ -419,6 +377,7 @@ mod tests {
                 Box::new(MockAdapter::healthy(vec![make_tool("tool")])),
                 "stdio".into(),
                 None,
+                Some("good".into()),
             )
             .await;
         registry
@@ -427,6 +386,7 @@ mod tests {
                 Box::new(MockAdapter::unhealthy()),
                 "stdio".into(),
                 None,
+                Some("bad".into()),
             )
             .await;
 
@@ -439,7 +399,7 @@ mod tests {
     // --- Route tool call ---
 
     #[tokio::test]
-    async fn test_route_tool_call() {
+    async fn test_route_tool_call_single_server() {
         let registry = AdapterRegistry::new();
         registry
             .register(
@@ -447,11 +407,13 @@ mod tests {
                 Box::new(MockAdapter::healthy(vec![make_tool("echo")])),
                 "stdio".into(),
                 None,
+                Some("ep".into()),
             )
             .await;
 
+        // Single server → no prefix
         let result = registry
-            .route_tool_call("ep__echo", json!({"msg": "hi"}))
+            .route_tool_call("echo", json!({"msg": "hi"}))
             .await
             .unwrap();
         assert_eq!(result["called"], "echo");
@@ -459,52 +421,35 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_route_tool_call_with_server_type() {
-        let registry = AdapterRegistry::new();
-        registry
-            .register(
-                "echo-ep".into(),
-                Box::new(MockAdapter::healthy_with_type(vec![make_tool("echo")], "echo_mcp")),
-                "stdio".into(),
-                None,
-            )
-            .await;
-
-        let result = registry
-            .route_tool_call("echo_mcp__echo", json!({"msg": "hi"}))
-            .await
-            .unwrap();
-        assert_eq!(result["called"], "echo");
-    }
-
-    #[tokio::test]
-    async fn test_route_tool_call_with_collision() {
+    async fn test_route_tool_call_multi_server() {
         let registry = AdapterRegistry::new();
         registry
             .register(
                 "fs-local".into(),
-                Box::new(MockAdapter::healthy_with_type(vec![make_tool("read")], "fs")),
+                Box::new(MockAdapter::healthy(vec![make_tool("read")])),
                 "stdio".into(),
                 None,
+                Some("fs-local".into()),
             )
             .await;
         registry
             .register(
                 "fs-remote".into(),
-                Box::new(MockAdapter::healthy_with_type(vec![make_tool("read")], "fs")),
+                Box::new(MockAdapter::healthy(vec![make_tool("read")])),
                 "stdio".into(),
                 None,
+                Some("fs-remote".into()),
             )
             .await;
 
         let result = registry
-            .route_tool_call("fs__fs-local__read", json!({}))
+            .route_tool_call("fs-local__read", json!({}))
             .await
             .unwrap();
         assert_eq!(result["called"], "read");
 
         let result = registry
-            .route_tool_call("fs__fs-remote__read", json!({}))
+            .route_tool_call("fs-remote__read", json!({}))
             .await
             .unwrap();
         assert_eq!(result["called"], "read");
@@ -537,6 +482,7 @@ mod tests {
                 Box::new(MockAdapter::healthy(vec![make_tool("t")])),
                 "stdio".into(),
                 None,
+                Some("ep".into()),
             )
             .await;
 
@@ -563,6 +509,7 @@ mod tests {
                 Box::new(MockAdapter::healthy(vec![])),
                 "stdio".into(),
                 None,
+                Some("good".into()),
             )
             .await;
         registry
@@ -571,6 +518,7 @@ mod tests {
                 Box::new(MockAdapter::unhealthy()),
                 "stdio".into(),
                 None,
+                Some("bad".into()),
             )
             .await;
 
@@ -599,6 +547,7 @@ mod tests {
                 Box::new(MockAdapter::healthy(vec![make_tool("old_tool")])),
                 "stdio".into(),
                 None,
+                Some("ep".into()),
             )
             .await;
         registry
@@ -607,12 +556,14 @@ mod tests {
                 Box::new(MockAdapter::healthy(vec![make_tool("new_tool")])),
                 "sse".into(),
                 None,
+                Some("ep".into()),
             )
             .await;
 
+        // After overwrite, single adapter → no prefix
         let catalog = registry.merged_catalog().await;
         assert_eq!(catalog.len(), 1);
-        assert_eq!(catalog[0].name, "ep__new_tool");
+        assert_eq!(catalog[0].name, "new_tool");
     }
 
     #[tokio::test]
@@ -624,10 +575,12 @@ mod tests {
                 Box::new(MockAdapter::unhealthy_with_tools(vec![make_tool("tool")])),
                 "stdio".into(),
                 None,
+                Some("sick".into()),
             )
             .await;
 
-        let result = registry.route_tool_call("sick__tool", json!({})).await;
+        // Single server → no prefix
+        let result = registry.route_tool_call("tool", json!({})).await;
         assert!(result.is_err());
         let err_msg = format!("{}", result.unwrap_err());
         assert!(err_msg.contains("not healthy"));
@@ -642,6 +595,7 @@ mod tests {
                 Box::new(MockAdapter::healthy(vec![])),
                 "stdio".into(),
                 None,
+                Some("ep".into()),
             )
             .await;
 
@@ -663,15 +617,17 @@ mod tests {
                 ])),
                 "stdio".into(),
                 None,
+                Some("ep".into()),
             )
             .await;
 
+        // Single adapter → no prefix
         let catalog = registry.merged_catalog().await;
         assert_eq!(catalog.len(), 3);
         let names: Vec<&str> = catalog.iter().map(|t| t.name.as_str()).collect();
-        assert!(names.contains(&"ep__read"));
-        assert!(names.contains(&"ep__write"));
-        assert!(names.contains(&"ep__delete"));
+        assert!(names.contains(&"read"));
+        assert!(names.contains(&"write"));
+        assert!(names.contains(&"delete"));
     }
 
     #[tokio::test]
@@ -683,6 +639,7 @@ mod tests {
                 Box::new(MockAdapter::healthy(vec![make_tool("t")])),
                 "stdio".into(),
                 None,
+                Some("ep".into()),
             )
             .await;
 
@@ -707,6 +664,7 @@ mod tests {
                 ])),
                 "stdio".into(),
                 None,
+                Some("ep".into()),
             )
             .await;
 
@@ -719,9 +677,10 @@ mod tests {
                 .insert("read".into());
         }
 
+        // Single adapter → no prefix
         let catalog = registry.merged_catalog().await;
         assert_eq!(catalog.len(), 1);
-        assert_eq!(catalog[0].name, "ep__write");
+        assert_eq!(catalog[0].name, "write");
     }
 
     #[tokio::test]
@@ -733,6 +692,7 @@ mod tests {
                 Box::new(MockAdapter::healthy(vec![make_tool("t")])),
                 "stdio".into(),
                 None,
+                Some("ep".into()),
             )
             .await;
 
@@ -746,7 +706,7 @@ mod tests {
         }
 
         // The tool is disabled so it won't appear in lookup → route fails
-        let result = registry.route_tool_call("ep__t", json!({})).await;
+        let result = registry.route_tool_call("t", json!({})).await;
         assert!(result.is_err());
     }
 
@@ -759,6 +719,7 @@ mod tests {
                 Box::new(MockAdapter::healthy(vec![make_tool("read")])),
                 "stdio".into(),
                 None,
+                Some("filesystem".into()),
             )
             .await;
 
@@ -779,6 +740,7 @@ mod tests {
                 Box::new(MockAdapter::healthy(vec![make_tool("read")])),
                 "stdio".into(),
                 Some("File System".into()),
+                Some("fs-server".into()),
             )
             .await;
 
@@ -805,6 +767,7 @@ mod tests {
                 Box::new(MockAdapter::healthy(vec![tool_no_desc])),
                 "stdio".into(),
                 None,
+                Some("ep".into()),
             )
             .await;
 
@@ -825,19 +788,21 @@ mod tests {
                 ])),
                 "stdio".into(),
                 None,
+                Some("broken".into()),
             )
             .await;
 
+        // Single adapter → no prefix
         let catalog = registry.merged_catalog().await;
         assert_eq!(catalog.len(), 2);
 
-        let read_tool = catalog.iter().find(|t| t.name == "broken__read").unwrap();
+        let read_tool = catalog.iter().find(|t| t.name == "read").unwrap();
         assert_eq!(
             read_tool.description.as_deref(),
             Some("[⚠️ UNAVAILABLE] [broken] read tool")
         );
 
-        let write_tool = catalog.iter().find(|t| t.name == "broken__write").unwrap();
+        let write_tool = catalog.iter().find(|t| t.name == "write").unwrap();
         assert_eq!(
             write_tool.description.as_deref(),
             Some("[⚠️ UNAVAILABLE] [broken] write tool")
@@ -853,6 +818,7 @@ mod tests {
                 Box::new(MockAdapter::unhealthy_with_tools(vec![make_tool("read")])),
                 "stdio".into(),
                 Some("My Server".into()),
+                Some("broken".into()),
             )
             .await;
 
@@ -873,11 +839,13 @@ mod tests {
                 Box::new(MockAdapter::unhealthy_with_tools(vec![make_tool("read")])),
                 "stdio".into(),
                 None,
+                Some("broken".into()),
             )
             .await;
 
+        // Single server → no prefix
         let result = registry
-            .route_tool_call("broken__read", json!({}))
+            .route_tool_call("read", json!({}))
             .await;
         assert!(result.is_err());
         let err_msg = format!("{}", result.unwrap_err());
@@ -885,11 +853,10 @@ mod tests {
         assert!(err_msg.contains("broken"));
     }
 
-    // --- Collision: multiple endpoints, no server_type override → endpoint name used ---
-    // Different endpoint names = no collision = no instance prefix
+    // --- Multiple endpoints with tool_prefix ---
 
     #[tokio::test]
-    async fn test_multiple_endpoints_different_names_no_collision() {
+    async fn test_multiple_endpoints_with_tool_prefix() {
         let registry = AdapterRegistry::new();
         registry
             .register(
@@ -900,6 +867,7 @@ mod tests {
                 ])),
                 "stdio".into(),
                 Some("Local FS".into()),
+                Some("fs-local".into()),
             )
             .await;
         registry
@@ -911,6 +879,7 @@ mod tests {
                 ])),
                 "stdio".into(),
                 Some("Remote FS".into()),
+                Some("fs-remote".into()),
             )
             .await;
 
@@ -918,7 +887,6 @@ mod tests {
         assert_eq!(catalog.len(), 4);
 
         let names: Vec<&str> = catalog.iter().map(|t| t.name.as_str()).collect();
-        // Different endpoint names → no collision → {endpoint}__{tool}
         assert!(names.contains(&"fs-local__read"));
         assert!(names.contains(&"fs-local__write"));
         assert!(names.contains(&"fs-remote__read"));
@@ -952,6 +920,7 @@ mod tests {
                 Box::new(MockAdapter::healthy(vec![make_tool("read")])),
                 "stdio".into(),
                 None,
+                Some("fs-ok".into()),
             )
             .await;
         registry
@@ -960,6 +929,7 @@ mod tests {
                 Box::new(MockAdapter::unhealthy_with_tools(vec![make_tool("read")])),
                 "stdio".into(),
                 None,
+                Some("fs-down".into()),
             )
             .await;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -245,7 +245,7 @@ pub fn build_router(state: AppState) -> Router {
         .with_state(state)
 }
 
-/// Create a future that resolves when a shutdown signal (SIGINT or SIGTERM) is received.
+/// Create a future that resolves when a shutdown signal (SIGINT, SIGTERM, or SIGHUP) is received.
 async fn shutdown_signal() {
     let ctrl_c = async {
         tokio::signal::ctrl_c()
@@ -261,8 +261,19 @@ async fn shutdown_signal() {
             .await;
     };
 
+    #[cfg(unix)]
+    let hangup = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::hangup())
+            .expect("failed to install SIGHUP handler")
+            .recv()
+            .await;
+    };
+
     #[cfg(not(unix))]
     let terminate = std::future::pending::<()>();
+
+    #[cfg(not(unix))]
+    let hangup = std::future::pending::<()>();
 
     tokio::select! {
         _ = ctrl_c => {
@@ -270,6 +281,9 @@ async fn shutdown_signal() {
         }
         _ = terminate => {
             info!("SIGTERM received, shutting down");
+        }
+        _ = hangup => {
+            info!("SIGHUP received, shutting down");
         }
     }
 }

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -67,8 +67,14 @@ async fn watch_loop(
 
     info!(path = %config_path.display(), "Config watcher started");
 
-    // Load initial config as baseline
-    let current_config = Arc::new(Mutex::new(config::load_config(&config_path)?));
+    // Load initial config as baseline (use graceful — fatal errors still propagate)
+    let (initial_config, initial_warnings) = config::load_config_graceful(&config_path)?;
+    if !initial_warnings.is_empty() {
+        for w in &initial_warnings {
+            warn!("{}", w);
+        }
+    }
+    let current_config = Arc::new(Mutex::new(initial_config));
 
     loop {
         // Wait for a filesystem event
@@ -88,21 +94,27 @@ async fn watch_loop(
 
         info!(path = %config_path.display(), "Config file change detected, reloading");
 
-        // Parse new config
-        let new_config = match config::load_config(&config_path) {
-            Ok(cfg) => cfg,
+        // Parse new config gracefully
+        let (new_config, warnings) = match config::load_config_graceful(&config_path) {
+            Ok(result) => result,
             Err(e) => {
                 warn!(error = %e, "Failed to parse updated config, keeping current config");
                 continue;
             }
         };
 
+        for w in &warnings {
+            warn!("{}", w);
+        }
+
+        let warned_names = config::warned_endpoint_names(&warnings);
+
         // Diff and apply
         let old_config = current_config.lock().await;
         let diff = config::diff_configs(&old_config, &new_config);
         drop(old_config);
 
-        apply_diff(&diff, &registry).await;
+        apply_diff_graceful(&diff, &registry, &warnings, &warned_names).await;
 
         // Update JS execution mode flag if it changed
         let new_js_mode = new_config.relay.local_js_execution.unwrap_or(false);
@@ -122,6 +134,7 @@ async fn watch_loop(
 /// Apply a config diff to the adapter registry.
 ///
 /// This is public so it can also be called from a manual reload endpoint.
+#[allow(dead_code)]
 pub async fn apply_diff(diff: &ConfigDiff, registry: &AdapterRegistry) {
     // Remove endpoints
     for name in &diff.removed {
@@ -155,7 +168,7 @@ pub async fn apply_diff(diff: &ConfigDiff, registry: &AdapterRegistry) {
         }
         let adapter = create_adapter(new_ep).await;
         registry
-            .register(name.clone(), adapter, new_ep.transport.to_string(), new_ep.description.clone())
+            .register(name.clone(), adapter, new_ep.transport.to_string(), new_ep.description.clone(), new_ep.resolved_tool_prefix())
             .await;
         // Re-apply disabled state
         let mut entries = registry.entries().write().await;
@@ -174,9 +187,116 @@ pub async fn apply_diff(diff: &ConfigDiff, registry: &AdapterRegistry) {
         info!(endpoint = %ep.name, transport = %ep.transport, "Adding new endpoint");
         let adapter = create_adapter(ep).await;
         registry
-            .register(ep.name.clone(), adapter, ep.transport.to_string(), ep.description.clone())
+            .register(ep.name.clone(), adapter, ep.transport.to_string(), ep.description.clone(), ep.resolved_tool_prefix())
             .await;
         // Apply disabled state from config
+        if ep.disabled || !ep.disabled_tools.is_empty() {
+            let mut entries = registry.entries().write().await;
+            if let Some(entry) = entries.get_mut(ep.name.as_str()) {
+                entry.disabled = ep.disabled;
+                entry.disabled_tools = ep.disabled_tools.iter().cloned().collect();
+                if ep.disabled {
+                    let _ = entry.adapter.shutdown().await;
+                }
+            }
+        }
+        info!(endpoint = %ep.name, "New endpoint registered");
+    }
+
+    // Log unchanged
+    for name in &diff.unchanged {
+        info!(endpoint = %name, "Endpoint unchanged, keeping running");
+    }
+}
+
+/// Like [`apply_diff`] but also handles per-endpoint validation warnings.
+///
+/// Endpoints whose names appear in `warned_names` are registered as `FailedAdapter`
+/// with the warning message instead of attempting initialization.
+pub async fn apply_diff_graceful(
+    diff: &ConfigDiff,
+    registry: &AdapterRegistry,
+    warnings: &[config::EndpointValidationWarning],
+    warned_names: &std::collections::HashSet<String>,
+) {
+    // Build warning message map
+    let warning_messages: std::collections::HashMap<String, String> = {
+        let mut map = std::collections::HashMap::new();
+        for w in warnings {
+            map.entry(w.endpoint_name.clone())
+                .and_modify(|msg: &mut String| {
+                    msg.push_str("; ");
+                    msg.push_str(&w.message);
+                })
+                .or_insert_with(|| w.message.clone());
+        }
+        map
+    };
+
+    // Remove endpoints
+    for name in &diff.removed {
+        info!(endpoint = %name, "Removing endpoint");
+        if let Some(mut entry) = registry.remove(name).await {
+            if let Err(e) = entry.adapter.shutdown().await {
+                warn!(endpoint = %name, error = %e, "Error shutting down removed adapter");
+            }
+        }
+    }
+
+    // Changed endpoints: shutdown old, create new, preserve disabled state
+    for (name, new_ep) in &diff.changed {
+        info!(endpoint = %name, "Restarting changed endpoint");
+        let (was_disabled, old_disabled_tools) = {
+            let entries = registry.entries().read().await;
+            if let Some(entry) = entries.get(name.as_str()) {
+                (entry.disabled, entry.disabled_tools.clone())
+            } else {
+                (
+                    new_ep.disabled,
+                    new_ep.disabled_tools.iter().cloned().collect(),
+                )
+            }
+        };
+        if let Some(mut entry) = registry.remove(name).await {
+            if let Err(e) = entry.adapter.shutdown().await {
+                warn!(endpoint = %name, error = %e, "Error shutting down old adapter");
+            }
+        }
+
+        let adapter: Box<dyn McpAdapter> = if warned_names.contains(name) {
+            let msg = warning_messages.get(name).cloned().unwrap_or_default();
+            warn!(endpoint = %name, "Registering as failed due to validation error: {}", msg);
+            Box::new(FailedAdapter::new(msg))
+        } else {
+            create_adapter(new_ep).await
+        };
+        registry
+            .register(name.clone(), adapter, new_ep.transport.to_string(), new_ep.description.clone(), new_ep.resolved_tool_prefix())
+            .await;
+        let mut entries = registry.entries().write().await;
+        if let Some(entry) = entries.get_mut(name.as_str()) {
+            entry.disabled = was_disabled;
+            entry.disabled_tools = old_disabled_tools;
+            if was_disabled {
+                let _ = entry.adapter.shutdown().await;
+            }
+        }
+        info!(endpoint = %name, "Changed endpoint re-registered");
+    }
+
+    // Added endpoints
+    for ep in &diff.added {
+        info!(endpoint = %ep.name, transport = %ep.transport, "Adding new endpoint");
+        let adapter: Box<dyn McpAdapter> = if warned_names.contains(&ep.name) {
+            let msg = warning_messages.get(&ep.name).cloned().unwrap_or_default();
+            warn!(endpoint = %ep.name, "Registering as failed due to validation error: {}", msg);
+            Box::new(FailedAdapter::new(msg))
+        } else {
+            create_adapter(ep).await
+        };
+        registry
+            .register(ep.name.clone(), adapter, ep.transport.to_string(), ep.description.clone(), ep.resolved_tool_prefix())
+            .await;
         if ep.disabled || !ep.disabled_tools.is_empty() {
             let mut entries = registry.entries().write().await;
             if let Some(entry) = entries.get_mut(ep.name.as_str()) {
@@ -326,6 +446,7 @@ mod tests {
                 Box::new(MockAdapter::healthy(vec![make_tool("t")], shutdown.clone())),
                 "stdio".into(),
                 None,
+                Some("existing".into()),
             )
             .await;
 
@@ -346,6 +467,7 @@ mod tests {
                 Box::new(MockAdapter::healthy(vec![make_tool("t")], shutdown.clone())),
                 "stdio".into(),
                 None,
+                Some("to_remove".into()),
             )
             .await;
 
@@ -382,6 +504,7 @@ mod tests {
                 Box::new(MockAdapter::healthy(vec![make_tool("t")], shutdown.clone())),
                 "stdio".into(),
                 None,
+                Some("ep".into()),
             )
             .await;
 
@@ -390,6 +513,7 @@ mod tests {
         let changed_ep = EndpointConfig {
             name: "ep".to_string(),
             description: None,
+            tool_prefix: None,
             transport: Transport::Stdio,
             command: Some("/nonexistent/binary/that/wont/start".to_string()),
             args: None,
@@ -417,6 +541,7 @@ mod tests {
         let new_ep = EndpointConfig {
             name: "bad_ep".to_string(),
             description: None,
+            tool_prefix: None,
             transport: Transport::Stdio,
             command: Some("/nonexistent/binary/that/wont/start".to_string()),
             args: None,
@@ -457,6 +582,7 @@ mod tests {
                 )),
                 "stdio".into(),
                 None,
+                Some("keep".into()),
             )
             .await;
         registry
@@ -468,6 +594,7 @@ mod tests {
                 )),
                 "stdio".into(),
                 None,
+                Some("remove".into()),
             )
             .await;
 
@@ -482,7 +609,8 @@ mod tests {
         // "keep" should still be alive
         assert!(!shutdown_keep.load(std::sync::atomic::Ordering::SeqCst));
         assert_eq!(registry.merged_catalog().await.len(), 1);
-        assert_eq!(registry.merged_catalog().await[0].name, "keep__t1");
+        // Single-server no-prefix mode: only one adapter remains, so no prefix
+        assert_eq!(registry.merged_catalog().await[0].name, "t1");
 
         // "remove" should be shut down
         assert!(shutdown_remove.load(std::sync::atomic::Ordering::SeqCst));

--- a/tests/hot_reload_integration.rs
+++ b/tests/hot_reload_integration.rs
@@ -35,7 +35,7 @@ async fn test_config_diff_add_endpoint() {
     let mut echo_adapter = StdioAdapter::new(echo_config);
     echo_adapter.initialize().await.expect("echo init failed");
     registry
-        .register("echo-ep".into(), Box::new(echo_adapter), "stdio".into(), None)
+        .register("echo-ep".into(), Box::new(echo_adapter), "stdio".into(), None, Some("echo_ep".into()))
         .await;
 
     // Verify initial state: 1 endpoint
@@ -51,6 +51,7 @@ async fn test_config_diff_add_endpoint() {
         endpoints: vec![config::EndpointConfig {
             name: "echo-ep".to_string(),
                 description: None,
+                tool_prefix: None,
             transport: config::Transport::Stdio,
             command: Some("bash".to_string()),
             args: Some(vec![echo_script_path().to_string_lossy().to_string()]),
@@ -71,6 +72,7 @@ async fn test_config_diff_add_endpoint() {
             config::EndpointConfig {
                 name: "echo-ep".to_string(),
                 description: None,
+                tool_prefix: None,
                 transport: config::Transport::Stdio,
                 command: Some("bash".to_string()),
                 args: Some(vec![echo_script_path().to_string_lossy().to_string()]),
@@ -83,6 +85,7 @@ async fn test_config_diff_add_endpoint() {
             config::EndpointConfig {
                 name: "multi-ep".to_string(),
                 description: None,
+                tool_prefix: None,
                 transport: config::Transport::Stdio,
                 command: Some(multi_tool_bin()),
                 args: Some(vec![]),
@@ -124,7 +127,7 @@ async fn test_config_diff_remove_endpoint() {
     let mut echo_adapter = StdioAdapter::new(echo_config);
     echo_adapter.initialize().await.expect("echo init failed");
     registry
-        .register("echo-ep".into(), Box::new(echo_adapter), "stdio".into(), None)
+        .register("echo-ep".into(), Box::new(echo_adapter), "stdio".into(), None, Some("echo_ep".into()))
         .await;
 
     let multi_config = StdioConfig {
@@ -135,7 +138,7 @@ async fn test_config_diff_remove_endpoint() {
     let mut multi_adapter = StdioAdapter::new(multi_config);
     multi_adapter.initialize().await.expect("multi init failed");
     registry
-        .register("multi-ep".into(), Box::new(multi_adapter), "stdio".into(), None)
+        .register("multi-ep".into(), Box::new(multi_adapter), "stdio".into(), None, Some("multi_ep".into()))
         .await;
 
     let catalog = registry.merged_catalog().await;
@@ -151,6 +154,7 @@ async fn test_config_diff_remove_endpoint() {
             config::EndpointConfig {
                 name: "echo-ep".to_string(),
                 description: None,
+                tool_prefix: None,
                 transport: config::Transport::Stdio,
                 command: Some("bash".to_string()),
                 args: Some(vec![echo_script_path().to_string_lossy().to_string()]),
@@ -163,6 +167,7 @@ async fn test_config_diff_remove_endpoint() {
             config::EndpointConfig {
                 name: "multi-ep".to_string(),
                 description: None,
+                tool_prefix: None,
                 transport: config::Transport::Stdio,
                 command: Some(multi_tool_bin()),
                 args: Some(vec![]),
@@ -183,6 +188,7 @@ async fn test_config_diff_remove_endpoint() {
         endpoints: vec![config::EndpointConfig {
             name: "echo-ep".to_string(),
                 description: None,
+                tool_prefix: None,
             transport: config::Transport::Stdio,
             command: Some("bash".to_string()),
             args: Some(vec![echo_script_path().to_string_lossy().to_string()]),

--- a/tests/js_execution_integration.rs
+++ b/tests/js_execution_integration.rs
@@ -34,7 +34,7 @@ async fn setup_js_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
     let mut adapter = StdioAdapter::new(config);
     adapter.initialize().await.expect("adapter init failed");
     registry
-        .register("echo-ep".into(), Box::new(adapter), "stdio".into(), None)
+        .register("echo-ep".into(), Box::new(adapter), "stdio".into(), None, Some("echo_ep".into()))
         .await;
 
     let registry_arc = Arc::new(registry.clone());
@@ -60,7 +60,7 @@ async fn test_execute_tools_with_echo() {
     // The sandbox exposes tools as `tools["prefixed_name"](args)` which
     // returns the parsed JSON result directly (synchronous, no await needed).
     let script = r#"
-        var result = tools["echo-mcp__echo"]({ message: "from js" });
+        var result = tools["echo"]({ message: "from js" });
         return result;
     "#;
 

--- a/tests/management_api_integration.rs
+++ b/tests/management_api_integration.rs
@@ -86,6 +86,7 @@ fn test_config() -> Config {
         endpoints: vec![EndpointConfig {
             name: "echo".to_string(),
             description: None,
+            tool_prefix: None,
             transport: Transport::Stdio,
             command: Some("echo".to_string()),
             args: Some(vec!["hello".to_string()]),
@@ -104,7 +105,7 @@ async fn start_management_server(
     let registry = AdapterRegistry::new();
     for (name, adapter) in adapters {
         registry
-            .register(name.to_string(), Box::new(adapter), "stdio".to_string(), None)
+            .register(name.to_string(), Box::new(adapter), "stdio".to_string(), None, Some(name.to_string()))
             .await;
     }
     let registry = Arc::new(registry);
@@ -281,7 +282,7 @@ async fn start_management_server_with_config(
     let registry = AdapterRegistry::new();
     for (name, adapter) in adapters {
         registry
-            .register(name.to_string(), Box::new(adapter), "stdio".to_string(), None)
+            .register(name.to_string(), Box::new(adapter), "stdio".to_string(), None, Some(name.to_string()))
             .await;
     }
     let registry = Arc::new(registry);

--- a/tests/mcp_server_integration.rs
+++ b/tests/mcp_server_integration.rs
@@ -29,7 +29,7 @@ async fn setup_server() -> (SocketAddr, AdapterRegistry, tokio::task::JoinHandle
     let mut adapter = StdioAdapter::new(config);
     adapter.initialize().await.expect("adapter init failed");
     registry
-        .register("echo-ep".into(), Box::new(adapter), "stdio".into(), None)
+        .register("echo-ep".into(), Box::new(adapter), "stdio".into(), None, Some("echo_ep".into()))
         .await;
 
     let registry_arc = Arc::new(registry.clone());
@@ -95,10 +95,10 @@ async fn test_mcp_tools_list_prefixed() {
     assert!(resp.status().is_success());
     let body: serde_json::Value = resp.json().await.unwrap();
     let tools = body["result"]["tools"].as_array().expect("tools array");
-    // 1 prefixed catalog tool + 3 meta-tools = 4 total
+    // 1 catalog tool (unprefixed in single-server mode) + 3 meta-tools = 4 total
     assert_eq!(tools.len(), 4);
-    // First tool should be prefixed: echo-mcp__echo (server_type from serverInfo.name)
-    assert_eq!(tools[0]["name"], "echo-mcp__echo");
+    // With single active endpoint, tool names are not prefixed
+    assert_eq!(tools[0]["name"], "echo");
     assert!(tools[0]["description"].as_str().is_some());
     assert!(tools[0]["inputSchema"].is_object());
     // Meta-tools should be present
@@ -119,7 +119,7 @@ async fn test_mcp_tools_call_routing() {
             "jsonrpc": "2.0",
             "method": "tools/call",
             "params": {
-                "name": "echo-mcp__echo",
+                "name": "echo",
                 "arguments": { "message": "hello from test" }
             },
             "id": 3

--- a/tests/multi_endpoint_integration.rs
+++ b/tests/multi_endpoint_integration.rs
@@ -45,7 +45,7 @@ async fn setup_multi_endpoint_server() -> (SocketAddr, AdapterRegistry, tokio::t
         .await
         .expect("echo adapter init failed");
     registry
-        .register("echo-ep".into(), Box::new(echo_adapter), "stdio".into(), None)
+        .register("echo-ep".into(), Box::new(echo_adapter), "stdio".into(), None, Some("echo_ep".into()))
         .await;
 
     // Endpoint 2: multi-tool server
@@ -60,7 +60,7 @@ async fn setup_multi_endpoint_server() -> (SocketAddr, AdapterRegistry, tokio::t
         .await
         .expect("multi-tool adapter init failed");
     registry
-        .register("multi-ep".into(), Box::new(multi_adapter), "stdio".into(), None)
+        .register("multi-ep".into(), Box::new(multi_adapter), "stdio".into(), None, Some("multi_ep".into()))
         .await;
 
     let registry_arc = Arc::new(registry.clone());
@@ -103,19 +103,19 @@ async fn test_multi_endpoint_merged_catalog() {
     );
 
     let tool_names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
-    // Verify prefixed names from echo endpoint
+    // Verify prefixed names from echo endpoint (tool_prefix = "echo_ep")
     assert!(
-        tool_names.contains(&"echo-mcp__echo"),
-        "missing echo-mcp echo tool"
+        tool_names.contains(&"echo_ep__echo"),
+        "missing echo_ep echo tool"
     );
-    // Verify prefixed names from multi-tool endpoint
+    // Verify prefixed names from multi-tool endpoint (tool_prefix = "multi_ep")
     assert!(
-        tool_names.contains(&"multi-tool-mcp__add"),
-        "missing multi-tool-mcp add tool"
+        tool_names.contains(&"multi_ep__add"),
+        "missing multi_ep add tool"
     );
     assert!(
-        tool_names.contains(&"multi-tool-mcp__uppercase"),
-        "missing multi-tool-mcp uppercase"
+        tool_names.contains(&"multi_ep__uppercase"),
+        "missing multi_ep uppercase"
     );
     // Verify meta-tools
     assert!(tool_names.contains(&"list_tools"));
@@ -133,7 +133,7 @@ async fn test_multi_endpoint_cross_routing() {
         .post(format!("http://{}/mcp/tools/call", addr))
         .json(&json!({
             "jsonrpc": "2.0", "method": "tools/call",
-            "params": {"name": "echo-mcp__echo", "arguments": {"message": "cross-route"}},
+            "params": {"name": "echo_ep__echo", "arguments": {"message": "cross-route"}},
             "id": 2
         }))
         .send().await.expect("request failed");
@@ -146,7 +146,7 @@ async fn test_multi_endpoint_cross_routing() {
         .post(format!("http://{}/mcp/tools/call", addr))
         .json(&json!({
             "jsonrpc": "2.0", "method": "tools/call",
-            "params": {"name": "multi-tool-mcp__add", "arguments": {"a": 3, "b": 7}},
+            "params": {"name": "multi_ep__add", "arguments": {"a": 3, "b": 7}},
             "id": 3
         }))
         .send()
@@ -161,7 +161,7 @@ async fn test_multi_endpoint_cross_routing() {
         .post(format!("http://{}/mcp/tools/call", addr))
         .json(&json!({
             "jsonrpc": "2.0", "method": "tools/call",
-            "params": {"name": "multi-tool-mcp__uppercase", "arguments": {"text": "hello"}},
+            "params": {"name": "multi_ep__uppercase", "arguments": {"text": "hello"}},
             "id": 4
         }))
         .send()
@@ -190,7 +190,7 @@ async fn test_multi_endpoint_overlapping_tool_names() {
             .await
             .expect(&format!("{} adapter init failed", ep_name));
         registry
-            .register(ep_name.to_string(), Box::new(adapter), "stdio".into(), None)
+            .register(ep_name.to_string(), Box::new(adapter), "stdio".into(), None, Some(ep_name.to_string()))
             .await;
     }
 
@@ -230,10 +230,10 @@ async fn test_multi_endpoint_overlapping_tool_names() {
     let tool_names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
 
     // Verify each endpoint has its own prefixed "add" tool
-    // All three share server_type "multi-tool-mcp" → collision → instance prefix
-    assert!(tool_names.contains(&"multi-tool-mcp__multi-a__add"));
-    assert!(tool_names.contains(&"multi-tool-mcp__multi-b__add"));
-    assert!(tool_names.contains(&"multi-tool-mcp__multi-c__add"));
+    // Each endpoint uses its own name as tool_prefix: "multi-a", "multi-b", "multi-c"
+    assert!(tool_names.contains(&"multi-a__add"));
+    assert!(tool_names.contains(&"multi-b__add"));
+    assert!(tool_names.contains(&"multi-c__add"));
 
     // All three should be distinct entries
     let add_count = tool_names
@@ -262,7 +262,7 @@ async fn test_calling_unavailable_tool_returns_mcp_error() {
         .post(format!("http://{}/mcp/tools/call", addr))
         .json(&json!({
             "jsonrpc": "2.0", "method": "tools/call",
-            "params": {"name": "multi-tool-mcp__add", "arguments": {"a": 1, "b": 2}},
+            "params": {"name": "multi_ep__add", "arguments": {"a": 1, "b": 2}},
             "id": 10
         }))
         .send()


### PR DESCRIPTION
## Changes

- Allow freeform endpoint names with auto-sanitized or user-defined `tool_prefix`
- Single-server no-prefix mode: skip tool prefixing when only one endpoint is active
- Handle SIGHUP gracefully in `shutdown_signal()` for clean TCP listener release
- Graceful config validation: individual endpoint errors don't prevent relay startup
- Update all integration tests for new tool_prefix naming scheme

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author