### PR TITLE
ci: add Rust caching and parallelize CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+      - uses: swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -37,7 +40,6 @@ jobs:
         run: cargo test --test '*' -- --test-threads=4
 
   build:
-    needs: check
     strategy:
       matrix:
         include:
@@ -55,6 +57,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+      - uses: swatinem/rust-cache@v2
+        with:
+          shared-key: build-${{ matrix.target }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+      - uses: swatinem/rust-cache@v2
+        with:
+          shared-key: build-${{ matrix.target }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install cross-compilation tools
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |


### PR DESCRIPTION
## Summary

Improve CI and release build times by adding Rust compilation caching and running check/build jobs in parallel.

### Changes

- **ci.yml**: Add `swatinem/rust-cache@v2` to both `check` and `build` jobs
- **ci.yml**: Remove `needs: check` from `build` job so they run in parallel (~4 min wall-clock savings)
- **release.yml**: Add `swatinem/rust-cache@v2` to the `build` job with per-target `shared-key`
- All cache steps use `save-if` to only persist caches on `main` branch pushes (avoids PR cache pollution)

### Expected Impact

- CI wall-clock time: ~12 min → ~8 min (parallel jobs) + faster compilation on cache hits
- Release builds: faster compilation on cache hits

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author