### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "endara-relay"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endara-relay"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Local MCP tool aggregator — aggregate multiple MCP servers behind a single endpoint"
 license = "Apache-2.0"


### PR DESCRIPTION
Bumps relay version to 0.1.1 in preparation for release tag `v0.1.1-rc.2`. The rc suffix comes from the git tag at release time and is not committed.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author