### PR TITLE
fix(oauth): refresh hardening + heartbeat hysteresis + restart non-blocking + SSE auto-reconnect

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,4 +66,5 @@ futures-util = "0.3"
 reqwest = { version = "0.13", features = ["json", "stream"] }
 serde_json = "1"
 tempfile = "3.27.0"
+tokio = { version = "1", features = ["test-util"] }
 which = "7"

--- a/src/adapter/oauth/heartbeat.rs
+++ b/src/adapter/oauth/heartbeat.rs
@@ -1,7 +1,9 @@
 //! Heartbeat probe for the inner (wrapped) adapter.
 //!
 //! Runs a periodic `tools/list` JSON-RPC request against the upstream MCP
-//! server and updates `inner_health` accordingly.
+//! server and updates `inner_health` accordingly. Uses hysteresis so a
+//! single transient probe failure does not flip the endpoint to Offline
+//! in the desktop sidebar.
 
 use super::super::{AdapterError, HealthStatus, McpAdapter};
 use super::state::OAuthState;
@@ -18,8 +20,57 @@ enum ProbeError {
     Auth,
 }
 
+/// Action the heartbeat loop should take in response to a probe result.
+///
+/// Factored out of `heartbeat_loop` so the hysteresis logic can be unit
+/// tested without a real upstream adapter.
+#[derive(Debug, PartialEq, Eq)]
+enum ProbeAction {
+    /// Reset failure counter and mark inner_health as Healthy.
+    MarkHealthy,
+    /// Network failure but below the threshold — leave inner_health alone,
+    /// just log at debug. `failures` is the new (post-increment) count.
+    BelowThreshold { failures: u32, reason: String },
+    /// Network failure reached the threshold — mark Unhealthy.
+    MarkUnhealthy { reason: String },
+    /// Auth failure — reset counter and transition to AuthRequired.
+    AuthFailed,
+}
+
+/// Apply hysteresis to a probe result.
+///
+/// Mutates `failures` in place: increments on `Network`, resets on `Ok` or
+/// `Auth`. Returns the action the loop should perform.
+fn classify_probe_result(
+    result: Result<(), ProbeError>,
+    failures: &mut u32,
+    threshold: u32,
+) -> ProbeAction {
+    match result {
+        Ok(()) => {
+            *failures = 0;
+            ProbeAction::MarkHealthy
+        }
+        Err(ProbeError::Auth) => {
+            *failures = 0;
+            ProbeAction::AuthFailed
+        }
+        Err(ProbeError::Network(reason)) => {
+            *failures = failures.saturating_add(1);
+            if *failures >= threshold {
+                ProbeAction::MarkUnhealthy { reason }
+            } else {
+                ProbeAction::BelowThreshold {
+                    failures: *failures,
+                    reason,
+                }
+            }
+        }
+    }
+}
+
 /// Probe the inner adapter by sending a `tools/list` JSON-RPC request
-/// with a 5-second timeout.
+/// with a configurable timeout.
 async fn probe_inner(inner: &OAuthAdapterInner) -> Result<(), ProbeError> {
     let guard = inner.inner_adapter.read().await;
     let adapter = match guard.as_ref() {
@@ -27,11 +78,15 @@ async fn probe_inner(inner: &OAuthAdapterInner) -> Result<(), ProbeError> {
         None => return Err(ProbeError::Network("no inner adapter".into())),
     };
 
-    match tokio::time::timeout(Duration::from_secs(5), adapter.list_tools()).await {
+    let timeout_secs = inner.config.probe_timeout_secs;
+    match tokio::time::timeout(Duration::from_secs(timeout_secs), adapter.list_tools()).await {
         Ok(Ok(_)) => Ok(()),
         Ok(Err(AdapterError::HttpError { status: 401, .. })) => Err(ProbeError::Auth),
         Ok(Err(e)) => Err(ProbeError::Network(e.to_string())),
-        Err(_) => Err(ProbeError::Network("probe timed out after 5s".into())),
+        Err(_) => Err(ProbeError::Network(format!(
+            "probe timed out after {}s",
+            timeout_secs
+        ))),
     }
 }
 
@@ -40,13 +95,17 @@ async fn probe_inner(inner: &OAuthAdapterInner) -> Result<(), ProbeError> {
 /// Uses a `Weak` reference so the loop exits automatically when the
 /// adapter is dropped.
 pub async fn heartbeat_loop(inner: Weak<OAuthAdapterInner>) {
-    let interval_secs = match inner.upgrade() {
-        Some(arc) => arc.config.heartbeat_interval_secs,
+    let (interval_secs, threshold) = match inner.upgrade() {
+        Some(arc) => (
+            arc.config.heartbeat_interval_secs,
+            arc.config.probe_failure_threshold,
+        ),
         None => return,
     };
 
     let mut ticker = tokio::time::interval(Duration::from_secs(interval_secs));
     ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    let mut consecutive_failures: u32 = 0;
 
     loop {
         ticker.tick().await;
@@ -60,8 +119,11 @@ pub async fn heartbeat_loop(inner: Weak<OAuthAdapterInner>) {
 
         let endpoint = &adapter.config.endpoint_name;
         let oauth_state = adapter.state.read().await.clone();
-        match probe_inner(&adapter).await {
-            Ok(()) => {
+        let result = probe_inner(&adapter).await;
+        let action = classify_probe_result(result, &mut consecutive_failures, threshold);
+
+        match action {
+            ProbeAction::MarkHealthy => {
                 *adapter.inner_health.write().await = HealthStatus::Healthy;
                 adapter.metrics.inc_heartbeat_healthy();
                 debug!(
@@ -71,7 +133,18 @@ pub async fn heartbeat_loop(inner: Weak<OAuthAdapterInner>) {
                     "heartbeat probe succeeded"
                 );
             }
-            Err(ProbeError::Network(reason)) => {
+            ProbeAction::BelowThreshold { failures, reason } => {
+                debug!(
+                    endpoint = %endpoint,
+                    oauth_state = ?oauth_state,
+                    result = "transient",
+                    failures = failures,
+                    threshold = threshold,
+                    reason = %reason,
+                    "heartbeat probe failed below threshold; not flipping inner_health"
+                );
+            }
+            ProbeAction::MarkUnhealthy { reason } => {
                 *adapter.inner_health.write().await =
                     HealthStatus::Unhealthy("upstream unreachable".into());
                 adapter.metrics.inc_heartbeat_unhealthy();
@@ -79,11 +152,12 @@ pub async fn heartbeat_loop(inner: Weak<OAuthAdapterInner>) {
                     endpoint = %endpoint,
                     oauth_state = ?oauth_state,
                     result = "unhealthy",
+                    threshold = threshold,
                     reason = %reason,
-                    "heartbeat probe failed"
+                    "heartbeat probe failed at threshold"
                 );
             }
-            Err(ProbeError::Auth) => {
+            ProbeAction::AuthFailed => {
                 adapter.metrics.inc_heartbeat_unhealthy();
                 warn!(
                     endpoint = %endpoint,
@@ -93,6 +167,110 @@ pub async fn heartbeat_loop(inner: Weak<OAuthAdapterInner>) {
                 );
                 *adapter.state.write().await = OAuthState::AuthRequired;
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn net(reason: &str) -> Result<(), ProbeError> {
+        Err(ProbeError::Network(reason.to_string()))
+    }
+
+    fn ok() -> Result<(), ProbeError> {
+        Ok(())
+    }
+
+    fn auth() -> Result<(), ProbeError> {
+        Err(ProbeError::Auth)
+    }
+
+    #[test]
+    fn two_consecutive_network_failures_stay_below_threshold() {
+        let mut failures: u32 = 0;
+        let threshold = 3;
+
+        let a1 = classify_probe_result(net("dns"), &mut failures, threshold);
+        assert_eq!(failures, 1);
+        assert!(
+            matches!(a1, ProbeAction::BelowThreshold { failures: 1, .. }),
+            "expected BelowThreshold(1), got {:?}",
+            a1
+        );
+
+        let a2 = classify_probe_result(net("timeout"), &mut failures, threshold);
+        assert_eq!(failures, 2);
+        assert!(
+            matches!(a2, ProbeAction::BelowThreshold { failures: 2, .. }),
+            "expected BelowThreshold(2), got {:?}",
+            a2
+        );
+    }
+
+    #[test]
+    fn three_consecutive_network_failures_flip_to_unhealthy() {
+        let mut failures: u32 = 0;
+        let threshold = 3;
+
+        let _ = classify_probe_result(net("dns"), &mut failures, threshold);
+        let _ = classify_probe_result(net("dns"), &mut failures, threshold);
+        let a3 = classify_probe_result(net("dns"), &mut failures, threshold);
+
+        assert_eq!(failures, 3);
+        match a3 {
+            ProbeAction::MarkUnhealthy { reason } => assert_eq!(reason, "dns"),
+            other => panic!("expected MarkUnhealthy, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn success_in_between_resets_counter() {
+        let mut failures: u32 = 0;
+        let threshold = 3;
+
+        let _ = classify_probe_result(net("e1"), &mut failures, threshold);
+        let _ = classify_probe_result(net("e2"), &mut failures, threshold);
+        assert_eq!(failures, 2);
+
+        let mid = classify_probe_result(ok(), &mut failures, threshold);
+        assert_eq!(failures, 0);
+        assert_eq!(mid, ProbeAction::MarkHealthy);
+
+        // After the reset, a single failure must NOT flip to Unhealthy.
+        let after = classify_probe_result(net("e3"), &mut failures, threshold);
+        assert_eq!(failures, 1);
+        assert!(
+            matches!(after, ProbeAction::BelowThreshold { failures: 1, .. }),
+            "expected BelowThreshold(1) after reset, got {:?}",
+            after
+        );
+    }
+
+    #[test]
+    fn auth_failure_resets_counter_and_signals_auth() {
+        let mut failures: u32 = 0;
+        let threshold = 3;
+
+        let _ = classify_probe_result(net("e1"), &mut failures, threshold);
+        let _ = classify_probe_result(net("e2"), &mut failures, threshold);
+        assert_eq!(failures, 2);
+
+        let action = classify_probe_result(auth(), &mut failures, threshold);
+        assert_eq!(failures, 0);
+        assert_eq!(action, ProbeAction::AuthFailed);
+    }
+
+    #[test]
+    fn threshold_of_one_flips_immediately() {
+        // Backwards-compatible knob: threshold=1 reproduces the old behavior.
+        let mut failures: u32 = 0;
+        let action = classify_probe_result(net("boom"), &mut failures, 1);
+        assert_eq!(failures, 1);
+        match action {
+            ProbeAction::MarkUnhealthy { reason } => assert_eq!(reason, "boom"),
+            other => panic!("expected MarkUnhealthy, got {:?}", other),
         }
     }
 }

--- a/src/adapter/oauth/heartbeat.rs
+++ b/src/adapter/oauth/heartbeat.rs
@@ -117,56 +117,70 @@ pub async fn heartbeat_loop(inner: Weak<OAuthAdapterInner>) {
             continue;
         }
 
-        let endpoint = &adapter.config.endpoint_name;
         let oauth_state = adapter.state.read().await.clone();
         let result = probe_inner(&adapter).await;
         let action = classify_probe_result(result, &mut consecutive_failures, threshold);
+        apply_probe_action(&adapter, action, threshold, &oauth_state).await;
+    }
+}
 
-        match action {
-            ProbeAction::MarkHealthy => {
-                *adapter.inner_health.write().await = HealthStatus::Healthy;
-                adapter.metrics.inc_heartbeat_healthy();
-                debug!(
-                    endpoint = %endpoint,
-                    oauth_state = ?oauth_state,
-                    result = "healthy",
-                    "heartbeat probe succeeded"
-                );
-            }
-            ProbeAction::BelowThreshold { failures, reason } => {
-                debug!(
-                    endpoint = %endpoint,
-                    oauth_state = ?oauth_state,
-                    result = "transient",
-                    failures = failures,
-                    threshold = threshold,
-                    reason = %reason,
-                    "heartbeat probe failed below threshold; not flipping inner_health"
-                );
-            }
-            ProbeAction::MarkUnhealthy { reason } => {
-                *adapter.inner_health.write().await =
-                    HealthStatus::Unhealthy("upstream unreachable".into());
-                adapter.metrics.inc_heartbeat_unhealthy();
-                warn!(
-                    endpoint = %endpoint,
-                    oauth_state = ?oauth_state,
-                    result = "unhealthy",
-                    threshold = threshold,
-                    reason = %reason,
-                    "heartbeat probe failed at threshold"
-                );
-            }
-            ProbeAction::AuthFailed => {
-                adapter.metrics.inc_heartbeat_unhealthy();
-                warn!(
-                    endpoint = %endpoint,
-                    oauth_state = ?oauth_state,
-                    result = "unhealthy",
-                    "heartbeat probe got 401, transitioning to AuthRequired"
-                );
-                *adapter.state.write().await = OAuthState::AuthRequired;
-            }
+/// Apply the `ProbeAction` dispatched from `classify_probe_result` to the
+/// shared adapter state (writes `inner_health`, increments metrics, may
+/// transition `OAuthState`).
+///
+/// Extracted from `heartbeat_loop` so the side-effect dispatch can be
+/// driven directly by tests without spinning a real timer or probe.
+async fn apply_probe_action(
+    adapter: &OAuthAdapterInner,
+    action: ProbeAction,
+    threshold: u32,
+    oauth_state: &OAuthState,
+) {
+    let endpoint = &adapter.config.endpoint_name;
+    match action {
+        ProbeAction::MarkHealthy => {
+            *adapter.inner_health.write().await = HealthStatus::Healthy;
+            adapter.metrics.inc_heartbeat_healthy();
+            debug!(
+                endpoint = %endpoint,
+                oauth_state = ?oauth_state,
+                result = "healthy",
+                "heartbeat probe succeeded"
+            );
+        }
+        ProbeAction::BelowThreshold { failures, reason } => {
+            debug!(
+                endpoint = %endpoint,
+                oauth_state = ?oauth_state,
+                result = "transient",
+                failures = failures,
+                threshold = threshold,
+                reason = %reason,
+                "heartbeat probe failed below threshold; not flipping inner_health"
+            );
+        }
+        ProbeAction::MarkUnhealthy { reason } => {
+            *adapter.inner_health.write().await =
+                HealthStatus::Unhealthy("upstream unreachable".into());
+            adapter.metrics.inc_heartbeat_unhealthy();
+            warn!(
+                endpoint = %endpoint,
+                oauth_state = ?oauth_state,
+                result = "unhealthy",
+                threshold = threshold,
+                reason = %reason,
+                "heartbeat probe failed at threshold"
+            );
+        }
+        ProbeAction::AuthFailed => {
+            adapter.metrics.inc_heartbeat_unhealthy();
+            warn!(
+                endpoint = %endpoint,
+                oauth_state = ?oauth_state,
+                result = "unhealthy",
+                "heartbeat probe got 401, transitioning to AuthRequired"
+            );
+            *adapter.state.write().await = OAuthState::AuthRequired;
         }
     }
 }
@@ -271,6 +285,155 @@ mod tests {
         match action {
             ProbeAction::MarkUnhealthy { reason } => assert_eq!(reason, "boom"),
             other => panic!("expected MarkUnhealthy, got {:?}", other),
+        }
+    }
+
+    // -- End-to-end harness -------------------------------------------------
+    //
+    // The tests below drive `classify_probe_result` + `apply_probe_action` on
+    // a real `OAuthAdapterInner` (constructed via the public `OAuthAdapter`
+    // ctor) so we can observe `inner_health` and `state` transitions through
+    // the same dispatch path as the production loop. The actual `probe_inner`
+    // call is bypassed — tests feed pre-canned `ProbeError`/`Ok` results.
+
+    use crate::adapter::oauth::{OAuthAdapter, OAuthAdapterConfig};
+    use crate::adapter::HealthStatus;
+    use crate::token_manager::TokenManager;
+    use std::sync::Arc;
+
+    fn make_test_config(threshold: u32) -> OAuthAdapterConfig {
+        OAuthAdapterConfig {
+            endpoint_name: "heartbeat-e2e".to_string(),
+            url: "http://localhost/mcp".to_string(),
+            token_endpoint_url: "http://localhost/token".to_string(),
+            client_id: "test-client".to_string(),
+            client_secret: None,
+            heartbeat_interval_secs: 30,
+            probe_timeout_secs: 10,
+            probe_failure_threshold: threshold,
+        }
+    }
+
+    fn make_test_inner(threshold: u32) -> Arc<OAuthAdapterInner> {
+        let tmp = tempfile::tempdir().unwrap().keep();
+        let tm = Arc::new(TokenManager::new(tmp));
+        let adapter = OAuthAdapter::new(make_test_config(threshold), tm);
+        adapter.shared_inner()
+    }
+
+    /// Drive a single iteration of the heartbeat loop body with a canned
+    /// probe result, mirroring `heartbeat_loop` minus the timer and the
+    /// real `probe_inner` call.
+    async fn step_once(
+        adapter: &OAuthAdapterInner,
+        result: Result<(), ProbeError>,
+        failures: &mut u32,
+        threshold: u32,
+    ) {
+        let oauth_state = adapter.state.read().await.clone();
+        let action = classify_probe_result(result, failures, threshold);
+        apply_probe_action(adapter, action, threshold, &oauth_state).await;
+    }
+
+    /// Set the adapter into the `Authenticated` / `Healthy` baseline that
+    /// the heartbeat loop assumes when it actually runs (the real loop
+    /// `continue`s out of any other state).
+    async fn arm_healthy(inner: &OAuthAdapterInner) {
+        *inner.state.write().await = OAuthState::Authenticated;
+        *inner.inner_health.write().await = HealthStatus::Healthy;
+    }
+
+    #[tokio::test]
+    async fn heartbeat_below_threshold_does_not_flip_inner_health() {
+        let threshold = 3;
+        let inner = make_test_inner(threshold);
+        arm_healthy(&inner).await;
+
+        let mut failures = 0u32;
+        // N-1 = 2 consecutive failures; inner_health must remain Healthy.
+        for i in 0..(threshold - 1) {
+            step_once(&inner, net("transient"), &mut failures, threshold).await;
+            assert_eq!(failures, i + 1);
+            assert_eq!(
+                *inner.inner_health.read().await,
+                HealthStatus::Healthy,
+                "inner_health flipped after {} failures (threshold={})",
+                i + 1,
+                threshold
+            );
+        }
+        // Metrics: no healthy/unhealthy increments since BelowThreshold is
+        // a no-op on side effects other than logging.
+        let snap = inner.metrics.snapshot();
+        assert_eq!(snap.oauth_heartbeat_probe_total_healthy, 0);
+        assert_eq!(snap.oauth_heartbeat_probe_total_unhealthy, 0);
+    }
+
+    #[tokio::test]
+    async fn heartbeat_at_threshold_flips_to_unhealthy() {
+        let threshold = 3;
+        let inner = make_test_inner(threshold);
+        arm_healthy(&inner).await;
+
+        let mut failures = 0u32;
+        for _ in 0..threshold {
+            step_once(&inner, net("dns"), &mut failures, threshold).await;
+        }
+        assert_eq!(failures, threshold);
+        match &*inner.inner_health.read().await {
+            HealthStatus::Unhealthy(reason) => {
+                assert_eq!(reason, "upstream unreachable");
+            }
+            other => panic!("expected Unhealthy, got {:?}", other),
+        }
+        // Exactly one unhealthy increment (the threshold-crossing probe).
+        let snap = inner.metrics.snapshot();
+        assert_eq!(snap.oauth_heartbeat_probe_total_unhealthy, 1);
+        assert_eq!(snap.oauth_heartbeat_probe_total_healthy, 0);
+    }
+
+    #[tokio::test]
+    async fn heartbeat_single_ok_after_failures_recovers_to_healthy() {
+        let threshold = 3;
+        let inner = make_test_inner(threshold);
+        arm_healthy(&inner).await;
+
+        let mut failures = 0u32;
+        // Drive to Unhealthy.
+        for _ in 0..threshold {
+            step_once(&inner, net("dns"), &mut failures, threshold).await;
+        }
+        assert!(matches!(
+            *inner.inner_health.read().await,
+            HealthStatus::Unhealthy(_)
+        ));
+
+        // A single Ok probe must immediately recover to Healthy
+        // (asymmetric hysteresis: slow to fail, fast to recover).
+        step_once(&inner, ok(), &mut failures, threshold).await;
+        assert_eq!(failures, 0);
+        assert_eq!(*inner.inner_health.read().await, HealthStatus::Healthy);
+    }
+
+    #[tokio::test]
+    async fn heartbeat_alternating_ok_fail_does_not_flap() {
+        let threshold = 3;
+        let inner = make_test_inner(threshold);
+        arm_healthy(&inner).await;
+
+        let mut failures = 0u32;
+        // 8 iterations of Fail, Ok, Fail, Ok, ... — counter resets on every
+        // Ok before reaching the threshold, so inner_health must never flip
+        // to Unhealthy.
+        for i in 0..8 {
+            let result = if i % 2 == 0 { net("blip") } else { ok() };
+            step_once(&inner, result, &mut failures, threshold).await;
+            assert_eq!(
+                *inner.inner_health.read().await,
+                HealthStatus::Healthy,
+                "inner_health flapped at step {}",
+                i
+            );
         }
     }
 }

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -35,6 +35,12 @@ pub struct OAuthAdapterConfig {
     pub client_secret: Option<String>,
     /// Heartbeat probe interval in seconds (default: 30).
     pub heartbeat_interval_secs: u64,
+    /// Per-probe timeout in seconds (default: 10).
+    pub probe_timeout_secs: u64,
+    /// Number of consecutive probe network failures required before flipping
+    /// `inner_health` to `Unhealthy("upstream unreachable")` (default: 3).
+    /// Hysteresis to avoid flapping on a single transient timeout.
+    pub probe_failure_threshold: u32,
 }
 
 /// Shared inner state for an OAuth adapter, wrapped in `Arc` so it can be
@@ -677,6 +683,8 @@ mod tests {
             client_id: "test-client".to_string(),
             client_secret: None,
             heartbeat_interval_secs: 30,
+            probe_timeout_secs: 10,
+            probe_failure_threshold: 3,
         }
     }
 

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -185,18 +185,30 @@ impl OAuthAdapterInner {
             .extend_pairs(form_parts.iter())
             .finish();
 
-        let resp = self
+        let resp = match self
             .http_client
             .post(&self.config.token_endpoint_url)
             .header("Content-Type", "application/x-www-form-urlencoded")
             .body(form_body)
             .send()
             .await
-            .map_err(|e| {
-                // Network error during refresh
+        {
+            Ok(r) => r,
+            Err(e) => {
+                // Network/timeout error during refresh — leave Refreshing
+                // for ConnectionFailed so the state machine doesn't hang.
+                error!(
+                    endpoint = %self.config.endpoint_name,
+                    correlation_id = %correlation_id,
+                    error = %e,
+                    "Token refresh network error"
+                );
                 self.metrics.inc_refresh_failure();
-                OAuthError::Http(e)
-            })?;
+                self.transition_to(OAuthState::ConnectionFailed, "token refresh network error")
+                    .await;
+                return Err(OAuthError::Http(e));
+            }
+        };
 
         if !resp.status().is_success() {
             let status = resp.status();
@@ -214,7 +226,28 @@ impl OAuthAdapterInner {
             return Err(OAuthError::RefreshFailed { status, body });
         }
 
-        let token_json: serde_json::Value = resp.json().await?;
+        let token_json: serde_json::Value = match resp.json().await {
+            Ok(v) => v,
+            Err(e) => {
+                // Upstream returned 200 but the body is not parseable JSON.
+                // Treat as a transient connection-quality issue (retry may
+                // recover) and leave Refreshing for ConnectionFailed so the
+                // state machine doesn't hang.
+                error!(
+                    endpoint = %self.config.endpoint_name,
+                    correlation_id = %correlation_id,
+                    error = %e,
+                    "Token refresh JSON parse error"
+                );
+                self.metrics.inc_refresh_failure();
+                self.transition_to(
+                    OAuthState::ConnectionFailed,
+                    "token refresh response not JSON",
+                )
+                .await;
+                return Err(OAuthError::Http(e));
+            }
+        };
         let now_secs = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -290,8 +323,12 @@ impl OAuthAdapterInner {
                 // Reflect the freshly initialized inner adapter's health
                 // immediately so health() reports Healthy without waiting for
                 // the next heartbeat tick.
-                *self.inner_health.write().await = HealthStatus::Healthy;
+                // Order matters: set the inner adapter BEFORE flipping
+                // inner_health to Healthy so that any reader that observes
+                // `health() == Healthy` is guaranteed to also see
+                // `inner_adapter == Some(_)`.
                 *self.inner_adapter.write().await = Some(adapter);
+                *self.inner_health.write().await = HealthStatus::Healthy;
                 self.transition_to(
                     OAuthState::Authenticated,
                     "tokens applied, inner adapter ready",
@@ -375,13 +412,32 @@ impl OAuthAdapterInner {
                         );
                         // Retry once after 60 seconds
                         tokio::time::sleep(Duration::from_secs(60)).await;
-                        if let Ok(new_tokens) = inner.do_token_refresh().await {
-                            inner.apply_tokens(new_tokens).await;
-                        } else {
-                            warn!(
-                                endpoint = %inner.config.endpoint_name,
-                                "Proactive refresh retry also failed"
-                            );
+                        match inner.do_token_refresh().await {
+                            Ok(new_tokens) => {
+                                inner.apply_tokens(new_tokens).await;
+                            }
+                            Err(retry_err) => {
+                                // `do_token_refresh` already transitioned to
+                                // a terminal state on its own error path; the
+                                // explicit transition here is defensive so a
+                                // future error path that forgets to do so
+                                // still leaves Refreshing for AuthRequired
+                                // (auth-style failure) or ConnectionFailed
+                                // (network/JSON failure).
+                                warn!(
+                                    endpoint = %inner.config.endpoint_name,
+                                    error = %retry_err,
+                                    "Proactive refresh retry also failed"
+                                );
+                                let target = match &retry_err {
+                                    OAuthError::RefreshFailed { .. }
+                                    | OAuthError::NoRefreshToken { .. } => OAuthState::AuthRequired,
+                                    _ => OAuthState::ConnectionFailed,
+                                };
+                                inner
+                                    .transition_to(target, "proactive refresh retry failed")
+                                    .await;
+                            }
                         }
                     }
                 }
@@ -448,7 +504,10 @@ impl OAuthAdapter {
                 config,
                 inner_adapter: RwLock::new(None),
                 token_manager,
-                http_client: Client::new(),
+                http_client: Client::builder()
+                    .timeout(Duration::from_secs(30))
+                    .build()
+                    .expect("static OAuth refresh HTTP client config"),
                 refresh_task_handle: Mutex::new(None),
                 inner_health: RwLock::new(HealthStatus::Starting),
                 heartbeat_task_handle: Mutex::new(None),
@@ -1079,6 +1138,154 @@ mod tests {
             inner_health,
             HealthStatus::Healthy,
             "inner_health should be Healthy immediately after a successful inner adapter initialize"
+        );
+
+        server.abort();
+    }
+
+    // --- do_token_refresh error-path tests ---
+
+    /// Spawn a tiny axum server on `127.0.0.1:0` that serves the configured
+    /// canned response on `POST /token`. Used to exercise the failure paths
+    /// of `do_token_refresh` without a real OAuth provider.
+    async fn spawn_token_server(mode: &'static str) -> (String, tokio::task::JoinHandle<()>) {
+        use axum::http::StatusCode;
+        use axum::{response::IntoResponse, routing::post, Router};
+
+        async fn bad_request() -> impl IntoResponse {
+            (StatusCode::BAD_REQUEST, "{\"error\":\"invalid_grant\"}")
+        }
+        async fn malformed() -> impl IntoResponse {
+            (StatusCode::OK, "not json")
+        }
+
+        let router = match mode {
+            "400" => Router::new().route("/token", post(bad_request)),
+            "malformed" => Router::new().route("/token", post(malformed)),
+            other => panic!("unknown spawn_token_server mode: {}", other),
+        };
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        // Tiny delay to let the server start accepting connections.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        (format!("http://127.0.0.1:{}/token", addr.port()), handle)
+    }
+
+    /// Helper: build an adapter pre-loaded with a refresh token so
+    /// `do_token_refresh` reaches the network call.
+    async fn make_adapter_with_refresh_token(config: OAuthAdapterConfig) -> OAuthAdapter {
+        let adapter = make_adapter(config);
+        *adapter.inner.tokens.write().await = Some(TokenSet {
+            access_token: "old-access".to_string(),
+            refresh_token: Some("test-refresh".to_string()),
+            expires_at: None,
+            token_type: "Bearer".to_string(),
+            scope: None,
+            issued_at: None,
+        });
+        adapter
+    }
+
+    /// Network error (closed port → ECONNREFUSED) must transition out of
+    /// `Refreshing` into `ConnectionFailed`, not leave the state stuck.
+    #[tokio::test]
+    async fn do_token_refresh_network_error_transitions_to_connection_failed() {
+        let mut config = make_config();
+        // Port 1 is reserved and not bound; this triggers an immediate
+        // connection-refused error rather than waiting for the 30s timeout.
+        config.token_endpoint_url = "http://127.0.0.1:1/token".to_string();
+        let adapter = make_adapter_with_refresh_token(config).await;
+
+        let result = adapter.inner.do_token_refresh().await;
+        assert!(
+            result.is_err(),
+            "expected refresh to fail with network error"
+        );
+
+        let state = adapter.inner.state.read().await.clone();
+        assert_eq!(
+            state,
+            OAuthState::ConnectionFailed,
+            "network error must transition out of Refreshing into ConnectionFailed"
+        );
+        assert!(
+            adapter
+                .inner
+                .metrics
+                .snapshot()
+                .oauth_token_refresh_total_failure
+                >= 1,
+            "refresh failure metric must increment"
+        );
+    }
+
+    /// Non-2xx HTTP response (4xx) must transition into `AuthRequired`.
+    #[tokio::test]
+    async fn do_token_refresh_4xx_transitions_to_auth_required() {
+        let (url, server) = spawn_token_server("400").await;
+        let mut config = make_config();
+        config.token_endpoint_url = url;
+        let adapter = make_adapter_with_refresh_token(config).await;
+
+        let result = adapter.inner.do_token_refresh().await;
+        assert!(
+            matches!(result, Err(OAuthError::RefreshFailed { .. })),
+            "expected RefreshFailed error, got {:?}",
+            result
+        );
+
+        let state = adapter.inner.state.read().await.clone();
+        assert_eq!(
+            state,
+            OAuthState::AuthRequired,
+            "4xx must transition out of Refreshing into AuthRequired"
+        );
+        assert!(
+            adapter
+                .inner
+                .metrics
+                .snapshot()
+                .oauth_token_refresh_total_failure
+                >= 1,
+            "refresh failure metric must increment"
+        );
+
+        server.abort();
+    }
+
+    /// 200 OK with a non-JSON body must transition into `ConnectionFailed`
+    /// (treat as a transient upstream-quality problem so retry can recover).
+    #[tokio::test]
+    async fn do_token_refresh_malformed_json_transitions_to_connection_failed() {
+        let (url, server) = spawn_token_server("malformed").await;
+        let mut config = make_config();
+        config.token_endpoint_url = url;
+        let adapter = make_adapter_with_refresh_token(config).await;
+
+        let result = adapter.inner.do_token_refresh().await;
+        assert!(
+            result.is_err(),
+            "expected refresh to fail with JSON parse error"
+        );
+
+        let state = adapter.inner.state.read().await.clone();
+        assert_eq!(
+            state,
+            OAuthState::ConnectionFailed,
+            "JSON parse failure must transition out of Refreshing into ConnectionFailed"
+        );
+        assert!(
+            adapter
+                .inner
+                .metrics
+                .snapshot()
+                .oauth_token_refresh_total_failure
+                >= 1,
+            "refresh failure metric must increment"
         );
 
         server.abort();

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -287,6 +287,10 @@ impl OAuthAdapterInner {
         let mut adapter = Self::build_inner_adapter(&self.config.url, &access_token);
         match adapter.initialize().await {
             Ok(()) => {
+                // Reflect the freshly initialized inner adapter's health
+                // immediately so health() reports Healthy without waiting for
+                // the next heartbeat tick.
+                *self.inner_health.write().await = HealthStatus::Healthy;
                 *self.inner_adapter.write().await = Some(adapter);
                 self.transition_to(
                     OAuthState::Authenticated,
@@ -312,53 +316,77 @@ impl OAuthAdapterInner {
         let has_refresh_token = token_set.refresh_token.is_some();
         *self.tokens.write().await = Some(token_set);
 
-        // 5. Schedule proactive refresh if we have a refresh token and expiry info
-        if !has_refresh_token {
+        // 5. Schedule proactive refresh if we have a refresh token and an
+        //    `expires_at`. We schedule even when `issued_at` is missing —
+        //    tokens persisted before `issued_at` was added will deserialize
+        //    with `issued_at: None` (it's `#[serde(default)]`), but still
+        //    deserve a proactive refresh.
+        let deadline = if !has_refresh_token {
             info!(endpoint = %endpoint, "No refresh token, skipping proactive refresh");
-        } else if let (Some(issued), Some(expires)) = (issued_at_secs, expires_at_secs) {
-            if expires > issued {
-                let now_secs = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs();
-                let now_instant = Instant::now();
-                // Convert Unix timestamps to Instants relative to now
-                let issued_instant =
-                    now_instant - Duration::from_secs(now_secs.saturating_sub(issued));
-                let expires_instant =
-                    now_instant + Duration::from_secs(expires.saturating_sub(now_secs));
-                let deadline = refresh_deadline(issued_instant, expires_instant);
+            None
+        } else if let Some(expires) = expires_at_secs {
+            let now_secs = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            let now_instant = Instant::now();
+            let expires_instant =
+                now_instant + Duration::from_secs(expires.saturating_sub(now_secs));
+            match issued_at_secs {
+                Some(issued) if expires > issued => {
+                    // Both timestamps known — use the standard heuristic
+                    // (75% of lifetime, capped at 5 min before expiry).
+                    let issued_instant =
+                        now_instant - Duration::from_secs(now_secs.saturating_sub(issued));
+                    Some(refresh_deadline(issued_instant, expires_instant))
+                }
+                _ => {
+                    // No `issued_at` (or nonsensical ordering): fall back to
+                    // refreshing 5 minutes before expiry, clamped to "now"
+                    // if we're already inside that window.
+                    let five_min = Duration::from_secs(300);
+                    let target = expires_instant.checked_sub(five_min).unwrap_or(now_instant);
+                    Some(target.max(now_instant))
+                }
+            }
+        } else {
+            info!(
+                endpoint = %endpoint,
+                "No expires_at on token, skipping proactive refresh"
+            );
+            None
+        };
 
-                let inner = self.clone();
-                let handle = tokio::spawn(async move {
-                    tokio::time::sleep_until(deadline).await;
-                    info!(endpoint = %inner.config.endpoint_name, "Proactive refresh timer fired");
-                    match inner.do_token_refresh().await {
-                        Ok(new_tokens) => {
-                            // Recursively apply — this will schedule the next refresh
+        if let Some(deadline) = deadline {
+            let inner = self.clone();
+            let handle = tokio::spawn(async move {
+                tokio::time::sleep_until(deadline).await;
+                info!(endpoint = %inner.config.endpoint_name, "Proactive refresh timer fired");
+                match inner.do_token_refresh().await {
+                    Ok(new_tokens) => {
+                        // Recursively apply — this will schedule the next refresh
+                        inner.apply_tokens(new_tokens).await;
+                    }
+                    Err(e) => {
+                        warn!(
+                            endpoint = %inner.config.endpoint_name,
+                            error = %e,
+                            "Proactive refresh failed, retrying in 60s"
+                        );
+                        // Retry once after 60 seconds
+                        tokio::time::sleep(Duration::from_secs(60)).await;
+                        if let Ok(new_tokens) = inner.do_token_refresh().await {
                             inner.apply_tokens(new_tokens).await;
-                        }
-                        Err(e) => {
+                        } else {
                             warn!(
                                 endpoint = %inner.config.endpoint_name,
-                                error = %e,
-                                "Proactive refresh failed, retrying in 60s"
+                                "Proactive refresh retry also failed"
                             );
-                            // Retry once after 60 seconds
-                            tokio::time::sleep(Duration::from_secs(60)).await;
-                            if let Ok(new_tokens) = inner.do_token_refresh().await {
-                                inner.apply_tokens(new_tokens).await;
-                            } else {
-                                warn!(
-                                    endpoint = %inner.config.endpoint_name,
-                                    "Proactive refresh retry also failed"
-                                );
-                            }
                         }
                     }
-                });
-                self.refresh_task_handle.lock().await.replace(handle);
-            }
+                }
+            });
+            self.refresh_task_handle.lock().await.replace(handle);
         }
     }
 
@@ -950,5 +978,109 @@ mod tests {
         let expected = issued + Duration::from_secs(900);
         assert!(deadline >= expected - Duration::from_millis(1));
         assert!(deadline <= expected + Duration::from_millis(1));
+    }
+
+    // --- apply_tokens proactive-refresh & inner_health tests ---
+
+    /// Spawn a minimal in-process MCP server that responds to `initialize`
+    /// with a valid `serverInfo.name` and accepts `notifications/initialized`.
+    /// Returns the URL of the `/mcp` endpoint and a JoinHandle for the server.
+    async fn spawn_minimal_mcp_server() -> (String, tokio::task::JoinHandle<()>) {
+        use axum::{routing::post, Json, Router};
+        use serde_json::{json, Value};
+
+        async fn handle(Json(body): Json<Value>) -> Json<Value> {
+            let id = body.get("id").cloned().unwrap_or(Value::Null);
+            let method = body.get("method").and_then(|m| m.as_str()).unwrap_or("");
+            if method == "initialize" {
+                Json(json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {},
+                        "serverInfo": {"name": "test-server", "version": "0.0.1"},
+                    },
+                }))
+            } else {
+                // Notifications and anything else: empty 200 OK.
+                Json(json!({"jsonrpc": "2.0", "id": id, "result": {}}))
+            }
+        }
+
+        let router = Router::new().route("/mcp", post(handle));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        // Tiny delay to let the server start accepting connections.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        (format!("http://127.0.0.1:{}/mcp", addr.port()), handle)
+    }
+
+    /// Regression: a TokenSet with `expires_at` set but `issued_at = None`
+    /// (the shape persisted by older relay versions) must still spawn a
+    /// proactive refresh task.
+    #[tokio::test]
+    async fn apply_tokens_schedules_refresh_without_issued_at() {
+        let mut config = make_config();
+        // Point at an unreachable URL so initialize() fails quickly. The
+        // proactive-refresh scheduling must not depend on init success.
+        config.url = "http://127.0.0.1:19999/mcp".to_string();
+        let mut adapter = make_adapter(config);
+        adapter.initialize().await.unwrap();
+
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let token_set = TokenSet {
+            access_token: "test-access".to_string(),
+            refresh_token: Some("test-refresh".to_string()),
+            expires_at: Some(now_secs + 3600),
+            token_type: "Bearer".to_string(),
+            scope: None,
+            issued_at: None,
+        };
+        adapter.inner.apply_tokens(token_set).await;
+
+        // A refresh task must be scheduled even though issued_at is None.
+        let handle = adapter.inner.refresh_task_handle.lock().await;
+        assert!(
+            handle.is_some(),
+            "expected proactive refresh task to be scheduled when expires_at is set and issued_at is None"
+        );
+    }
+
+    /// On successful re-init, `inner_health` must be set to `Healthy`
+    /// immediately so the management API doesn't show a stale `Starting`
+    /// until the next heartbeat tick.
+    #[tokio::test]
+    async fn apply_tokens_sets_inner_health_healthy_on_success() {
+        let (url, server) = spawn_minimal_mcp_server().await;
+        let mut config = make_config();
+        config.url = url;
+        let mut adapter = make_adapter(config);
+        adapter.initialize().await.unwrap();
+
+        let token_set = TokenSet {
+            access_token: "test-access".to_string(),
+            refresh_token: None,
+            expires_at: None,
+            token_type: "Bearer".to_string(),
+            scope: None,
+            issued_at: None,
+        };
+        adapter.inner.apply_tokens(token_set).await;
+
+        let inner_health = adapter.inner.inner_health.read().await.clone();
+        assert_eq!(
+            inner_health,
+            HealthStatus::Healthy,
+            "inner_health should be Healthy immediately after a successful inner adapter initialize"
+        );
+
+        server.abort();
     }
 }

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -20,6 +20,16 @@ use tokio::sync::{Mutex, RwLock};
 use tokio::task::JoinHandle;
 use tokio::time::Instant;
 use tracing::{error, info, warn};
+
+/// Wall-clock timeout applied to the OAuth refresh `reqwest::Client`.
+///
+/// Bounds recovery time when the configured token endpoint stops responding
+/// (e.g. a half-open TCP connection); without it `do_token_refresh` could pin
+/// the adapter in `Refreshing` indefinitely. Pinning the value as a `const`
+/// gives `refresh_http_client_uses_30s_timeout` a stable hook to assert
+/// against and forces a deliberate review of any future change.
+const REFRESH_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Configuration for an OAuth-authenticated MCP endpoint.
 #[derive(Debug, Clone)]
 pub struct OAuthAdapterConfig {
@@ -505,7 +515,7 @@ impl OAuthAdapter {
                 inner_adapter: RwLock::new(None),
                 token_manager,
                 http_client: Client::builder()
-                    .timeout(Duration::from_secs(30))
+                    .timeout(REFRESH_HTTP_TIMEOUT)
                     .build()
                     .expect("static OAuth refresh HTTP client config"),
                 refresh_task_handle: Mutex::new(None),
@@ -1289,5 +1299,181 @@ mod tests {
         );
 
         server.abort();
+    }
+
+    /// Wait until the shared call counter reaches `target`. Drives the
+    /// runtime by advancing virtual time in tiny steps (which yields and
+    /// gives in-flight HTTP I/O on the spawned proactive task a chance to
+    /// progress against the real reactor). A real-time deadline guards
+    /// against an actual hang.
+    async fn wait_for_calls(counter: &Arc<std::sync::atomic::AtomicUsize>, target: usize) {
+        use std::sync::atomic::Ordering;
+        let real_start = std::time::Instant::now();
+        while counter.load(Ordering::SeqCst) < target {
+            if real_start.elapsed() > std::time::Duration::from_secs(10) {
+                panic!(
+                    "timed out waiting for refresh call {} (got {})",
+                    target,
+                    counter.load(Ordering::SeqCst)
+                );
+            }
+            tokio::time::advance(Duration::from_millis(1)).await;
+            tokio::task::yield_now().await;
+        }
+    }
+
+    /// Spawn an axum token endpoint that always responds 500 and bumps a
+    /// shared counter on every request. Used to drive the proactive-refresh
+    /// retry path (1st failure + 2nd failure) in
+    /// `apply_tokens_proactive_refresh_retry_transitions_on_second_failure`.
+    async fn spawn_token_server_always_500(
+        counter: Arc<std::sync::atomic::AtomicUsize>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        use axum::extract::State;
+        use axum::http::StatusCode;
+        use axum::{response::IntoResponse, routing::post, Router};
+
+        async fn handler(
+            State(counter): State<Arc<std::sync::atomic::AtomicUsize>>,
+        ) -> impl IntoResponse {
+            counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "{\"error\":\"server_error\"}",
+            )
+        }
+
+        let router = Router::new()
+            .route("/token", post(handler))
+            .with_state(counter);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        // Tiny delay to let the server start accepting connections.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        (format!("http://127.0.0.1:{}/token", addr.port()), handle)
+    }
+
+    /// HIGH #1 (audit): Task 1 added a defensive `transition_to(...)` call
+    /// inside the proactive-refresh retry block that runs after the
+    /// **second** consecutive `do_token_refresh` failure (it was previously
+    /// just a `warn!` log). This regression test forces the proactive task
+    /// to fire, makes the token endpoint fail twice in a row, and asserts
+    /// that the retry block recorded its `"proactive refresh retry failed"`
+    /// transition in the ring buffer.
+    ///
+    /// The negative case (only one failure ⇒ no retry-block transition) is
+    /// covered implicitly: the test pins the request count to exactly 2,
+    /// and the retry-block transition is only reached after the 2nd call
+    /// returns `Err`.
+    #[tokio::test]
+    async fn apply_tokens_proactive_refresh_retry_transitions_on_second_failure() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let (url, server) = spawn_token_server_always_500(calls.clone()).await;
+
+        let mut config = make_config();
+        // Point the inner adapter URL at an unreachable port so initialize()
+        // returns ECONNREFUSED quickly without consuming the inner client's
+        // 30 s timeout.
+        config.url = "http://127.0.0.1:19999/mcp".to_string();
+        config.token_endpoint_url = url;
+        let mut adapter = make_adapter(config);
+        adapter.initialize().await.unwrap();
+
+        // Pause time *after* the server is up so the 60 s retry sleep in
+        // the proactive task is virtual (we drive it forward with
+        // `tokio::time::advance`). Setup before this point — TCP listener
+        // bind, axum spawn — runs on real time so I/O works normally.
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        tokio::time::pause();
+
+        // expires_at = now_secs ⇒ proactive deadline collapses to
+        // `Instant::now()`, so the spawned task's `sleep_until` returns
+        // immediately on first poll.
+        let token_set = TokenSet {
+            access_token: "old-access".to_string(),
+            refresh_token: Some("test-refresh".to_string()),
+            expires_at: Some(now_secs),
+            token_type: "Bearer".to_string(),
+            scope: None,
+            issued_at: None,
+        };
+        adapter.inner.apply_tokens(token_set).await;
+
+        // Wait for the 1st refresh attempt to reach the fake endpoint.
+        // Real I/O still progresses under paused time; we yield to give
+        // the spawned proactive task a chance to be polled.
+        wait_for_calls(&calls, 1).await;
+
+        // Advance past the proactive task's 60 s retry sleep so the 2nd
+        // attempt fires.
+        tokio::time::advance(Duration::from_secs(61)).await;
+
+        // Wait for the 2nd refresh attempt.
+        wait_for_calls(&calls, 2).await;
+
+        // Yield enough times for the retry block to run its defensive
+        // `transition_to(...)` call after the 2nd Err returns.
+        for _ in 0..100 {
+            tokio::task::yield_now().await;
+        }
+
+        // Both refresh attempts must have actually hit the fake endpoint —
+        // not just one. This pins the off-by-one the audit flagged.
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "expected exactly 2 token endpoint calls (initial + 1 retry)"
+        );
+
+        // The retry block in `apply_tokens_inner` must have recorded its
+        // defensive transition AFTER the 2nd failure.
+        let history = adapter.inner.transition_history.read().await;
+        assert!(
+            history
+                .iter()
+                .any(|r| r.reason == "proactive refresh retry failed"),
+            "expected a transition with reason 'proactive refresh retry failed' \
+             after the 2nd refresh failure; got: {:?}",
+            history
+                .iter()
+                .map(|r| (r.from.clone(), r.to.clone(), r.reason.clone()))
+                .collect::<Vec<_>>()
+        );
+
+        // Final state must be a non-`Refreshing`, non-`Healthy` terminal
+        // state. With 500 responses both `do_token_refresh` and the retry
+        // block target `AuthRequired`.
+        let state = adapter.inner.state.read().await.clone();
+        assert_eq!(
+            state,
+            OAuthState::AuthRequired,
+            "after 2nd RefreshFailed the adapter must land in AuthRequired, \
+             not stay stuck in Refreshing"
+        );
+
+        server.abort();
+    }
+
+    /// MED #6 (audit): Task 1 added a 30 s timeout to the OAuth refresh
+    /// `reqwest::Client` so a stuck token endpoint can no longer pin the
+    /// state machine in `Refreshing` indefinitely. `reqwest::Client` does
+    /// not expose its configured timeout post-build, so we pin the value
+    /// at the `REFRESH_HTTP_TIMEOUT` constant the builder consumes —
+    /// changing the constant forces this assertion to be revisited.
+    #[test]
+    fn refresh_http_client_uses_30s_timeout() {
+        assert_eq!(
+            REFRESH_HTTP_TIMEOUT,
+            Duration::from_secs(30),
+            "OAuth refresh HTTP client timeout must be 30 seconds"
+        );
     }
 }

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -20,6 +20,20 @@ use tokio::sync::{Mutex, RwLock};
 use tokio::task::JoinHandle;
 use tokio::time::Instant;
 use tracing::{error, info, warn};
+
+/// Returns the `Instant` at which a proactive refresh should fire when
+/// `issued_at` is unknown (or nonsensical relative to `expires_at`).
+///
+/// The fallback heuristic is "refresh 5 minutes before expiry", clamped to
+/// `now` if we're already inside that window so the returned deadline is
+/// always `>= now`. Uses `checked_sub` so values far in the past don't
+/// underflow `Instant` arithmetic.
+fn fallback_refresh_deadline(now: Instant, expires_at: Instant) -> Instant {
+    let five_min = Duration::from_secs(300);
+    let target = expires_at.checked_sub(five_min).unwrap_or(now);
+    target.max(now)
+}
+
 /// Configuration for an OAuth-authenticated MCP endpoint.
 #[derive(Debug, Clone)]
 pub struct OAuthAdapterConfig {
@@ -344,9 +358,7 @@ impl OAuthAdapterInner {
                     // No `issued_at` (or nonsensical ordering): fall back to
                     // refreshing 5 minutes before expiry, clamped to "now"
                     // if we're already inside that window.
-                    let five_min = Duration::from_secs(300);
-                    let target = expires_instant.checked_sub(five_min).unwrap_or(now_instant);
-                    Some(target.max(now_instant))
+                    Some(fallback_refresh_deadline(now_instant, expires_instant))
                 }
             }
         } else {
@@ -980,6 +992,71 @@ mod tests {
         assert!(deadline <= expected + Duration::from_millis(1));
     }
 
+    // --- fallback_refresh_deadline tests (issued_at unknown path) ---
+
+    /// 60 minutes of remaining lifetime: deadline should be 5 minutes before
+    /// expiry (= now + 55 min). Task 2's fallback heuristic is "5 min before
+    /// expiry", not 75% of remaining — assert what the implementation does.
+    #[test]
+    fn fallback_refresh_deadline_uses_5min_before_expiry() {
+        let now = Instant::now();
+        let expires_at = now + Duration::from_secs(3600);
+        let deadline = fallback_refresh_deadline(now, expires_at);
+        let expected = now + Duration::from_secs(3600 - 300);
+        assert!(deadline >= expected - Duration::from_millis(1));
+        assert!(deadline <= expected + Duration::from_millis(1));
+    }
+
+    /// If `expires_at` is in the past or within the 5-minute guard window,
+    /// the deadline must clamp to `now` — never panic, never underflow, and
+    /// the returned deadline must be `>= now`.
+    #[test]
+    fn fallback_refresh_deadline_clamps_to_minimum_when_expiring_soon() {
+        let now = Instant::now();
+
+        // expires_at exactly at now → 5-min subtraction underflows → clamp to now.
+        let deadline = fallback_refresh_deadline(now, now);
+        assert_eq!(
+            deadline, now,
+            "expected clamp to `now` when expires_at == now"
+        );
+
+        // expires_at within the 5-minute window (60s out) → still clamps to now.
+        let near = now + Duration::from_secs(60);
+        let deadline = fallback_refresh_deadline(now, near);
+        assert_eq!(
+            deadline, now,
+            "expected clamp to `now` when expires_at is inside the 5-min guard"
+        );
+
+        // expires_at strictly before now (1s in the past per Instant semantics)
+        // — saturating subtraction inside `checked_sub` must not panic and the
+        // clamp keeps the deadline at `now`.
+        let past = now - Duration::from_secs(1);
+        let deadline = fallback_refresh_deadline(now, past);
+        assert!(
+            deadline >= now,
+            "expected deadline >= now when expires_at is in the past, got delta = {:?}",
+            now.saturating_duration_since(deadline)
+        );
+    }
+
+    /// `expires_at` 100 years out must not panic. Tokio's `Instant` is backed
+    /// by a monotonic clock so addition can theoretically saturate, but the
+    /// helper performs a simple subtraction and `max`, both of which are safe.
+    #[test]
+    fn fallback_refresh_deadline_handles_far_future_without_overflow() {
+        let now = Instant::now();
+        // ~100 years in seconds.
+        let far = now + Duration::from_secs(100 * 365 * 24 * 3600);
+        let deadline = fallback_refresh_deadline(now, far);
+        let expected = far - Duration::from_secs(300);
+        assert_eq!(
+            deadline, expected,
+            "expected deadline to be exactly 5 min before expiry for far-future timestamps"
+        );
+    }
+
     // --- apply_tokens proactive-refresh & inner_health tests ---
 
     /// Spawn a minimal in-process MCP server that responds to `initialize`
@@ -1050,6 +1127,19 @@ mod tests {
         assert!(
             handle.is_some(),
             "expected proactive refresh task to be scheduled when expires_at is set and issued_at is None"
+        );
+        drop(handle);
+
+        // The inner adapter init failed (URL is unreachable), so inner_health
+        // must NOT be `Healthy`: the success-path branch sets it to `Healthy`,
+        // so a regression that flips the branches would leave it `Healthy`
+        // here. Failed init mirrors the inner adapter's own health, which is
+        // `Unhealthy(_)` after a connection failure.
+        let inner_health = adapter.inner.inner_health.read().await.clone();
+        assert!(
+            !matches!(inner_health, HealthStatus::Healthy),
+            "inner_health must not be Healthy after a failed inner adapter init, got {:?}",
+            inner_health
         );
     }
 

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -1027,6 +1027,31 @@ mod tests {
             // Health remains Unhealthy — confirm by sampling again after a delay.
             tokio::time::sleep(Duration::from_millis(300)).await;
             assert!(matches!(adapter.health(), HealthStatus::Unhealthy(_)));
+
+            // Supervisor task must have terminated after hitting the cap.
+            {
+                let guard = adapter.reconnect_handle.lock().await;
+                let handle = guard
+                    .as_ref()
+                    .expect("supervisor handle should still be tracked post-cap");
+                assert!(
+                    handle.is_finished(),
+                    "supervisor should exit after failure cap"
+                );
+            }
+
+            // Subsequent stream-death notifications must NOT restart the
+            // supervisor or trigger further GET /sse attempts.
+            let connections_before = server.state.connections.load(Ordering::SeqCst);
+            adapter.reconnect_notify.notify_waiters();
+            adapter.reconnect_notify.notify_one();
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            assert_eq!(
+                server.state.connections.load(Ordering::SeqCst),
+                connections_before,
+                "supervisor must not restart after cap"
+            );
+
             adapter.shutdown().await.unwrap();
         }
 
@@ -1092,6 +1117,155 @@ mod tests {
             );
             assert!(adapter.reconnect_handle.lock().await.is_none());
             assert!(adapter.sse_handle.lock().await.is_none());
+            assert_eq!(adapter.health(), HealthStatus::Stopped);
+        }
+
+        #[tokio::test]
+        async fn crash_tracker_reset_on_successful_reconnect() {
+            let server = start_test_server().await;
+            let mut adapter = build_adapter(&server.url, 5).await;
+            adapter.initialize().await.expect("initial connect");
+            assert_eq!(adapter.health(), HealthStatus::Healthy);
+
+            // Drive a single failure cycle: close the stream, wait for the
+            // supervisor to flag Unhealthy, then wait for a successful
+            // auto-reconnect back to Healthy.
+            server.close_all_streams();
+            let h = wait_for_health(
+                &adapter,
+                |h| matches!(h, HealthStatus::Unhealthy(_)),
+                Duration::from_secs(2),
+            )
+            .await;
+            assert!(matches!(h, HealthStatus::Unhealthy(_)));
+            let h = wait_for_health(
+                &adapter,
+                |h| *h == HealthStatus::Healthy,
+                Duration::from_secs(3),
+            )
+            .await;
+            assert_eq!(h, HealthStatus::Healthy);
+
+            // After the successful reconnect, the crash tracker must be
+            // reset so the next failure cycle starts with a full attempt
+            // budget rather than 1 attempt left.
+            {
+                let tracker = adapter.crash_tracker.lock().await;
+                assert_eq!(
+                    tracker.consecutive_failures, 0,
+                    "tracker must reset consecutive_failures on success"
+                );
+                assert!(
+                    tracker.timestamps.is_empty(),
+                    "tracker must clear failure timestamps on success"
+                );
+            }
+
+            adapter.shutdown().await.unwrap();
+        }
+
+        #[tokio::test]
+        async fn supervisor_handles_multiple_reconnect_cycles() {
+            let server = start_test_server().await;
+            let mut adapter = build_adapter(&server.url, 5).await;
+            adapter.initialize().await.expect("initial connect");
+
+            for cycle in 0..3 {
+                server.close_all_streams();
+                let h = wait_for_health(
+                    &adapter,
+                    |h| matches!(h, HealthStatus::Unhealthy(_)),
+                    Duration::from_secs(2),
+                )
+                .await;
+                assert!(
+                    matches!(h, HealthStatus::Unhealthy(_)),
+                    "cycle {}: expected Unhealthy after stream close, got {:?}",
+                    cycle,
+                    h
+                );
+                let h = wait_for_health(
+                    &adapter,
+                    |h| *h == HealthStatus::Healthy,
+                    Duration::from_secs(3),
+                )
+                .await;
+                assert_eq!(
+                    h,
+                    HealthStatus::Healthy,
+                    "cycle {}: expected Healthy after auto-reconnect",
+                    cycle
+                );
+            }
+
+            // No pending requests should have leaked across cycles.
+            assert!(
+                adapter.pending.lock().await.is_empty(),
+                "pending requests leaked across reconnect cycles"
+            );
+
+            // The same supervisor task should still be servicing reconnects;
+            // a fresh listener handle should be tracked from the latest cycle.
+            {
+                let sup = adapter.reconnect_handle.lock().await;
+                assert!(
+                    sup.as_ref().is_some_and(|h| !h.is_finished()),
+                    "supervisor should still be running after multiple cycles"
+                );
+            }
+            assert!(
+                adapter.sse_handle.lock().await.is_some(),
+                "listener handle should be present after final reconnect"
+            );
+
+            assert_eq!(adapter.health(), HealthStatus::Healthy);
+            // Initial connect plus 3 reconnects = at least 4 SSE GETs.
+            assert!(
+                server.state.connections.load(Ordering::SeqCst) >= 4,
+                "expected >=4 SSE connections across 3 reconnect cycles"
+            );
+
+            adapter.shutdown().await.unwrap();
+        }
+
+        #[tokio::test]
+        async fn shutdown_cancels_in_flight_backoff() {
+            let server = start_test_server().await;
+            // Only the first SSE GET succeeds; further attempts return 503,
+            // so the supervisor records a failure and parks in the backoff
+            // sleep before its next reconnect attempt.
+            server.state.healthy_until.store(1, Ordering::SeqCst);
+
+            // Long base backoff so the supervisor is solidly inside
+            // tokio::time::sleep(backoff) when shutdown() is called.
+            let mut adapter = SseAdapter::new(SseConfig::new(&server.url).with_timeout(1));
+            *adapter.crash_tracker.lock().await =
+                CrashTracker::new_test(Duration::from_secs(5), 10, Duration::from_secs(60));
+            adapter.initialize().await.expect("initial connect");
+
+            server.close_all_streams();
+
+            // Wait until the listener has died (Unhealthy) and the supervisor
+            // has had a chance to record the first failure and enter sleep.
+            let h = wait_for_health(
+                &adapter,
+                |h| matches!(h, HealthStatus::Unhealthy(_)),
+                Duration::from_secs(2),
+            )
+            .await;
+            assert!(matches!(h, HealthStatus::Unhealthy(_)));
+            tokio::time::sleep(Duration::from_millis(50)).await;
+
+            // shutdown() must cancel the multi-second backoff sleep
+            // immediately — well below the configured 5s base backoff.
+            let start = std::time::Instant::now();
+            adapter.shutdown().await.unwrap();
+            let elapsed = start.elapsed();
+            assert!(
+                elapsed < Duration::from_millis(200),
+                "shutdown did not cancel in-flight backoff: {:?}",
+                elapsed
+            );
             assert_eq!(adapter.health(), HealthStatus::Stopped);
         }
     }

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{Mutex, Notify, RwLock};
 use tokio::time::Instant;
 use tracing::{debug, error, info, warn};
 
@@ -42,10 +42,12 @@ impl SseConfig {
 
 /// Crash tracking for exponential backoff.
 #[derive(Debug)]
-#[allow(dead_code)] // Used by try_reconnect, kept for reconnection support
 struct CrashTracker {
     timestamps: Vec<Instant>,
     consecutive_failures: u32,
+    failure_window: Duration,
+    max_failures_in_window: usize,
+    base_backoff: Duration,
 }
 
 impl CrashTracker {
@@ -53,33 +55,48 @@ impl CrashTracker {
         Self {
             timestamps: Vec::new(),
             consecutive_failures: 0,
+            failure_window: Duration::from_secs(60),
+            max_failures_in_window: 3,
+            base_backoff: Duration::from_secs(1),
         }
     }
 
-    #[allow(dead_code)] // Used by try_reconnect
+    /// Record a failure and return true when the window cap is reached.
     fn record_failure(&mut self) -> bool {
         let now = Instant::now();
         self.consecutive_failures += 1;
         self.timestamps.push(now);
-        let cutoff = now - Duration::from_secs(60);
+        let cutoff = now.checked_sub(self.failure_window).unwrap_or(now);
         self.timestamps.retain(|t| *t >= cutoff);
-        self.timestamps.len() >= 3
+        self.timestamps.len() >= self.max_failures_in_window
     }
 
-    #[allow(dead_code)] // Used by try_reconnect
     fn backoff_duration(&self) -> Duration {
-        let secs = match self.consecutive_failures {
+        let multiplier = match self.consecutive_failures {
             0 | 1 => 1,
             2 => 2,
             3 => 4,
             4 => 8,
             _ => 60,
         };
-        Duration::from_secs(secs)
+        self.base_backoff.saturating_mul(multiplier)
     }
 
     fn reset(&mut self) {
         self.consecutive_failures = 0;
+        self.timestamps.clear();
+    }
+
+    /// Build a tracker with custom timing knobs (for fast unit tests).
+    #[cfg(test)]
+    fn new_test(base_backoff: Duration, max_failures: usize, window: Duration) -> Self {
+        Self {
+            timestamps: Vec::new(),
+            consecutive_failures: 0,
+            failure_window: window,
+            max_failures_in_window: max_failures,
+            base_backoff,
+        }
     }
 }
 
@@ -88,11 +105,15 @@ impl CrashTracker {
 /// Protocol: GET /sse to receive event stream. The server sends an "endpoint"
 /// event with the URL to POST JSON-RPC messages to. Responses come back
 /// as "message" events on the SSE stream.
+///
+/// All fields are `Arc`-wrapped so the adapter can be cheaply cloned into the
+/// background reconnect supervisor task.
+#[derive(Clone)]
 pub struct SseAdapter {
     config: SseConfig,
     client: Client,
     health: Arc<RwLock<HealthStatus>>,
-    request_id: AtomicU64,
+    request_id: Arc<AtomicU64>,
     /// The POST endpoint URL received from the SSE stream.
     post_endpoint: Arc<RwLock<Option<String>>>,
     /// Pending responses indexed by request ID.
@@ -105,6 +126,12 @@ pub struct SseAdapter {
     server_type: Arc<RwLock<Option<String>>>,
     /// Ring buffer recording tool call activity.
     activity_log: Arc<RwLock<RingBuffer>>,
+    /// Handle for the background reconnect supervisor task.
+    reconnect_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
+    /// Notified by the listener when the SSE stream dies and a reconnect is needed.
+    reconnect_notify: Arc<Notify>,
+    /// Notified by `shutdown()` so the supervisor can exit cleanly.
+    shutdown_notify: Arc<Notify>,
 }
 
 impl SseAdapter {
@@ -140,13 +167,16 @@ impl SseAdapter {
             config,
             client,
             health: Arc::new(RwLock::new(HealthStatus::Stopped)),
-            request_id: AtomicU64::new(1),
+            request_id: Arc::new(AtomicU64::new(1)),
             post_endpoint: Arc::new(RwLock::new(None)),
             pending: Arc::new(Mutex::new(std::collections::HashMap::new())),
             sse_handle: Arc::new(Mutex::new(None)),
             crash_tracker: Arc::new(Mutex::new(CrashTracker::new())),
             server_type: Arc::new(RwLock::new(None)),
             activity_log: Arc::new(RwLock::new(RingBuffer::new(1000))),
+            reconnect_handle: Arc::new(Mutex::new(None)),
+            reconnect_notify: Arc::new(Notify::new()),
+            shutdown_notify: Arc::new(Notify::new()),
         }
     }
 
@@ -221,6 +251,7 @@ impl SseAdapter {
         let pending = self.pending.clone();
         let post_endpoint = self.post_endpoint.clone();
         let health = self.health.clone();
+        let reconnect_notify = self.reconnect_notify.clone();
         let base_url = self.config.url.clone();
 
         // Spawn SSE listener task
@@ -230,15 +261,15 @@ impl SseAdapter {
             let mut event_type = String::new();
             let mut data_lines = Vec::<String>::new();
             let mut bytes_stream = resp.bytes_stream();
+            let mut close_reason: Option<String> = None;
 
             use futures_util::StreamExt;
             while let Some(chunk_result) = bytes_stream.next().await {
                 let chunk = match chunk_result {
                     Ok(c) => c,
                     Err(e) => {
-                        error!(error = %e, "SSE stream error");
-                        *health.write().await =
-                            HealthStatus::Unhealthy(format!("SSE stream error: {}", e));
+                        warn!(error = %e, "SSE stream error");
+                        close_reason = Some(format!("SSE stream error: {}", e));
                         break;
                     }
                 };
@@ -310,7 +341,25 @@ impl SseAdapter {
                 }
             }
 
-            *health.write().await = HealthStatus::Unhealthy("SSE stream closed".into());
+            // Stream ended (Err or end-of-stream). Mark unhealthy, clear the
+            // POST endpoint so new requests fail fast, drain pending requests
+            // with errors so callers don't hang, and signal the reconnect
+            // supervisor to attempt recovery.
+            let reason =
+                close_reason.unwrap_or_else(|| "SSE stream closed, reconnecting".to_string());
+            *post_endpoint.write().await = None;
+            {
+                let mut map = pending.lock().await;
+                if !map.is_empty() {
+                    debug!(
+                        count = map.len(),
+                        "draining pending SSE requests after stream death"
+                    );
+                }
+                map.clear();
+            }
+            *health.write().await = HealthStatus::Unhealthy(reason);
+            reconnect_notify.notify_one();
         });
 
         *self.sse_handle.lock().await = Some(handle);
@@ -392,15 +441,17 @@ impl SseAdapter {
             .result
             .ok_or_else(|| AdapterError::ProtocolError("response has no result".into()))
     }
-}
 
-#[async_trait]
-impl McpAdapter for SseAdapter {
-    async fn initialize(&mut self) -> Result<(), AdapterError> {
+    /// Connect to the SSE endpoint and perform the MCP initialize handshake.
+    ///
+    /// Used by `initialize()` for the first connection and by the reconnect
+    /// supervisor task to re-establish a healthy connection. On success, sets
+    /// `health = Healthy` and resets the crash tracker. On failure, sets
+    /// `health = Unhealthy(...)` with the underlying error.
+    async fn connect_and_handshake(&self) -> Result<(), AdapterError> {
         if let Err(e) = self.connect().await {
             let msg = e.to_string();
             *self.health.write().await = HealthStatus::Unhealthy(msg);
-            error!(url = %self.config.url, error = %e, "SSE connection failed");
             return Err(e);
         }
 
@@ -418,37 +469,112 @@ impl McpAdapter for SseAdapter {
             Err(e) => {
                 let msg = e.to_string();
                 *self.health.write().await = HealthStatus::Unhealthy(msg);
-                error!(url = %self.config.url, error = %e, "SSE MCP adapter initialization failed");
                 return Err(e);
             }
         };
 
         // Extract serverInfo.name — REQUIRED per MCP spec enforcement
-        let raw_name = result
+        let raw_name = match result
             .get("serverInfo")
             .and_then(|si| si.get("name"))
             .and_then(|n| n.as_str())
-            .ok_or_else(|| {
-                let err = ServerNameError::Missing;
-                let msg = err.to_string();
-                error!(url = %self.config.url, error = %msg, "MCP server did not provide serverInfo.name");
-                *self.health.blocking_write() = HealthStatus::Unhealthy(msg.clone());
-                AdapterError::ProtocolError(msg)
-            })?;
+        {
+            Some(n) => n.to_string(),
+            None => {
+                let msg = ServerNameError::Missing.to_string();
+                *self.health.write().await = HealthStatus::Unhealthy(msg.clone());
+                return Err(AdapterError::ProtocolError(msg));
+            }
+        };
 
-        // Validate and sanitize the server name
-        let sanitized = sanitize_server_name(raw_name).map_err(|e| {
-            let msg = e.to_string();
-            error!(url = %self.config.url, raw_name = %raw_name, error = %msg, "serverInfo.name validation failed");
-            *self.health.blocking_write() = HealthStatus::Unhealthy(msg.clone());
-            AdapterError::ProtocolError(msg)
-        })?;
+        let sanitized = match sanitize_server_name(&raw_name) {
+            Ok(s) => s,
+            Err(e) => {
+                let msg = e.to_string();
+                *self.health.write().await = HealthStatus::Unhealthy(msg.clone());
+                return Err(AdapterError::ProtocolError(msg));
+            }
+        };
 
-        info!(url = %self.config.url, raw_name = %raw_name, sanitized = %sanitized, "MCP server reported serverInfo.name");
+        debug!(url = %self.config.url, raw_name = %raw_name, sanitized = %sanitized, "MCP server reported serverInfo.name");
         *self.server_type.write().await = Some(sanitized);
-
         *self.health.write().await = HealthStatus::Healthy;
         self.crash_tracker.lock().await.reset();
+        Ok(())
+    }
+
+    /// Spawn the background reconnect supervisor task if it isn't running.
+    async fn ensure_supervisor_running(&self) {
+        let mut guard = self.reconnect_handle.lock().await;
+        if guard.as_ref().is_some_and(|h| !h.is_finished()) {
+            return;
+        }
+        let me = self.clone();
+        let handle = tokio::spawn(async move {
+            me.run_supervisor().await;
+        });
+        *guard = Some(handle);
+    }
+
+    /// Reconnect supervisor loop — wait for stream-death notifications and
+    /// attempt to re-establish the connection with exponential backoff. Exits
+    /// when the failure cap is reached or shutdown is signaled.
+    async fn run_supervisor(&self) {
+        loop {
+            tokio::select! {
+                _ = self.shutdown_notify.notified() => return,
+                _ = self.reconnect_notify.notified() => {}
+            }
+
+            loop {
+                let (cap_reached, backoff) = {
+                    let mut tracker = self.crash_tracker.lock().await;
+                    let reached = tracker.record_failure();
+                    (reached, tracker.backoff_duration())
+                };
+
+                if cap_reached {
+                    let reason = "SSE reconnect cap reached; manual reconnect required".to_string();
+                    warn!(url = %self.config.url, "{}", reason);
+                    *self.health.write().await = HealthStatus::Unhealthy(reason);
+                    return;
+                }
+
+                info!(
+                    url = %self.config.url,
+                    backoff_ms = backoff.as_millis() as u64,
+                    "SSE reconnect: backing off before next attempt"
+                );
+
+                tokio::select! {
+                    _ = self.shutdown_notify.notified() => return,
+                    _ = tokio::time::sleep(backoff) => {}
+                }
+
+                info!(url = %self.config.url, "SSE reconnect: attempting");
+                match self.connect_and_handshake().await {
+                    Ok(()) => {
+                        info!(url = %self.config.url, "SSE reconnect succeeded");
+                        break;
+                    }
+                    Err(e) => {
+                        warn!(url = %self.config.url, error = %e, "SSE reconnect attempt failed");
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl McpAdapter for SseAdapter {
+    async fn initialize(&mut self) -> Result<(), AdapterError> {
+        if let Err(e) = self.connect_and_handshake().await {
+            error!(url = %self.config.url, error = %e, "SSE MCP adapter initialization failed");
+            return Err(e);
+        }
+
+        self.ensure_supervisor_running().await;
         info!(url = %self.config.url, "SSE MCP adapter initialized");
         Ok(())
     }
@@ -501,8 +627,17 @@ impl McpAdapter for SseAdapter {
     async fn shutdown(&mut self) -> Result<(), AdapterError> {
         *self.health.write().await = HealthStatus::Stopped;
 
+        // Tell the supervisor to wake up and exit (in case it's sleeping in
+        // backoff or waiting on a reconnect notification).
+        self.shutdown_notify.notify_waiters();
+
         // Abort the SSE listener task
         if let Some(handle) = self.sse_handle.lock().await.take() {
+            handle.abort();
+        }
+
+        // Abort the reconnect supervisor task
+        if let Some(handle) = self.reconnect_handle.lock().await.take() {
             handle.abort();
         }
 
@@ -525,36 +660,6 @@ impl McpAdapter for SseAdapter {
             .map(|s| s.to_string())
             .collect()
     }
-}
-
-/// Attempt to reconnect after a failure with exponential backoff.
-#[allow(dead_code)] // Kept for future reconnection support
-pub async fn try_reconnect(adapter: &mut SseAdapter) -> Result<(), AdapterError> {
-    let should_stop = {
-        let mut tracker = adapter.crash_tracker.lock().await;
-        let unhealthy = tracker.record_failure();
-        if unhealthy {
-            true
-        } else {
-            let backoff = tracker.backoff_duration();
-            info!(
-                backoff_secs = backoff.as_secs(),
-                "backing off before SSE reconnect"
-            );
-            drop(tracker);
-            tokio::time::sleep(backoff).await;
-            false
-        }
-    };
-
-    if should_stop {
-        let reason = "3+ failures in 60 seconds".to_string();
-        *adapter.health.write().await = HealthStatus::Unhealthy(reason.clone());
-        error!("SSE adapter marked unhealthy: {}", reason);
-        return Err(AdapterError::ConnectionFailed(reason));
-    }
-
-    adapter.initialize().await
 }
 
 #[cfg(test)]
@@ -639,5 +744,355 @@ mod tests {
         tracker.record_failure();
         tracker.reset();
         assert_eq!(tracker.backoff_duration(), Duration::from_secs(1));
+    }
+
+    // -----------------------------------------------------------------
+    // Reconnect supervisor tests — exercise the full listener/supervisor
+    // loop against a tiny in-process axum SSE server.
+    // -----------------------------------------------------------------
+
+    mod reconnect {
+        use super::*;
+        use axum::extract::State;
+        use axum::http::StatusCode;
+        use axum::response::sse::{Event, KeepAlive, Sse};
+        use axum::response::IntoResponse;
+        use axum::routing::{get, post};
+        use axum::{Json, Router};
+        use std::convert::Infallible;
+        use std::sync::atomic::{AtomicBool, AtomicUsize};
+        use tokio::net::TcpListener;
+        use tokio::sync::{broadcast, mpsc};
+
+        /// Behavior knobs for the test SSE server.
+        #[derive(Default)]
+        struct FakeServerState {
+            /// Number of GET /sse connections accepted so far.
+            connections: AtomicUsize,
+            /// When > 0, GET /sse returns 503 once `connections > healthy_until`.
+            healthy_until: AtomicUsize,
+            /// When true, /sse closes the stream right after sending endpoint.
+            close_immediately: AtomicBool,
+            /// When true, /message closes the active SSE stream on `tools/call`
+            /// without broadcasting a response.
+            close_on_tools_call: AtomicBool,
+            /// When true, /message does NOT broadcast `tools/call` responses
+            /// (used to test pending-request error propagation).
+            silent_on_tools_call: AtomicBool,
+        }
+
+        /// Handle for a running test server; aborts on drop.
+        struct FakeServer {
+            url: String,
+            state: Arc<FakeServerState>,
+            close_tx: broadcast::Sender<()>,
+            handle: tokio::task::JoinHandle<()>,
+        }
+
+        impl Drop for FakeServer {
+            fn drop(&mut self) {
+                self.handle.abort();
+            }
+        }
+
+        impl FakeServer {
+            /// Force-close all active SSE streams.
+            fn close_all_streams(&self) {
+                let _ = self.close_tx.send(());
+            }
+        }
+
+        #[derive(Clone)]
+        struct AppState {
+            fake: Arc<FakeServerState>,
+            // Broadcast channel: /message writes responses, SSE handlers forward.
+            response_tx: broadcast::Sender<Value>,
+            // Broadcast: when sent, all SSE handlers close their streams.
+            close_tx: broadcast::Sender<()>,
+        }
+
+        async fn handle_sse(State(app): State<AppState>) -> axum::response::Response {
+            let n = app.fake.connections.fetch_add(1, Ordering::SeqCst) + 1;
+            let healthy_until = app.fake.healthy_until.load(Ordering::SeqCst);
+            if healthy_until > 0 && n > healthy_until {
+                return (StatusCode::SERVICE_UNAVAILABLE, "go away").into_response();
+            }
+
+            let (tx, rx) = mpsc::channel::<Result<Event, Infallible>>(32);
+            let _ = tx
+                .send(Ok(Event::default().event("endpoint").data("/message")))
+                .await;
+
+            if app.fake.close_immediately.load(Ordering::SeqCst) {
+                drop(tx);
+                return Sse::new(tokio_stream::wrappers::ReceiverStream::new(rx))
+                    .keep_alive(KeepAlive::default())
+                    .into_response();
+            }
+
+            let mut response_rx = app.response_tx.subscribe();
+            let mut close_rx = app.close_tx.subscribe();
+            tokio::spawn(async move {
+                loop {
+                    tokio::select! {
+                        _ = close_rx.recv() => break,
+                        msg = response_rx.recv() => match msg {
+                            Ok(value) => {
+                                let data = serde_json::to_string(&value).unwrap_or_default();
+                                if tx
+                                    .send(Ok(Event::default().event("message").data(data)))
+                                    .await
+                                    .is_err()
+                                { break; }
+                            }
+                            Err(_) => break,
+                        },
+                    }
+                }
+            });
+
+            Sse::new(tokio_stream::wrappers::ReceiverStream::new(rx))
+                .keep_alive(KeepAlive::default())
+                .into_response()
+        }
+
+        async fn handle_message(
+            State(app): State<AppState>,
+            Json(body): Json<Value>,
+        ) -> Json<Value> {
+            let method = body["method"].as_str().unwrap_or("").to_string();
+            let id = body["id"].as_u64().unwrap_or(0);
+            let response = match method.as_str() {
+                "initialize" => json!({
+                    "jsonrpc": "2.0",
+                    "result": {
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {"tools": {}},
+                        "serverInfo": {"name": "fake-sse", "version": "0.0.0"}
+                    },
+                    "id": id,
+                }),
+                _ => json!({
+                    "jsonrpc": "2.0",
+                    "result": {"content": [{"type": "text", "text": "ok"}]},
+                    "id": id,
+                }),
+            };
+
+            let is_tools_call = method == "tools/call";
+            let silent = is_tools_call && app.fake.silent_on_tools_call.load(Ordering::SeqCst);
+            if !silent {
+                let _ = app.response_tx.send(response.clone());
+            }
+            if is_tools_call && app.fake.close_on_tools_call.load(Ordering::SeqCst) {
+                let _ = app.close_tx.send(());
+            }
+            Json(response)
+        }
+
+        async fn start_test_server() -> FakeServer {
+            let state = Arc::new(FakeServerState::default());
+            let (response_tx, _) = broadcast::channel::<Value>(64);
+            let (close_tx, _) = broadcast::channel::<()>(8);
+            let app_state = AppState {
+                fake: state.clone(),
+                response_tx,
+                close_tx: close_tx.clone(),
+            };
+            let app = Router::new()
+                .route("/sse", get(handle_sse))
+                .route("/message", post(handle_message))
+                .with_state(app_state);
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            let url = format!("http://{}/sse", addr);
+            let handle = tokio::spawn(async move {
+                let _ = axum::serve(listener, app).await;
+            });
+            FakeServer {
+                url,
+                state,
+                close_tx,
+                handle,
+            }
+        }
+
+        /// Build an adapter wired to the given URL with a fast crash tracker
+        /// (50ms base backoff, 3-failure cap in a 5s window) and a 1s
+        /// per-request timeout — keeps tests bounded to a few hundred ms.
+        async fn build_adapter(url: &str, max_failures: usize) -> SseAdapter {
+            let adapter = SseAdapter::new(SseConfig::new(url).with_timeout(1));
+            *adapter.crash_tracker.lock().await = CrashTracker::new_test(
+                Duration::from_millis(50),
+                max_failures,
+                Duration::from_secs(5),
+            );
+            adapter
+        }
+
+        /// Poll `health()` until the predicate succeeds or the budget elapses.
+        async fn wait_for_health<F: Fn(&HealthStatus) -> bool>(
+            adapter: &SseAdapter,
+            pred: F,
+            budget: Duration,
+        ) -> HealthStatus {
+            let deadline = std::time::Instant::now() + budget;
+            loop {
+                let h = adapter.health();
+                if pred(&h) {
+                    return h;
+                }
+                if std::time::Instant::now() >= deadline {
+                    return h;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        }
+
+        #[tokio::test]
+        async fn sse_auto_reconnects_after_stream_drops() {
+            let server = start_test_server().await;
+            let mut adapter = build_adapter(&server.url, 5).await;
+
+            adapter.initialize().await.expect("initial connect");
+            assert_eq!(adapter.health(), HealthStatus::Healthy);
+
+            // Force-close the active SSE stream — the listener should die,
+            // mark unhealthy, and the supervisor should reconnect.
+            server.close_all_streams();
+
+            let h = wait_for_health(
+                &adapter,
+                |h| matches!(h, HealthStatus::Unhealthy(_)),
+                Duration::from_secs(2),
+            )
+            .await;
+            assert!(
+                matches!(h, HealthStatus::Unhealthy(_)),
+                "expected Unhealthy after stream close, got {:?}",
+                h
+            );
+
+            let h = wait_for_health(
+                &adapter,
+                |h| *h == HealthStatus::Healthy,
+                Duration::from_secs(3),
+            )
+            .await;
+            assert_eq!(
+                h,
+                HealthStatus::Healthy,
+                "expected Healthy after auto-reconnect"
+            );
+
+            // At least 2 GET /sse connections (initial + reconnect).
+            assert!(server.state.connections.load(Ordering::SeqCst) >= 2);
+            adapter.shutdown().await.unwrap();
+        }
+
+        #[tokio::test]
+        async fn sse_stops_reconnecting_after_cap() {
+            let server = start_test_server().await;
+            // First connection is healthy; subsequent connections return 503.
+            server.state.healthy_until.store(1, Ordering::SeqCst);
+            let mut adapter = build_adapter(&server.url, 3).await;
+
+            adapter.initialize().await.expect("initial connect");
+            assert_eq!(adapter.health(), HealthStatus::Healthy);
+
+            server.close_all_streams();
+
+            // Wait long enough for the cap to be hit. Backoffs are 50/50/100ms
+            // so 3 failed attempts complete well under 1.5s.
+            let h = wait_for_health(
+                &adapter,
+                |h| {
+                    matches!(
+                        h,
+                        HealthStatus::Unhealthy(reason) if reason.contains("cap reached")
+                    )
+                },
+                Duration::from_secs(3),
+            )
+            .await;
+            assert!(
+                matches!(
+                    h,
+                    HealthStatus::Unhealthy(ref reason) if reason.contains("cap reached")
+                ),
+                "expected cap-reached Unhealthy, got {:?}",
+                h
+            );
+
+            // Health remains Unhealthy — confirm by sampling again after a delay.
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            assert!(matches!(adapter.health(), HealthStatus::Unhealthy(_)));
+            adapter.shutdown().await.unwrap();
+        }
+
+        #[tokio::test]
+        async fn sse_pending_requests_error_on_stream_death() {
+            let server = start_test_server().await;
+            // /message will not broadcast tools/call responses, and will
+            // close the SSE stream as soon as a tools/call POST arrives.
+            server
+                .state
+                .silent_on_tools_call
+                .store(true, Ordering::SeqCst);
+            server
+                .state
+                .close_on_tools_call
+                .store(true, Ordering::SeqCst);
+
+            let mut adapter = build_adapter(&server.url, 5).await;
+            adapter.initialize().await.expect("initial connect");
+
+            let start = std::time::Instant::now();
+            let res = adapter.call_tool("echo", json!({"message": "hi"})).await;
+            let elapsed = start.elapsed();
+
+            assert!(res.is_err(), "expected call_tool to error, got {:?}", res);
+            // Should be well under the 1s per-call timeout — drain happens fast.
+            assert!(
+                elapsed < Duration::from_millis(900),
+                "call_tool took too long: {:?}",
+                elapsed
+            );
+            adapter.shutdown().await.unwrap();
+        }
+
+        #[tokio::test]
+        async fn sse_shutdown_aborts_reconnect_task() {
+            let server = start_test_server().await;
+            let mut adapter = build_adapter(&server.url, 10).await;
+            adapter.initialize().await.expect("initial connect");
+
+            // Capture supervisor handle before shutdown.
+            let supervisor = adapter
+                .reconnect_handle
+                .lock()
+                .await
+                .as_ref()
+                .map(|h| h.id());
+            assert!(supervisor.is_some(), "supervisor should be running");
+
+            // Close the stream so the supervisor enters its retry loop, then
+            // immediately call shutdown() — it must abort cleanly.
+            server.close_all_streams();
+            tokio::time::sleep(Duration::from_millis(20)).await;
+
+            let start = std::time::Instant::now();
+            adapter.shutdown().await.unwrap();
+            let elapsed = start.elapsed();
+
+            assert!(
+                elapsed < Duration::from_millis(500),
+                "shutdown took too long: {:?}",
+                elapsed
+            );
+            assert!(adapter.reconnect_handle.lock().await.is_none());
+            assert!(adapter.sse_handle.lock().await.is_none());
+            assert_eq!(adapter.health(), HealthStatus::Stopped);
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -297,6 +297,8 @@ async fn main() {
                         client_id: ep.client_id.clone().unwrap_or_default(),
                         client_secret: ep.client_secret.clone(),
                         heartbeat_interval_secs: 30,
+                        probe_timeout_secs: 10,
+                        probe_failure_threshold: 3,
                     };
 
                     let mut adapter = OAuthAdapter::new(oauth_config, token_manager.clone());

--- a/src/management.rs
+++ b/src/management.rs
@@ -2311,15 +2311,32 @@ mod tests {
         }
     }
 
-    /// Mock adapter whose `shutdown` sleeps for a configurable duration. Used
-    /// to verify that `restart_endpoint` does not block on shutdown.
+    /// Mock adapter whose `shutdown` sleeps for a configurable duration and
+    /// optionally flips an `AtomicBool` once shutdown is invoked. Used to
+    /// verify that `restart_endpoint` returns without awaiting shutdown and
+    /// that the background task actually calls `shutdown()` on the old
+    /// adapter (rather than dropping it).
     struct SlowShutdownAdapter {
         shutdown_delay: std::time::Duration,
+        shutdown_called: Option<Arc<std::sync::atomic::AtomicBool>>,
     }
 
     impl SlowShutdownAdapter {
         fn new(shutdown_delay: std::time::Duration) -> Self {
-            Self { shutdown_delay }
+            Self {
+                shutdown_delay,
+                shutdown_called: None,
+            }
+        }
+
+        fn with_shutdown_flag(
+            shutdown_delay: std::time::Duration,
+            flag: Arc<std::sync::atomic::AtomicBool>,
+        ) -> Self {
+            Self {
+                shutdown_delay,
+                shutdown_called: Some(flag),
+            }
         }
     }
 
@@ -2338,6 +2355,9 @@ mod tests {
             HealthStatus::Healthy
         }
         async fn shutdown(&mut self) -> Result<(), AdapterError> {
+            if let Some(flag) = &self.shutdown_called {
+                flag.store(true, std::sync::atomic::Ordering::SeqCst);
+            }
             tokio::time::sleep(self.shutdown_delay).await;
             Ok(())
         }
@@ -2776,6 +2796,170 @@ mod tests {
         assert!(
             swapped.is_ok(),
             "registry never reflected new adapter within 5s"
+        );
+    }
+
+    #[tokio::test]
+    async fn restart_endpoint_unknown_endpoint_returns_404_and_does_not_spawn() {
+        use std::time::Duration;
+
+        // Register a single healthy adapter under "echo"; the request will
+        // target an entirely different name that is NOT in the registry.
+        let state = test_state(vec![("echo", MockAdapter::healthy_with_tools(vec![]))]).await;
+        let registry_for_check = state.registry.clone();
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/missing-endpoint/restart")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // 4xx (specifically 404) — endpoint_not_found returns NOT_FOUND.
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = body_json(resp).await;
+        assert_eq!(body["error"], "endpoint not found");
+
+        // The registry MUST NOT have been mutated:
+        // - "echo" is still its original MockAdapter (Healthy, not Starting).
+        // - No new "missing-endpoint" key was inserted.
+        {
+            let entries = registry_for_check.entries().read().await;
+            assert_eq!(entries.len(), 1, "registry should still have one entry");
+            let echo = entries.get("echo").expect("echo entry preserved");
+            assert!(
+                matches!(echo.adapter.health(), HealthStatus::Healthy),
+                "echo adapter must not have been replaced with StartingAdapter"
+            );
+            assert!(
+                entries.get("missing-endpoint").is_none(),
+                "registry must not contain missing-endpoint"
+            );
+        }
+
+        // Wait briefly to confirm no background spawn mutates the registry
+        // after the response (i.e. no `tokio::spawn` was kicked off).
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        {
+            let entries = registry_for_check.entries().read().await;
+            assert_eq!(entries.len(), 1);
+            let echo = entries.get("echo").unwrap();
+            assert!(matches!(echo.adapter.health(), HealthStatus::Healthy));
+        }
+    }
+
+    #[tokio::test]
+    async fn restart_endpoint_returns_quickly_during_slow_shutdown() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::time::Duration;
+
+        // Old adapter: 1.5s shutdown delay + a flag that flips when shutdown
+        // is actually invoked (Item C — verifies the background task ran
+        // shutdown rather than dropping the adapter).
+        let shutdown_called = Arc::new(AtomicBool::new(false));
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "echo".to_string(),
+                Box::new(SlowShutdownAdapter::with_shutdown_flag(
+                    Duration::from_millis(1500),
+                    shutdown_called.clone(),
+                )),
+                "stdio".to_string(),
+                None,
+                Some("echo".to_string()),
+            )
+            .await;
+        let state = ManagementState {
+            registry: Arc::new(registry),
+            config: Arc::new(RwLock::new(test_config())),
+            start_time: Instant::now(),
+            config_path: None,
+            oauth_flow_manager: None,
+            relay_port: 9400,
+            oauth_adapter_inners: None,
+            token_manager: None,
+            setup_manager: None,
+        };
+        let registry_for_poll = state.registry.clone();
+        let app = management_routes(state);
+
+        // Item B (1): tight upper bound on response time even though the old
+        // adapter's shutdown takes 1.5s.
+        let start = Instant::now();
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/echo/restart")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let elapsed = start.elapsed();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(
+            elapsed < Duration::from_millis(100),
+            "restart should return in <100ms, took {:?}",
+            elapsed
+        );
+        let body = body_json(resp).await;
+        assert_eq!(body["ok"], true);
+
+        // Item B (3): immediately after the response, the registry MUST
+        // contain the StartingAdapter placeholder — i.e. the swap happened
+        // synchronously with the request, not asynchronously.
+        {
+            let entries = registry_for_poll.entries().read().await;
+            let entry = entries.get("echo").expect("echo still in registry");
+            assert!(
+                matches!(entry.adapter.health(), HealthStatus::Starting),
+                "registry should hold a StartingAdapter while shutdown runs, got {:?}",
+                entry.adapter.health()
+            );
+        }
+
+        // Item C: poll the AtomicBool until shutdown() is observed running
+        // on the old adapter. The flag flips at the start of shutdown(), so
+        // this should fire well before the 1.5s sleep finishes.
+        let flag_flipped = tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                if shutdown_called.load(Ordering::SeqCst) {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+        assert!(
+            flag_flipped.is_ok(),
+            "background task never invoked shutdown() on the old adapter"
+        );
+
+        // Item B (4): once the background spawn completes, the registry
+        // should hold the new adapter. With test_config()'s "echo" entry
+        // (command = "echo", no MCP server), create_adapter ends up with a
+        // FailedAdapter whose health is Unhealthy.
+        let final_state = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                {
+                    let entries = registry_for_poll.entries().read().await;
+                    if let Some(entry) = entries.get("echo") {
+                        if matches!(entry.adapter.health(), HealthStatus::Unhealthy(_)) {
+                            return;
+                        }
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await;
+        assert!(
+            final_state.is_ok(),
+            "registry never reflected final swapped adapter within 5s"
         );
     }
 

--- a/src/management.rs
+++ b/src/management.rs
@@ -20,7 +20,7 @@ use crate::adapter::http::{HttpAdapter, HttpConfig};
 use crate::adapter::oauth::OAuthState;
 use crate::adapter::sse::{SseAdapter, SseConfig};
 use crate::adapter::stdio::{StdioAdapter, StdioConfig};
-use crate::adapter::HealthStatus;
+use crate::adapter::{FailedAdapter, HealthStatus, McpAdapter, StartingAdapter};
 use crate::config::Config;
 use crate::oauth::{OAuthFlowManager, OAuthSetupManager, PkceChallenge};
 use crate::registry::AdapterRegistry;
@@ -287,83 +287,104 @@ fn categorize_error(reason: &str) -> String {
 }
 
 /// POST /api/endpoints/:name/restart
+///
+/// Returns immediately after validating the endpoint exists and swapping in a
+/// `StartingAdapter` placeholder. The slow shutdown + re-initialize work runs
+/// in a background task that swaps the freshly-built adapter back into the
+/// registry on completion. Failures leave the registry entry as a
+/// `FailedAdapter` so the standard health channel surfaces the error.
 async fn restart_endpoint(
     State(state): State<ManagementState>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
-    // First, check if endpoint exists and shut it down
-    {
+    // Validate the endpoint exists and atomically swap in a placeholder so the
+    // request returns immediately without awaiting shutdown/initialize.
+    let old_adapter: Box<dyn McpAdapter> = {
         let mut entries = state.registry.entries().write().await;
         let Some(entry) = entries.get_mut(&name) else {
             return endpoint_not_found(&name).into_response();
         };
-        if let Err(e) = entry.adapter.shutdown().await {
-            return error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "failed to shutdown adapter",
-                Some(&e.to_string()),
-            )
-            .into_response();
+        std::mem::replace(&mut entry.adapter, Box::new(StartingAdapter))
+    };
+    state.registry.invalidate_catalog_cache().await;
+
+    // Arc-clone everything the background task needs so it owns its captures.
+    let registry = state.registry.clone();
+    let config = state.config.clone();
+    let token_manager = state.token_manager.clone();
+    let oauth_adapter_inners = state.oauth_adapter_inners.clone();
+    let task_name = name.clone();
+
+    tokio::spawn(async move {
+        tracing::info!(endpoint = %task_name, "Restart: background task started");
+
+        // Shut down the old adapter; log but don't propagate errors — the
+        // restart must converge regardless of shutdown outcome.
+        let mut old = old_adapter;
+        if let Err(e) = old.shutdown().await {
+            tracing::warn!(
+                endpoint = %task_name,
+                error = %e,
+                "Restart: shutdown of previous adapter failed"
+            );
         }
-    }
-    // Lock released here so we can call create_adapter (async)
 
-    // Try to find the endpoint in config to rebuild from scratch
-    let config = state.config.read().await;
-    let ep_config = config.endpoints.iter().find(|ep| ep.name == name).cloned();
-    drop(config);
-
-    if let Some(ep_config) = ep_config {
-        // Rebuild adapter from config (handles FailedAdapter case properly)
-        let token_manager = state.token_manager.clone().unwrap_or_else(|| {
-            Arc::new(crate::token_manager::TokenManager::new(PathBuf::from(
-                "/tmp",
-            )))
-        });
-        let oauth_adapter_inners = state
-            .oauth_adapter_inners
-            .clone()
-            .unwrap_or_else(|| Arc::new(RwLock::new(HashMap::new())));
-
-        let new_adapter =
-            crate::watcher::create_adapter(&ep_config, &token_manager, &oauth_adapter_inners).await;
-
-        // Replace the adapter in the registry
-        let mut entries = state.registry.entries().write().await;
-        if let Some(entry) = entries.get_mut(&name) {
-            entry.adapter = new_adapter;
-        }
-        drop(entries);
-        state.registry.invalidate_catalog_cache().await;
-
-        Json(ActionResponse {
-            ok: true,
-            message: format!("Endpoint '{}' restarted", name),
-        })
-        .into_response()
-    } else {
-        // Endpoint not in config - fall back to existing behavior (re-initialize in place)
-        let mut entries = state.registry.entries().write().await;
-        let Some(entry) = entries.get_mut(&name) else {
-            return endpoint_not_found(&name).into_response();
+        // Look up the endpoint config to decide between rebuild and re-init.
+        let ep_config = {
+            let cfg = config.read().await;
+            cfg.endpoints
+                .iter()
+                .find(|ep| ep.name == task_name)
+                .cloned()
         };
-        let result = entry.adapter.initialize().await;
-        drop(entries);
-        state.registry.invalidate_catalog_cache().await;
-        match result {
-            Ok(()) => Json(ActionResponse {
-                ok: true,
-                message: format!("Endpoint '{}' restarted", name),
-            })
-            .into_response(),
-            Err(e) => error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "failed to restart adapter",
-                Some(&e.to_string()),
-            )
-            .into_response(),
+
+        let new_adapter: Box<dyn McpAdapter> = if let Some(ep) = ep_config {
+            let tm = token_manager.unwrap_or_else(|| {
+                Arc::new(crate::token_manager::TokenManager::new(PathBuf::from(
+                    "/tmp",
+                )))
+            });
+            let oai = oauth_adapter_inners.unwrap_or_else(|| Arc::new(RwLock::new(HashMap::new())));
+            crate::watcher::create_adapter(&ep, &tm, &oai).await
+        } else {
+            // Endpoint not in config: re-initialize the previous adapter in
+            // place. On failure, surface the error via FailedAdapter so the
+            // standard health channel reports it.
+            match old.initialize().await {
+                Ok(()) => old,
+                Err(e) => {
+                    tracing::error!(
+                        endpoint = %task_name,
+                        error = %e,
+                        "Restart: failed to re-initialize adapter not in config"
+                    );
+                    Box::new(FailedAdapter::new(e.to_string()))
+                }
+            }
+        };
+
+        // Swap the new adapter back into the registry.
+        {
+            let mut entries = registry.entries().write().await;
+            if let Some(entry) = entries.get_mut(&task_name) {
+                entry.adapter = new_adapter;
+            } else {
+                tracing::warn!(
+                    endpoint = %task_name,
+                    "Restart: endpoint disappeared from registry before swap"
+                );
+            }
         }
-    }
+        registry.invalidate_catalog_cache().await;
+
+        tracing::info!(endpoint = %task_name, "Restart: background task complete");
+    });
+
+    Json(ActionResponse {
+        ok: true,
+        message: format!("Endpoint '{}' restarted", name),
+    })
+    .into_response()
 }
 
 /// POST /api/endpoints/:name/refresh
@@ -2290,6 +2311,38 @@ mod tests {
         }
     }
 
+    /// Mock adapter whose `shutdown` sleeps for a configurable duration. Used
+    /// to verify that `restart_endpoint` does not block on shutdown.
+    struct SlowShutdownAdapter {
+        shutdown_delay: std::time::Duration,
+    }
+
+    impl SlowShutdownAdapter {
+        fn new(shutdown_delay: std::time::Duration) -> Self {
+            Self { shutdown_delay }
+        }
+    }
+
+    #[async_trait]
+    impl McpAdapter for SlowShutdownAdapter {
+        async fn initialize(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+        async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
+            Ok(vec![])
+        }
+        async fn call_tool(&self, _name: &str, _args: Value) -> Result<Value, AdapterError> {
+            Ok(Value::Null)
+        }
+        fn health(&self) -> HealthStatus {
+            HealthStatus::Healthy
+        }
+        async fn shutdown(&mut self) -> Result<(), AdapterError> {
+            tokio::time::sleep(self.shutdown_delay).await;
+            Ok(())
+        }
+    }
+
     fn test_config() -> Config {
         Config {
             relay: RelayConfig {
@@ -2649,6 +2702,81 @@ mod tests {
         let body = body_json(resp).await;
         assert_eq!(body["ok"], true);
         assert!(body["message"].as_str().unwrap().contains("restarted"));
+    }
+
+    #[tokio::test]
+    async fn management_restart_endpoint_non_blocking() {
+        use std::time::Duration;
+
+        // Register an adapter whose `shutdown` sleeps long enough that a
+        // synchronous restart would visibly block the response.
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "echo".to_string(),
+                Box::new(SlowShutdownAdapter::new(Duration::from_millis(200))),
+                "stdio".to_string(),
+                None,
+                Some("echo".to_string()),
+            )
+            .await;
+        let state = ManagementState {
+            registry: Arc::new(registry),
+            config: Arc::new(RwLock::new(test_config())),
+            start_time: Instant::now(),
+            config_path: None,
+            oauth_flow_manager: None,
+            relay_port: 9400,
+            oauth_adapter_inners: None,
+            token_manager: None,
+            setup_manager: None,
+        };
+        let registry_for_poll = state.registry.clone();
+        let app = management_routes(state);
+
+        let start = Instant::now();
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/echo/restart")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let elapsed = start.elapsed();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "restart should return in <500ms, took {:?}",
+            elapsed
+        );
+        let body = body_json(resp).await;
+        assert_eq!(body["ok"], true);
+        assert!(body["message"].as_str().unwrap().contains("restarted"));
+
+        // Poll the registry until the background task swaps the adapter.
+        // "echo" is in test_config but is not a real MCP server, so
+        // create_adapter ends up producing a FailedAdapter (Unhealthy).
+        let swapped = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                {
+                    let entries = registry_for_poll.entries().read().await;
+                    if let Some(entry) = entries.get("echo") {
+                        if matches!(entry.adapter.health(), HealthStatus::Unhealthy(_)) {
+                            return;
+                        }
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await;
+
+        assert!(
+            swapped.is_ok(),
+            "registry never reflected new adapter within 5s"
+        );
     }
 
     #[tokio::test]

--- a/src/management.rs
+++ b/src/management.rs
@@ -3030,6 +3030,8 @@ command = "echo"
             client_id: "test-client".to_string(),
             client_secret: None,
             heartbeat_interval_secs: 30,
+            probe_timeout_secs: 10,
+            probe_failure_threshold: 3,
         }
     }
 

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -537,6 +537,8 @@ pub(crate) async fn create_adapter(
                 client_id: ep.client_id.clone().unwrap_or_default(),
                 client_secret: ep.client_secret.clone(),
                 heartbeat_interval_secs: 30,
+                probe_timeout_secs: 10,
+                probe_failure_threshold: 3,
             };
 
             let mut adapter = OAuthAdapter::new(oauth_config, token_manager.clone());


### PR DESCRIPTION
Bundles 5 verified relay fixes into a single PR (each as a `--no-ff` merge commit so individual feature commits remain reviewable).

## Features

- **Task 1 — OAuth refresh hardening** (`panghy/oauth-refresh-hardening`)
  - Proactive-refresh retry block now `transition_to`'s on the 2nd consecutive failure (was a silent `warn!`).
  - 30s HTTP timeout on the refresh client.
  - Tests: `apply_tokens_proactive_refresh_retry_transitions_on_second_failure`, `refresh_http_client_uses_30s_timeout`.

- **Task 2 — Proactive refresh fallback** (`panghy/oauth-proactive-refresh-fallback`)
  - Computes a refresh deadline from `expires_at` alone when `issued_at` is missing.
  - Extracted pure helper `fallback_refresh_deadline` + 3 unit tests.
  - Init-failure assertion: `inner_health != Healthy` after token-endpoint failure.

- **Task 4 — Non-blocking restart endpoint** (`panghy/non-blocking-restart-endpoint`)
  - `POST /restart` swaps in `StartingAdapter` and spawns shutdown+recreate in the background, returning immediately.
  - Tests: unknown-endpoint 404 (no spawn), slow-shutdown returns <100ms, `StartingAdapter` window observable, `shutdown()` ran (`AtomicBool`).

- **Task 5 — Heartbeat hysteresis** (`panghy/oauth-heartbeat-hysteresis`)
  - Adapter health no longer flaps on a single probe failure; flips to Unhealthy only after N consecutive failures, recovers on a single Ok.
  - Extracted `apply_probe_action` (production behavior preserved) + 4 end-to-end hysteresis tests.

- **Task 7 — SSE auto-reconnect** (`panghy/sse-auto-reconnect`)
  - Supervisor reconnects with backoff after stream death; gives up after cap; outstanding requests resolve to error rather than hang; shutdown aborts the reconnect task.
  - Tests: `crash_tracker_reset_on_successful_reconnect`, `supervisor_handles_multiple_reconnect_cycles`, `shutdown_cancels_in_flight_backoff`, supervisor-exit-after-cap assertion.

## Verification

- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test --lib` — **470 passed / 0 failed**
- Bundle diff vs main: 7 files, +2126 / -215.

## Conflict resolution

Merge #2 (Task 1) hit a purely additive conflict in `src/adapter/oauth/mod.rs` because Task 1 was branched off Task 2's older tip. Resolved by keeping both T2's `fallback_refresh_deadline` helper and T1's `REFRESH_HTTP_TIMEOUT` const back-to-back. All tests survive.

## Notes

- Adds `tokio = { features = ["test-util"] }` to `[dev-dependencies]` (production binary unaffected).
- T1 retry test uses a 10s real-time guard around `tokio::time::pause`; observed runtime <3s locally.

