### PR TITLE
docs(readme): mark Homebrew as recommended install

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ No cloud. No accounts. Everything runs on your machine.
 ### 1. Install
 
 ```bash
-# Homebrew (macOS / Linux)
+# Homebrew — recommended (macOS / Linux)
 brew install endara-ai/tap/endara-relay
 
-# Cargo
+# Or, with cargo:
 cargo install endara-relay
 
 # Or download a pre-built binary from GitHub Releases:


### PR DESCRIPTION
Polishes the `### 1. Install` block in the relay README to make Homebrew the explicitly recommended install path. Cargo and direct-download remain as listed alternatives.

**Change:**
```diff
-# Homebrew (macOS / Linux)
+# Homebrew — recommended (macOS / Linux)
 brew install endara-ai/tap/endara-relay

-# Cargo
+# Or, with cargo:
 cargo install endara-relay
```

README-only. No code, workflow, or config changes.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author