### PR TITLE
ci: add merge_group trigger for merge queue support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds `merge_group` event trigger to the CI workflow so GitHub merge queue can validate PRs before merging.

## Changes
- Added `merge_group:` to `on:` triggers in `.github/workflows/ci.yml`
- `pr-title` job remains guarded to `pull_request` only

The merge queue ruleset has already been enabled on this repo.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author