### PR TITLE
ci: mark rc releases as prerelease in GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,5 +67,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, 'rc') }}
           files: artifacts/*
 


### PR DESCRIPTION
Adds `prerelease: ${{ contains(github.ref_name, 'rc') }}` to the release workflow so that release candidate tags (e.g. `v0.1.0-rc2`) are automatically marked as prerelease on GitHub.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author