### PR TITLE
feat(management): pass advanced OAuth client fields through /api/oauth/setup

### DIFF
--- a/src/management.rs
+++ b/src/management.rs
@@ -1445,6 +1445,14 @@ struct OAuthSetupRequest {
     scopes: Option<Vec<String>>,
     #[serde(default)]
     tool_prefix: Option<String>,
+    /// If provided, skip DCR and use these client credentials directly.
+    #[serde(default)]
+    client_id: Option<String>,
+    #[serde(default)]
+    client_secret: Option<String>,
+    /// If provided, use this URL as the discovery base instead of `url`.
+    #[serde(default)]
+    oauth_server_url: Option<String>,
 }
 
 /// Response for POST /api/oauth/setup
@@ -1528,8 +1536,18 @@ async fn oauth_setup(
     let redirect_uri = format!("http://127.0.0.1:{}/oauth/callback", state.relay_port);
 
     // ── Step 1: Discover OAuth server ──────────────────────────────────
+    // If the caller supplied an explicit `oauth_server_url`, use that as the
+    // discovery base instead of the resource URL — this lets users point at an
+    // authorization server that doesn't expose RFC 9728 protected-resource
+    // metadata on the resource URL itself.
+    let discovery_base = body
+        .oauth_server_url
+        .as_ref()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .unwrap_or(body.url.as_str());
     let http = reqwest::Client::new();
-    let disc = match discovery::discover_oauth_server(&http, &body.url).await {
+    let disc = match discovery::discover_oauth_server(&http, discovery_base).await {
         Ok(d) => d,
         Err(e) => {
             // Clean up session on failure
@@ -1559,8 +1577,42 @@ async fn oauth_setup(
         })
         .await;
 
-    // ── Step 2: Resolve client credentials (DCR) ───────────────────────
-    let dcr_result = if let Some(ref reg_endpoint) = registration_endpoint {
+    // ── Step 2: Resolve client credentials ─────────────────────────────
+    // If the caller already supplied a client_id, skip DCR entirely and use
+    // the provided credentials. This mirrors the DCR success path: persist
+    // via the token manager and proceed straight to authorize URL building.
+    let manual_client_id = body
+        .client_id
+        .as_ref()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    let manual_client_secret = body
+        .client_secret
+        .as_ref()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    let used_dcr = manual_client_id.is_none();
+
+    let dcr_result: Result<(String, Option<String>), String> = if let Some(client_id) =
+        manual_client_id
+    {
+        // Persist manual credentials so future re-auth can find them
+        if let Some(ref tm) = state.token_manager {
+            let creds = DcrCredentials {
+                client_id: client_id.clone(),
+                client_secret: manual_client_secret.clone(),
+                client_secret_expires_at: 0,
+                registered_at: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs(),
+            };
+            if let Err(e) = tm.save_dcr(&body.name, &creds).await {
+                warn!(endpoint = %body.name, error = %e, "Failed to persist manual credentials");
+            }
+        }
+        Ok((client_id, manual_client_secret))
+    } else if let Some(ref reg_endpoint) = registration_endpoint {
         match dcr::register_client(&http, reg_endpoint, &redirect_uri, &body.name).await {
             Ok(resp) => {
                 // Persist DCR credentials for future re-auth
@@ -1629,7 +1681,7 @@ async fn oauth_setup(
 
             let discovery_info = OAuthDiscoveryInfo {
                 auth_server: auth_server_url,
-                dcr_used: true,
+                dcr_used: used_dcr,
                 scopes_available: discovered_scopes,
             };
 

--- a/tests/oauth_setup_integration.rs
+++ b/tests/oauth_setup_integration.rs
@@ -1,0 +1,139 @@
+//! Integration test: POST /api/oauth/setup advanced fields.
+//!
+//! Exercises the path where the caller provides explicit `client_id` /
+//! `client_secret` in the setup request, which should bypass DCR entirely.
+
+mod common;
+
+use endara_relay::config::{Config, EndpointConfig, RelayConfig, Transport};
+use endara_relay::management::{management_routes, ManagementState};
+use endara_relay::oauth::{OAuthFlowManager, OAuthSetupManager};
+use endara_relay::registry::AdapterRegistry;
+use serde_json::{json, Value};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::net::TcpListener;
+use tokio::sync::RwLock;
+
+use common::mock_oauth_server::MockOAuthServer;
+
+fn empty_config() -> Config {
+    Config {
+        relay: RelayConfig {
+            machine_name: "test-machine".to_string(),
+            local_js_execution: None,
+            token_dir: None,
+        },
+        endpoints: vec![EndpointConfig {
+            name: "echo".to_string(),
+            description: None,
+            tool_prefix: None,
+            transport: Transport::Stdio,
+            command: Some("echo".to_string()),
+            args: Some(vec!["hello".to_string()]),
+            url: None,
+            env: None,
+            headers: None,
+            disabled: false,
+            disabled_tools: Vec::new(),
+            oauth_server_url: None,
+            client_id: None,
+            client_secret: None,
+            scopes: None,
+            token_endpoint: None,
+        }],
+    }
+}
+
+async fn start_setup_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let registry = Arc::new(AdapterRegistry::new());
+    let state = ManagementState {
+        registry,
+        config: Arc::new(RwLock::new(empty_config())),
+        start_time: Instant::now(),
+        config_path: None,
+        oauth_flow_manager: Some(Arc::new(OAuthFlowManager::new())),
+        relay_port: 9400,
+        oauth_adapter_inners: None,
+        token_manager: None,
+        setup_manager: Some(Arc::new(OAuthSetupManager::new())),
+    };
+
+    let app = management_routes(state);
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.ok();
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    (addr, handle)
+}
+
+#[tokio::test]
+async fn oauth_setup_with_client_id_skips_dcr() {
+    let mock = MockOAuthServer::start().await;
+    let (addr, _handle) = start_setup_server().await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("http://{}/api/oauth/setup", addr))
+        .json(&json!({
+            "name": "manual-creds",
+            "url": mock.base_url(),
+            "client_id": "user-supplied-client",
+            "client_secret": "user-supplied-secret",
+            "scopes": ["read", "write"],
+        }))
+        .send()
+        .await
+        .expect("setup request failed");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: Value = resp.json().await.unwrap();
+
+    assert_eq!(body["status"], "awaiting_auth");
+    assert!(body["session_id"].as_str().is_some());
+    let authorize_url = body["authorize_url"]
+        .as_str()
+        .expect("authorize_url present");
+    assert!(authorize_url.contains("client_id=user-supplied-client"));
+    assert!(authorize_url.contains("response_type=code"));
+    assert!(authorize_url.contains("code_challenge_method=S256"));
+    // Scopes were forwarded (form-urlencoded: spaces become '+')
+    assert!(authorize_url.contains("scope=read+write"));
+    assert_eq!(body["dcr_error"], Value::Null);
+    assert_eq!(body["discovery"]["dcr_used"], false);
+
+    // DCR endpoint must not have been called when client_id is supplied.
+    let register_calls = mock.requests_to("/register").await;
+    assert!(
+        register_calls.is_empty(),
+        "expected DCR /register to be skipped, got {} calls",
+        register_calls.len()
+    );
+}
+
+#[tokio::test]
+async fn oauth_setup_without_client_id_still_uses_dcr() {
+    let mock = MockOAuthServer::start().await;
+    let (addr, _handle) = start_setup_server().await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("http://{}/api/oauth/setup", addr))
+        .json(&json!({
+            "name": "auto-dcr",
+            "url": mock.base_url(),
+        }))
+        .send()
+        .await
+        .expect("setup request failed");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["status"], "awaiting_auth");
+    assert_eq!(body["discovery"]["dcr_used"], true);
+
+    // DCR /register should have been called exactly once
+    let register_calls = mock.requests_to("/register").await;
+    assert_eq!(register_calls.len(), 1);
+}


### PR DESCRIPTION
## Summary

Extend `OAuthSetupRequest` with optional `client_id`, `client_secret`, and `oauth_server_url`. When the caller supplies an explicit `client_id`, the setup handler now skips DCR entirely:

- Persists the supplied credentials via the token manager (mirroring the DCR success path) so future re-auth can find them.
- Proceeds straight to building the authorize URL.

When `oauth_server_url` is provided, it is used as the discovery base instead of the resource URL — useful when the resource doesn't expose RFC 9728 protected-resource metadata.

## Why

The desktop Custom Server (OAUTH) form already collects Client ID / Client Secret / OAuth Server URL in the Advanced section, but the relay was always forcing DCR. For providers that don't support DCR (e.g. Google), this triggered a redundant manual-credentials prompt asking for the same values the user just typed.

## Tests

- `tests/oauth_setup_integration.rs` (new):
  - `oauth_setup_with_client_id_skips_dcr` — verifies the `/register` endpoint is **not** called when `client_id` is supplied; the response has `status=awaiting_auth`, an `authorize_url` containing the supplied `client_id`, and `discovery.dcr_used=false`.
  - `oauth_setup_without_client_id_still_uses_dcr` — guards the existing DCR path so blank `client_id` still calls `/register` exactly once.
- `cargo fmt --check`, `cargo build`, `cargo test` all green.

## Backwards compatibility

All new request fields use `#[serde(default)]`, so existing clients that don't send them are unaffected. The DCR fallback path (`status=awaiting_credentials` + `dcr_error`) is preserved verbatim when `client_id` is blank and DCR fails.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author