### PR TITLE
fix: update Linear MCP URL from /sse to /mcp in catalog tests

### DIFF
--- a/src/oauth/discovery.rs
+++ b/src/oauth/discovery.rs
@@ -511,7 +511,7 @@ mod tests {
 
     #[test]
     fn test_has_path_with_path() {
-        assert!(has_path("https://mcp.linear.app/sse"));
+        assert!(has_path("https://mcp.linear.app/mcp"));
         assert!(has_path("https://api.githubcopilot.com/mcp/"));
         assert!(has_path("https://github.com/login/oauth"));
     }
@@ -519,7 +519,7 @@ mod tests {
     #[test]
     fn test_build_well_known_url_root() {
         let url =
-            build_well_known_url_root("https://mcp.linear.app/sse", "oauth-protected-resource")
+            build_well_known_url_root("https://mcp.linear.app/mcp", "oauth-protected-resource")
                 .unwrap();
         assert_eq!(
             url,

--- a/tests/catalog_validation_integration.rs
+++ b/tests/catalog_validation_integration.rs
@@ -172,7 +172,7 @@ async fn validate_oauth_discovery(
 #[ignore] // Run with: cargo test -- --ignored
 async fn test_linear_discovery_live() {
     let client = Client::new();
-    validate_oauth_discovery(&client, "https://mcp.linear.app/sse", true)
+    validate_oauth_discovery(&client, "https://mcp.linear.app/mcp", true)
         .await
         .unwrap();
 }


### PR DESCRIPTION
Updates Linear MCP URL fixtures from `/sse` to `/mcp` to match Linear's current MCP endpoint and the desktop catalog.

## Changes

- `tests/catalog_validation_integration.rs` — `test_linear_discovery_live` (`#[ignore]`d) now points at `https://mcp.linear.app/mcp`.
- `src/oauth/discovery.rs` — `test_has_path_with_path` and `test_build_well_known_url_root` use `/mcp` instead of `/sse`. The expected `.well-known/oauth-protected-resource` URL is unchanged (host-only).

Bare-host `https://mcp.linear.app` fixtures (no path) are intentionally left alone — they reflect Linear's actual issuer/resource metadata format and exercise path-less URL handling.

## Verification

- `cargo fmt --check` ✅
- `cargo test` ✅ (all non-`#[ignore]` tests pass)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author