### PR TITLE
feat: OAuth token lifecycle management (Slice 2)

### DIFF
--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -128,17 +128,20 @@ impl HttpAdapter {
                 } else if e.is_connect() {
                     AdapterError::ConnectionFailed(format!("{}: {}", self.config.url, e))
                 } else {
-                    AdapterError::HttpError(e.to_string())
+                    AdapterError::HttpError {
+                        status: 0,
+                        body: e.to_string(),
+                    }
                 }
             })?;
 
         let status = resp.status();
         if !status.is_success() {
             let body = resp.text().await.unwrap_or_default();
-            return Err(AdapterError::HttpError(format!(
-                "HTTP {}: {}",
-                status, body
-            )));
+            return Err(AdapterError::HttpError {
+                status: status.as_u16(),
+                body,
+            });
         }
 
         let response: JsonRpcResponse = resp.json().await.map_err(|e| {

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -67,8 +67,17 @@ pub enum AdapterError {
     #[error("connection failed: {0}")]
     ConnectionFailed(String),
 
-    #[error("HTTP error: {0}")]
-    HttpError(String),
+    #[error("HTTP error {status}: {body}")]
+    HttpError {
+        status: u16,
+        body: String,
+    },
+
+    #[error("Authentication required for endpoint '{endpoint}': {message}")]
+    AuthenticationRequired {
+        endpoint: String,
+        message: String,
+    },
 
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -68,16 +68,10 @@ pub enum AdapterError {
     ConnectionFailed(String),
 
     #[error("HTTP error {status}: {body}")]
-    HttpError {
-        status: u16,
-        body: String,
-    },
+    HttpError { status: u16, body: String },
 
     #[error("Authentication required for endpoint '{endpoint}': {message}")]
-    AuthenticationRequired {
-        endpoint: String,
-        message: String,
-    },
+    AuthenticationRequired { endpoint: String, message: String },
 
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),

--- a/src/adapter/oauth.rs
+++ b/src/adapter/oauth.rs
@@ -1,53 +1,90 @@
 use super::http::{HttpAdapter, HttpConfig};
 use super::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
+use crate::oauth::OAuthError;
+use crate::token_manager::{TokenManager, TokenSet};
 use async_trait::async_trait;
 use reqwest::Client;
 use serde_json::Value;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{watch, RwLock};
-use tracing::{info, warn};
+use tokio::sync::{Mutex, RwLock};
+use tokio::task::JoinHandle;
+use tokio::time::Instant;
+use tracing::{error, info, warn};
 
-/// OAuth MCP adapter — wraps an HttpAdapter with Bearer token injection.
+/// Internal state of an OAuth-authenticated endpoint.
 ///
-/// When no tokens are available, reports `Unhealthy("needs login")` and returns
-/// empty tool lists / errors for tool calls. Once tokens arrive (via the watch
-/// channel), it builds an inner HttpAdapter with the Bearer header and delegates.
-pub struct OAuthAdapter {
-    /// The endpoint name (used for logging).
-    endpoint_name: String,
-    /// URL of the upstream MCP server (e.g. http://localhost:5000/mcp).
-    url: String,
-    /// Current inner adapter (None until tokens are available).
-    inner: Arc<RwLock<Option<HttpAdapter>>>,
-    /// Receiver for token notifications. Sender is held by the callback handler.
-    token_rx: watch::Receiver<Option<String>>,
-    /// Current health status.
-    health: Arc<RwLock<HealthStatus>>,
+/// Maps to `HealthStatus` in the `health()` method but carries richer
+/// semantic meaning for lifecycle management (refresh scheduling,
+/// startup restore, management API responses).
+#[derive(Debug, Clone, PartialEq)]
+pub enum OAuthState {
+    /// No tokens, never authenticated.
+    NeedsLogin,
+    /// Valid tokens, inner adapter healthy.
+    Authenticated,
+    /// Proactive or reactive refresh in progress.
+    Refreshing,
+    /// Refresh failed, needs re-login.
+    AuthRequired,
+    /// Token valid but MCP server unreachable.
+    ConnectionFailed,
+    /// User explicitly disconnected.
+    Disconnected,
 }
 
-impl OAuthAdapter {
-    /// Create a new OAuthAdapter.
-    ///
-    /// - `endpoint_name`: name of this endpoint in the registry.
-    /// - `url`: the upstream MCP server URL.
-    /// - `token_rx`: watch channel that receives the current access token (or None).
-    pub fn new(
-        endpoint_name: String,
-        url: String,
-        token_rx: watch::Receiver<Option<String>>,
-    ) -> Self {
-        Self {
-            endpoint_name,
-            url,
-            inner: Arc::new(RwLock::new(None)),
-            token_rx,
-            health: Arc::new(RwLock::new(HealthStatus::Stopped)),
-        }
-    }
+/// Compute the deadline at which a proactive token refresh should fire.
+///
+/// Returns the earlier of:
+/// - 75 % of token lifetime after `issued_at`
+/// - 5 minutes before `expires_at`
+///
+/// If `expires_at` is unknown (server didn't return `expires_in`), returns
+/// `None` — the caller should skip proactive refresh and rely on 401 retry.
+pub fn refresh_deadline(issued_at: Instant, expires_at: Instant) -> Instant {
+    let lifetime = expires_at - issued_at;
+    let seventy_five_pct = issued_at + (lifetime * 3 / 4);
+    let five_min_before = expires_at - Duration::from_secs(300);
+    std::cmp::min(seventy_five_pct, five_min_before)
+}
 
+/// Configuration for an OAuth-authenticated MCP endpoint.
+#[derive(Debug, Clone)]
+pub struct OAuthAdapterConfig {
+    /// Endpoint name in the registry (used for logging, token persistence key).
+    pub endpoint_name: String,
+    /// URL of the upstream MCP server (e.g. http://localhost:5000/mcp).
+    pub url: String,
+    /// Token endpoint URL for refresh grants.
+    pub token_endpoint_url: String,
+    /// OAuth client ID.
+    pub client_id: String,
+    /// OAuth client secret (optional for public clients).
+    pub client_secret: Option<String>,
+}
+
+/// Shared inner state for an OAuth adapter, wrapped in `Arc` so it can be
+/// referenced from the callback handler and proactive-refresh task.
+pub struct OAuthAdapterInner {
+    /// Current lifecycle state.
+    pub state: RwLock<OAuthState>,
+    /// Current token set (None when not authenticated).
+    pub tokens: RwLock<Option<TokenSet>>,
+    /// Static configuration.
+    pub config: OAuthAdapterConfig,
+    /// The inner HTTP/SSE adapter that talks to the upstream MCP server.
+    inner_adapter: RwLock<Option<HttpAdapter>>,
+    /// Token persistence layer.
+    token_manager: Arc<TokenManager>,
+    /// Shared HTTP client for token refresh requests.
+    http_client: Client,
+    /// Handle to the proactive refresh background task.
+    refresh_task_handle: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl OAuthAdapterInner {
     /// Build an inner HttpAdapter with a Bearer token in the default headers.
-    fn build_inner(url: &str, access_token: &str) -> HttpAdapter {
+    fn build_inner_adapter(url: &str, access_token: &str) -> HttpAdapter {
         let client = Client::builder()
             .timeout(Duration::from_secs(30))
             .default_headers({
@@ -63,116 +100,468 @@ impl OAuthAdapter {
             .expect("failed to build HTTP client");
         HttpAdapter::new_with_client(HttpConfig::new(url), client)
     }
+
+    /// Perform a token refresh using the refresh_token grant.
+    ///
+    /// POSTs to the token endpoint with grant_type=refresh_token.
+    /// On success, calls `apply_tokens_inner` with the new token set.
+    /// On failure, transitions to `AuthRequired`.
+    pub async fn do_token_refresh(self: &Arc<Self>) -> Result<TokenSet, OAuthError> {
+        let refresh_token = {
+            let tokens = self.tokens.read().await;
+            match tokens.as_ref().and_then(|t| t.refresh_token.clone()) {
+                Some(rt) => rt,
+                None => {
+                    *self.state.write().await = OAuthState::AuthRequired;
+                    return Err(OAuthError::NoRefreshToken {
+                        endpoint: self.config.endpoint_name.clone(),
+                    });
+                }
+            }
+        };
+
+        // Mark as refreshing
+        *self.state.write().await = OAuthState::Refreshing;
+        info!(endpoint = %self.config.endpoint_name, "Starting token refresh");
+
+        let mut form_parts: Vec<(&str, String)> = vec![
+            ("grant_type", "refresh_token".to_string()),
+            ("refresh_token", refresh_token),
+            ("client_id", self.config.client_id.clone()),
+        ];
+        if let Some(ref secret) = self.config.client_secret {
+            form_parts.push(("client_secret", secret.clone()));
+        }
+
+        let form_body: String = url::form_urlencoded::Serializer::new(String::new())
+            .extend_pairs(form_parts.iter())
+            .finish();
+
+        let resp = self
+            .http_client
+            .post(&self.config.token_endpoint_url)
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .body(form_body)
+            .send()
+            .await
+            .map_err(|e| {
+                // Network error during refresh
+                OAuthError::Http(e)
+            })?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            error!(
+                endpoint = %self.config.endpoint_name,
+                %status,
+                body = %body,
+                "Token refresh failed"
+            );
+            *self.state.write().await = OAuthState::AuthRequired;
+            return Err(OAuthError::RefreshFailed { status, body });
+        }
+
+        let token_json: serde_json::Value = resp.json().await?;
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        // Handle token rotation: if the server returns a new refresh_token, use it;
+        // otherwise keep the old one.
+        let old_refresh_token = {
+            let tokens = self.tokens.read().await;
+            tokens.as_ref().and_then(|t| t.refresh_token.clone())
+        };
+
+        let new_token_set = TokenSet {
+            access_token: token_json["access_token"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string(),
+            refresh_token: token_json["refresh_token"]
+                .as_str()
+                .map(|s| s.to_string())
+                .or(old_refresh_token),
+            expires_at: token_json["expires_in"]
+                .as_u64()
+                .map(|secs| now_secs + secs),
+            token_type: token_json["token_type"]
+                .as_str()
+                .unwrap_or("Bearer")
+                .to_string(),
+            scope: token_json["scope"].as_str().map(|s| s.to_string()),
+            issued_at: Some(now_secs),
+        };
+
+        info!(endpoint = %self.config.endpoint_name, "Token refresh successful");
+        Ok(new_token_set)
+    }
+
+    /// Apply a new token set: update in-memory state, persist to disk,
+    /// abort any existing refresh task, spawn a new proactive refresh task,
+    /// and rebuild the inner adapter.
+    pub fn apply_tokens(
+        self: &Arc<Self>,
+        token_set: TokenSet,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+        Box::pin(self.apply_tokens_inner(token_set))
+    }
+
+    async fn apply_tokens_inner(self: &Arc<Self>, token_set: TokenSet) {
+        let endpoint = &self.config.endpoint_name;
+
+        // 1. Persist to disk
+        if let Err(e) = self.token_manager.save(endpoint, &token_set).await {
+            error!(endpoint = %endpoint, error = %e, "Failed to persist tokens");
+        }
+
+        // 2. Abort old refresh task
+        {
+            let mut handle = self.refresh_task_handle.lock().await;
+            if let Some(h) = handle.take() {
+                h.abort();
+            }
+        }
+
+        // 3. Rebuild inner adapter
+        let access_token = token_set.access_token.clone();
+        let mut adapter = Self::build_inner_adapter(&self.config.url, &access_token);
+        match adapter.initialize().await {
+            Ok(()) => {
+                *self.inner_adapter.write().await = Some(adapter);
+                *self.state.write().await = OAuthState::Authenticated;
+                info!(endpoint = %endpoint, "Inner adapter rebuilt with new token");
+            }
+            Err(e) => {
+                *self.inner_adapter.write().await = None;
+                *self.state.write().await = OAuthState::ConnectionFailed;
+                warn!(endpoint = %endpoint, error = %e, "Inner adapter init failed after token apply");
+            }
+        }
+
+        // 4. Update in-memory tokens
+        let issued_at_secs = token_set.issued_at;
+        let expires_at_secs = token_set.expires_at;
+        *self.tokens.write().await = Some(token_set);
+
+        // 5. Schedule proactive refresh if we have expiry info
+        if let (Some(issued), Some(expires)) = (issued_at_secs, expires_at_secs) {
+            if expires > issued {
+                let now_secs = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs();
+                let now_instant = Instant::now();
+                // Convert Unix timestamps to Instants relative to now
+                let issued_instant =
+                    now_instant - Duration::from_secs(now_secs.saturating_sub(issued));
+                let expires_instant =
+                    now_instant + Duration::from_secs(expires.saturating_sub(now_secs));
+                let deadline = refresh_deadline(issued_instant, expires_instant);
+
+                let inner = self.clone();
+                let handle = tokio::spawn(async move {
+                    tokio::time::sleep_until(deadline).await;
+                    info!(endpoint = %inner.config.endpoint_name, "Proactive refresh timer fired");
+                    match inner.do_token_refresh().await {
+                        Ok(new_tokens) => {
+                            // Recursively apply — this will schedule the next refresh
+                            inner.apply_tokens(new_tokens).await;
+                        }
+                        Err(e) => {
+                            warn!(
+                                endpoint = %inner.config.endpoint_name,
+                                error = %e,
+                                "Proactive refresh failed, retrying in 60s"
+                            );
+                            // Retry once after 60 seconds
+                            tokio::time::sleep(Duration::from_secs(60)).await;
+                            if let Ok(new_tokens) = inner.do_token_refresh().await {
+                                inner.apply_tokens(new_tokens).await;
+                            } else {
+                                warn!(
+                                    endpoint = %inner.config.endpoint_name,
+                                    "Proactive refresh retry also failed"
+                                );
+                            }
+                        }
+                    }
+                });
+                self.refresh_task_handle.lock().await.replace(handle);
+            }
+        }
+    }
+
+    /// Disconnect: abort refresh task, clear tokens, delete from disk, set Disconnected.
+    pub async fn disconnect(self: &Arc<Self>) {
+        let endpoint = &self.config.endpoint_name;
+
+        // Abort refresh task
+        {
+            let mut handle = self.refresh_task_handle.lock().await;
+            if let Some(h) = handle.take() {
+                h.abort();
+            }
+        }
+
+        // Shut down inner adapter
+        {
+            let mut guard = self.inner_adapter.write().await;
+            if let Some(ref mut adapter) = *guard {
+                let _ = adapter.shutdown().await;
+            }
+            *guard = None;
+        }
+
+        // Clear in-memory tokens
+        *self.tokens.write().await = None;
+
+        // Delete from disk
+        if let Err(e) = self.token_manager.delete(endpoint).await {
+            error!(endpoint = %endpoint, error = %e, "Failed to delete tokens from disk");
+        }
+
+        // Set state
+        *self.state.write().await = OAuthState::Disconnected;
+        info!(endpoint = %endpoint, "OAuth adapter disconnected");
+    }
+}
+
+/// OAuth MCP adapter — wraps an HttpAdapter with Bearer token injection.
+///
+/// Owns its token state internally via `Arc<OAuthAdapterInner>`. The callback
+/// handler and proactive refresh tasks use the same `Arc` to apply new tokens.
+pub struct OAuthAdapter {
+    inner: Arc<OAuthAdapterInner>,
+}
+
+impl OAuthAdapter {
+    /// Create a new OAuthAdapter.
+    pub fn new(
+        config: OAuthAdapterConfig,
+        token_manager: Arc<TokenManager>,
+    ) -> Self {
+        Self {
+            inner: Arc::new(OAuthAdapterInner {
+                state: RwLock::new(OAuthState::NeedsLogin),
+                tokens: RwLock::new(None),
+                config,
+                inner_adapter: RwLock::new(None),
+                token_manager,
+                http_client: Client::new(),
+                refresh_task_handle: Mutex::new(None),
+            }),
+        }
+    }
+
+    /// Get a clone of the shared inner state (for use by callback handlers).
+    pub fn shared_inner(&self) -> Arc<OAuthAdapterInner> {
+        self.inner.clone()
+    }
+
+    /// Map OAuthState → HealthStatus.
+    fn map_health(state: &OAuthState) -> HealthStatus {
+        match state {
+            OAuthState::NeedsLogin => HealthStatus::Unhealthy("needs login".to_string()),
+            OAuthState::Authenticated => HealthStatus::Healthy,
+            OAuthState::Refreshing => HealthStatus::Healthy, // still serving with current token
+            OAuthState::AuthRequired => HealthStatus::Unhealthy("authentication required".to_string()),
+            OAuthState::ConnectionFailed => HealthStatus::Unhealthy("connection failed".to_string()),
+            OAuthState::Disconnected => HealthStatus::Stopped,
+        }
+    }
 }
 
 #[async_trait]
 impl McpAdapter for OAuthAdapter {
     async fn initialize(&mut self) -> Result<(), AdapterError> {
-        // Check if we already have a token
-        let token = self.token_rx.borrow().clone();
-        if let Some(ref access_token) = token {
-            info!(endpoint = %self.endpoint_name, "OAuth adapter initializing with existing token");
-            let mut adapter = Self::build_inner(&self.url, access_token);
-            match adapter.initialize().await {
-                Ok(()) => {
-                    *self.inner.write().await = Some(adapter);
-                    *self.health.write().await = HealthStatus::Healthy;
-                    info!(endpoint = %self.endpoint_name, "OAuth adapter initialized");
+        // Try to load existing tokens from disk
+        let loaded = self
+            .inner
+            .token_manager
+            .load(&self.inner.config.endpoint_name)
+            .await;
+
+        if let Ok(Some(token_set)) = loaded {
+            if token_set.is_valid() {
+                info!(
+                    endpoint = %self.inner.config.endpoint_name,
+                    "Loaded valid OAuth tokens from disk"
+                );
+                self.inner.apply_tokens(token_set).await;
+            } else if token_set.refresh_token.is_some() {
+                info!(
+                    endpoint = %self.inner.config.endpoint_name,
+                    "Loaded expired tokens with refresh token, attempting refresh"
+                );
+                // Store expired tokens so refresh can use the refresh_token
+                *self.inner.tokens.write().await = Some(token_set);
+                match self.inner.do_token_refresh().await {
+                    Ok(new_tokens) => {
+                        self.inner.apply_tokens(new_tokens).await;
+                    }
+                    Err(e) => {
+                        warn!(
+                            endpoint = %self.inner.config.endpoint_name,
+                            error = %e,
+                            "Token refresh at startup failed"
+                        );
+                        *self.inner.state.write().await = OAuthState::AuthRequired;
+                    }
                 }
-                Err(e) => {
-                    let msg = format!("upstream init failed: {}", e);
-                    *self.health.write().await = HealthStatus::Unhealthy(msg.clone());
-                    warn!(endpoint = %self.endpoint_name, error = %e, "OAuth adapter upstream init failed");
-                }
+            } else {
+                info!(
+                    endpoint = %self.inner.config.endpoint_name,
+                    "Loaded expired tokens without refresh token"
+                );
+                *self.inner.state.write().await = OAuthState::AuthRequired;
             }
         } else {
-            // No tokens yet — that's OK, we stay in "needs login" state
-            *self.health.write().await = HealthStatus::Unhealthy("needs login".to_string());
-            info!(endpoint = %self.endpoint_name, "OAuth adapter awaiting login");
+            info!(
+                endpoint = %self.inner.config.endpoint_name,
+                "No existing OAuth tokens, awaiting login"
+            );
+            *self.inner.state.write().await = OAuthState::NeedsLogin;
         }
-
-        // Spawn a background task to watch for token changes
-        let inner = self.inner.clone();
-        let health = self.health.clone();
-        let url = self.url.clone();
-        let endpoint_name = self.endpoint_name.clone();
-        let mut rx = self.token_rx.clone();
-        tokio::spawn(async move {
-            while rx.changed().await.is_ok() {
-                let token = rx.borrow().clone();
-                match token {
-                    Some(access_token) => {
-                        info!(endpoint = %endpoint_name, "Token received, reinitializing inner adapter");
-                        let mut adapter = Self::build_inner(&url, &access_token);
-                        match adapter.initialize().await {
-                            Ok(()) => {
-                                *inner.write().await = Some(adapter);
-                                *health.write().await = HealthStatus::Healthy;
-                                info!(endpoint = %endpoint_name, "Inner adapter reinitialized");
-                            }
-                            Err(e) => {
-                                let msg = format!("upstream init failed: {}", e);
-                                *health.write().await = HealthStatus::Unhealthy(msg);
-                                warn!(endpoint = %endpoint_name, error = %e, "Failed to reinitialize");
-                            }
-                        }
-                    }
-                    None => {
-                        *inner.write().await = None;
-                        *health.write().await = HealthStatus::Unhealthy("needs login".to_string());
-                    }
-                }
-            }
-        });
 
         Ok(()) // initialize always succeeds for OAuth
     }
 
     async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
-        let guard = self.inner.read().await;
+        let guard = self.inner.inner_adapter.read().await;
         match guard.as_ref() {
-            Some(adapter) => adapter.list_tools().await,
+            Some(adapter) => {
+                match adapter.list_tools().await {
+                    Ok(tools) => Ok(tools),
+                    Err(AdapterError::HttpError { status: 401, .. }) => {
+                        // Drop the read lock before refreshing
+                        drop(guard);
+
+                        info!(
+                            endpoint = %self.inner.config.endpoint_name,
+                            "Got 401 on list_tools, attempting token refresh"
+                        );
+
+                        match self.inner.do_token_refresh().await {
+                            Ok(new_tokens) => {
+                                self.inner.apply_tokens(new_tokens).await;
+                                // Retry with new token
+                                let guard = self.inner.inner_adapter.read().await;
+                                match guard.as_ref() {
+                                    Some(adapter) => adapter.list_tools().await,
+                                    None => Ok(vec![]),
+                                }
+                            }
+                            Err(e) => {
+                                warn!(
+                                    endpoint = %self.inner.config.endpoint_name,
+                                    error = %e,
+                                    "Token refresh after 401 on list_tools failed"
+                                );
+                                *self.inner.state.write().await = OAuthState::AuthRequired;
+                                Err(AdapterError::AuthenticationRequired {
+                                    endpoint: self.inner.config.endpoint_name.clone(),
+                                    message: "Token expired and refresh failed. Re-authenticate in Endara Desktop.".to_string(),
+                                })
+                            }
+                        }
+                    }
+                    Err(other) => Err(other),
+                }
+            }
             None => Ok(vec![]),
         }
     }
 
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
-        let guard = self.inner.read().await;
-        match guard.as_ref() {
-            Some(adapter) => adapter.call_tool(name, arguments).await,
-            None => Err(AdapterError::ConnectionFailed(
-                "not authenticated — complete OAuth login first".to_string(),
-            )),
+        let guard = self.inner.inner_adapter.read().await;
+        let adapter = match guard.as_ref() {
+            Some(a) => a,
+            None => {
+                return Err(AdapterError::ConnectionFailed(
+                    "not authenticated — complete OAuth login first".to_string(),
+                ));
+            }
+        };
+
+        match adapter.call_tool(name, arguments.clone()).await {
+            Ok(result) => Ok(result),
+            Err(AdapterError::HttpError { status: 401, .. }) => {
+                // Drop the read lock before refreshing
+                drop(guard);
+
+                info!(
+                    endpoint = %self.inner.config.endpoint_name,
+                    "Got 401, attempting token refresh"
+                );
+
+                match self.inner.do_token_refresh().await {
+                    Ok(new_tokens) => {
+                        self.inner.apply_tokens(new_tokens).await;
+                        // Retry with new token
+                        let guard = self.inner.inner_adapter.read().await;
+                        let adapter = guard.as_ref().ok_or_else(|| {
+                            AdapterError::ConnectionFailed(
+                                "Adapter lost during refresh".to_string(),
+                            )
+                        })?;
+                        adapter.call_tool(name, arguments).await
+                    }
+                    Err(e) => {
+                        warn!(
+                            endpoint = %self.inner.config.endpoint_name,
+                            error = %e,
+                            "Token refresh after 401 failed"
+                        );
+                        *self.inner.state.write().await = OAuthState::AuthRequired;
+                        Err(AdapterError::AuthenticationRequired {
+                            endpoint: self.inner.config.endpoint_name.clone(),
+                            message: "Token expired and refresh failed. Re-authenticate in Endara Desktop.".to_string(),
+                        })
+                    }
+                }
+            }
+            Err(other) => Err(other),
         }
     }
 
     fn server_type(&self) -> Option<String> {
         self.inner
+            .inner_adapter
             .try_read()
             .ok()
             .and_then(|g| g.as_ref().and_then(|a| a.server_type()))
     }
 
     async fn shutdown(&mut self) -> Result<(), AdapterError> {
-        let mut guard = self.inner.write().await;
+        // Abort refresh task
+        {
+            let mut handle = self.inner.refresh_task_handle.lock().await;
+            if let Some(h) = handle.take() {
+                h.abort();
+            }
+        }
+        let mut guard = self.inner.inner_adapter.write().await;
         if let Some(ref mut adapter) = *guard {
             adapter.shutdown().await?;
         }
         *guard = None;
-        *self.health.write().await = HealthStatus::Stopped;
-        info!(endpoint = %self.endpoint_name, "OAuth adapter shut down");
+        *self.inner.state.write().await = OAuthState::Disconnected;
+        info!(endpoint = %self.inner.config.endpoint_name, "OAuth adapter shut down");
         Ok(())
     }
 
     fn health(&self) -> HealthStatus {
-        match self.health.try_read() {
-            Ok(h) => h.clone(),
+        match self.inner.state.try_read() {
+            Ok(s) => Self::map_health(&s),
             Err(_) => HealthStatus::Starting,
         }
     }
 
     async fn activity_log(&self) -> Vec<String> {
-        let guard = self.inner.read().await;
+        let guard = self.inner.inner_adapter.read().await;
         match guard.as_ref() {
             Some(adapter) => adapter.activity_log().await,
             None => vec![],
@@ -184,17 +573,26 @@ impl McpAdapter for OAuthAdapter {
 mod tests {
     use super::*;
 
-    fn make_watch() -> (
-        watch::Sender<Option<String>>,
-        watch::Receiver<Option<String>>,
-    ) {
-        watch::channel(None)
+    fn make_config() -> OAuthAdapterConfig {
+        OAuthAdapterConfig {
+            endpoint_name: "test".to_string(),
+            url: "http://localhost/mcp".to_string(),
+            token_endpoint_url: "http://localhost/token".to_string(),
+            client_id: "test-client".to_string(),
+            client_secret: None,
+        }
+    }
+
+    fn make_adapter(config: OAuthAdapterConfig) -> OAuthAdapter {
+        let tmp = std::env::temp_dir().join(format!("oauth-test-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&tmp);
+        let tm = Arc::new(TokenManager::new(tmp));
+        OAuthAdapter::new(config, tm)
     }
 
     #[tokio::test]
     async fn health_no_tokens_is_unhealthy() {
-        let (_tx, rx) = make_watch();
-        let mut adapter = OAuthAdapter::new("test".into(), "http://localhost/mcp".into(), rx);
+        let mut adapter = make_adapter(make_config());
         adapter.initialize().await.unwrap();
         match adapter.health() {
             HealthStatus::Unhealthy(msg) => assert_eq!(msg, "needs login"),
@@ -204,8 +602,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_tools_no_tokens_returns_empty() {
-        let (_tx, rx) = make_watch();
-        let mut adapter = OAuthAdapter::new("test".into(), "http://localhost/mcp".into(), rx);
+        let mut adapter = make_adapter(make_config());
         adapter.initialize().await.unwrap();
         let tools = adapter.list_tools().await.unwrap();
         assert!(tools.is_empty());
@@ -213,8 +610,7 @@ mod tests {
 
     #[tokio::test]
     async fn call_tool_no_tokens_returns_error() {
-        let (_tx, rx) = make_watch();
-        let mut adapter = OAuthAdapter::new("test".into(), "http://localhost/mcp".into(), rx);
+        let mut adapter = make_adapter(make_config());
         adapter.initialize().await.unwrap();
         let result = adapter.call_tool("any", serde_json::json!({})).await;
         assert!(result.is_err());
@@ -227,29 +623,186 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn health_with_token_but_unreachable_is_unhealthy() {
+    async fn health_with_token_but_unreachable_is_connection_failed() {
         // If we have a token but the upstream server is unreachable,
-        // the adapter should report unhealthy after init
-        let (tx, rx) = make_watch();
-        tx.send(Some("fake-token".into())).unwrap();
-        let mut adapter = OAuthAdapter::new("test".into(), "http://127.0.0.1:19999/mcp".into(), rx);
+        // the adapter should report connection failed after apply_tokens
+        let mut config = make_config();
+        config.url = "http://127.0.0.1:19999/mcp".to_string();
+        let mut adapter = make_adapter(config);
         adapter.initialize().await.unwrap();
-        // Give a moment for init to complete
-        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let token_set = TokenSet {
+            access_token: "fake-token".to_string(),
+            refresh_token: None,
+            expires_at: None,
+            token_type: "Bearer".to_string(),
+            scope: None,
+            issued_at: None,
+        };
+        adapter.inner.apply_tokens(token_set).await;
+
         match adapter.health() {
             HealthStatus::Unhealthy(msg) => {
-                assert!(msg.contains("upstream init failed"));
+                assert!(msg.contains("connection failed"));
             }
-            other => panic!("expected Unhealthy, got {:?}", other),
+            other => panic!("expected Unhealthy('connection failed'), got {:?}", other),
         }
     }
 
     #[tokio::test]
     async fn shutdown_sets_stopped() {
-        let (_tx, rx) = make_watch();
-        let mut adapter = OAuthAdapter::new("test".into(), "http://localhost/mcp".into(), rx);
+        let mut adapter = make_adapter(make_config());
         adapter.initialize().await.unwrap();
         adapter.shutdown().await.unwrap();
         assert_eq!(adapter.health(), HealthStatus::Stopped);
+    }
+
+    #[tokio::test]
+    async fn apply_tokens_then_disconnect() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let config = make_config();
+        let mut adapter = OAuthAdapter::new(config, tm.clone());
+        adapter.initialize().await.unwrap();
+
+        // Apply tokens (will fail to connect, but tokens are stored)
+        let token_set = TokenSet {
+            access_token: "test-access".to_string(),
+            refresh_token: Some("test-refresh".to_string()),
+            expires_at: None,
+            token_type: "Bearer".to_string(),
+            scope: None,
+            issued_at: None,
+        };
+        adapter.inner.apply_tokens(token_set).await;
+
+        // Verify tokens are persisted
+        let loaded = tm.load("test").await.unwrap();
+        assert!(loaded.is_some());
+        assert_eq!(loaded.unwrap().access_token, "test-access");
+
+        // Disconnect
+        adapter.inner.disconnect().await;
+        assert_eq!(adapter.health(), HealthStatus::Stopped);
+
+        // Verify tokens are deleted from disk
+        let loaded = tm.load("test").await.unwrap();
+        assert!(loaded.is_none());
+
+        // Verify in-memory tokens cleared
+        let tokens = adapter.inner.tokens.read().await;
+        assert!(tokens.is_none());
+    }
+
+    #[test]
+    fn health_mapping() {
+        assert_eq!(
+            OAuthAdapter::map_health(&OAuthState::NeedsLogin),
+            HealthStatus::Unhealthy("needs login".to_string())
+        );
+        assert_eq!(
+            OAuthAdapter::map_health(&OAuthState::Authenticated),
+            HealthStatus::Healthy
+        );
+        assert_eq!(
+            OAuthAdapter::map_health(&OAuthState::Refreshing),
+            HealthStatus::Healthy
+        );
+        assert_eq!(
+            OAuthAdapter::map_health(&OAuthState::AuthRequired),
+            HealthStatus::Unhealthy("authentication required".to_string())
+        );
+        assert_eq!(
+            OAuthAdapter::map_health(&OAuthState::ConnectionFailed),
+            HealthStatus::Unhealthy("connection failed".to_string())
+        );
+        assert_eq!(
+            OAuthAdapter::map_health(&OAuthState::Disconnected),
+            HealthStatus::Stopped
+        );
+    }
+
+    // --- OAuthState enum tests ---
+
+    #[test]
+    fn oauth_state_variants_are_distinct() {
+        let states = vec![
+            OAuthState::NeedsLogin,
+            OAuthState::Authenticated,
+            OAuthState::Refreshing,
+            OAuthState::AuthRequired,
+            OAuthState::ConnectionFailed,
+            OAuthState::Disconnected,
+        ];
+        for (i, a) in states.iter().enumerate() {
+            for (j, b) in states.iter().enumerate() {
+                if i == j {
+                    assert_eq!(a, b);
+                } else {
+                    assert_ne!(a, b);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn oauth_state_clone_and_debug() {
+        let state = OAuthState::Authenticated;
+        let cloned = state.clone();
+        assert_eq!(state, cloned);
+        // Debug should not panic
+        let _dbg = format!("{:?}", state);
+    }
+
+    // --- refresh_deadline tests ---
+
+    #[test]
+    fn refresh_deadline_1h_token() {
+        // 1-hour token: 75% = 45min, 5-min-before = 55min. Min = 45min.
+        let issued = Instant::now();
+        let expires = issued + Duration::from_secs(3600);
+        let deadline = refresh_deadline(issued, expires);
+        let expected = issued + Duration::from_secs(2700); // 45 min
+        // Allow 1ms tolerance for Instant arithmetic
+        assert!(deadline >= expected - Duration::from_millis(1));
+        assert!(deadline <= expected + Duration::from_millis(1));
+    }
+
+    #[test]
+    fn refresh_deadline_10min_token() {
+        // 10-min token: 75% = 7.5min (450s), 5-min-before = 5min (300s). Min = 5min.
+        let issued = Instant::now();
+        let expires = issued + Duration::from_secs(600);
+        let deadline = refresh_deadline(issued, expires);
+        let expected = issued + Duration::from_secs(300); // 5 min before
+        assert!(deadline >= expected - Duration::from_millis(1));
+        assert!(deadline <= expected + Duration::from_millis(1));
+    }
+
+    #[test]
+    fn refresh_deadline_2min_token() {
+        // 2-min token: 75% = 90s, 5-min-before would be negative → clamped.
+        // Instant subtraction that underflows saturates to zero, so
+        // five_min_before = expires_at - 300s. If lifetime=120s, this would be
+        // issued_at - 180s which saturates to Instant(0) or earlier.
+        // 75% = issued + 90s. min(issued+90s, saturated) → the saturated value.
+        // But that's in the past — which is correct: refresh immediately.
+        let issued = Instant::now();
+        let expires = issued + Duration::from_secs(120);
+        let deadline = refresh_deadline(issued, expires);
+        // For very short tokens, deadline should be before 75% mark
+        // (5-min-before goes negative/past, which means refresh ASAP)
+        assert!(deadline <= issued + Duration::from_secs(90));
+    }
+
+    #[test]
+    fn refresh_deadline_exactly_20min_token() {
+        // 20-min token: 75% = 15min (900s), 5-min-before = 15min (900s). Equal.
+        let issued = Instant::now();
+        let expires = issued + Duration::from_secs(1200);
+        let deadline = refresh_deadline(issued, expires);
+        let expected = issued + Duration::from_secs(900);
+        assert!(deadline >= expected - Duration::from_millis(1));
+        assert!(deadline <= expected + Duration::from_millis(1));
     }
 }

--- a/src/adapter/oauth.rs
+++ b/src/adapter/oauth.rs
@@ -339,10 +339,7 @@ pub struct OAuthAdapter {
 
 impl OAuthAdapter {
     /// Create a new OAuthAdapter.
-    pub fn new(
-        config: OAuthAdapterConfig,
-        token_manager: Arc<TokenManager>,
-    ) -> Self {
+    pub fn new(config: OAuthAdapterConfig, token_manager: Arc<TokenManager>) -> Self {
         Self {
             inner: Arc::new(OAuthAdapterInner {
                 state: RwLock::new(OAuthState::NeedsLogin),
@@ -367,8 +364,12 @@ impl OAuthAdapter {
             OAuthState::NeedsLogin => HealthStatus::Unhealthy("needs login".to_string()),
             OAuthState::Authenticated => HealthStatus::Healthy,
             OAuthState::Refreshing => HealthStatus::Healthy, // still serving with current token
-            OAuthState::AuthRequired => HealthStatus::Unhealthy("authentication required".to_string()),
-            OAuthState::ConnectionFailed => HealthStatus::Unhealthy("connection failed".to_string()),
+            OAuthState::AuthRequired => {
+                HealthStatus::Unhealthy("authentication required".to_string())
+            }
+            OAuthState::ConnectionFailed => {
+                HealthStatus::Unhealthy("connection failed".to_string())
+            }
             OAuthState::Disconnected => HealthStatus::Stopped,
         }
     }
@@ -763,7 +764,7 @@ mod tests {
         let expires = issued + Duration::from_secs(3600);
         let deadline = refresh_deadline(issued, expires);
         let expected = issued + Duration::from_secs(2700); // 45 min
-        // Allow 1ms tolerance for Instant arithmetic
+                                                           // Allow 1ms tolerance for Instant arithmetic
         assert!(deadline >= expected - Duration::from_millis(1));
         assert!(deadline <= expected + Duration::from_millis(1));
     }

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -202,7 +202,10 @@ impl SseAdapter {
                 if e.is_connect() {
                     AdapterError::ConnectionFailed(format!("{}: {}", self.config.url, e))
                 } else {
-                    AdapterError::HttpError(e.to_string())
+                    AdapterError::HttpError {
+                        status: 0,
+                        body: e.to_string(),
+                    }
                 }
             })?;
 
@@ -357,7 +360,10 @@ impl SseAdapter {
                 } else if e.is_connect() {
                     AdapterError::ConnectionFailed(format!("{}: {}", endpoint, e))
                 } else {
-                    AdapterError::HttpError(e.to_string())
+                    AdapterError::HttpError {
+                        status: 0,
+                        body: e.to_string(),
+                    }
                 }
             })?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,10 +12,11 @@ pub mod token_manager;
 pub mod token_security;
 pub mod watcher;
 
+use adapter::oauth::OAuthAdapterInner;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-/// Per-endpoint OAuth token notifiers: endpoint_name → watch::Sender.
-pub type OAuthTokenNotifiers =
-    Arc<RwLock<HashMap<String, tokio::sync::watch::Sender<Option<String>>>>>;
+/// Per-endpoint shared OAuth adapter inner states, keyed by endpoint name.
+/// Used by the callback handler to apply tokens to the correct adapter.
+pub type OAuthAdapterInners = Arc<RwLock<HashMap<String, Arc<OAuthAdapterInner>>>>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ mod registry;
 mod server;
 mod shell_env;
 
-use adapter::oauth::OAuthAdapter;
+use adapter::oauth::{OAuthAdapter, OAuthAdapterConfig, OAuthAdapterInner};
 use adapter::{FailedAdapter, McpAdapter, StartingAdapter};
 use clap::{Parser, Subcommand};
 use js_sandbox::MetaToolHandler;
@@ -29,9 +29,9 @@ use token_manager::TokenManager;
 use tokio::sync::RwLock;
 use tracing::{error, info, warn};
 
-/// Per-endpoint OAuth token notifiers: endpoint_name → watch::Sender.
-pub type OAuthTokenNotifiers =
-    Arc<RwLock<HashMap<String, tokio::sync::watch::Sender<Option<String>>>>>;
+/// Per-endpoint shared OAuth adapter inner states, keyed by endpoint name.
+/// Used by the callback handler to apply tokens to the correct adapter.
+pub type OAuthAdapterInners = Arc<RwLock<HashMap<String, Arc<OAuthAdapterInner>>>>;
 use watcher::ConfigWatcher;
 
 #[derive(Parser)]
@@ -176,7 +176,7 @@ async fn main() {
                 };
             let token_manager = Arc::new(TokenManager::new(token_dir));
             let oauth_flow_manager = Arc::new(OAuthFlowManager::new());
-            let oauth_token_notifiers: OAuthTokenNotifiers = Arc::new(RwLock::new(HashMap::new()));
+            let oauth_adapter_inners: OAuthAdapterInners = Arc::new(RwLock::new(HashMap::new()));
 
             // Create adapter registry
             let registry = AdapterRegistry::new();
@@ -217,22 +217,24 @@ async fn main() {
 
                 // OAuth endpoints initialize inline (always fast)
                 if ep.transport == config::Transport::Oauth {
-                    let url = ep.url.clone().unwrap_or_default();
-                    let (tx, rx) = tokio::sync::watch::channel(None);
-                    oauth_token_notifiers
+                    let oauth_config = OAuthAdapterConfig {
+                        endpoint_name: ep.name.clone(),
+                        url: ep.url.clone().unwrap_or_default(),
+                        token_endpoint_url: format!(
+                            "{}/token",
+                            ep.oauth_server_url.as_deref().unwrap_or_default()
+                        ),
+                        client_id: ep.client_id.clone().unwrap_or_default(),
+                        client_secret: ep.client_secret.clone(),
+                    };
+
+                    let mut adapter = OAuthAdapter::new(oauth_config, token_manager.clone());
+                    let shared_inner = adapter.shared_inner();
+                    oauth_adapter_inners
                         .write()
                         .await
-                        .insert(ep.name.clone(), tx);
+                        .insert(ep.name.clone(), shared_inner);
 
-                    if let Ok(Some(token_set)) = token_manager.load(&ep.name).await {
-                        info!(endpoint = %ep.name, "Loaded existing OAuth tokens from disk");
-                        let notifiers = oauth_token_notifiers.read().await;
-                        if let Some(tx) = notifiers.get(&ep.name) {
-                            let _ = tx.send(Some(token_set.access_token));
-                        }
-                    }
-
-                    let mut adapter = OAuthAdapter::new(ep.name.clone(), url, rx);
                     adapter.initialize().await.ok();
                     info!(endpoint = %ep.name, "OAuth adapter initialized");
                     registry
@@ -283,9 +285,9 @@ async fn main() {
             for ep in deferred_init {
                 let reg = registry.clone();
                 let tm = token_manager.clone();
-                let otn = oauth_token_notifiers.clone();
+                let oai = oauth_adapter_inners.clone();
                 tokio::spawn(async move {
-                    let adapter = watcher::create_adapter(&ep, &tm, &otn).await;
+                    let adapter = watcher::create_adapter(&ep, &tm, &oai).await;
                     let mut entries = reg.entries().write().await;
                     if let Some(entry) = entries.get_mut(ep.name.as_str()) {
                         entry.adapter = adapter;
@@ -309,7 +311,7 @@ async fn main() {
                 meta_tool_handler,
                 oauth_flow_manager: Some(oauth_flow_manager.clone()),
                 token_manager: Some(token_manager.clone()),
-                oauth_token_notifiers: Some(oauth_token_notifiers.clone()),
+                oauth_adapter_inners: Some(oauth_adapter_inners.clone()),
             };
             let mgmt_state = management::ManagementState {
                 registry: registry.clone(),
@@ -318,6 +320,7 @@ async fn main() {
                 config_path: Some(config_path.clone()),
                 oauth_flow_manager: Some(oauth_flow_manager.clone()),
                 relay_port: port,
+                oauth_adapter_inners: Some(oauth_adapter_inners.clone()),
             };
             let router = build_router(state).merge(management::management_routes(mgmt_state));
             let addr: SocketAddr = ([0, 0, 0, 0], port).into();
@@ -334,7 +337,7 @@ async fn main() {
                         js_execution_mode.clone(),
                         token_manager.clone(),
                         oauth_flow_manager.clone(),
-                        oauth_token_notifiers.clone(),
+                        oauth_adapter_inners.clone(),
                     );
 
                     handle.await.ok();

--- a/src/management.rs
+++ b/src/management.rs
@@ -17,12 +17,14 @@ use tower_http::cors::CorsLayer;
 use tracing::warn;
 
 use crate::adapter::http::{HttpAdapter, HttpConfig};
+use crate::adapter::oauth::OAuthState;
 use crate::adapter::sse::{SseAdapter, SseConfig};
 use crate::adapter::stdio::{StdioAdapter, StdioConfig};
 use crate::adapter::HealthStatus;
 use crate::config::Config;
 use crate::oauth::{OAuthFlowManager, PkceChallenge};
 use crate::registry::AdapterRegistry;
+use crate::OAuthAdapterInners;
 
 // ---------------------------------------------------------------------------
 // App state
@@ -40,6 +42,8 @@ pub struct ManagementState {
     pub oauth_flow_manager: Option<Arc<OAuthFlowManager>>,
     /// Port the relay is listening on (used to construct redirect_uri).
     pub relay_port: u16,
+    /// Per-endpoint shared OAuth adapter inner states.
+    pub oauth_adapter_inners: Option<OAuthAdapterInners>,
 }
 
 // ---------------------------------------------------------------------------
@@ -591,10 +595,44 @@ struct OAuthStartResponse {
     authorize_url: String,
 }
 
-/// Response for GET /api/endpoints/:name/oauth/status
+/// Response for GET /api/endpoints/:name/oauth/status (simple)
 #[derive(Serialize)]
 struct OAuthStatusResponse {
     status: String,
+}
+
+/// Enhanced response for GET /api/endpoints/:name/oauth/status
+#[derive(Serialize)]
+struct OAuthStatusDetailedResponse {
+    status: String,
+    has_access_token: bool,
+    has_refresh_token: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expires_at: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expires_in_seconds: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_refreshed_at: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    next_refresh_at: Option<u64>,
+    state: String,
+}
+
+/// Response for POST /api/endpoints/:name/oauth/revoke
+#[derive(Serialize)]
+struct OAuthRevokeResponse {
+    status: String,
+    endpoint: String,
+}
+
+/// Response for POST /api/endpoints/:name/oauth/refresh
+#[derive(Serialize)]
+struct OAuthRefreshResponse {
+    status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expires_at: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    refreshed_at: Option<u64>,
 }
 
 /// POST /api/endpoints/:name/oauth/start
@@ -688,16 +726,83 @@ fn urlencoding(s: &str) -> String {
 
 /// GET /api/endpoints/:name/oauth/status
 ///
-/// Returns whether the endpoint is authenticated or needs login.
+/// Returns detailed OAuth status for the endpoint including token info.
 async fn oauth_status(
     State(state): State<ManagementState>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
-    let entries = state.registry.entries().read().await;
-    let Some(entry) = entries.get(&name) else {
-        return endpoint_not_found(&name).into_response();
-    };
+    // Verify endpoint exists in registry
+    {
+        let entries = state.registry.entries().read().await;
+        if !entries.contains_key(&name) {
+            return endpoint_not_found(&name).into_response();
+        }
+    }
 
+    // Try to get detailed OAuth info from the adapter inners
+    if let Some(ref inners) = state.oauth_adapter_inners {
+        let inners_guard = inners.read().await;
+        if let Some(inner) = inners_guard.get(&name) {
+            let oauth_state = inner.state.read().await.clone();
+            let tokens = inner.tokens.read().await;
+
+            let now_secs = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+
+            let has_access_token = tokens.is_some();
+            let has_refresh_token = tokens
+                .as_ref()
+                .and_then(|t| t.refresh_token.as_ref())
+                .is_some();
+            let expires_at = tokens.as_ref().and_then(|t| t.expires_at);
+            let expires_in_seconds = expires_at.map(|exp| exp as i64 - now_secs as i64);
+            let last_refreshed_at = tokens.as_ref().and_then(|t| t.issued_at);
+
+            // Compute next_refresh_at from token expiry using the 75% rule
+            let next_refresh_at = tokens
+                .as_ref()
+                .and_then(|t| {
+                    match (t.issued_at, t.expires_at) {
+                        (Some(issued), Some(expires)) if expires > issued => {
+                            let lifetime = expires - issued;
+                            let seventy_five_pct = issued + (lifetime * 3 / 4);
+                            let five_min_before = expires.saturating_sub(300);
+                            Some(std::cmp::min(seventy_five_pct, five_min_before))
+                        }
+                        _ => None,
+                    }
+                });
+
+            let status = match oauth_state {
+                OAuthState::Authenticated => "authenticated",
+                OAuthState::NeedsLogin => "needs_login",
+                OAuthState::Refreshing => "refreshing",
+                OAuthState::AuthRequired => "auth_required",
+                OAuthState::Disconnected => "disconnected",
+                OAuthState::ConnectionFailed => "connection_failed",
+            };
+
+            let state_str = format!("{:?}", oauth_state);
+
+            return Json(OAuthStatusDetailedResponse {
+                status: status.to_string(),
+                has_access_token,
+                has_refresh_token,
+                expires_at,
+                expires_in_seconds,
+                last_refreshed_at,
+                next_refresh_at,
+                state: state_str,
+            })
+            .into_response();
+        }
+    }
+
+    // Fallback: endpoint exists but is not an OAuth endpoint
+    let entries = state.registry.entries().read().await;
+    let entry = entries.get(&name).unwrap();
     let status = match entry.adapter.health() {
         HealthStatus::Healthy => "authorized",
         HealthStatus::Unhealthy(ref msg) if msg == "needs login" => "needs_login",
@@ -708,6 +813,134 @@ async fn oauth_status(
         status: status.to_string(),
     })
     .into_response()
+}
+
+/// POST /api/endpoints/:name/oauth/revoke
+///
+/// Disconnects the OAuth adapter and deletes tokens.
+async fn oauth_revoke(
+    State(state): State<ManagementState>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    // Verify endpoint exists in registry
+    {
+        let entries = state.registry.entries().read().await;
+        if !entries.contains_key(&name) {
+            return endpoint_not_found(&name).into_response();
+        }
+    }
+
+    let Some(ref inners) = state.oauth_adapter_inners else {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "endpoint is not configured for OAuth",
+            Some("No OAuth adapter inners available"),
+        )
+        .into_response();
+    };
+
+    let inners_guard = inners.read().await;
+    let Some(inner) = inners_guard.get(&name) else {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "endpoint is not configured for OAuth",
+            Some(&format!("Endpoint '{}' is not an OAuth endpoint", name)),
+        )
+        .into_response();
+    };
+
+    let inner = inner.clone();
+    drop(inners_guard);
+
+    // Call disconnect (aborts refresh task, clears tokens, deletes from disk)
+    inner.disconnect().await;
+
+    Json(OAuthRevokeResponse {
+        status: "disconnected".to_string(),
+        endpoint: name,
+    })
+    .into_response()
+}
+
+/// POST /api/endpoints/:name/oauth/refresh
+///
+/// Triggers a manual token refresh.
+async fn oauth_refresh(
+    State(state): State<ManagementState>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    // Verify endpoint exists in registry
+    {
+        let entries = state.registry.entries().read().await;
+        if !entries.contains_key(&name) {
+            return endpoint_not_found(&name).into_response();
+        }
+    }
+
+    let Some(ref inners) = state.oauth_adapter_inners else {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "endpoint is not configured for OAuth",
+            Some("No OAuth adapter inners available"),
+        )
+        .into_response();
+    };
+
+    let inners_guard = inners.read().await;
+    let Some(inner) = inners_guard.get(&name) else {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "endpoint is not configured for OAuth",
+            Some(&format!("Endpoint '{}' is not an OAuth endpoint", name)),
+        )
+        .into_response();
+    };
+
+    // Check current state — refuse if NeedsLogin or Disconnected
+    let current_state = inner.state.read().await.clone();
+    if matches!(current_state, OAuthState::NeedsLogin | OAuthState::Disconnected) {
+        let reason = match current_state {
+            OAuthState::NeedsLogin => "endpoint has never been authenticated",
+            OAuthState::Disconnected => "endpoint is disconnected",
+            _ => unreachable!(),
+        };
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "cannot refresh tokens",
+            Some(reason),
+        )
+        .into_response();
+    }
+
+    let inner = inner.clone();
+    drop(inners_guard);
+
+    // Attempt refresh
+    match inner.do_token_refresh().await {
+        Ok(new_tokens) => {
+            let expires_at = new_tokens.expires_at;
+            let refreshed_at = new_tokens.issued_at;
+            inner.apply_tokens(new_tokens).await;
+
+            let status = {
+                let s = inner.state.read().await;
+                format!("{:?}", *s)
+            };
+
+            Json(OAuthRefreshResponse {
+                status,
+                expires_at,
+                refreshed_at,
+            })
+            .into_response()
+        }
+        Err(e) => error_response(
+            StatusCode::BAD_GATEWAY,
+            "token refresh failed",
+            Some(&e.to_string()),
+        )
+        .into_response(),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -736,6 +969,8 @@ pub fn management_routes(state: ManagementState) -> Router {
         )
         .route("/api/endpoints/{name}/oauth/start", post(oauth_start))
         .route("/api/endpoints/{name}/oauth/status", get(oauth_status))
+        .route("/api/endpoints/{name}/oauth/revoke", post(oauth_revoke))
+        .route("/api/endpoints/{name}/oauth/refresh", post(oauth_refresh))
         .route("/api/catalog", get(get_catalog))
         .route("/api/config", get(get_config))
         .route("/api/config/reload", post(reload_config))
@@ -1039,6 +1274,7 @@ mod tests {
             config_path: None,
             oauth_flow_manager: None,
             relay_port: 9400,
+            oauth_adapter_inners: None,
         }
     }
 
@@ -1638,5 +1874,292 @@ command = "echo"
         let body = body_json(resp).await;
         assert_eq!(body["success"], false);
         assert!(body["error"].is_string());
+    }
+
+    // --- OAuth management route tests ---
+
+    use crate::adapter::oauth::{OAuthAdapter, OAuthAdapterConfig, OAuthAdapterInner, OAuthState};
+    use crate::token_manager::TokenManager;
+
+    fn make_oauth_config(name: &str) -> OAuthAdapterConfig {
+        OAuthAdapterConfig {
+            endpoint_name: name.to_string(),
+            url: "http://127.0.0.1:19999/mcp".to_string(),
+            token_endpoint_url: "http://127.0.0.1:19999/token".to_string(),
+            client_id: "test-client".to_string(),
+            client_secret: None,
+        }
+    }
+
+    async fn test_state_with_oauth(
+        name: &str,
+        tmp_dir: &std::path::Path,
+    ) -> (ManagementState, Arc<OAuthAdapterInner>) {
+        let token_manager = Arc::new(TokenManager::new(tmp_dir.to_path_buf()));
+        let config = make_oauth_config(name);
+        let adapter = OAuthAdapter::new(config, token_manager.clone());
+        let shared_inner = adapter.shared_inner();
+
+        let oauth_inners: OAuthAdapterInners =
+            Arc::new(RwLock::new(std::collections::HashMap::new()));
+        oauth_inners
+            .write()
+            .await
+            .insert(name.to_string(), shared_inner.clone());
+
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                name.to_string(),
+                Box::new(adapter),
+                "oauth".to_string(),
+                None,
+                None,
+            )
+            .await;
+
+        let state = ManagementState {
+            registry: Arc::new(registry),
+            config: Arc::new(RwLock::new(test_config())),
+            start_time: Instant::now(),
+            config_path: None,
+            oauth_flow_manager: None,
+            relay_port: 9400,
+            oauth_adapter_inners: Some(oauth_inners),
+        };
+
+        (state, shared_inner)
+    }
+
+    #[tokio::test]
+    async fn oauth_status_detailed_needs_login() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (state, _inner) = test_state_with_oauth("oauth-ep", tmp.path()).await;
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::get("/api/endpoints/oauth-ep/oauth/status")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["status"], "needs_login");
+        assert_eq!(body["has_access_token"], false);
+        assert_eq!(body["has_refresh_token"], false);
+    }
+
+    #[tokio::test]
+    async fn oauth_status_detailed_with_tokens() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (state, inner) = test_state_with_oauth("oauth-ep", tmp.path()).await;
+
+        // Set up tokens with expiry
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let token_set = crate::token_manager::TokenSet {
+            access_token: "test-access".to_string(),
+            refresh_token: Some("test-refresh".to_string()),
+            expires_at: Some(now + 3600),
+            token_type: "Bearer".to_string(),
+            scope: None,
+            issued_at: Some(now),
+        };
+        *inner.tokens.write().await = Some(token_set);
+        *inner.state.write().await = OAuthState::Authenticated;
+
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::get("/api/endpoints/oauth-ep/oauth/status")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["status"], "authenticated");
+        assert_eq!(body["has_access_token"], true);
+        assert_eq!(body["has_refresh_token"], true);
+        assert!(body["expires_at"].is_number());
+        assert!(body["expires_in_seconds"].is_number());
+        assert!(body["last_refreshed_at"].is_number());
+        assert!(body["next_refresh_at"].is_number());
+    }
+
+    #[tokio::test]
+    async fn oauth_status_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (state, _inner) = test_state_with_oauth("oauth-ep", tmp.path()).await;
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::get("/api/endpoints/nonexistent/oauth/status")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn oauth_revoke_success() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (state, inner) = test_state_with_oauth("oauth-ep", tmp.path()).await;
+
+        // Set authenticated state
+        *inner.state.write().await = OAuthState::Authenticated;
+
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/oauth-ep/oauth/revoke")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["status"], "disconnected");
+        assert_eq!(body["endpoint"], "oauth-ep");
+
+        // Verify state changed to Disconnected
+        let state = inner.state.read().await;
+        assert_eq!(*state, OAuthState::Disconnected);
+    }
+
+    #[tokio::test]
+    async fn oauth_revoke_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (state, _inner) = test_state_with_oauth("oauth-ep", tmp.path()).await;
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/nonexistent/oauth/revoke")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn oauth_revoke_not_oauth_endpoint() {
+        // Non-OAuth endpoint with no adapter inners
+        let state = test_state(vec![("echo", MockAdapter::healthy_with_tools(vec![]))]).await;
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/echo/oauth/revoke")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn oauth_refresh_needs_login_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (state, _inner) = test_state_with_oauth("oauth-ep", tmp.path()).await;
+        // State is NeedsLogin by default
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/oauth-ep/oauth/refresh")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = body_json(resp).await;
+        assert!(body["detail"]
+            .as_str()
+            .unwrap()
+            .contains("never been authenticated"));
+    }
+
+    #[tokio::test]
+    async fn oauth_refresh_disconnected_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (state, inner) = test_state_with_oauth("oauth-ep", tmp.path()).await;
+        *inner.state.write().await = OAuthState::Disconnected;
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/oauth-ep/oauth/refresh")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = body_json(resp).await;
+        assert!(body["detail"]
+            .as_str()
+            .unwrap()
+            .contains("disconnected"));
+    }
+
+    #[tokio::test]
+    async fn oauth_refresh_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (state, _inner) = test_state_with_oauth("oauth-ep", tmp.path()).await;
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/nonexistent/oauth/refresh")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn oauth_refresh_no_refresh_token_returns_502() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (state, inner) = test_state_with_oauth("oauth-ep", tmp.path()).await;
+
+        // Set Authenticated state but with no refresh token
+        *inner.state.write().await = OAuthState::Authenticated;
+        *inner.tokens.write().await = Some(crate::token_manager::TokenSet {
+            access_token: "test-access".to_string(),
+            refresh_token: None,
+            expires_at: None,
+            token_type: "Bearer".to_string(),
+            scope: None,
+            issued_at: None,
+        });
+
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/oauth-ep/oauth/refresh")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        // Should return 502 because refresh fails (no refresh token)
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
     }
 }

--- a/src/management.rs
+++ b/src/management.rs
@@ -763,16 +763,14 @@ async fn oauth_status(
             // Compute next_refresh_at from token expiry using the 75% rule
             let next_refresh_at = tokens
                 .as_ref()
-                .and_then(|t| {
-                    match (t.issued_at, t.expires_at) {
-                        (Some(issued), Some(expires)) if expires > issued => {
-                            let lifetime = expires - issued;
-                            let seventy_five_pct = issued + (lifetime * 3 / 4);
-                            let five_min_before = expires.saturating_sub(300);
-                            Some(std::cmp::min(seventy_five_pct, five_min_before))
-                        }
-                        _ => None,
+                .and_then(|t| match (t.issued_at, t.expires_at) {
+                    (Some(issued), Some(expires)) if expires > issued => {
+                        let lifetime = expires - issued;
+                        let seventy_five_pct = issued + (lifetime * 3 / 4);
+                        let five_min_before = expires.saturating_sub(300);
+                        Some(std::cmp::min(seventy_five_pct, five_min_before))
                     }
+                    _ => None,
                 });
 
             let status = match oauth_state {
@@ -898,7 +896,10 @@ async fn oauth_refresh(
 
     // Check current state — refuse if NeedsLogin or Disconnected
     let current_state = inner.state.read().await.clone();
-    if matches!(current_state, OAuthState::NeedsLogin | OAuthState::Disconnected) {
+    if matches!(
+        current_state,
+        OAuthState::NeedsLogin | OAuthState::Disconnected
+    ) {
         let reason = match current_state {
             OAuthState::NeedsLogin => "endpoint has never been authenticated",
             OAuthState::Disconnected => "endpoint is disconnected",
@@ -2111,10 +2112,7 @@ command = "echo"
             .unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         let body = body_json(resp).await;
-        assert!(body["detail"]
-            .as_str()
-            .unwrap()
-            .contains("disconnected"));
+        assert!(body["detail"].as_str().unwrap().contains("disconnected"));
     }
 
     #[tokio::test]

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -4,6 +4,36 @@ use std::collections::HashMap;
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 
+use crate::token_manager::TokenError;
+
+/// Dedicated error type for OAuth-specific failures.
+#[derive(Debug, thiserror::Error)]
+pub enum OAuthError {
+    #[error("No refresh token available for endpoint '{endpoint}'")]
+    NoRefreshToken { endpoint: String },
+
+    #[error("Token refresh failed — {status}: {body}")]
+    RefreshFailed {
+        status: reqwest::StatusCode,
+        body: String,
+    },
+
+    #[error("Token exchange failed — {status}: {body}")]
+    ExchangeFailed {
+        status: reqwest::StatusCode,
+        body: String,
+    },
+
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("JSON parse error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("Token storage error: {0}")]
+    Storage(#[from] TokenError),
+}
+
 /// PKCE (Proof Key for Code Exchange) challenge pair for OAuth 2.0 S256.
 pub struct PkceChallenge {
     /// The code verifier: 43-char URL-safe base64 string from 32 random bytes.

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -252,6 +252,7 @@ mod tests {
             }
         }
 
+        #[allow(dead_code)]
         fn healthy_with_type(tools: Vec<ToolInfo>, st: &str) -> Self {
             Self {
                 health: HealthStatus::Healthy,

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,7 +2,7 @@ use crate::js_sandbox::MetaToolHandler;
 use crate::oauth::OAuthFlowManager;
 use crate::registry::AdapterRegistry;
 use crate::token_manager::TokenManager;
-use crate::OAuthTokenNotifiers;
+use crate::OAuthAdapterInners;
 use axum::{
     extract::{Query, State},
     http::StatusCode,
@@ -35,8 +35,8 @@ pub struct AppState {
     pub oauth_flow_manager: Option<Arc<OAuthFlowManager>>,
     /// Token manager for persisting OAuth tokens.
     pub token_manager: Option<Arc<TokenManager>>,
-    /// Per-endpoint token notifiers: endpoint_name -> watch::Sender.
-    pub oauth_token_notifiers: Option<OAuthTokenNotifiers>,
+    /// Per-endpoint shared OAuth adapter inner states.
+    pub oauth_adapter_inners: Option<OAuthAdapterInners>,
 }
 
 /// JSON-RPC request body expected by MCP routes.
@@ -373,21 +373,22 @@ async fn oauth_callback(
         );
     }
 
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
     let token_set = crate::token_manager::TokenSet {
         access_token: access_token.clone(),
         refresh_token: token_json["refresh_token"].as_str().map(|s| s.to_string()),
-        expires_at: token_json["expires_in"].as_u64().map(|secs| {
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs()
-                + secs
-        }),
+        expires_at: token_json["expires_in"]
+            .as_u64()
+            .map(|secs| now_secs + secs),
         token_type: token_json["token_type"]
             .as_str()
             .unwrap_or("Bearer")
             .to_string(),
         scope: token_json["scope"].as_str().map(|s| s.to_string()),
+        issued_at: Some(now_secs),
     };
 
     // Save tokens to disk
@@ -397,12 +398,12 @@ async fn oauth_callback(
         }
     }
 
-    // Signal the adapter via watch channel
-    if let Some(ref notifiers) = state.oauth_token_notifiers {
-        let notifiers = notifiers.read().await;
-        if let Some(tx) = notifiers.get(&flow.endpoint_name) {
-            let _ = tx.send(Some(access_token));
-            info!(endpoint = %flow.endpoint_name, "Token notification sent to adapter");
+    // Apply tokens to the adapter's shared inner state
+    if let Some(ref inners) = state.oauth_adapter_inners {
+        let inners = inners.read().await;
+        if let Some(inner) = inners.get(&flow.endpoint_name) {
+            inner.apply_tokens(token_set.clone()).await;
+            info!(endpoint = %flow.endpoint_name, "Tokens applied to OAuth adapter");
         }
     }
 

--- a/src/token_manager.rs
+++ b/src/token_manager.rs
@@ -184,7 +184,10 @@ mod tests {
     fn is_valid_with_no_expiry() {
         let mut ts = make_token_set();
         ts.expires_at = None;
-        assert!(ts.is_valid(), "Tokens with no expiry should be considered valid");
+        assert!(
+            ts.is_valid(),
+            "Tokens with no expiry should be considered valid"
+        );
     }
 
     #[test]
@@ -196,7 +199,10 @@ mod tests {
         let mut ts = make_token_set();
         // Expires in 20 seconds — within the 30-second buffer, so should be invalid
         ts.expires_at = Some(now + 20);
-        assert!(!ts.is_valid(), "Token expiring within 30s buffer should be invalid");
+        assert!(
+            !ts.is_valid(),
+            "Token expiring within 30s buffer should be invalid"
+        );
     }
 
     #[test]
@@ -208,7 +214,10 @@ mod tests {
         let mut ts = make_token_set();
         // Expires in 31 seconds — just outside the 30-second buffer
         ts.expires_at = Some(now + 31);
-        assert!(ts.is_valid(), "Token expiring in 31s should be valid (outside 30s buffer)");
+        assert!(
+            ts.is_valid(),
+            "Token expiring in 31s should be valid (outside 30s buffer)"
+        );
     }
 
     #[test]

--- a/src/token_manager.rs
+++ b/src/token_manager.rs
@@ -20,6 +20,26 @@ pub struct TokenSet {
     pub token_type: String,
     /// Space-delimited scopes as returned by the authorization server.
     pub scope: Option<String>,
+    /// Unix timestamp (seconds) when the token was issued.
+    #[serde(default)]
+    pub issued_at: Option<u64>,
+}
+
+impl TokenSet {
+    /// Returns `true` if the token has not expired, using a 30-second buffer
+    /// for clock skew. Tokens with no `expires_at` are assumed valid.
+    pub fn is_valid(&self) -> bool {
+        match self.expires_at {
+            Some(exp) => {
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs();
+                exp > now + 30 // 30-second buffer for clock skew
+            }
+            None => true, // No expiry = assume valid
+        }
+    }
 }
 
 /// Owns token persistence. One instance shared across all OAuth adapters via `Arc<TokenManager>`.
@@ -84,6 +104,7 @@ mod tests {
             expires_at: Some(1700000000),
             token_type: "Bearer".to_string(),
             scope: Some("read write".to_string()),
+            issued_at: Some(1699996400),
         }
     }
 
@@ -137,5 +158,82 @@ mod tests {
         let path = tmp.path().join("perm-test.json");
         let mode = std::fs::metadata(&path).unwrap().permissions().mode();
         assert_eq!(mode & 0o777, 0o600, "Expected 0600, got {:o}", mode & 0o777);
+    }
+
+    // --- TokenSet::is_valid() tests ---
+
+    #[test]
+    fn is_valid_with_future_expiry() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let mut ts = make_token_set();
+        ts.expires_at = Some(now + 3600); // expires in 1 hour
+        assert!(ts.is_valid());
+    }
+
+    #[test]
+    fn is_valid_with_past_expiry() {
+        let mut ts = make_token_set();
+        ts.expires_at = Some(1000); // long expired
+        assert!(!ts.is_valid());
+    }
+
+    #[test]
+    fn is_valid_with_no_expiry() {
+        let mut ts = make_token_set();
+        ts.expires_at = None;
+        assert!(ts.is_valid(), "Tokens with no expiry should be considered valid");
+    }
+
+    #[test]
+    fn is_valid_within_30s_buffer() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let mut ts = make_token_set();
+        // Expires in 20 seconds — within the 30-second buffer, so should be invalid
+        ts.expires_at = Some(now + 20);
+        assert!(!ts.is_valid(), "Token expiring within 30s buffer should be invalid");
+    }
+
+    #[test]
+    fn is_valid_just_outside_buffer() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let mut ts = make_token_set();
+        // Expires in 31 seconds — just outside the 30-second buffer
+        ts.expires_at = Some(now + 31);
+        assert!(ts.is_valid(), "Token expiring in 31s should be valid (outside 30s buffer)");
+    }
+
+    #[test]
+    fn is_valid_issued_at_field_present() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let ts = TokenSet {
+            access_token: "tok".into(),
+            refresh_token: None,
+            expires_at: Some(now + 3600),
+            token_type: "Bearer".into(),
+            scope: None,
+            issued_at: Some(now),
+        };
+        assert!(ts.is_valid());
+        assert_eq!(ts.issued_at, Some(now));
+    }
+
+    #[test]
+    fn issued_at_defaults_to_none_on_deserialize() {
+        // Tokens saved by Slice 1 (without issued_at) should deserialize with issued_at = None
+        let json = r#"{"access_token":"tok","refresh_token":null,"expires_at":999999999999,"token_type":"Bearer","scope":null}"#;
+        let ts: TokenSet = serde_json::from_str(json).unwrap();
+        assert_eq!(ts.issued_at, None);
     }
 }

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,5 +1,5 @@
 use crate::adapter::http::{HttpAdapter, HttpConfig};
-use crate::adapter::oauth::OAuthAdapter;
+use crate::adapter::oauth::{OAuthAdapter, OAuthAdapterConfig};
 use crate::adapter::sse::{SseAdapter, SseConfig};
 use crate::adapter::stdio::{StdioAdapter, StdioConfig};
 use crate::adapter::{FailedAdapter, McpAdapter, StartingAdapter};
@@ -7,7 +7,7 @@ use crate::config::{self, ConfigDiff, EndpointConfig, Transport};
 use crate::oauth::OAuthFlowManager;
 use crate::registry::AdapterRegistry;
 use crate::token_manager::TokenManager;
-use crate::OAuthTokenNotifiers;
+use crate::OAuthAdapterInners;
 use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 
 use std::path::PathBuf;
@@ -36,7 +36,7 @@ impl ConfigWatcher {
         js_execution_mode: Arc<AtomicBool>,
         token_manager: Arc<TokenManager>,
         _oauth_flow_manager: Arc<OAuthFlowManager>,
-        oauth_token_notifiers: OAuthTokenNotifiers,
+        oauth_adapter_inners: OAuthAdapterInners,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
             if let Err(e) = watch_loop(
@@ -45,7 +45,7 @@ impl ConfigWatcher {
                 machine_name,
                 js_execution_mode,
                 token_manager,
-                oauth_token_notifiers,
+                oauth_adapter_inners,
             )
             .await
             {
@@ -61,7 +61,7 @@ async fn watch_loop(
     _machine_name: String,
     js_execution_mode: Arc<AtomicBool>,
     token_manager: Arc<TokenManager>,
-    oauth_token_notifiers: OAuthTokenNotifiers,
+    oauth_adapter_inners: OAuthAdapterInners,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let (tx, mut rx) = tokio::sync::mpsc::channel(16);
 
@@ -138,7 +138,7 @@ async fn watch_loop(
             &warnings,
             &warned_names,
             &token_manager,
-            &oauth_token_notifiers,
+            &oauth_adapter_inners,
         )
         .await;
 
@@ -165,7 +165,7 @@ pub async fn apply_diff(
     diff: &ConfigDiff,
     registry: &AdapterRegistry,
     token_manager: &Arc<TokenManager>,
-    oauth_token_notifiers: &OAuthTokenNotifiers,
+    oauth_adapter_inners: &OAuthAdapterInners,
 ) {
     // Remove endpoints
     for name in &diff.removed {
@@ -220,9 +220,9 @@ pub async fn apply_diff(
         let ep_clone = new_ep.clone();
         let name_clone = name.clone();
         let tm = token_manager.clone();
-        let otn = oauth_token_notifiers.clone();
+        let oai = oauth_adapter_inners.clone();
         tokio::spawn(async move {
-            let adapter = create_adapter(&ep_clone, &tm, &otn).await;
+            let adapter = create_adapter(&ep_clone, &tm, &oai).await;
             let mut entries = reg.entries().write().await;
             if let Some(entry) = entries.get_mut(name_clone.as_str()) {
                 entry.adapter = adapter;
@@ -260,9 +260,9 @@ pub async fn apply_diff(
         let reg = registry.clone();
         let ep_clone = ep.clone();
         let tm = token_manager.clone();
-        let otn = oauth_token_notifiers.clone();
+        let oai = oauth_adapter_inners.clone();
         tokio::spawn(async move {
-            let adapter = create_adapter(&ep_clone, &tm, &otn).await;
+            let adapter = create_adapter(&ep_clone, &tm, &oai).await;
             let mut entries = reg.entries().write().await;
             if let Some(entry) = entries.get_mut(ep_clone.name.as_str()) {
                 entry.adapter = adapter;
@@ -290,7 +290,7 @@ pub async fn apply_diff_graceful(
     warnings: &[config::EndpointValidationWarning],
     warned_names: &std::collections::HashSet<String>,
     token_manager: &Arc<TokenManager>,
-    oauth_token_notifiers: &OAuthTokenNotifiers,
+    oauth_adapter_inners: &OAuthAdapterInners,
 ) {
     // Build warning message map
     let warning_messages: std::collections::HashMap<String, String> = {
@@ -381,9 +381,9 @@ pub async fn apply_diff_graceful(
         let ep_clone = new_ep.clone();
         let name_clone = name.clone();
         let tm = token_manager.clone();
-        let otn = oauth_token_notifiers.clone();
+        let oai = oauth_adapter_inners.clone();
         tokio::spawn(async move {
-            let adapter = create_adapter(&ep_clone, &tm, &otn).await;
+            let adapter = create_adapter(&ep_clone, &tm, &oai).await;
             let mut entries = reg.entries().write().await;
             if let Some(entry) = entries.get_mut(name_clone.as_str()) {
                 entry.adapter = adapter;
@@ -445,9 +445,9 @@ pub async fn apply_diff_graceful(
         let reg = registry.clone();
         let ep_clone = ep.clone();
         let tm = token_manager.clone();
-        let otn = oauth_token_notifiers.clone();
+        let oai = oauth_adapter_inners.clone();
         tokio::spawn(async move {
-            let adapter = create_adapter(&ep_clone, &tm, &otn).await;
+            let adapter = create_adapter(&ep_clone, &tm, &oai).await;
             let mut entries = reg.entries().write().await;
             if let Some(entry) = entries.get_mut(ep_clone.name.as_str()) {
                 entry.adapter = adapter;
@@ -472,7 +472,7 @@ pub async fn apply_diff_graceful(
 pub(crate) async fn create_adapter(
     ep: &EndpointConfig,
     token_manager: &Arc<TokenManager>,
-    oauth_token_notifiers: &OAuthTokenNotifiers,
+    oauth_adapter_inners: &OAuthAdapterInners,
 ) -> Box<dyn McpAdapter> {
     match ep.transport {
         Transport::Stdio => {
@@ -517,24 +517,24 @@ pub(crate) async fn create_adapter(
             }
         }
         Transport::Oauth => {
-            let url = ep.url.clone().unwrap_or_default();
-            // Create a watch channel for this endpoint's tokens
-            let (tx, rx) = tokio::sync::watch::channel(None);
-            oauth_token_notifiers
+            let oauth_config = OAuthAdapterConfig {
+                endpoint_name: ep.name.clone(),
+                url: ep.url.clone().unwrap_or_default(),
+                token_endpoint_url: format!(
+                    "{}/token",
+                    ep.oauth_server_url.as_deref().unwrap_or_default()
+                ),
+                client_id: ep.client_id.clone().unwrap_or_default(),
+                client_secret: ep.client_secret.clone(),
+            };
+
+            let mut adapter = OAuthAdapter::new(oauth_config, token_manager.clone());
+            let shared_inner = adapter.shared_inner();
+            oauth_adapter_inners
                 .write()
                 .await
-                .insert(ep.name.clone(), tx);
+                .insert(ep.name.clone(), shared_inner);
 
-            // Try to load existing tokens from disk
-            if let Ok(Some(token_set)) = token_manager.load(&ep.name).await {
-                info!(endpoint = %ep.name, "Loaded existing OAuth tokens from disk");
-                let notifiers = oauth_token_notifiers.read().await;
-                if let Some(tx) = notifiers.get(&ep.name) {
-                    let _ = tx.send(Some(token_set.access_token));
-                }
-            }
-
-            let mut adapter = OAuthAdapter::new(ep.name.clone(), url, rx);
             adapter.initialize().await.ok();
             info!(endpoint = %ep.name, "OAuth adapter initialized");
             Box::new(adapter)
@@ -614,19 +614,19 @@ mod tests {
         }
     }
 
-    fn test_oauth_infra() -> (Arc<TokenManager>, OAuthTokenNotifiers) {
+    fn test_oauth_infra() -> (Arc<TokenManager>, OAuthAdapterInners) {
         let tmp = tempfile::tempdir().unwrap();
         let token_manager = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
-        let notifiers = Arc::new(RwLock::new(HashMap::new()));
+        let inners = Arc::new(RwLock::new(HashMap::new()));
         // Leak the tempdir so it lives for the duration of the test
         std::mem::forget(tmp);
-        (token_manager, notifiers)
+        (token_manager, inners)
     }
 
     #[tokio::test]
     async fn apply_diff_empty_is_noop() {
         let registry = Arc::new(AdapterRegistry::new());
-        let (tm, notifiers) = test_oauth_infra();
+        let (tm, inners) = test_oauth_infra();
         let shutdown = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         registry
             .register(
@@ -638,7 +638,7 @@ mod tests {
             )
             .await;
 
-        apply_diff(&empty_diff(), &registry, &tm, &notifiers).await;
+        apply_diff(&empty_diff(), &registry, &tm, &inners).await;
 
         // Existing adapter should still be there, not shut down
         assert!(!shutdown.load(std::sync::atomic::Ordering::SeqCst));
@@ -648,7 +648,7 @@ mod tests {
     #[tokio::test]
     async fn apply_diff_removes_endpoint() {
         let registry = Arc::new(AdapterRegistry::new());
-        let (tm, notifiers) = test_oauth_infra();
+        let (tm, inners) = test_oauth_infra();
         let shutdown = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         registry
             .register(
@@ -665,7 +665,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &notifiers).await;
+        apply_diff(&diff, &registry, &tm, &inners).await;
 
         assert!(shutdown.load(std::sync::atomic::Ordering::SeqCst));
         assert!(registry.merged_catalog().await.is_empty());
@@ -674,20 +674,20 @@ mod tests {
     #[tokio::test]
     async fn apply_diff_remove_nonexistent_is_ok() {
         let registry = Arc::new(AdapterRegistry::new());
-        let (tm, notifiers) = test_oauth_infra();
+        let (tm, inners) = test_oauth_infra();
         let diff = ConfigDiff {
             removed: vec!["ghost".to_string()],
             ..empty_diff()
         };
 
         // Should not panic
-        apply_diff(&diff, &registry, &tm, &notifiers).await;
+        apply_diff(&diff, &registry, &tm, &inners).await;
     }
 
     #[tokio::test]
     async fn apply_diff_changed_shuts_down_old() {
         let registry = Arc::new(AdapterRegistry::new());
-        let (tm, notifiers) = test_oauth_infra();
+        let (tm, inners) = test_oauth_infra();
         let shutdown = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         registry
             .register(
@@ -723,7 +723,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &notifiers).await;
+        apply_diff(&diff, &registry, &tm, &inners).await;
 
         // Old adapter should have been shut down
         assert!(shutdown.load(std::sync::atomic::Ordering::SeqCst));
@@ -732,7 +732,7 @@ mod tests {
     #[tokio::test]
     async fn apply_diff_added_with_invalid_command_registers_as_failed() {
         let registry = Arc::new(AdapterRegistry::new());
-        let (tm, notifiers) = test_oauth_infra();
+        let (tm, inners) = test_oauth_infra();
 
         let new_ep = EndpointConfig {
             name: "bad_ep".to_string(),
@@ -756,7 +756,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &notifiers).await;
+        apply_diff(&diff, &registry, &tm, &inners).await;
 
         // Wait for background initialization to complete
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -773,7 +773,7 @@ mod tests {
     #[tokio::test]
     async fn apply_diff_preserves_unchanged_endpoints() {
         let registry = Arc::new(AdapterRegistry::new());
-        let (tm, notifiers) = test_oauth_infra();
+        let (tm, inners) = test_oauth_infra();
         let shutdown_keep = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let shutdown_remove = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
 
@@ -808,7 +808,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &notifiers).await;
+        apply_diff(&diff, &registry, &tm, &inners).await;
 
         // "keep" should still be alive
         assert!(!shutdown_keep.load(std::sync::atomic::Ordering::SeqCst));
@@ -823,7 +823,7 @@ mod tests {
     #[tokio::test]
     async fn apply_diff_added_oauth_creates_oauth_adapter() {
         let registry = Arc::new(AdapterRegistry::new());
-        let (tm, notifiers) = test_oauth_infra();
+        let (tm, inners) = test_oauth_infra();
 
         let new_ep = EndpointConfig {
             name: "oauth_ep".to_string(),
@@ -847,7 +847,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &notifiers).await;
+        apply_diff(&diff, &registry, &tm, &inners).await;
 
         // Wait for background initialization to complete
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -879,11 +879,11 @@ mod tests {
             }
         }
 
-        // Verify the notifier was inserted
-        let notifier_map = notifiers.read().await;
+        // Verify the inner was inserted
+        let inner_map = inners.read().await;
         assert!(
-            notifier_map.contains_key("oauth_ep"),
-            "Notifier should be registered for oauth_ep"
+            inner_map.contains_key("oauth_ep"),
+            "Inner should be registered for oauth_ep"
         );
     }
 }

--- a/tests/hot_reload_integration.rs
+++ b/tests/hot_reload_integration.rs
@@ -129,10 +129,10 @@ async fn test_config_diff_add_endpoint() {
     // Apply the diff
     let tmp = tempfile::tempdir().unwrap();
     let token_manager = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
-    let oauth_token_notifiers: Arc<
-        RwLock<HashMap<String, tokio::sync::watch::Sender<Option<String>>>>,
+    let oauth_adapter_inners: Arc<
+        RwLock<HashMap<String, Arc<endara_relay::adapter::oauth::OAuthAdapterInner>>>,
     > = Arc::new(RwLock::new(HashMap::new()));
-    watcher::apply_diff(&diff, &registry, &token_manager, &oauth_token_notifiers).await;
+    watcher::apply_diff(&diff, &registry, &token_manager, &oauth_adapter_inners).await;
 
     // Wait for background initialization to complete
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
@@ -263,10 +263,10 @@ async fn test_config_diff_remove_endpoint() {
 
     let tmp2 = tempfile::tempdir().unwrap();
     let token_manager2 = Arc::new(TokenManager::new(tmp2.path().to_path_buf()));
-    let oauth_token_notifiers2: Arc<
-        RwLock<HashMap<String, tokio::sync::watch::Sender<Option<String>>>>,
+    let oauth_adapter_inners2: Arc<
+        RwLock<HashMap<String, Arc<endara_relay::adapter::oauth::OAuthAdapterInner>>>,
     > = Arc::new(RwLock::new(HashMap::new()));
-    watcher::apply_diff(&diff, &registry, &token_manager2, &oauth_token_notifiers2).await;
+    watcher::apply_diff(&diff, &registry, &token_manager2, &oauth_adapter_inners2).await;
 
     // Verify the endpoint was removed
     let catalog = registry.merged_catalog().await;

--- a/tests/js_execution_integration.rs
+++ b/tests/js_execution_integration.rs
@@ -50,7 +50,7 @@ async fn setup_js_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
         meta_tool_handler: Arc::new(MetaToolHandler::new(registry_arc, Duration::from_secs(30))),
         oauth_flow_manager: None,
         token_manager: None,
-        oauth_token_notifiers: None,
+        oauth_adapter_inners: None,
     };
     let router = build_router(state);
     let addr: SocketAddr = ([127, 0, 0, 1], 0).into();

--- a/tests/management_api_integration.rs
+++ b/tests/management_api_integration.rs
@@ -127,6 +127,7 @@ async fn start_management_server(
         config_path: None,
         oauth_flow_manager: None,
         relay_port: 9400,
+        oauth_adapter_inners: None,
     };
 
     let app = management_routes(state);
@@ -312,6 +313,7 @@ async fn start_management_server_with_config(
         config_path: Some(config_path),
         oauth_flow_manager: None,
         relay_port: 9400,
+        oauth_adapter_inners: None,
     };
 
     let app = management_routes(state);

--- a/tests/mcp_server_integration.rs
+++ b/tests/mcp_server_integration.rs
@@ -45,7 +45,7 @@ async fn setup_server() -> (SocketAddr, AdapterRegistry, tokio::task::JoinHandle
         meta_tool_handler: Arc::new(MetaToolHandler::new(registry_arc, Duration::from_secs(30))),
         oauth_flow_manager: None,
         token_manager: None,
-        oauth_token_notifiers: None,
+        oauth_adapter_inners: None,
     };
     let router = build_router(state);
     // Bind to port 0 to get a random available port

--- a/tests/multi_endpoint_integration.rs
+++ b/tests/multi_endpoint_integration.rs
@@ -16,7 +16,6 @@ use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::time::timeout;
 
 fn echo_script_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -82,7 +81,7 @@ async fn setup_multi_endpoint_server() -> (SocketAddr, AdapterRegistry, tokio::t
         meta_tool_handler: Arc::new(MetaToolHandler::new(registry_arc, Duration::from_secs(30))),
         oauth_flow_manager: None,
         token_manager: None,
-        oauth_token_notifiers: None,
+        oauth_adapter_inners: None,
     };
     let router = build_router(state);
     let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
@@ -223,7 +222,7 @@ async fn test_multi_endpoint_overlapping_tool_names() {
         meta_tool_handler: Arc::new(MetaToolHandler::new(registry_arc, Duration::from_secs(30))),
         oauth_flow_manager: None,
         token_manager: None,
-        oauth_token_notifiers: None,
+        oauth_adapter_inners: None,
     };
     let router = build_router(state);
     let addr: SocketAddr = ([127, 0, 0, 1], 0).into();


### PR DESCRIPTION
## Summary

Implements OAuth token lifecycle management (Slice 2 of the OAuth engineering spec). This adds proactive token refresh, automatic retry on auth failures, management API routes, and enhanced error handling.

## Changes

### Token Manager (`src/token_manager.rs`)
- Proactive token refresh with configurable threshold
- Background refresh scheduling before token expiry

### OAuth Adapter (`src/adapter/oauth.rs`)
- Automatic 401 retry with token refresh
- Enhanced error handling for auth failure scenarios
- OAuthState enum for tracking authentication lifecycle

### Management API (`src/management.rs`)
- `POST /oauth/revoke` — Revoke OAuth tokens for an endpoint
- `POST /oauth/refresh` — Force token refresh for an endpoint
- `GET /oauth/status` — Enhanced OAuth status with token expiry, refresh info

### Error Handling (`src/oauth.rs`, `src/adapter/mod.rs`)
- OAuthError enhancements for granular auth failure reporting
- AdapterError enhancements for HTTP auth scenarios

### Startup (`src/main.rs`)
- Enhanced token restore from persistent storage on startup

### Other
- Updated server routing for new management endpoints
- Updated integration tests for new functionality

## Files Changed (17)
- `src/adapter/http.rs`, `src/adapter/mod.rs`, `src/adapter/oauth.rs`, `src/adapter/sse.rs`
- `src/lib.rs`, `src/main.rs`, `src/management.rs`, `src/oauth.rs`
- `src/registry.rs`, `src/server.rs`, `src/token_manager.rs`, `src/watcher.rs`
- `tests/hot_reload_integration.rs`, `tests/js_execution_integration.rs`
- `tests/management_api_integration.rs`, `tests/mcp_server_integration.rs`, `tests/multi_endpoint_integration.rs`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author