### PR TITLE
fix(cli): expose --version flag (closes #33)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ pub type OAuthAdapterInners = Arc<RwLock<HashMap<String, Arc<OAuthAdapterInner>>
 use watcher::ConfigWatcher;
 
 #[derive(Parser)]
-#[command(name = "endara-relay", about = "Endara Relay agent")]
+#[command(name = "endara-relay", version, about = "Endara Relay agent")]
 struct Cli {
     #[command(subcommand)]
     command: Commands,


### PR DESCRIPTION
Closes #33.

## Change

One-line clap derive change in the top-level `Cli` struct in `src/main.rs`: add `version` to the `#[command(...)]` attribute. clap reads `CARGO_PKG_VERSION` automatically, exposing both `--version` and `-V`.

```diff
 #[derive(Parser)]
-#[command(name = "endara-relay", about = "Endara Relay agent")]
+#[command(name = "endara-relay", version, about = "Endara Relay agent")]
 struct Cli {
```

This fixes `brew test endara-ai/tap/endara-relay`, whose auto-generated `test do` block calls `endara-relay --version` (see issue #33). Crate version stays at 0.1.1; no `Cargo.toml` change.

## Manual verification

```
$ ./target/release/endara-relay --version
endara-relay 0.1.1

$ ./target/release/endara-relay -V
endara-relay 0.1.1

$ ./target/release/endara-relay --help
Endara Relay agent

Usage: endara-relay <COMMAND>

Commands:
  start  Start the relay agent
  help   Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version

$ ./target/release/endara-relay help        # subcommand still works
$ ./target/release/endara-relay start --help # subcommand still works
```

`cargo fmt --check` passes. `cargo test --release` passes (all existing tests).

No new tests added — clap's `--version` flag derivation is well-tested upstream and verified manually here.

No tag pushed; the next stable tag (likely `v0.1.2`) will auto-publish the fixed formula via the existing pipeline.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author