### PR TITLE
feat(relay): per-adapter tools cache with event-driven invalidation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,10 @@ path = "tests/fixtures/http_server.rs"
 name = "fixture-bad-server"
 path = "tests/fixtures/bad_server.rs"
 
+[[bin]]
+name = "fixture-swap-notify-server"
+path = "tests/fixtures/swap_notify_server.rs"
+
 [dev-dependencies]
 futures-util = "0.3"
 reqwest = { version = "0.13", features = ["json", "stream"] }

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -126,6 +126,19 @@ pub trait McpAdapter: Send + Sync {
     fn server_type(&self) -> Option<String> {
         None
     }
+
+    /// Subscribe to MCP `notifications/tools/list_changed` ticks emitted by the
+    /// underlying server. Each `recv()` represents at least one change
+    /// notification observed since the previous receive; the registry treats
+    /// every tick as an opaque cache-invalidation signal.
+    ///
+    /// The default implementation returns `None`, indicating the adapter does
+    /// not surface tools-changed events. Adapters that handle the MCP
+    /// notification override this and return a fresh `Receiver` from a
+    /// long-lived `broadcast::Sender`.
+    fn subscribe_tools_changed(&self) -> Option<tokio::sync::broadcast::Receiver<()>> {
+        None
+    }
 }
 
 /// A placeholder adapter registered when the real adapter fails to initialize.

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -16,8 +16,8 @@ use serde_json::Value;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{Mutex, RwLock};
-use tokio::task::JoinHandle;
+use tokio::sync::{broadcast, Mutex, RwLock};
+use tokio::task::{AbortHandle, JoinHandle};
 use tokio::time::Instant;
 use tracing::{error, info, warn};
 /// Configuration for an OAuth-authenticated MCP endpoint.
@@ -64,6 +64,14 @@ pub struct OAuthAdapterInner {
     pub metrics: OAuthMetrics,
     /// Guards concurrent refresh attempts so only one proceeds at a time.
     refresh_mutex: Mutex<()>,
+    /// Outer tools-changed broadcast — the registry subscribes here once and
+    /// keeps that receiver across inner-adapter swaps. Forwarder tasks pump
+    /// ticks from each inner adapter's `subscribe_tools_changed` receiver into
+    /// this sender.
+    outer_tools_changed_tx: broadcast::Sender<()>,
+    /// Abort handle for the current inner→outer tools-changed forwarder task,
+    /// if any. Re-bound on every inner-adapter swap.
+    inner_forwarder_handle: Mutex<Option<AbortHandle>>,
 }
 
 impl OAuthAdapterInner {
@@ -287,7 +295,12 @@ impl OAuthAdapterInner {
         let mut adapter = Self::build_inner_adapter(&self.config.url, &access_token);
         match adapter.initialize().await {
             Ok(()) => {
+                // Bind a forwarder against the new inner's tools-changed
+                // receiver (if any) before publishing it. No synthetic tick
+                // is emitted on swap — real ticks come from inner reconnects.
+                let rx = adapter.subscribe_tools_changed();
                 *self.inner_adapter.write().await = Some(adapter);
+                self.swap_tools_forwarder(rx).await;
                 self.transition_to(
                     OAuthState::Authenticated,
                     "tokens applied, inner adapter ready",
@@ -298,6 +311,7 @@ impl OAuthAdapterInner {
                 // Capture inner adapter's health before clearing it
                 *self.inner_health.write().await = adapter.health();
                 *self.inner_adapter.write().await = None;
+                self.swap_tools_forwarder(None).await;
                 self.transition_to(
                     OAuthState::ConnectionFailed,
                     &format!("inner adapter init failed: {}", e),
@@ -362,6 +376,33 @@ impl OAuthAdapterInner {
         }
     }
 
+    /// Abort any existing inner→outer tools-changed forwarder and, if `rx` is
+    /// `Some`, spawn a fresh forwarder that pumps each inner tick into
+    /// `outer_tools_changed_tx`. `Lagged` is forwarded as a tick (matching the
+    /// registry listener); `Closed` ends the task.
+    async fn swap_tools_forwarder(&self, rx: Option<broadcast::Receiver<()>>) {
+        let mut handle_guard = self.inner_forwarder_handle.lock().await;
+        if let Some(h) = handle_guard.take() {
+            h.abort();
+        }
+        let Some(mut rx) = rx else { return };
+        let outer_tx = self.outer_tools_changed_tx.clone();
+        let join = tokio::spawn(async move {
+            loop {
+                match rx.recv().await {
+                    Ok(()) => {
+                        let _ = outer_tx.send(());
+                    }
+                    Err(broadcast::error::RecvError::Lagged(_)) => {
+                        let _ = outer_tx.send(());
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+        *handle_guard = Some(join.abort_handle());
+    }
+
     /// Disconnect: abort refresh task, clear tokens, delete from disk, set Disconnected.
     pub async fn disconnect(self: &Arc<Self>) {
         let endpoint = &self.config.endpoint_name;
@@ -373,6 +414,9 @@ impl OAuthAdapterInner {
                 h.abort();
             }
         }
+
+        // Abort inner→outer tools-changed forwarder
+        self.swap_tools_forwarder(None).await;
 
         // Shut down inner adapter
         {
@@ -413,6 +457,7 @@ pub struct OAuthAdapter {
 impl OAuthAdapter {
     /// Create a new OAuthAdapter.
     pub fn new(config: OAuthAdapterConfig, token_manager: Arc<TokenManager>) -> Self {
+        let (outer_tools_changed_tx, _) = broadcast::channel(16);
         Self {
             inner: Arc::new(OAuthAdapterInner {
                 state: RwLock::new(OAuthState::NeedsLogin),
@@ -427,6 +472,8 @@ impl OAuthAdapter {
                 transition_history: RwLock::new(VecDeque::new()),
                 metrics: OAuthMetrics::new(),
                 refresh_mutex: Mutex::new(()),
+                outer_tools_changed_tx,
+                inner_forwarder_handle: Mutex::new(None),
             }),
         }
     }
@@ -633,6 +680,8 @@ impl McpAdapter for OAuthAdapter {
                 h.abort();
             }
         }
+        // Abort inner→outer tools-changed forwarder
+        self.inner.swap_tools_forwarder(None).await;
         let mut guard = self.inner.inner_adapter.write().await;
         if let Some(ref mut adapter) = *guard {
             adapter.shutdown().await?;
@@ -642,6 +691,10 @@ impl McpAdapter for OAuthAdapter {
             .transition_to(OAuthState::Disconnected, "shutdown")
             .await;
         Ok(())
+    }
+
+    fn subscribe_tools_changed(&self) -> Option<broadcast::Receiver<()>> {
+        Some(self.inner.outer_tools_changed_tx.subscribe())
     }
 
     fn health(&self) -> HealthStatus {
@@ -950,5 +1003,102 @@ mod tests {
         let expected = issued + Duration::from_secs(900);
         assert!(deadline >= expected - Duration::from_millis(1));
         assert!(deadline <= expected + Duration::from_millis(1));
+    }
+
+    // --- Tools-changed forwarder (T5) ---
+
+    /// Drain any already-queued ticks so subsequent `recv` reflects new sends.
+    async fn drain(rx: &mut broadcast::Receiver<()>) {
+        loop {
+            match tokio::time::timeout(Duration::from_millis(20), rx.recv()).await {
+                Ok(Ok(())) => continue,
+                Ok(Err(broadcast::error::RecvError::Lagged(_))) => continue,
+                Ok(Err(broadcast::error::RecvError::Closed)) | Err(_) => break,
+            }
+        }
+    }
+
+    /// Wait briefly for an outer tick. Returns whether one arrived.
+    async fn recv_tick(rx: &mut broadcast::Receiver<()>, timeout: Duration) -> bool {
+        matches!(
+            tokio::time::timeout(timeout, rx.recv()).await,
+            Ok(Ok(())) | Ok(Err(broadcast::error::RecvError::Lagged(_)))
+        )
+    }
+
+    #[tokio::test]
+    async fn subscribe_tools_changed_returns_some() {
+        let adapter = make_adapter(make_config());
+        // OAuth always exposes its outer broadcast — registry subscribes once.
+        assert!(adapter.subscribe_tools_changed().is_some());
+    }
+
+    #[tokio::test]
+    async fn forwarder_propagates_inner_tick_to_outer_subscriber() {
+        let adapter = make_adapter(make_config());
+        let mut outer_rx = adapter.subscribe_tools_changed().expect("outer rx");
+
+        let (inner_tx, inner_rx) = broadcast::channel::<()>(16);
+        adapter.inner.swap_tools_forwarder(Some(inner_rx)).await;
+
+        inner_tx.send(()).expect("inner send");
+        assert!(
+            recv_tick(&mut outer_rx, Duration::from_millis(500)).await,
+            "outer subscriber should receive tick forwarded from inner"
+        );
+    }
+
+    #[tokio::test]
+    async fn inner_swap_aborts_old_forwarder_and_rebinds_new() {
+        let adapter = make_adapter(make_config());
+        let mut outer_rx = adapter.subscribe_tools_changed().expect("outer rx");
+
+        // Bind forwarder to inner A.
+        let (inner_tx_a, inner_rx_a) = broadcast::channel::<()>(16);
+        adapter.inner.swap_tools_forwarder(Some(inner_rx_a)).await;
+        // Sanity-check: A propagates.
+        inner_tx_a.send(()).expect("inner A send");
+        assert!(recv_tick(&mut outer_rx, Duration::from_millis(500)).await);
+
+        // Swap to inner B (simulates inner-adapter replacement).
+        let (inner_tx_b, inner_rx_b) = broadcast::channel::<()>(16);
+        adapter.inner.swap_tools_forwarder(Some(inner_rx_b)).await;
+        drain(&mut outer_rx).await;
+
+        // Firing on the OLD inner must NOT propagate (forwarder aborted →
+        // the only subscriber was dropped, so `send` may return SendError;
+        // either way nothing should reach the outer subscriber).
+        let _ = inner_tx_a.send(());
+        assert!(
+            !recv_tick(&mut outer_rx, Duration::from_millis(150)).await,
+            "old inner sender must not propagate after swap"
+        );
+
+        // Firing on the NEW inner DOES propagate (forwarder rebound).
+        inner_tx_b.send(()).expect("inner B send");
+        assert!(
+            recv_tick(&mut outer_rx, Duration::from_millis(500)).await,
+            "new inner sender must propagate after swap"
+        );
+    }
+
+    #[tokio::test]
+    async fn forwarder_swap_to_none_disables_forwarding() {
+        // Simulates inner adapters that don't expose `subscribe_tools_changed`
+        // (returns `None`): no forwarder is spawned and OAuth still works.
+        let adapter = make_adapter(make_config());
+        let mut outer_rx = adapter.subscribe_tools_changed().expect("outer rx");
+
+        let (inner_tx, inner_rx) = broadcast::channel::<()>(16);
+        adapter.inner.swap_tools_forwarder(Some(inner_rx)).await;
+        adapter.inner.swap_tools_forwarder(None).await;
+
+        // After abort, the forwarder's receiver is dropped — `send` may return
+        // SendError (no subscribers). Either way, nothing reaches outer.
+        let _ = inner_tx.send(());
+        assert!(
+            !recv_tick(&mut outer_rx, Duration::from_millis(150)).await,
+            "no tick should reach outer subscriber after forwarder disabled"
+        );
     }
 }

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -1083,6 +1083,67 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn apply_tokens_rebinds_forwarder_aborting_prior_inner() {
+        // G3 coverage: apply_tokens must drive swap_tools_forwarder so that
+        // a stale forwarder bound to a previous inner is aborted. Here the
+        // upstream URL is unreachable, so apply_tokens hits the
+        // ConnectionFailed branch which calls swap_tools_forwarder(None) —
+        // the prior forwarder must stop propagating ticks regardless.
+        let mut config = make_config();
+        config.url = "http://127.0.0.1:19998/mcp".to_string();
+        let mut adapter = make_adapter(config);
+        adapter.initialize().await.unwrap();
+        let mut outer_rx = adapter.subscribe_tools_changed().expect("outer rx");
+
+        // Pre-bind a forwarder to a fake "previous" inner receiver.
+        let (prev_inner_tx, prev_inner_rx) = broadcast::channel::<()>(16);
+        adapter
+            .inner
+            .swap_tools_forwarder(Some(prev_inner_rx))
+            .await;
+        // Sanity: forwarder propagates ticks before apply_tokens runs.
+        prev_inner_tx.send(()).expect("pre-apply send");
+        assert!(
+            recv_tick(&mut outer_rx, Duration::from_millis(500)).await,
+            "pre-apply forwarder should propagate"
+        );
+        drain(&mut outer_rx).await;
+
+        // apply_tokens with unreachable URL → ConnectionFailed branch →
+        // swap_tools_forwarder(None) → prior forwarder is aborted.
+        let token_set = TokenSet {
+            access_token: "fake-token".to_string(),
+            refresh_token: None,
+            expires_at: None,
+            token_type: "Bearer".to_string(),
+            scope: None,
+            issued_at: None,
+        };
+        adapter.inner.apply_tokens(token_set).await;
+
+        // Ticks on the previous inner sender must no longer propagate.
+        let _ = prev_inner_tx.send(());
+        assert!(
+            !recv_tick(&mut outer_rx, Duration::from_millis(150)).await,
+            "apply_tokens must rebind the forwarder, aborting the prior one"
+        );
+
+        // The outer broadcast itself remains alive (registry subscription
+        // survives across rebinds): a fresh forwarder bound after apply_tokens
+        // still reaches the same outer subscriber.
+        let (post_inner_tx, post_inner_rx) = broadcast::channel::<()>(16);
+        adapter
+            .inner
+            .swap_tools_forwarder(Some(post_inner_rx))
+            .await;
+        post_inner_tx.send(()).expect("post-apply send");
+        assert!(
+            recv_tick(&mut outer_rx, Duration::from_millis(500)).await,
+            "outer broadcast must survive apply_tokens rebind"
+        );
+    }
+
+    #[tokio::test]
     async fn forwarder_swap_to_none_disables_forwarding() {
         // Simulates inner adapters that don't expose `subscribe_tools_changed`
         // (returns `None`): no forwarder is spawned and OAuth still works.

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio::time::Instant;
 use tracing::{debug, error, info, warn};
 
@@ -105,6 +105,9 @@ pub struct SseAdapter {
     server_type: Arc<RwLock<Option<String>>>,
     /// Ring buffer recording tool call activity.
     activity_log: Arc<RwLock<RingBuffer>>,
+    /// Broadcast emitter for `notifications/tools/list_changed` events. Each
+    /// tick is an opaque cache-invalidation signal consumed by the registry.
+    tools_changed_tx: broadcast::Sender<()>,
 }
 
 impl SseAdapter {
@@ -136,6 +139,8 @@ impl SseAdapter {
             .build()
             .expect("failed to build HTTP client");
 
+        let (tools_changed_tx, _) = broadcast::channel(16);
+
         Self {
             config,
             client,
@@ -147,6 +152,7 @@ impl SseAdapter {
             crash_tracker: Arc::new(Mutex::new(CrashTracker::new())),
             server_type: Arc::new(RwLock::new(None)),
             activity_log: Arc::new(RwLock::new(RingBuffer::new(1000))),
+            tools_changed_tx,
         }
     }
 
@@ -222,6 +228,7 @@ impl SseAdapter {
         let post_endpoint = self.post_endpoint.clone();
         let health = self.health.clone();
         let base_url = self.config.url.clone();
+        let tools_changed_tx = self.tools_changed_tx.clone();
 
         // Spawn SSE listener task
         let handle = tokio::spawn(async move {
@@ -281,12 +288,42 @@ impl SseAdapter {
                                         let _ = tx.send(endpoint_url);
                                     }
                                 }
-                                "message" => match serde_json::from_str::<JsonRpcResponse>(&data) {
-                                    Ok(response) => {
-                                        if let Some(id) = response.id {
-                                            let mut map = pending.lock().await;
-                                            if let Some(tx) = map.remove(&id) {
-                                                let _ = tx.send(response);
+                                "message" => match serde_json::from_str::<Value>(&data) {
+                                    Ok(value) => {
+                                        let id_opt = value.get("id").and_then(|v| v.as_u64());
+                                        let method_opt =
+                                            value.get("method").and_then(|v| v.as_str());
+                                        if id_opt.is_none() {
+                                            // No id → JSON-RPC notification (or malformed
+                                            // response). Surface tools-changed ticks; log
+                                            // others.
+                                            match method_opt {
+                                                Some("notifications/tools/list_changed") => {
+                                                    debug!(
+                                                        "received tools/list_changed notification"
+                                                    );
+                                                    let _ = tools_changed_tx.send(());
+                                                }
+                                                Some(method) => {
+                                                    debug!(method = %method, "ignoring SSE notification");
+                                                }
+                                                None => {
+                                                    warn!(data = %data, "SSE message has no id and no method");
+                                                }
+                                            }
+                                        } else {
+                                            match serde_json::from_value::<JsonRpcResponse>(value) {
+                                                Ok(response) => {
+                                                    if let Some(id) = response.id {
+                                                        let mut map = pending.lock().await;
+                                                        if let Some(tx) = map.remove(&id) {
+                                                            let _ = tx.send(response);
+                                                        }
+                                                    }
+                                                }
+                                                Err(e) => {
+                                                    warn!(error = %e, data = %data, "failed to parse SSE response");
+                                                }
                                             }
                                         }
                                     }
@@ -449,6 +486,11 @@ impl McpAdapter for SseAdapter {
 
         *self.health.write().await = HealthStatus::Healthy;
         self.crash_tracker.lock().await.reset();
+        // Emit a tick after every successful (re)connect + handshake so any
+        // stale post-disconnect tools cache gets invalidated. The registry's
+        // listener loop is idempotent; a no-op invalidation on an empty cache
+        // is harmless. `SendError` (no subscribers) is harmless — drop it.
+        let _ = self.tools_changed_tx.send(());
         info!(url = %self.config.url, "SSE MCP adapter initialized");
         Ok(())
     }
@@ -496,6 +538,10 @@ impl McpAdapter for SseAdapter {
 
     fn server_type(&self) -> Option<String> {
         self.server_type.try_read().ok().and_then(|g| g.clone())
+    }
+
+    fn subscribe_tools_changed(&self) -> Option<broadcast::Receiver<()>> {
+        Some(self.tools_changed_tx.subscribe())
     }
 
     async fn shutdown(&mut self) -> Result<(), AdapterError> {

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio::time::{Duration, Instant};
 use tracing::{debug, error, info, warn};
 
@@ -154,6 +154,10 @@ pub struct StdioAdapter {
     crash_tracker: Arc<Mutex<CrashTracker>>,
     /// Sanitized server name from the MCP initialize response.
     server_type: Arc<RwLock<Option<String>>>,
+    /// Broadcast sender used to fan out `notifications/tools/list_changed`
+    /// observations to subscribers (the registry's listener loop). Capacity is
+    /// 16; `SendError` (no subscribers) is intentionally ignored.
+    tools_changed_tx: broadcast::Sender<()>,
     // Background task handles
     _stderr_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
     _stdout_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
@@ -162,6 +166,7 @@ pub struct StdioAdapter {
 impl StdioAdapter {
     /// Create a new StdioAdapter with the given configuration.
     pub fn new(config: StdioConfig) -> Self {
+        let (tools_changed_tx, _) = broadcast::channel(16);
         Self {
             config,
             child: Arc::new(Mutex::new(None)),
@@ -172,6 +177,7 @@ impl StdioAdapter {
             request_id: AtomicU64::new(1),
             crash_tracker: Arc::new(Mutex::new(CrashTracker::new())),
             server_type: Arc::new(RwLock::new(None)),
+            tools_changed_tx,
             _stderr_handle: Arc::new(Mutex::new(None)),
             _stdout_handle: Arc::new(Mutex::new(None)),
         }
@@ -222,6 +228,8 @@ impl StdioAdapter {
 
         // Set up stdout line reader that dispatches by JSON-RPC response ID
         let pending = self.pending_requests.clone();
+        let tools_changed_tx = self.tools_changed_tx.clone();
+        // TODO: emit tick after post-restart handshake when auto-restart is added
         let stdout_handle = tokio::spawn(async move {
             let reader = BufReader::new(stdout);
             let mut lines = reader.lines();
@@ -244,8 +252,16 @@ impl StdioAdapter {
                                 }
                             }
                         } else {
-                            // Server notification (no id) — log and drop
-                            debug!(line = %line, "MCP server notification (no id), dropping");
+                            // Server notification (no id) — surface tools-changed
+                            // ticks; debug-log everything else and drop.
+                            match obj.get("method").and_then(|v| v.as_str()) {
+                                Some("notifications/tools/list_changed") => {
+                                    let _ = tools_changed_tx.send(());
+                                }
+                                _ => {
+                                    debug!(line = %line, "MCP server notification (no id), dropping");
+                                }
+                            }
                         }
                     }
                     Err(e) => {
@@ -441,6 +457,10 @@ impl McpAdapter for StdioAdapter {
 
     fn server_type(&self) -> Option<String> {
         self.server_type.try_read().ok().and_then(|g| g.clone())
+    }
+
+    fn subscribe_tools_changed(&self) -> Option<broadcast::Receiver<()>> {
+        Some(self.tools_changed_tx.subscribe())
     }
 
     async fn stderr_lines(&self) -> Vec<String> {
@@ -907,6 +927,118 @@ for line in sys.stdin:
         // The notification should be silently dropped, not returned as a response
         let result = adapter.send_request("tools/list", None).await.unwrap();
         assert_eq!(result["echo_method"], "tools/list");
+
+        adapter.shutdown().await.unwrap();
+    }
+
+    // -----------------------------------------------------------------------
+    // tools-changed broadcast tests
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_subscribe_tools_changed_returns_some() {
+        let adapter = StdioAdapter::new(StdioConfig {
+            command: "python3".to_string(),
+            args: vec!["-c".to_string(), "pass".to_string()],
+            env: HashMap::new(),
+        });
+        assert!(
+            (&adapter as &dyn McpAdapter)
+                .subscribe_tools_changed()
+                .is_some(),
+            "stdio adapter should expose a tools-changed receiver"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stdio_emits_tick_on_list_changed_notification() {
+        // Server that, after each request, prints a tools/list_changed
+        // notification *before* its response. Subscribing before triggering
+        // the request must yield at least one tick on the broadcast channel.
+        let script = r#"
+import sys, json
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        req = json.loads(line)
+        notif = {"jsonrpc": "2.0", "method": "notifications/tools/list_changed"}
+        sys.stdout.write(json.dumps(notif) + "\n")
+        sys.stdout.flush()
+        resp = {"jsonrpc": "2.0", "result": {"echo_method": req.get("method")}, "id": req.get("id")}
+        sys.stdout.write(json.dumps(resp) + "\n")
+        sys.stdout.flush()
+    except Exception:
+        pass
+"#;
+        let mut adapter = StdioAdapter::new(StdioConfig {
+            command: "python3".to_string(),
+            args: vec!["-c".to_string(), script.to_string()],
+            env: HashMap::new(),
+        });
+        adapter.spawn_process().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let mut rx = (&adapter as &dyn McpAdapter)
+            .subscribe_tools_changed()
+            .expect("stdio adapter exposes a tools-changed receiver");
+
+        // Trigger the server to emit the notification.
+        let _ = adapter.send_request("tools/list", None).await.unwrap();
+
+        let recv = tokio::time::timeout(Duration::from_secs(1), rx.recv()).await;
+        match recv {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => panic!("broadcast recv error: {:?}", e),
+            Err(_) => panic!("did not receive tools-changed tick within 1s"),
+        }
+
+        adapter.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_stdio_unrelated_notification_does_not_emit_tick() {
+        // Server that emits an unrelated notification before its response.
+        // The tools-changed subscriber must NOT receive a tick.
+        let script = r#"
+import sys, json
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        req = json.loads(line)
+        notif = {"jsonrpc": "2.0", "method": "notifications/message", "params": {"level": "info", "data": "hi"}}
+        sys.stdout.write(json.dumps(notif) + "\n")
+        sys.stdout.flush()
+        resp = {"jsonrpc": "2.0", "result": {"echo_method": req.get("method")}, "id": req.get("id")}
+        sys.stdout.write(json.dumps(resp) + "\n")
+        sys.stdout.flush()
+    except Exception:
+        pass
+"#;
+        let mut adapter = StdioAdapter::new(StdioConfig {
+            command: "python3".to_string(),
+            args: vec!["-c".to_string(), script.to_string()],
+            env: HashMap::new(),
+        });
+        adapter.spawn_process().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let mut rx = (&adapter as &dyn McpAdapter)
+            .subscribe_tools_changed()
+            .expect("stdio adapter exposes a tools-changed receiver");
+
+        let _ = adapter.send_request("tools/list", None).await.unwrap();
+
+        // Give the stdout reader a moment to process the notification line.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        match rx.try_recv() {
+            Err(broadcast::error::TryRecvError::Empty) => {}
+            other => panic!("expected no tick, got {:?}", other),
+        }
 
         adapter.shutdown().await.unwrap();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -367,6 +367,7 @@ async fn main() {
                         }
                     }
                     drop(entries);
+                    reg.rewire_tools_changed_listener(&ep.name).await;
                     reg.invalidate_catalog_cache().await;
                     info!(endpoint = %ep.name, "Adapter initialized");
                 });

--- a/src/management.rs
+++ b/src/management.rs
@@ -224,8 +224,7 @@ async fn get_endpoints(State(state): State<ManagementState>) -> Json<Vec<Endpoin
             match entry.adapter.health() {
                 HealthStatus::Healthy => {
                     let count = entry
-                        .adapter
-                        .list_tools()
+                        .cached_list_tools()
                         .await
                         .map(|t| t.len())
                         .unwrap_or(0);
@@ -334,6 +333,7 @@ async fn restart_endpoint(
             entry.adapter = new_adapter;
         }
         drop(entries);
+        state.registry.rewire_tools_changed_listener(&name).await;
         state.registry.invalidate_endpoint_tool_cache(&name).await;
 
         Json(ActionResponse {

--- a/src/management.rs
+++ b/src/management.rs
@@ -334,7 +334,7 @@ async fn restart_endpoint(
             entry.adapter = new_adapter;
         }
         drop(entries);
-        state.registry.invalidate_catalog_cache().await;
+        state.registry.invalidate_endpoint_tool_cache(&name).await;
 
         Json(ActionResponse {
             ok: true,
@@ -349,7 +349,7 @@ async fn restart_endpoint(
         };
         let result = entry.adapter.initialize().await;
         drop(entries);
-        state.registry.invalidate_catalog_cache().await;
+        state.registry.invalidate_endpoint_tool_cache(&name).await;
         match result {
             Ok(()) => Json(ActionResponse {
                 ok: true,
@@ -371,13 +371,15 @@ async fn refresh_endpoint(
     State(state): State<ManagementState>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
+    // Drop the prior cached tools so the next read fetches fresh data,
+    // then repopulate the cache eagerly so callers see the new list.
+    state.registry.invalidate_endpoint_tool_cache(&name).await;
     let entries = state.registry.entries().read().await;
     let Some(entry) = entries.get(&name) else {
         return endpoint_not_found(&name).into_response();
     };
-    let result = entry.adapter.list_tools().await;
+    let result = entry.cached_list_tools().await;
     drop(entries);
-    state.registry.invalidate_catalog_cache().await;
     match result {
         Ok(tools) => Json(ActionResponse {
             ok: true,
@@ -2048,7 +2050,7 @@ async fn get_endpoint_tools(
     let Some(entry) = entries.get(&name) else {
         return endpoint_not_found(&name).into_response();
     };
-    match entry.adapter.list_tools().await {
+    match entry.cached_list_tools().await {
         Ok(tools) => {
             let mut tools_with_status: Vec<ToolInfoWithStatus> = tools
                 .into_iter()

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 use tracing::{debug, warn};
 
 /// A registered adapter with its metadata.
@@ -16,6 +16,32 @@ pub struct RegisteredAdapter {
     pub last_activity: Option<Instant>,
     pub disabled: bool,
     pub disabled_tools: HashSet<String>,
+    /// Per-adapter cache of the most recent successful `list_tools()` result.
+    /// Purely event-driven (no TTL); cleared by registry invalidation methods
+    /// or when the adapter is swapped/restarted.
+    pub(crate) tool_cache: RwLock<Option<Vec<ToolInfo>>>,
+    /// Coalesces concurrent cache misses so only one `list_tools()` call is
+    /// in-flight per adapter at a time.
+    pub(crate) tool_cache_populate_lock: Mutex<()>,
+}
+
+impl RegisteredAdapter {
+    /// List tools using the per-adapter cache. On a hit, returns a clone of the
+    /// cached vector without calling the underlying adapter. On a miss, takes
+    /// the populate lock, re-checks the cache (in case another waiter already
+    /// populated it), then calls `adapter.list_tools()` and stores the result.
+    pub async fn cached_list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
+        if let Some(cached) = self.tool_cache.read().await.as_ref() {
+            return Ok(cached.clone());
+        }
+        let _populate = self.tool_cache_populate_lock.lock().await;
+        if let Some(cached) = self.tool_cache.read().await.as_ref() {
+            return Ok(cached.clone());
+        }
+        let tools = self.adapter.list_tools().await?;
+        *self.tool_cache.write().await = Some(tools.clone());
+        Ok(tools)
+    }
 }
 
 /// Cached catalog type: `(tool_list, reverse_lookup_map)`.
@@ -69,6 +95,8 @@ impl AdapterRegistry {
                 last_activity: None,
                 disabled: false,
                 disabled_tools: HashSet::new(),
+                tool_cache: RwLock::new(None),
+                tool_cache_populate_lock: Mutex::new(()),
             },
         );
         self.invalidate_catalog_cache().await;
@@ -85,10 +113,39 @@ impl AdapterRegistry {
 
     /// Invalidate the cached catalog so the next read rebuilds it, and bump
     /// the catalog generation counter so downstream caches (e.g. search
-    /// index) can detect the change.
+    /// index) can detect the change. Also clears every per-endpoint tools
+    /// cache so existing callers don't regress when the underlying adapters
+    /// might have changed.
     pub async fn invalidate_catalog_cache(&self) {
+        self.invalidate_all_tool_caches().await;
         *self.catalog_cache.write().await = None;
         self.catalog_generation.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Invalidate the per-endpoint tools cache for a single adapter, clear
+    /// the merged catalog cache, and bump the catalog generation counter.
+    /// Used when an adapter is swapped in place (e.g. background init,
+    /// restart) so the next read fetches fresh tools from the new adapter.
+    pub async fn invalidate_endpoint_tool_cache(&self, name: &str) {
+        {
+            let entries = self.adapters.read().await;
+            if let Some(entry) = entries.get(name) {
+                *entry.tool_cache.write().await = None;
+            }
+        }
+        *self.catalog_cache.write().await = None;
+        self.catalog_generation.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Clear every per-endpoint tools cache without touching the merged
+    /// catalog cache or the generation counter. Used internally by
+    /// [`invalidate_catalog_cache`] and available to callers that want a
+    /// surgical sweep across all adapters.
+    pub async fn invalidate_all_tool_caches(&self) {
+        let entries = self.adapters.read().await;
+        for entry in entries.values() {
+            *entry.tool_cache.write().await = None;
+        }
     }
 
     /// Return the current catalog generation. Starts at 0; incremented on
@@ -189,7 +246,7 @@ impl AdapterRegistry {
                 entry.tool_prefix.clone()
             };
 
-            match entry.adapter.list_tools().await {
+            match entry.cached_list_tools().await {
                 Ok(tools) => {
                     for tool in tools {
                         if entry.disabled_tools.contains(&tool.name) {
@@ -1203,6 +1260,8 @@ mod tests {
                     last_activity: None,
                     disabled: false,
                     disabled_tools: HashSet::new(),
+                    tool_cache: RwLock::new(None),
+                    tool_cache_populate_lock: Mutex::new(()),
                 },
             );
         }
@@ -1214,5 +1273,332 @@ mod tests {
         let catalog = registry.merged_catalog().await;
         assert_eq!(catalog.len(), 1);
         assert_eq!(catalog[0].name, "surprise");
+    }
+
+    // --- Per-adapter tools cache (T1) ---
+
+    /// Mock adapter that records the number of `list_tools` invocations.
+    struct CountingAdapter {
+        tools: Vec<ToolInfo>,
+        calls: Arc<std::sync::atomic::AtomicUsize>,
+        delay: Option<std::time::Duration>,
+    }
+
+    impl CountingAdapter {
+        fn new(tools: Vec<ToolInfo>) -> (Self, Arc<std::sync::atomic::AtomicUsize>) {
+            let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+            (
+                Self {
+                    tools,
+                    calls: calls.clone(),
+                    delay: None,
+                },
+                calls,
+            )
+        }
+
+        fn with_delay(mut self, delay: std::time::Duration) -> Self {
+            self.delay = Some(delay);
+            self
+        }
+    }
+
+    #[async_trait]
+    impl McpAdapter for CountingAdapter {
+        async fn initialize(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+        async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            if let Some(d) = self.delay {
+                tokio::time::sleep(d).await;
+            }
+            Ok(self.tools.clone())
+        }
+        async fn call_tool(
+            &self,
+            _name: &str,
+            _arguments: serde_json::Value,
+        ) -> Result<serde_json::Value, AdapterError> {
+            Ok(json!({}))
+        }
+        fn health(&self) -> HealthStatus {
+            HealthStatus::Healthy
+        }
+        async fn shutdown(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cached_list_tools_hit_does_not_call_adapter() {
+        let registry = AdapterRegistry::new();
+        let (adapter, calls) = CountingAdapter::new(vec![make_tool("a"), make_tool("b")]);
+        registry
+            .register(
+                "ep".into(),
+                Box::new(adapter),
+                "stdio".into(),
+                None,
+                Some("ep".into()),
+            )
+            .await;
+
+        let entries = registry.entries().read().await;
+        let entry = entries.get("ep").unwrap();
+        let first = entry.cached_list_tools().await.unwrap();
+        let second = entry.cached_list_tools().await.unwrap();
+        assert_eq!(first.len(), 2);
+        assert_eq!(second.len(), 2);
+        assert_eq!(
+            calls.load(Ordering::Relaxed),
+            1,
+            "second cached_list_tools call should hit the cache"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cached_list_tools_populates_once_under_concurrency() {
+        let registry = AdapterRegistry::new();
+        let (adapter, calls) = CountingAdapter::new(vec![make_tool("a")]);
+        let adapter = adapter.with_delay(std::time::Duration::from_millis(50));
+        registry
+            .register(
+                "ep".into(),
+                Box::new(adapter),
+                "stdio".into(),
+                None,
+                Some("ep".into()),
+            )
+            .await;
+
+        let registry = Arc::new(registry);
+        let mut handles = Vec::new();
+        for _ in 0..10 {
+            let reg = registry.clone();
+            handles.push(tokio::spawn(async move {
+                let entries = reg.entries().read().await;
+                let entry = entries.get("ep").unwrap();
+                entry.cached_list_tools().await.unwrap()
+            }));
+        }
+        for h in handles {
+            let tools = h.await.unwrap();
+            assert_eq!(tools.len(), 1);
+        }
+        assert_eq!(
+            calls.load(Ordering::Relaxed),
+            1,
+            "concurrent cached_list_tools calls must coalesce into a single populate"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_invalidate_endpoint_tool_cache_clears_only_target() {
+        let registry = AdapterRegistry::new();
+        let (a1, calls1) = CountingAdapter::new(vec![make_tool("x")]);
+        let (a2, calls2) = CountingAdapter::new(vec![make_tool("y")]);
+        registry
+            .register(
+                "ep1".into(),
+                Box::new(a1),
+                "stdio".into(),
+                None,
+                Some("ep1".into()),
+            )
+            .await;
+        registry
+            .register(
+                "ep2".into(),
+                Box::new(a2),
+                "stdio".into(),
+                None,
+                Some("ep2".into()),
+            )
+            .await;
+
+        // Prime both caches.
+        {
+            let entries = registry.entries().read().await;
+            entries
+                .get("ep1")
+                .unwrap()
+                .cached_list_tools()
+                .await
+                .unwrap();
+            entries
+                .get("ep2")
+                .unwrap()
+                .cached_list_tools()
+                .await
+                .unwrap();
+        }
+        assert_eq!(calls1.load(Ordering::Relaxed), 1);
+        assert_eq!(calls2.load(Ordering::Relaxed), 1);
+
+        // Invalidate only ep1.
+        registry.invalidate_endpoint_tool_cache("ep1").await;
+
+        {
+            let entries = registry.entries().read().await;
+            entries
+                .get("ep1")
+                .unwrap()
+                .cached_list_tools()
+                .await
+                .unwrap();
+            entries
+                .get("ep2")
+                .unwrap()
+                .cached_list_tools()
+                .await
+                .unwrap();
+        }
+        assert_eq!(
+            calls1.load(Ordering::Relaxed),
+            2,
+            "ep1 cache should be invalidated and refetched"
+        );
+        assert_eq!(
+            calls2.load(Ordering::Relaxed),
+            1,
+            "ep2 cache should remain intact"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_invalidate_all_tool_caches_clears_every_entry() {
+        let registry = AdapterRegistry::new();
+        let (a1, calls1) = CountingAdapter::new(vec![make_tool("x")]);
+        let (a2, calls2) = CountingAdapter::new(vec![make_tool("y")]);
+        registry
+            .register(
+                "ep1".into(),
+                Box::new(a1),
+                "stdio".into(),
+                None,
+                Some("ep1".into()),
+            )
+            .await;
+        registry
+            .register(
+                "ep2".into(),
+                Box::new(a2),
+                "stdio".into(),
+                None,
+                Some("ep2".into()),
+            )
+            .await;
+
+        {
+            let entries = registry.entries().read().await;
+            entries
+                .get("ep1")
+                .unwrap()
+                .cached_list_tools()
+                .await
+                .unwrap();
+            entries
+                .get("ep2")
+                .unwrap()
+                .cached_list_tools()
+                .await
+                .unwrap();
+        }
+        registry.invalidate_all_tool_caches().await;
+        {
+            let entries = registry.entries().read().await;
+            entries
+                .get("ep1")
+                .unwrap()
+                .cached_list_tools()
+                .await
+                .unwrap();
+            entries
+                .get("ep2")
+                .unwrap()
+                .cached_list_tools()
+                .await
+                .unwrap();
+        }
+        assert_eq!(calls1.load(Ordering::Relaxed), 2);
+        assert_eq!(calls2.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn test_invalidate_catalog_cache_clears_per_endpoint_caches() {
+        let registry = AdapterRegistry::new();
+        let (adapter, calls) = CountingAdapter::new(vec![make_tool("a")]);
+        registry
+            .register(
+                "ep".into(),
+                Box::new(adapter),
+                "stdio".into(),
+                None,
+                Some("ep".into()),
+            )
+            .await;
+
+        // First merged_catalog populates the per-endpoint cache.
+        let _ = registry.merged_catalog().await;
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+
+        // A second merged_catalog hits the catalog cache (no list_tools call).
+        let _ = registry.merged_catalog().await;
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+
+        // Global invalidation should clear the per-endpoint cache too,
+        // forcing a fresh list_tools on the next rebuild.
+        registry.invalidate_catalog_cache().await;
+        let _ = registry.merged_catalog().await;
+        assert_eq!(
+            calls.load(Ordering::Relaxed),
+            2,
+            "invalidate_catalog_cache must clear per-endpoint caches"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_invalidate_endpoint_tool_cache_bumps_generation_and_clears_catalog() {
+        let registry = AdapterRegistry::new();
+        let (adapter, _calls) = CountingAdapter::new(vec![make_tool("a")]);
+        registry
+            .register(
+                "ep".into(),
+                Box::new(adapter),
+                "stdio".into(),
+                None,
+                Some("ep".into()),
+            )
+            .await;
+
+        let _ = registry.merged_catalog().await;
+        let gen_before = registry.catalog_generation();
+        registry.invalidate_endpoint_tool_cache("ep").await;
+        assert!(registry.catalog_generation() > gen_before);
+        // catalog_cache should be cleared; merged_catalog rebuilds.
+        let catalog = registry.merged_catalog().await;
+        assert_eq!(catalog.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_invalidate_endpoint_tool_cache_unknown_name_is_noop() {
+        let registry = AdapterRegistry::new();
+        let (adapter, _calls) = CountingAdapter::new(vec![make_tool("a")]);
+        registry
+            .register(
+                "ep".into(),
+                Box::new(adapter),
+                "stdio".into(),
+                None,
+                Some("ep".into()),
+            )
+            .await;
+        // Should not panic and should still bump generation / clear catalog.
+        let gen_before = registry.catalog_generation();
+        registry
+            .invalidate_endpoint_tool_cache("does-not-exist")
+            .await;
+        assert!(registry.catalog_generation() > gen_before);
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -4,7 +4,8 @@ use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{broadcast, Mutex, RwLock};
+use tokio::task::AbortHandle;
 use tracing::{debug, warn};
 
 /// A registered adapter with its metadata.
@@ -23,6 +24,10 @@ pub struct RegisteredAdapter {
     /// Coalesces concurrent cache misses so only one `list_tools()` call is
     /// in-flight per adapter at a time.
     pub(crate) tool_cache_populate_lock: Mutex<()>,
+    /// Abort handle for the background task that listens to the adapter's
+    /// `subscribe_tools_changed` broadcast and triggers cache invalidation
+    /// on each tick. `None` when the adapter does not expose a receiver.
+    pub(crate) tools_changed_task: Option<AbortHandle>,
 }
 
 impl RegisteredAdapter {
@@ -85,7 +90,8 @@ impl AdapterRegistry {
         tool_prefix: Option<String>,
     ) {
         debug!(endpoint = %name, ?tool_prefix, "Registering adapter");
-        self.adapters.write().await.insert(
+        let listener_handle = self.spawn_tools_changed_listener(&name, adapter.as_ref());
+        let previous = self.adapters.write().await.insert(
             name,
             RegisteredAdapter {
                 adapter,
@@ -97,18 +103,100 @@ impl AdapterRegistry {
                 disabled_tools: HashSet::new(),
                 tool_cache: RwLock::new(None),
                 tool_cache_populate_lock: Mutex::new(()),
+                tools_changed_task: listener_handle,
             },
         );
+        if let Some(prev) = previous {
+            if let Some(handle) = prev.tools_changed_task {
+                handle.abort();
+            }
+        }
         self.invalidate_catalog_cache().await;
     }
 
     /// Remove an adapter by endpoint name.
     pub async fn remove(&self, name: &str) -> Option<RegisteredAdapter> {
         let result = self.adapters.write().await.remove(name);
-        if result.is_some() {
+        if let Some(entry) = &result {
+            if let Some(handle) = &entry.tools_changed_task {
+                handle.abort();
+            }
             self.invalidate_catalog_cache().await;
         }
         result
+    }
+
+    /// Subscribe to the adapter's tools-changed broadcast (if any) and spawn a
+    /// background task that invalidates the per-endpoint and catalog caches on
+    /// every tick. Returns the spawned task's [`AbortHandle`], or `None` if the
+    /// adapter does not expose a receiver.
+    fn spawn_tools_changed_listener(
+        &self,
+        name: &str,
+        adapter: &dyn McpAdapter,
+    ) -> Option<AbortHandle> {
+        let rx = adapter.subscribe_tools_changed()?;
+        let registry = self.clone();
+        let endpoint = name.to_string();
+        let task = tokio::spawn(async move {
+            Self::tools_changed_listener_loop(registry, endpoint, rx).await;
+        });
+        Some(task.abort_handle())
+    }
+
+    /// Listener loop driven by `subscribe_tools_changed`. Each successful tick
+    /// — as well as a `Lagged` error (treated as a missed-but-coalesced tick)
+    /// — invalidates the per-endpoint tools cache followed by the merged
+    /// catalog cache. A `Closed` receiver terminates the loop.
+    async fn tools_changed_listener_loop(
+        registry: Self,
+        endpoint: String,
+        mut rx: broadcast::Receiver<()>,
+    ) {
+        loop {
+            match rx.recv().await {
+                Ok(()) => {
+                    registry.invalidate_endpoint_tool_cache(&endpoint).await;
+                    registry.invalidate_catalog_cache().await;
+                }
+                Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                    debug!(
+                        endpoint = %endpoint,
+                        skipped,
+                        "tools-changed listener lagged; treating as tick"
+                    );
+                    registry.invalidate_endpoint_tool_cache(&endpoint).await;
+                    registry.invalidate_catalog_cache().await;
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    debug!(endpoint = %endpoint, "tools-changed listener channel closed");
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Abort any existing tools-changed listener for `name` and re-subscribe
+    /// against the adapter currently stored at that endpoint. Call this after
+    /// swapping `entry.adapter` in place (e.g. background init, restart). No-op
+    /// if `name` is not registered.
+    pub async fn rewire_tools_changed_listener(&self, name: &str) {
+        let new_handle = {
+            let entries = self.adapters.read().await;
+            match entries.get(name) {
+                Some(entry) => self.spawn_tools_changed_listener(name, entry.adapter.as_ref()),
+                None => return,
+            }
+        };
+        let mut entries = self.adapters.write().await;
+        if let Some(entry) = entries.get_mut(name) {
+            if let Some(old) = entry.tools_changed_task.take() {
+                old.abort();
+            }
+            entry.tools_changed_task = new_handle;
+        } else if let Some(handle) = new_handle {
+            handle.abort();
+        }
     }
 
     /// Invalidate the cached catalog so the next read rebuilds it, and bump
@@ -1262,6 +1350,7 @@ mod tests {
                     disabled_tools: HashSet::new(),
                     tool_cache: RwLock::new(None),
                     tool_cache_populate_lock: Mutex::new(()),
+                    tools_changed_task: None,
                 },
             );
         }
@@ -1600,5 +1689,269 @@ mod tests {
             .invalidate_endpoint_tool_cache("does-not-exist")
             .await;
         assert!(registry.catalog_generation() > gen_before);
+    }
+
+    // --- Tools-changed listener (T2) ---
+
+    /// Mock adapter exposing a `broadcast::Sender<()>` so tests can drive
+    /// `subscribe_tools_changed` ticks. Each `list_tools` invocation is
+    /// counted via the shared atomic.
+    struct NotifyingAdapter {
+        tools: Vec<ToolInfo>,
+        calls: Arc<std::sync::atomic::AtomicUsize>,
+        tx: broadcast::Sender<()>,
+    }
+
+    impl NotifyingAdapter {
+        fn new(
+            tools: Vec<ToolInfo>,
+            capacity: usize,
+        ) -> (
+            Self,
+            Arc<std::sync::atomic::AtomicUsize>,
+            broadcast::Sender<()>,
+        ) {
+            let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+            let (tx, _) = broadcast::channel(capacity);
+            (
+                Self {
+                    tools,
+                    calls: calls.clone(),
+                    tx: tx.clone(),
+                },
+                calls,
+                tx,
+            )
+        }
+    }
+
+    #[async_trait]
+    impl McpAdapter for NotifyingAdapter {
+        async fn initialize(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+        async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            Ok(self.tools.clone())
+        }
+        async fn call_tool(
+            &self,
+            _name: &str,
+            _arguments: serde_json::Value,
+        ) -> Result<serde_json::Value, AdapterError> {
+            Ok(json!({}))
+        }
+        fn health(&self) -> HealthStatus {
+            HealthStatus::Healthy
+        }
+        async fn shutdown(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+        fn subscribe_tools_changed(&self) -> Option<broadcast::Receiver<()>> {
+            Some(self.tx.subscribe())
+        }
+    }
+
+    /// Spin until `cond` returns true or the deadline elapses.
+    async fn await_until<F>(timeout: std::time::Duration, mut cond: F) -> bool
+    where
+        F: FnMut() -> bool,
+    {
+        let deadline = std::time::Instant::now() + timeout;
+        while std::time::Instant::now() < deadline {
+            if cond() {
+                return true;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        cond()
+    }
+
+    #[tokio::test]
+    async fn test_tools_changed_tick_invalidates_cache() {
+        let registry = AdapterRegistry::new();
+        let (adapter, calls, tx) = NotifyingAdapter::new(vec![make_tool("a")], 8);
+        registry
+            .register(
+                "ep".into(),
+                Box::new(adapter),
+                "stdio".into(),
+                None,
+                Some("ep".into()),
+            )
+            .await;
+
+        // Populate the per-endpoint cache (call #1).
+        {
+            let entries = registry.entries().read().await;
+            entries
+                .get("ep")
+                .unwrap()
+                .cached_list_tools()
+                .await
+                .unwrap();
+        }
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+
+        // Send a tick and wait for the listener to invalidate.
+        let gen_before = registry.catalog_generation();
+        tx.send(()).unwrap();
+        let observed = await_until(std::time::Duration::from_secs(1), || {
+            registry.catalog_generation() > gen_before
+        })
+        .await;
+        assert!(observed, "catalog generation should advance after tick");
+
+        // Next cached_list_tools should re-invoke the adapter (call #2).
+        {
+            let entries = registry.entries().read().await;
+            entries
+                .get("ep")
+                .unwrap()
+                .cached_list_tools()
+                .await
+                .unwrap();
+        }
+        assert_eq!(
+            calls.load(Ordering::Relaxed),
+            2,
+            "cache should have been cleared by the tools-changed tick"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_remove_aborts_listener_task() {
+        let registry = AdapterRegistry::new();
+        let (adapter, _calls, tx) = NotifyingAdapter::new(vec![make_tool("a")], 8);
+        registry
+            .register(
+                "ep".into(),
+                Box::new(adapter),
+                "stdio".into(),
+                None,
+                Some("ep".into()),
+            )
+            .await;
+
+        // Sender should observe one receiver (the listener task).
+        assert_eq!(tx.receiver_count(), 1);
+
+        let removed = registry.remove("ep").await;
+        assert!(removed.is_some());
+
+        // After remove + abort, the listener task drops its receiver.
+        let dropped = await_until(std::time::Duration::from_secs(1), || {
+            tx.receiver_count() == 0
+        })
+        .await;
+        assert!(
+            dropped,
+            "listener receiver should be dropped after remove()"
+        );
+
+        // Sending after remove must not panic and must not affect the registry.
+        let gen_before = registry.catalog_generation();
+        // No active receivers → send returns Err, which we deliberately ignore.
+        let _ = tx.send(());
+        // Give any (lingering) tasks a chance to run.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert_eq!(
+            registry.catalog_generation(),
+            gen_before,
+            "no listener should remain to bump the generation"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_watcher_swap_rewires_listener() {
+        let registry = AdapterRegistry::new();
+        let (a1, _calls1, tx_old) = NotifyingAdapter::new(vec![make_tool("old")], 8);
+        registry
+            .register(
+                "ep".into(),
+                Box::new(a1),
+                "stdio".into(),
+                None,
+                Some("ep".into()),
+            )
+            .await;
+        assert_eq!(tx_old.receiver_count(), 1);
+
+        // Simulate the watcher swap: replace adapter in place, then rewire.
+        let (a2, _calls2, tx_new) = NotifyingAdapter::new(vec![make_tool("new")], 8);
+        {
+            let mut entries = registry.entries().write().await;
+            entries.get_mut("ep").unwrap().adapter = Box::new(a2);
+        }
+        registry.rewire_tools_changed_listener("ep").await;
+
+        // Old sender's listener must be torn down; new sender must have one.
+        let old_dropped = await_until(std::time::Duration::from_secs(1), || {
+            tx_old.receiver_count() == 0
+        })
+        .await;
+        assert!(old_dropped, "old listener should be aborted on swap");
+        assert_eq!(tx_new.receiver_count(), 1);
+
+        // Tick on the OLD sender must NOT bump the registry.
+        let gen_before = registry.catalog_generation();
+        let _ = tx_old.send(());
+        tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+        assert_eq!(
+            registry.catalog_generation(),
+            gen_before,
+            "old sender ticks must be ignored after swap"
+        );
+
+        // Tick on the NEW sender must bump the registry.
+        tx_new.send(()).unwrap();
+        let observed = await_until(std::time::Duration::from_secs(1), || {
+            registry.catalog_generation() > gen_before
+        })
+        .await;
+        assert!(observed, "new sender ticks must drive invalidation");
+    }
+
+    #[tokio::test]
+    async fn test_tools_changed_lagged_invalidates() {
+        let registry = AdapterRegistry::new();
+        // Capacity = 1: any burst beyond a single buffered message forces
+        // `Lagged` on the next `recv()` after the listener drains.
+        let (adapter, _calls, tx) = NotifyingAdapter::new(vec![make_tool("a")], 1);
+        registry
+            .register(
+                "ep".into(),
+                Box::new(adapter),
+                "stdio".into(),
+                None,
+                Some("ep".into()),
+            )
+            .await;
+
+        // Drive one Ok tick first so the listener is back at `recv()` with
+        // an empty buffer. Catalog generation bumps twice per tick (per-endpoint
+        // cache + catalog cache).
+        tx.send(()).unwrap();
+        let _ = await_until(std::time::Duration::from_secs(1), || {
+            registry.catalog_generation() >= 3
+        })
+        .await;
+        let gen_after_first = registry.catalog_generation();
+
+        // Now send a burst that overruns capacity. The listener will observe
+        // exactly one `Lagged` on its next `recv()`, which must still trigger
+        // an invalidation per the spec.
+        for _ in 0..5 {
+            let _ = tx.send(());
+        }
+
+        let observed = await_until(std::time::Duration::from_secs(1), || {
+            registry.catalog_generation() > gen_after_first
+        })
+        .await;
+        assert!(
+            observed,
+            "Lagged ticks must still trigger cache invalidation"
+        );
     }
 }

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -231,7 +231,7 @@ pub async fn apply_diff(
                 }
             }
             drop(entries);
-            reg.invalidate_catalog_cache().await;
+            reg.invalidate_endpoint_tool_cache(&name_clone).await;
             info!(endpoint = %name_clone, "Changed endpoint initialized");
         });
     }
@@ -273,7 +273,7 @@ pub async fn apply_diff(
                 }
             }
             drop(entries);
-            reg.invalidate_catalog_cache().await;
+            reg.invalidate_endpoint_tool_cache(&ep_clone.name).await;
             info!(endpoint = %ep_clone.name, "New endpoint initialized");
         });
     }
@@ -396,7 +396,7 @@ pub async fn apply_diff_graceful(
                 }
             }
             drop(entries);
-            reg.invalidate_catalog_cache().await;
+            reg.invalidate_endpoint_tool_cache(&name_clone).await;
             info!(endpoint = %name_clone, "Changed endpoint initialized");
         });
     }
@@ -462,7 +462,7 @@ pub async fn apply_diff_graceful(
                 }
             }
             drop(entries);
-            reg.invalidate_catalog_cache().await;
+            reg.invalidate_endpoint_tool_cache(&ep_clone.name).await;
             info!(endpoint = %ep_clone.name, "New endpoint initialized");
         });
     }

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -564,7 +564,7 @@ mod tests {
     use async_trait::async_trait;
     use serde_json::json;
     use std::collections::HashMap;
-    use tokio::sync::RwLock;
+    use tokio::sync::{broadcast, RwLock};
 
     /// A mock adapter that tracks whether shutdown was called.
     struct MockAdapter {
@@ -611,12 +611,73 @@ mod tests {
         }
     }
 
+    /// Mock adapter that exposes a tools-changed broadcast receiver. Used to
+    /// verify that registry rewires its listener against the *new* adapter
+    /// after an in-place swap.
+    struct NotifyingMockAdapter {
+        tools: Vec<ToolInfo>,
+        tx: broadcast::Sender<()>,
+    }
+
+    impl NotifyingMockAdapter {
+        fn new(tools: Vec<ToolInfo>, tx: broadcast::Sender<()>) -> Self {
+            Self { tools, tx }
+        }
+    }
+
+    #[async_trait]
+    impl McpAdapter for NotifyingMockAdapter {
+        async fn initialize(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+        async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
+            Ok(self.tools.clone())
+        }
+        async fn call_tool(
+            &self,
+            _name: &str,
+            _arguments: serde_json::Value,
+        ) -> Result<serde_json::Value, AdapterError> {
+            Ok(json!({}))
+        }
+        fn health(&self) -> HealthStatus {
+            HealthStatus::Healthy
+        }
+        async fn shutdown(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+        fn subscribe_tools_changed(&self) -> Option<broadcast::Receiver<()>> {
+            Some(self.tx.subscribe())
+        }
+    }
+
     fn make_tool(name: &str) -> ToolInfo {
         ToolInfo {
             name: name.to_string(),
             description: Some(format!("{} tool", name)),
             input_schema: json!({"type": "object"}),
             annotations: None,
+        }
+    }
+
+    fn endpoint_with_bad_command(name: &str) -> EndpointConfig {
+        EndpointConfig {
+            name: name.to_string(),
+            description: None,
+            tool_prefix: None,
+            transport: Transport::Stdio,
+            command: Some("/nonexistent/binary/that/wont/start".to_string()),
+            args: None,
+            url: None,
+            env: None,
+            headers: None,
+            disabled: false,
+            disabled_tools: Vec::new(),
+            oauth_server_url: None,
+            client_id: None,
+            client_secret: None,
+            scopes: None,
+            token_endpoint: None,
         }
     }
 
@@ -902,6 +963,224 @@ mod tests {
         assert!(
             inner_map.contains_key("oauth_ep"),
             "Inner should be registered for oauth_ep"
+        );
+    }
+
+    // ---- G1: apply_diff_graceful direct coverage ------------------------
+
+    #[tokio::test]
+    async fn apply_diff_graceful_no_warnings_added_initializes_in_background() {
+        // Drives apply_diff_graceful's added-endpoint branch with no warnings:
+        // create_adapter fails fast (bad command) so the spawn replaces the
+        // StartingAdapter with a FailedAdapter and runs rewire+invalidate.
+        let registry = Arc::new(AdapterRegistry::new());
+        let (tm, inners) = test_oauth_infra();
+        let new_ep = endpoint_with_bad_command("bad_added");
+        let diff = ConfigDiff {
+            added: vec![new_ep],
+            ..empty_diff()
+        };
+
+        apply_diff_graceful(&diff, &registry, &[], &Default::default(), &tm, &inners).await;
+
+        // Wait for the background spawn to swap StartingAdapter for the
+        // (Failed) adapter produced by create_adapter.
+        let stop = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            let entries = registry.entries().read().await;
+            if let Some(entry) = entries.get("bad_added") {
+                if !matches!(entry.adapter.health(), HealthStatus::Starting) {
+                    break;
+                }
+            }
+            drop(entries);
+            if std::time::Instant::now() >= stop {
+                panic!("background init never replaced StartingAdapter");
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        let entries = registry.entries().read().await;
+        let entry = entries.get("bad_added").expect("bad_added registered");
+        assert!(matches!(entry.adapter.health(), HealthStatus::Unhealthy(_)));
+        // create_adapter failure path => empty cache, so invalidate ran cleanly.
+        assert!(entry.tool_cache.read().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn apply_diff_graceful_added_warned_endpoint_registers_failed_adapter() {
+        // Warned added endpoints must be registered as FailedAdapter immediately
+        // (no background init, no create_adapter call).
+        let registry = Arc::new(AdapterRegistry::new());
+        let (tm, inners) = test_oauth_infra();
+
+        let mut new_ep = endpoint_with_bad_command("warned_added");
+        new_ep.disabled_tools = vec!["x".to_string()];
+        let diff = ConfigDiff {
+            added: vec![new_ep],
+            ..empty_diff()
+        };
+        let warnings = vec![config::EndpointValidationWarning {
+            endpoint_name: "warned_added".to_string(),
+            message: "bogus command".to_string(),
+        }];
+        let warned: std::collections::HashSet<String> =
+            warnings.iter().map(|w| w.endpoint_name.clone()).collect();
+
+        apply_diff_graceful(&diff, &registry, &warnings, &warned, &tm, &inners).await;
+
+        // No background spawn for warned endpoints — entry is final immediately.
+        let entries = registry.entries().read().await;
+        let entry = entries
+            .get("warned_added")
+            .expect("warned_added registered");
+        match entry.adapter.health() {
+            HealthStatus::Unhealthy(msg) => assert!(msg.contains("bogus command")),
+            other => panic!("expected Unhealthy with warning message, got {:?}", other),
+        }
+        // disabled_tools preserved from the new endpoint config
+        assert!(entry.disabled_tools.contains("x"));
+    }
+
+    #[tokio::test]
+    async fn apply_diff_graceful_changed_warned_endpoint_registers_failed_adapter() {
+        // Warned changed endpoints must shut down old adapter and register a
+        // FailedAdapter immediately (no background init), preserving prior
+        // disabled/disabled_tools state.
+        let registry = Arc::new(AdapterRegistry::new());
+        let (tm, inners) = test_oauth_infra();
+        let shutdown = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        registry
+            .register(
+                "ep".into(),
+                Box::new(MockAdapter::healthy(vec![make_tool("t")], shutdown.clone())),
+                "stdio".into(),
+                None,
+                Some("ep".into()),
+            )
+            .await;
+        // Mark prior disabled state to verify it carries through the swap.
+        {
+            let mut entries = registry.entries().write().await;
+            let entry = entries.get_mut("ep").unwrap();
+            entry.disabled_tools.insert("preexisting".to_string());
+        }
+
+        let changed_ep = endpoint_with_bad_command("ep");
+        let diff = ConfigDiff {
+            changed: vec![("ep".to_string(), changed_ep)],
+            ..empty_diff()
+        };
+        let warnings = vec![config::EndpointValidationWarning {
+            endpoint_name: "ep".to_string(),
+            message: "validation failed".to_string(),
+        }];
+        let warned: std::collections::HashSet<String> = ["ep".to_string()].into_iter().collect();
+
+        apply_diff_graceful(&diff, &registry, &warnings, &warned, &tm, &inners).await;
+
+        // Old adapter shut down synchronously.
+        assert!(shutdown.load(std::sync::atomic::Ordering::SeqCst));
+        let entries = registry.entries().read().await;
+        let entry = entries.get("ep").expect("ep still registered");
+        match entry.adapter.health() {
+            HealthStatus::Unhealthy(msg) => assert!(msg.contains("validation failed")),
+            other => panic!("expected Unhealthy with warning, got {:?}", other),
+        }
+        // Prior disabled_tools must be preserved across the warning swap.
+        assert!(entry.disabled_tools.contains("preexisting"));
+    }
+
+    // ---- G2: registry rewires tools-changed listener after swap --------
+
+    #[tokio::test]
+    async fn registry_swap_rewires_tools_changed_listener() {
+        // Mirrors apply_diff_graceful's spawn block: in-place swap of
+        // entry.adapter, followed by rewire_tools_changed_listener +
+        // invalidate_endpoint_tool_cache. After the swap, ticks on the NEW
+        // adapter's sender must invalidate the per-endpoint cache; ticks on
+        // the OLD adapter's sender must be ignored (its forwarder was aborted
+        // and the only subscriber was dropped).
+        let registry = Arc::new(AdapterRegistry::new());
+        let (tx_old, _) = broadcast::channel::<()>(16);
+        let (tx_new, _) = broadcast::channel::<()>(16);
+
+        registry
+            .register(
+                "ep".into(),
+                Box::new(NotifyingMockAdapter::new(
+                    vec![make_tool("old_tool")],
+                    tx_old.clone(),
+                )),
+                "stdio".into(),
+                None,
+                Some("ep".into()),
+            )
+            .await;
+
+        // Prime the per-endpoint cache so we can later detect invalidation.
+        let _ = registry.merged_catalog().await;
+        {
+            let entries = registry.entries().read().await;
+            let entry = entries.get("ep").unwrap();
+            assert!(
+                entry.tool_cache.read().await.is_some(),
+                "cache should be primed before swap"
+            );
+        }
+
+        // Simulate apply_diff_graceful's in-place swap + rewire + invalidate.
+        {
+            let mut entries = registry.entries().write().await;
+            let entry = entries.get_mut("ep").unwrap();
+            entry.adapter = Box::new(NotifyingMockAdapter::new(
+                vec![make_tool("new_tool")],
+                tx_new.clone(),
+            ));
+        }
+        registry.rewire_tools_changed_listener("ep").await;
+        registry.invalidate_endpoint_tool_cache("ep").await;
+
+        // Re-prime the cache so the next tick has something to invalidate.
+        let _ = registry.merged_catalog().await;
+        {
+            let entries = registry.entries().read().await;
+            let entry = entries.get("ep").unwrap();
+            assert!(
+                entry.tool_cache.read().await.is_some(),
+                "cache should be re-primed after swap"
+            );
+        }
+
+        // Tick on NEW sender must propagate to the listener and clear cache.
+        tx_new.send(()).expect("new send");
+        let stop = std::time::Instant::now() + std::time::Duration::from_secs(1);
+        let mut cleared = false;
+        while std::time::Instant::now() < stop {
+            let entries = registry.entries().read().await;
+            let entry = entries.get("ep").unwrap();
+            if entry.tool_cache.read().await.is_none() {
+                cleared = true;
+                break;
+            }
+            drop(entries);
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(
+            cleared,
+            "listener was not rewired against the new adapter's sender"
+        );
+
+        // Re-prime once more, then fire on the OLD sender. The OLD listener
+        // was aborted by rewire_tools_changed_listener; the per-endpoint
+        // cache must remain intact.
+        let _ = registry.merged_catalog().await;
+        let _ = tx_old.send(()); // may be Err(_) if no subscribers — that's fine
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        let entries = registry.entries().read().await;
+        let entry = entries.get("ep").unwrap();
+        assert!(
+            entry.tool_cache.read().await.is_some(),
+            "old adapter's sender must NOT invalidate the cache after rewire"
         );
     }
 }

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -231,6 +231,7 @@ pub async fn apply_diff(
                 }
             }
             drop(entries);
+            reg.rewire_tools_changed_listener(&name_clone).await;
             reg.invalidate_endpoint_tool_cache(&name_clone).await;
             info!(endpoint = %name_clone, "Changed endpoint initialized");
         });
@@ -273,6 +274,7 @@ pub async fn apply_diff(
                 }
             }
             drop(entries);
+            reg.rewire_tools_changed_listener(&ep_clone.name).await;
             reg.invalidate_endpoint_tool_cache(&ep_clone.name).await;
             info!(endpoint = %ep_clone.name, "New endpoint initialized");
         });
@@ -396,6 +398,7 @@ pub async fn apply_diff_graceful(
                 }
             }
             drop(entries);
+            reg.rewire_tools_changed_listener(&name_clone).await;
             reg.invalidate_endpoint_tool_cache(&name_clone).await;
             info!(endpoint = %name_clone, "Changed endpoint initialized");
         });
@@ -462,6 +465,7 @@ pub async fn apply_diff_graceful(
                 }
             }
             drop(entries);
+            reg.rewire_tools_changed_listener(&ep_clone.name).await;
             reg.invalidate_endpoint_tool_cache(&ep_clone.name).await;
             info!(endpoint = %ep_clone.name, "New endpoint initialized");
         });

--- a/tests/fixtures/sse_server.rs
+++ b/tests/fixtures/sse_server.rs
@@ -109,6 +109,17 @@ async fn handle_message(State(state): State<AppState>, Json(body): Json<Value>) 
     Json(response)
 }
 
+/// Test-only admin endpoint: broadcast a `notifications/tools/list_changed`
+/// JSON-RPC notification (no `id`) to all connected SSE clients.
+async fn handle_notify_list_changed(State(state): State<AppState>) -> Json<Value> {
+    let notif = json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/tools/list_changed"
+    });
+    let _ = state.tx.send((0, notif));
+    Json(json!({"ok": true}))
+}
+
 #[tokio::main]
 async fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -132,6 +143,7 @@ async fn main() {
     let app = Router::new()
         .route("/sse", get(handle_sse))
         .route("/message", post(handle_message))
+        .route("/notify-list-changed", post(handle_notify_list_changed))
         .with_state(state);
 
     let listener = TcpListener::bind(format!("127.0.0.1:{}", port))

--- a/tests/fixtures/swap_notify_server.rs
+++ b/tests/fixtures/swap_notify_server.rs
@@ -1,0 +1,168 @@
+//! Test fixture: stdio MCP server that supports tool-list swapping with
+//! `notifications/tools/list_changed`, plus a writable `tools/list` call
+//! counter for cache-behaviour assertions.
+//!
+//! Behaviour:
+//! - On startup, advertises tools `swap_tools` and `get_status`.
+//! - On `tools/call swap_tools`: flips internal state to "swapped",
+//!   appends a `notifications/tools/list_changed` line to stdout *before*
+//!   the tool-call response, then returns a small text result.
+//! - After the swap, `tools/list` returns three tools (the original two
+//!   plus `extra_tool_after_swap`).
+//! - Every `tools/list` increments a persistent counter stored at the path
+//!   given by the env var `FIXTURE_LIST_COUNT_FILE` (when set). The counter
+//!   is seeded from the file on startup so it survives process restarts —
+//!   integration tests that disable/enable the endpoint can keep using a
+//!   single monotonic counter for assertions.
+//!
+//! Usage: `fixture-swap-notify-server`
+
+use serde_json::{json, Value};
+use std::io::{self, BufRead, Write};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+fn initial_tools() -> Value {
+    json!([
+        {"name": "swap_tools",
+         "description": "Trigger a tool-list swap and emit list_changed",
+         "inputSchema": {"type": "object", "properties": {}}},
+        {"name": "get_status",
+         "description": "Returns whether the swap has happened",
+         "inputSchema": {"type": "object", "properties": {}}}
+    ])
+}
+
+fn swapped_tools() -> Value {
+    json!([
+        {"name": "swap_tools",
+         "description": "Trigger a tool-list swap and emit list_changed",
+         "inputSchema": {"type": "object", "properties": {}}},
+        {"name": "get_status",
+         "description": "Returns whether the swap has happened",
+         "inputSchema": {"type": "object", "properties": {}}},
+        {"name": "extra_tool_after_swap",
+         "description": "Tool that only appears after swap_tools is invoked",
+         "inputSchema": {"type": "object", "properties": {}}}
+    ])
+}
+
+fn write_count(path: &Option<String>, value: u64) {
+    if let Some(p) = path {
+        let _ = std::fs::write(p, value.to_string());
+    }
+}
+
+fn main() {
+    eprintln!("swap-notify-server: starting");
+    let count_file = std::env::var("FIXTURE_LIST_COUNT_FILE").ok();
+    // Seed the counter from the file (if any) so disable→enable restarts
+    // observe a single monotonic counter across the whole test.
+    let initial_count: u64 = count_file
+        .as_deref()
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .and_then(|s| s.trim().parse().ok())
+        .unwrap_or(0);
+    let list_count = AtomicU64::new(initial_count);
+    let swapped = AtomicBool::new(false);
+
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+
+    for line in stdin.lock().lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => break,
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let request: Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("parse error: {}", e);
+                continue;
+            }
+        };
+        let method = request["method"].as_str().unwrap_or("");
+        let id = &request["id"];
+
+        let response: Option<Value> = match method {
+            "initialize" => Some(json!({
+                "jsonrpc": "2.0",
+                "result": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {"listChanged": true}},
+                    "serverInfo": {"name": "swap-notify-mcp", "version": "0.1.0"}
+                },
+                "id": id
+            })),
+            "tools/list" => {
+                let new_count = list_count.fetch_add(1, Ordering::SeqCst) + 1;
+                write_count(&count_file, new_count);
+                let tools = if swapped.load(Ordering::SeqCst) {
+                    swapped_tools()
+                } else {
+                    initial_tools()
+                };
+                Some(json!({
+                    "jsonrpc": "2.0",
+                    "result": {"tools": tools},
+                    "id": id
+                }))
+            }
+            "tools/call" => {
+                let p = &request["params"];
+                let name = p["name"].as_str().unwrap_or("");
+                let text = match name {
+                    "swap_tools" => {
+                        swapped.store(true, Ordering::SeqCst);
+                        // Emit list_changed BEFORE returning the call response so
+                        // the relay observes the notification first.
+                        let mut out = stdout.lock();
+                        let notif = json!({
+                            "jsonrpc": "2.0",
+                            "method": "notifications/tools/list_changed"
+                        });
+                        serde_json::to_writer(&mut out, &notif).unwrap();
+                        out.write_all(b"\n").unwrap();
+                        out.flush().unwrap();
+                        drop(out);
+                        "swap triggered".to_string()
+                    }
+                    "get_status" => {
+                        if swapped.load(Ordering::SeqCst) {
+                            "swapped".to_string()
+                        } else {
+                            "initial".to_string()
+                        }
+                    }
+                    "extra_tool_after_swap" => "extra".to_string(),
+                    other => format!("unknown tool: {}", other),
+                };
+                Some(json!({
+                    "jsonrpc": "2.0",
+                    "result": {"content": [{"type": "text", "text": text}]},
+                    "id": id
+                }))
+            }
+            _ => {
+                if id.is_null() {
+                    None
+                } else {
+                    Some(json!({
+                        "jsonrpc": "2.0",
+                        "error": {"code": -32601, "message": "Method not found"},
+                        "id": id
+                    }))
+                }
+            }
+        };
+
+        if let Some(response) = response {
+            let mut out = stdout.lock();
+            serde_json::to_writer(&mut out, &response).unwrap();
+            out.write_all(b"\n").unwrap();
+            out.flush().unwrap();
+        }
+    }
+}

--- a/tests/sse_adapter_integration.rs
+++ b/tests/sse_adapter_integration.rs
@@ -92,6 +92,83 @@ async fn test_sse_adapter_full_lifecycle() {
 }
 
 #[tokio::test]
+async fn test_sse_adapter_emits_tick_on_list_changed() {
+    let (mut child, port) = start_sse_server().await;
+    let url = format!("http://127.0.0.1:{}/sse", port);
+
+    let mut adapter = SseAdapter::new(SseConfig::new(&url));
+    let mut rx = adapter
+        .subscribe_tools_changed()
+        .expect("SSE adapter should expose tools-changed receiver");
+
+    timeout(Duration::from_secs(10), adapter.initialize())
+        .await
+        .expect("initialize timed out")
+        .expect("initialize failed");
+
+    // Drain the post-handshake tick so subsequent recv() reflects only the
+    // notification.
+    timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("expected post-handshake tick within 2s")
+        .expect("post-handshake tick recv failed");
+
+    // Trigger the fixture to broadcast a notifications/tools/list_changed frame.
+    let notify_url = format!("http://127.0.0.1:{}/notify-list-changed", port);
+    reqwest::Client::new()
+        .post(&notify_url)
+        .send()
+        .await
+        .expect("failed to POST /notify-list-changed");
+
+    timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("expected list_changed tick within 5s")
+        .expect("list_changed tick recv failed");
+
+    adapter.shutdown().await.ok();
+    child.kill().await.ok();
+}
+
+#[tokio::test]
+async fn test_sse_adapter_reconnect_emits_tick() {
+    let (mut child, port) = start_sse_server().await;
+    let url = format!("http://127.0.0.1:{}/sse", port);
+
+    let mut adapter = SseAdapter::new(SseConfig::new(&url));
+    let mut rx = adapter
+        .subscribe_tools_changed()
+        .expect("SSE adapter should expose tools-changed receiver");
+
+    timeout(Duration::from_secs(10), adapter.initialize())
+        .await
+        .expect("initialize timed out")
+        .expect("initialize failed");
+
+    // Drain the first post-handshake tick.
+    timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("expected first post-handshake tick within 2s")
+        .expect("first tick recv failed");
+
+    // Simulate a disconnect + reconnect by tearing down the SSE listener and
+    // re-running the handshake against the same fixture.
+    adapter.shutdown().await.expect("shutdown failed");
+    timeout(Duration::from_secs(10), adapter.initialize())
+        .await
+        .expect("re-initialize timed out")
+        .expect("re-initialize failed");
+
+    timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("expected post-reconnect tick within 5s")
+        .expect("post-reconnect tick recv failed");
+
+    adapter.shutdown().await.ok();
+    child.kill().await.ok();
+}
+
+#[tokio::test]
 async fn test_sse_adapter_server_death_detection() {
     let (mut child, port) = start_sse_server().await;
     let url = format!("http://127.0.0.1:{}/sse", port);

--- a/tests/tools_cache_e2e_integration.rs
+++ b/tests/tools_cache_e2e_integration.rs
@@ -192,3 +192,218 @@ async fn test_per_adapter_tools_cache_end_to_end() {
          (before={count_after_lifecycle}, after={final_count})"
     );
 }
+
+/// G4 — `/api/endpoints/:name/refresh` cache-invalidation behaviour.
+///
+/// Strengthens the existing `management_refresh_endpoint` unit test (which
+/// only inspects the response string) by asserting the upstream call counter
+/// behaves as the per-adapter cache invariants require:
+///   1. Two consecutive GETs hit the cache: counter == 1.
+///   2. POST refresh evicts the cache and re-primes it: counter == 2.
+///   3. A subsequent GET stays a cache hit: counter == 2.
+#[tokio::test]
+async fn test_refresh_endpoint_invalidates_per_endpoint_cache() {
+    let count_file = NamedTempFile::new().expect("create count file");
+    let count_path = count_file.path().to_path_buf();
+    let count_path_str = count_path.to_str().unwrap().to_string();
+
+    let fixture_bin = env!("CARGO_BIN_EXE_fixture-swap-notify-server");
+    let config = ConfigBuilder::new()
+        .add_stdio_with_env(
+            "swapper",
+            fixture_bin,
+            &[],
+            &[("FIXTURE_LIST_COUNT_FILE", count_path_str.as_str())],
+        )
+        .build();
+
+    let harness = RelayHarness::start(&config).await;
+    harness
+        .wait_healthy("swapper", Duration::from_secs(15))
+        .await
+        .expect("swapper endpoint did not become healthy");
+
+    let client = reqwest::Client::new();
+    let base = harness.base_url();
+    let tools_url = format!("{}/api/endpoints/swapper/tools", base);
+    let refresh_url = format!("{}/api/endpoints/swapper/refresh", base);
+
+    // 1. First GET primes the cache → upstream count = 1.
+    let _ = fetch_tool_names(&client, &tools_url).await;
+    assert!(
+        poll_until(Duration::from_secs(2), || read_count(&count_path) >= 1).await,
+        "fixture never recorded the first tools/list call"
+    );
+    assert_eq!(
+        read_count(&count_path),
+        1,
+        "first GET should hit upstream exactly once"
+    );
+
+    // 2. Second GET is a cache hit → counter unchanged.
+    let _ = fetch_tool_names(&client, &tools_url).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(
+        read_count(&count_path),
+        1,
+        "second GET should be a per-endpoint cache hit"
+    );
+
+    // 3. POST refresh: invalidates per-endpoint cache and re-primes it
+    //    eagerly via cached_list_tools(). Upstream count must increment by
+    //    exactly one.
+    let resp = client.post(&refresh_url).send().await.unwrap();
+    assert!(resp.status().is_success(), "refresh failed: {resp:?}");
+    assert!(
+        poll_until(Duration::from_secs(2), || read_count(&count_path) >= 2).await,
+        "refresh: expected upstream count to reach 2, got {}",
+        read_count(&count_path)
+    );
+    assert_eq!(
+        read_count(&count_path),
+        2,
+        "refresh should produce exactly one upstream tools/list call"
+    );
+
+    // 4. Subsequent GET stays a cache hit (refresh re-primed the cache).
+    let _ = fetch_tool_names(&client, &tools_url).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(
+        read_count(&count_path),
+        2,
+        "GET after refresh must hit the re-primed cache"
+    );
+}
+
+/// G5 — Per-tool disable/enable invalidates the merged catalog cache.
+///
+/// Verifies the management API contract documented in registry.rs:
+/// `invalidate_catalog_cache` (which also clears every per-endpoint tools
+/// cache, per its docstring) must be called on per-tool disable/enable so
+/// the next `/api/catalog` read reflects the new disabled-tools set.
+#[tokio::test]
+async fn test_per_tool_disable_enable_invalidates_catalog_cache() {
+    let count_file = NamedTempFile::new().expect("create count file");
+    let count_path = count_file.path().to_path_buf();
+    let count_path_str = count_path.to_str().unwrap().to_string();
+
+    let fixture_bin = env!("CARGO_BIN_EXE_fixture-swap-notify-server");
+    let config = ConfigBuilder::new()
+        .add_stdio_with_env(
+            "swapper",
+            fixture_bin,
+            &[],
+            &[("FIXTURE_LIST_COUNT_FILE", count_path_str.as_str())],
+        )
+        .build();
+
+    let harness = RelayHarness::start(&config).await;
+    harness
+        .wait_healthy("swapper", Duration::from_secs(15))
+        .await
+        .expect("swapper endpoint did not become healthy");
+
+    let client = reqwest::Client::new();
+    let base = harness.base_url();
+    let catalog_url = format!("{}/api/catalog", base);
+    let disable_url = format!("{}/api/endpoints/swapper/tools/get_status/disable", base);
+    let enable_url = format!("{}/api/endpoints/swapper/tools/get_status/enable", base);
+
+    // Helper: GET /api/catalog and return tool names.
+    async fn catalog_names(client: &reqwest::Client, url: &str) -> Vec<String> {
+        let resp: Value = client.get(url).send().await.unwrap().json().await.unwrap();
+        resp.as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|t| t["name"].as_str().map(|s| s.to_string()))
+            .collect()
+    }
+
+    // 1. Prime the catalog cache → upstream count = 1.
+    let names = catalog_names(&client, &catalog_url).await;
+    assert!(
+        names.iter().any(|n| n == "get_status"),
+        "expected get_status in initial catalog, got {names:?}"
+    );
+    assert!(
+        poll_until(Duration::from_secs(2), || read_count(&count_path) >= 1).await,
+        "fixture never recorded the first tools/list call"
+    );
+    assert_eq!(
+        read_count(&count_path),
+        1,
+        "first catalog read should hit upstream exactly once"
+    );
+
+    // 2. Second catalog read hits the catalog cache → counter unchanged.
+    let _ = catalog_names(&client, &catalog_url).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(
+        read_count(&count_path),
+        1,
+        "second catalog read should be a cache hit"
+    );
+
+    // 3. POST disable_tool: must invalidate the catalog cache so the next
+    //    GET re-merges the tool list with the new disabled-tools set. Because
+    //    invalidate_catalog_cache also clears every per-endpoint tool cache
+    //    (per its docstring), the next catalog rebuild re-fetches upstream,
+    //    bumping the counter by exactly one.
+    let resp = client.post(&disable_url).send().await.unwrap();
+    assert!(resp.status().is_success(), "disable_tool failed: {resp:?}");
+
+    let names_after_disable = catalog_names(&client, &catalog_url).await;
+    assert!(
+        !names_after_disable.iter().any(|n| n == "get_status"),
+        "catalog cache was not invalidated: get_status still present after disable: {names_after_disable:?}"
+    );
+    assert!(
+        names_after_disable.iter().any(|n| n == "swap_tools"),
+        "non-disabled tool swap_tools must remain in catalog: {names_after_disable:?}"
+    );
+    assert!(
+        poll_until(Duration::from_secs(2), || read_count(&count_path) >= 2).await,
+        "per-tool disable: expected upstream count to reach 2, got {}",
+        read_count(&count_path)
+    );
+    let count_after_disable = read_count(&count_path);
+    assert_eq!(
+        count_after_disable, 2,
+        "disable_tool's catalog invalidation should produce exactly one upstream re-fetch"
+    );
+
+    // 4. Second catalog read after disable is a cache hit: counter unchanged.
+    let _ = catalog_names(&client, &catalog_url).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(
+        read_count(&count_path),
+        count_after_disable,
+        "post-disable catalog read should be a cache hit"
+    );
+
+    // 5. POST enable_tool: must again invalidate the catalog cache, re-merge
+    //    so the re-enabled tool reappears, and produce exactly one extra
+    //    upstream re-fetch.
+    let resp = client.post(&enable_url).send().await.unwrap();
+    assert!(resp.status().is_success(), "enable_tool failed: {resp:?}");
+
+    let names_after_enable = catalog_names(&client, &catalog_url).await;
+    assert!(
+        names_after_enable.iter().any(|n| n == "get_status"),
+        "catalog cache was not invalidated on enable: get_status missing: {names_after_enable:?}"
+    );
+    assert!(
+        poll_until(Duration::from_secs(2), || {
+            read_count(&count_path) > count_after_disable
+        })
+        .await,
+        "per-tool enable: expected upstream count to reach {}, got {}",
+        count_after_disable + 1,
+        read_count(&count_path)
+    );
+    assert_eq!(
+        read_count(&count_path),
+        count_after_disable + 1,
+        "enable_tool's catalog invalidation should produce exactly one upstream re-fetch"
+    );
+}

--- a/tests/tools_cache_e2e_integration.rs
+++ b/tests/tools_cache_e2e_integration.rs
@@ -1,0 +1,194 @@
+//! End-to-end integration test for the per-adapter tools cache.
+//!
+//! Exercises the user-visible behaviour wired up in T1–T5:
+//! 1. Repeat reads of `/api/endpoints/<name>/tools` hit the cache.
+//! 2. `/api/catalog` reuses the per-endpoint cache.
+//! 3. Disable→enable invalidates the cache (lifecycle invalidation).
+//! 4. Upstream `notifications/tools/list_changed` invalidates the cache and
+//!    surfaces the new tool list (push-driven invalidation).
+
+mod common;
+
+use common::config::ConfigBuilder;
+use common::harness::RelayHarness;
+use serde_json::{json, Value};
+use std::path::Path;
+use std::time::{Duration, Instant};
+use tempfile::NamedTempFile;
+
+/// Read the fixture's `tools/list` counter file. Returns 0 when missing/empty.
+fn read_count(path: &Path) -> u64 {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+        .unwrap_or(0)
+}
+
+/// Poll `predicate` every 20ms until it returns true or `deadline` elapses.
+async fn poll_until<F: FnMut() -> bool>(deadline: Duration, mut predicate: F) -> bool {
+    let stop = Instant::now() + deadline;
+    while Instant::now() < stop {
+        if predicate() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    predicate()
+}
+
+/// GET `/api/endpoints/<name>/tools` and return the tool name set.
+async fn fetch_tool_names(client: &reqwest::Client, url: &str) -> Vec<String> {
+    let resp: Value = client.get(url).send().await.unwrap().json().await.unwrap();
+    resp.as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|t| t["name"].as_str().map(|s| s.to_string()))
+        .collect()
+}
+
+#[tokio::test]
+async fn test_per_adapter_tools_cache_end_to_end() {
+    // Counter file the fixture writes after every tools/list request.
+    let count_file = NamedTempFile::new().expect("create count file");
+    let count_path = count_file.path().to_path_buf();
+    let count_path_str = count_path.to_str().unwrap().to_string();
+
+    let fixture_bin = env!("CARGO_BIN_EXE_fixture-swap-notify-server");
+    let config = ConfigBuilder::new()
+        .add_stdio_with_env(
+            "swapper",
+            fixture_bin,
+            &[],
+            &[("FIXTURE_LIST_COUNT_FILE", count_path_str.as_str())],
+        )
+        .build();
+
+    let harness = RelayHarness::start(&config).await;
+    harness
+        .wait_healthy("swapper", Duration::from_secs(15))
+        .await
+        .expect("swapper endpoint did not become healthy");
+
+    let client = reqwest::Client::new();
+    let base = harness.base_url();
+    let tools_url = format!("{}/api/endpoints/swapper/tools", base);
+    let catalog_url = format!("{}/api/catalog", base);
+
+    // Step 1: First read populates per-endpoint cache → upstream count = 1.
+    let names = fetch_tool_names(&client, &tools_url).await;
+    assert!(
+        names.iter().any(|n| n == "swap_tools") && names.iter().any(|n| n == "get_status"),
+        "expected initial tools, got {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| n == "extra_tool_after_swap"),
+        "extra tool should NOT be present before swap, got {names:?}"
+    );
+    assert!(
+        poll_until(Duration::from_secs(2), || read_count(&count_path) >= 1).await,
+        "fixture never recorded the first tools/list call"
+    );
+    assert_eq!(
+        read_count(&count_path),
+        1,
+        "first GET should hit upstream exactly once"
+    );
+
+    // Step 2: Second read hits the per-endpoint cache → no upstream traffic.
+    let _ = fetch_tool_names(&client, &tools_url).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(
+        read_count(&count_path),
+        1,
+        "second GET should be a per-endpoint cache hit"
+    );
+
+    // Step 3: Catalog reuses the per-endpoint cache → still no upstream.
+    let _: Value = client
+        .get(&catalog_url)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(
+        read_count(&count_path),
+        1,
+        "catalog should reuse the per-endpoint cache"
+    );
+
+    // Step 4: Disable → enable invalidates the cache; the next GET re-fetches.
+    let resp = client
+        .post(format!("{}/api/endpoints/swapper/disable", base))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success(), "disable failed: {resp:?}");
+    let resp = client
+        .post(format!("{}/api/endpoints/swapper/enable", base))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success(), "enable failed: {resp:?}");
+    harness
+        .wait_healthy("swapper", Duration::from_secs(15))
+        .await
+        .expect("swapper did not become healthy after re-enable");
+
+    let _ = fetch_tool_names(&client, &tools_url).await;
+    assert!(
+        poll_until(Duration::from_secs(2), || read_count(&count_path) >= 2).await,
+        "lifecycle invalidation: expected upstream count to reach 2, got {}",
+        read_count(&count_path)
+    );
+    let count_after_lifecycle = read_count(&count_path);
+    assert_eq!(
+        count_after_lifecycle, 2,
+        "lifecycle invalidation should produce exactly one upstream call"
+    );
+
+    // Step 5: Trigger upstream swap via tools/call → fixture emits
+    // notifications/tools/list_changed → registry invalidates the cache →
+    // next GET returns the swapped list and bumps the upstream counter by 1.
+    let mut mcp = common::mcp_client::McpClient::new(base.clone());
+    mcp.initialize().await.expect("initialize handshake failed");
+    let call_resp = mcp
+        .call_tool("swap_tools", json!({}))
+        .await
+        .expect("swap_tools call failed");
+    assert!(
+        call_resp.get("result").is_some(),
+        "swap_tools returned no result: {call_resp:?}"
+    );
+
+    // Poll until the next GET returns the swapped tool list. Each pre-
+    // invalidation read is a cache hit (no upstream traffic), so the upstream
+    // counter only ticks once when the cache miss finally happens.
+    let mut last_names: Vec<String> = Vec::new();
+    let mut saw_new_tool = false;
+    let stop = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < stop {
+        let names = fetch_tool_names(&client, &tools_url).await;
+        if names.iter().any(|n| n == "extra_tool_after_swap") {
+            saw_new_tool = true;
+            last_names = names;
+            break;
+        }
+        last_names = names;
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        saw_new_tool,
+        "push-driven invalidation never surfaced the new tool list; last names: {last_names:?}"
+    );
+
+    let final_count = read_count(&count_path);
+    assert_eq!(
+        final_count,
+        count_after_lifecycle + 1,
+        "swap-driven invalidation should produce exactly one extra upstream tools/list \
+         (before={count_after_lifecycle}, after={final_count})"
+    );
+}


### PR DESCRIPTION
## Summary

Eliminates redundant upstream `tools/list` calls for the desktop's per-endpoint **Tools** tab and the merged catalog by caching tool listings **per adapter** in the registry. Caches are invalidated by:

- Upstream `notifications/tools/list_changed` (push)
- Adapter reconnect (post-disconnect re-handshake)
- Lifecycle events: register / remove / disable / enable / watcher swap / restart

## Acceptance criteria — all PASS

1. ✅ Two consecutive `GET /api/endpoints/<name>/tools` → exactly one upstream `tools/list`.
2. ✅ `GET /api/catalog` reuses per-endpoint caches; single-endpoint invalidation only refetches that endpoint.
3. ✅ Upstream `notifications/tools/list_changed` (stdio or SSE) clears per-endpoint + merged caches; next read returns updated tools.
4. ✅ Adapter reconnect emits a tick on the same channel and invalidates.
5. ✅ Lifecycle events (register / remove / disable / enable / watcher swap / restart) clear the relevant per-endpoint cache.
6. ✅ HTTP and OAuth (over plain HTTP) continue to work; their caches still get cleared on lifecycle events.
7. ✅ All existing tests pass; fmt + clippy clean.

## Architecture

- **Registry** (`src/registry.rs`): `RegisteredAdapter.tool_cache` (`RwLock<Option<Vec<ToolInfo>>>`) + per-endpoint listener task. `cached_list_tools(name)` returns from cache or fetches + populates. `invalidate_endpoint_tool_cache(name)` and `invalidate_catalog_cache()` are called from every lifecycle event. `rewire_tools_changed_listener` aborts the old listener task and binds against the new adapter's `subscribe_tools_changed()` after a swap.
- **Trait** (`McpAdapter`): new `subscribe_tools_changed() -> Option<broadcast::Receiver<()>>` (default: `None`).
- **Stdio adapter** (`src/adapter/stdio.rs`): emits a tick on every `notifications/tools/list_changed` from the upstream child.
- **SSE adapter** (`src/adapter/sse.rs`): emits a tick on every `list_changed` event AND after every successful (re)connect + handshake — so reconnects also invalidate.
- **OAuth adapter** (`src/adapter/oauth/mod.rs`): exposes its own outer broadcast and a rebindable forwarder task; `apply_tokens` swaps the forwarder against the new inner adapter's receiver. No synthetic tick on token-refresh.
- **Watcher** (`src/watcher.rs`, `src/main.rs`): `apply_diff_graceful` rewires the listener after each in-place adapter swap and invalidates the per-endpoint cache. `main.rs` registers the listener at startup once the registry is initialized.

## Branch chain (collapsed via `--no-ff` merges)

```
T1  cache + lifecycle invalidation
T2  trait + listener wiring
T3  stdio emit + main.rs startup-rewire
T4  SSE emit + reconnect tick
T5  OAuth outer broadcast + rebindable forwarder
wave3  T2 + T3/T4/T5 (clean three-way merge, conflict-free per pre-flight git merge-tree)
T6  end-to-end integration test
T7  close SHOULD-ADD coverage gaps (mutation-tested)
```

## Tests

- **End-to-end** (`tests/tools_cache_e2e_integration.rs`): pins upstream-call-count semantics (1 → 1 → 1 → 2 → 3) across cache hit, catalog reuse, lifecycle invalidation (disable/enable), and push-driven invalidation via `list_changed`. Also covers `/refresh` endpoint cache invalidation (G4) and per-tool disable/enable catalog invalidation (G5).
- **Unit / integration**: registry primitives, listener machinery (subscribe / abort / rewire / lagged), stdio + SSE emit paths, OAuth forwarder swap semantics, watcher `apply_diff_graceful` (G1) and rewire-after-swap (G2), OAuth `apply_tokens` forwarder rebind (G3).
- **Mutation-tested**: each new test was sanity-checked by commenting out the production line it's supposed to protect; all 7 mutations caught.
- **Totals**: 1043 passed / 0 failed / 5 ignored; stable across 3 back-to-back full runs. fmt + clippy clean.

## Non-blocking follow-ups (not in this PR)

- Tighten per-tool disable/enable to use `invalidate_endpoint_tool_cache(name)` instead of the all-caches sweep (current behaviour is correct, this is a minor optimisation).
- Resolve the `stdio.rs:232` TODO if/when stdio auto-restart lands.
- Drive `apply_tokens` through the success branch (line 303 of `oauth/mod.rs`) with a stub HTTP MCP server — pins the symmetry of the forwarder rebind invariant. Pre-existing gap, not a regression.

## Merge

Squash-merge preferred (per `AGENTS.md`). Monorepo bump to follow.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author