### PR TITLE
feat: add macOS codesigning and notarization to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,30 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+      - name: Import Apple certificate
+        if: runner.os == 'macOS'
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          CERTIFICATE_PATH=$RUNNER_TEMP/certificate.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -hex 12)
+          echo -n "$APPLE_CERTIFICATE" | base64 --decode -o $CERTIFICATE_PATH
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security import $CERTIFICATE_PATH -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
       - name: Build release
         run: cargo build --release --target ${{ matrix.target }}
+      - name: Codesign binary
+        if: runner.os == 'macOS'
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: |
+          codesign --force --options runtime --sign "$APPLE_SIGNING_IDENTITY" "target/${{ matrix.target }}/release/${{ matrix.binary }}"
       - name: Rename binary
         shell: bash
         run: |
@@ -49,6 +71,20 @@ jobs:
             dst="${dst}.exe"
           fi
           cp "$src" "$dst"
+      - name: Notarize binary
+        if: runner.os == 'macOS'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          dst="endara-relay-${{ matrix.target }}"
+          zip "${dst}.zip" "$dst"
+          xcrun notarytool submit "${dst}.zip" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

Adds macOS code signing and notarization to the relay release workflow so that relay binaries can run as Tauri sidecars on macOS without Gatekeeper blocking.

## Changes

- **Import Apple certificate** step (macOS only): decodes base64-encoded .p12 certificate, creates a temporary keychain, and imports the cert
- **Codesign binary** step (macOS only): signs the built binary with `--options runtime` (hardened runtime, required for notarization)
- **Notarize binary** step (macOS only): zips the renamed binary and submits to Apple's notarization service via `xcrun notarytool`
- All 6 Apple signing secrets have been set on this repo (APPLE_CERTIFICATE, APPLE_CERTIFICATE_PASSWORD, APPLE_SIGNING_IDENTITY, APPLE_ID, APPLE_PASSWORD, APPLE_TEAM_ID)

Non-macOS builds (Linux, Windows) are completely unchanged.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author