### PR TITLE
feat(oauth): route client credentials through TokenManager

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -67,6 +67,10 @@ pub struct EndpointConfig {
     pub oauth_server_url: Option<String>,
     #[serde(default)]
     pub client_id: Option<String>,
+    /// **Legacy** — read on adapter init only for backwards compatibility with
+    /// existing `config.toml` files. New callers should write client credentials
+    /// via `POST /api/endpoints/{name}/credentials`, which persists them through
+    /// the `TokenManager` (DCR file) instead of TOML.
     #[serde(default)]
     pub client_secret: Option<String>,
     #[serde(default)]
@@ -194,6 +198,22 @@ pub fn default_config() -> Config {
     }
 }
 
+/// Write `contents` to `path` and tighten permissions to 0o600 on Unix.
+///
+/// This is the preferred helper for any callsite that writes `config.toml`, so
+/// that secrets that legacy callers may still place in TOML are at least
+/// protected at rest. The mode change is best-effort: if it fails it is
+/// surfaced as the underlying io error.
+pub fn write_config_file(path: &Path, contents: &str) -> std::io::Result<()> {
+    std::fs::write(path, contents)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
+}
+
 /// Write a default config file to the given path, creating parent directories as needed.
 pub fn create_default_config_file(path: &Path) -> Result<Config, ConfigError> {
     let resolved = expand_tilde(path);
@@ -204,7 +224,7 @@ pub fn create_default_config_file(path: &Path) -> Result<Config, ConfigError> {
     let toml_str = toml::to_string_pretty(&config).map_err(|e| {
         ConfigError::ValidationError(format!("Failed to serialize default config: {}", e))
     })?;
-    std::fs::write(&resolved, &toml_str)?;
+    write_config_file(&resolved, &toml_str)?;
     Ok(config)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,6 +287,8 @@ async fn main() {
                 // OAuth endpoints initialize inline (always fast)
                 if ep.transport == config::Transport::Oauth {
                     let base = ep.oauth_server_url.as_deref().unwrap_or_default();
+                    let (client_id, client_secret) =
+                        watcher::resolve_oauth_client_creds(ep, token_manager.as_ref()).await;
                     let oauth_config = OAuthAdapterConfig {
                         endpoint_name: ep.name.clone(),
                         url: ep.url.clone().unwrap_or_default(),
@@ -294,8 +296,8 @@ async fn main() {
                             .token_endpoint
                             .clone()
                             .unwrap_or_else(|| format!("{}/token", base)),
-                        client_id: ep.client_id.clone().unwrap_or_default(),
-                        client_secret: ep.client_secret.clone(),
+                        client_id,
+                        client_secret,
                         heartbeat_interval_secs: 30,
                         probe_timeout_secs: 10,
                         probe_failure_threshold: 3,

--- a/src/management.rs
+++ b/src/management.rs
@@ -1445,6 +1445,14 @@ struct OAuthSetupRequest {
     scopes: Option<Vec<String>>,
     #[serde(default)]
     tool_prefix: Option<String>,
+    /// If provided, skip DCR and use these client credentials directly.
+    #[serde(default)]
+    client_id: Option<String>,
+    #[serde(default)]
+    client_secret: Option<String>,
+    /// If provided, use this URL as the discovery base instead of `url`.
+    #[serde(default)]
+    oauth_server_url: Option<String>,
 }
 
 /// Response for POST /api/oauth/setup
@@ -1528,8 +1536,18 @@ async fn oauth_setup(
     let redirect_uri = format!("http://127.0.0.1:{}/oauth/callback", state.relay_port);
 
     // ── Step 1: Discover OAuth server ──────────────────────────────────
+    // If the caller supplied an explicit `oauth_server_url`, use that as the
+    // discovery base instead of the resource URL — this lets users point at an
+    // authorization server that doesn't expose RFC 9728 protected-resource
+    // metadata on the resource URL itself.
+    let discovery_base = body
+        .oauth_server_url
+        .as_ref()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .unwrap_or(body.url.as_str());
     let http = reqwest::Client::new();
-    let disc = match discovery::discover_oauth_server(&http, &body.url).await {
+    let disc = match discovery::discover_oauth_server(&http, discovery_base).await {
         Ok(d) => d,
         Err(e) => {
             // Clean up session on failure
@@ -1559,8 +1577,42 @@ async fn oauth_setup(
         })
         .await;
 
-    // ── Step 2: Resolve client credentials (DCR) ───────────────────────
-    let dcr_result = if let Some(ref reg_endpoint) = registration_endpoint {
+    // ── Step 2: Resolve client credentials ─────────────────────────────
+    // If the caller already supplied a client_id, skip DCR entirely and use
+    // the provided credentials. This mirrors the DCR success path: persist
+    // via the token manager and proceed straight to authorize URL building.
+    let manual_client_id = body
+        .client_id
+        .as_ref()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    let manual_client_secret = body
+        .client_secret
+        .as_ref()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    let used_dcr = manual_client_id.is_none();
+
+    let dcr_result: Result<(String, Option<String>), String> = if let Some(client_id) =
+        manual_client_id
+    {
+        // Persist manual credentials so future re-auth can find them
+        if let Some(ref tm) = state.token_manager {
+            let creds = DcrCredentials {
+                client_id: client_id.clone(),
+                client_secret: manual_client_secret.clone(),
+                client_secret_expires_at: 0,
+                registered_at: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs(),
+            };
+            if let Err(e) = tm.save_dcr(&body.name, &creds).await {
+                warn!(endpoint = %body.name, error = %e, "Failed to persist manual credentials");
+            }
+        }
+        Ok((client_id, manual_client_secret))
+    } else if let Some(ref reg_endpoint) = registration_endpoint {
         match dcr::register_client(&http, reg_endpoint, &redirect_uri, &body.name).await {
             Ok(resp) => {
                 // Persist DCR credentials for future re-auth
@@ -1629,7 +1681,7 @@ async fn oauth_setup(
 
             let discovery_info = OAuthDiscoveryInfo {
                 auth_server: auth_server_url,
-                dcr_used: true,
+                dcr_used: used_dcr,
                 scopes_available: discovered_scopes,
             };
 

--- a/src/management.rs
+++ b/src/management.rs
@@ -641,7 +641,7 @@ async fn delete_endpoint(
         }
     };
 
-    if let Err(e) = std::fs::write(&resolved, &new_contents) {
+    if let Err(e) = crate::config::write_config_file(&resolved, &new_contents) {
         return error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             "failed to write config file",
@@ -683,7 +683,7 @@ async fn persist_disabled_state(state: &ManagementState) {
     // Write back to file
     let resolved = crate::config::expand_tilde(config_path);
     if let Ok(toml_str) = toml::to_string_pretty(&*config) {
-        if let Err(e) = std::fs::write(&resolved, &toml_str) {
+        if let Err(e) = crate::config::write_config_file(&resolved, &toml_str) {
             warn!(error = %e, "Failed to persist disabled state");
         }
     }
@@ -832,6 +832,36 @@ struct OAuthCredentialsRequest {
     client_id: String,
     #[serde(default)]
     client_secret: Option<String>,
+}
+
+/// Request body for POST /api/endpoints/:name/credentials.
+///
+/// All fields are optional in the JSON shape so callers can omit secrets they
+/// don't want to update. `client_id` is required at runtime — if missing, the
+/// handler responds with 400.
+#[derive(Deserialize)]
+struct EndpointCredentialsRequest {
+    #[serde(default)]
+    client_id: Option<String>,
+    #[serde(default)]
+    client_secret: Option<String>,
+    /// Currently informational — `DcrCredentials` does not yet persist this
+    /// field, so it's accepted for forward compatibility but ignored.
+    #[serde(default)]
+    #[allow(dead_code)]
+    oauth_server_url: Option<String>,
+}
+
+/// Response body for GET /api/endpoints/:name/credentials.
+#[derive(Serialize)]
+struct EndpointCredentialsResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    client_id: Option<String>,
+    client_secret_set: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    oauth_server_url: Option<String>,
+    /// Where the credentials surfaced from: "dcr" or "config" or "none".
+    source: &'static str,
 }
 
 /// Response for GET /api/endpoints/:name/oauth/status (simple)
@@ -1152,6 +1182,131 @@ async fn oauth_credentials(
     }
 
     Json(serde_json::json!({ "status": "saved" })).into_response()
+}
+
+/// POST /api/endpoints/:name/credentials
+///
+/// Persist caller-supplied OAuth client credentials via `TokenManager` (the
+/// DCR file). Never writes them to `config.toml`. Used by Wave 3a so that
+/// `client_secret` is no longer treated as a static config value.
+async fn set_endpoint_credentials(
+    State(state): State<ManagementState>,
+    Path(name): Path<String>,
+    Json(body): Json<EndpointCredentialsRequest>,
+) -> impl IntoResponse {
+    // Verify endpoint exists.
+    {
+        let config = state.config.read().await;
+        let exists = config.endpoints.iter().any(|e| e.name == name);
+        if !exists {
+            return endpoint_not_found(&name).into_response();
+        }
+    }
+
+    let client_id = match body.client_id.as_deref().map(str::trim) {
+        Some(id) if !id.is_empty() => id.to_string(),
+        _ => {
+            return error_response(StatusCode::BAD_REQUEST, "client_id must not be empty", None)
+                .into_response();
+        }
+    };
+
+    let Some(ref tm) = state.token_manager else {
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Token manager not available",
+            None,
+        )
+        .into_response();
+    };
+
+    let client_secret_set = body
+        .client_secret
+        .as_deref()
+        .map(|s| !s.is_empty())
+        .unwrap_or(false);
+
+    let creds = DcrCredentials {
+        client_id,
+        client_secret: body.client_secret.filter(|s| !s.is_empty()),
+        client_secret_expires_at: 0,
+        registered_at: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+    };
+
+    if let Err(e) = tm.save_dcr(&name, &creds).await {
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to save credentials",
+            Some(&e.to_string()),
+        )
+        .into_response();
+    }
+
+    Json(serde_json::json!({
+        "ok": true,
+        "client_secret_set": client_secret_set,
+    }))
+    .into_response()
+}
+
+/// GET /api/endpoints/:name/credentials
+///
+/// Returns the resolved credential view for an endpoint, preferring the DCR
+/// file and falling back to `EndpointConfig` (legacy TOML). Never returns the
+/// secret value itself — only `client_secret_set: bool`.
+async fn get_endpoint_credentials(
+    State(state): State<ManagementState>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    // Verify endpoint exists and capture legacy fields.
+    let (cfg_client_id, cfg_secret, cfg_oauth_server_url) = {
+        let config = state.config.read().await;
+        let Some(ep) = config.endpoints.iter().find(|e| e.name == name) else {
+            return endpoint_not_found(&name).into_response();
+        };
+        (
+            ep.client_id.clone(),
+            ep.client_secret.clone(),
+            ep.oauth_server_url.clone(),
+        )
+    };
+
+    if let Some(ref tm) = state.token_manager {
+        match tm.load_dcr(&name).await {
+            Ok(Some(creds)) => {
+                return Json(EndpointCredentialsResponse {
+                    client_id: Some(creds.client_id),
+                    client_secret_set: creds.client_secret.is_some(),
+                    oauth_server_url: cfg_oauth_server_url,
+                    source: "dcr",
+                })
+                .into_response();
+            }
+            Ok(None) => {}
+            Err(e) => {
+                warn!(endpoint = %name, error = %e, "Failed to read DCR credentials; falling back to config");
+            }
+        }
+    }
+
+    let source = if cfg_client_id.is_some() || cfg_secret.is_some() {
+        "config"
+    } else {
+        "none"
+    };
+    Json(EndpointCredentialsResponse {
+        client_id: cfg_client_id,
+        client_secret_set: cfg_secret
+            .as_deref()
+            .map(|s| !s.is_empty())
+            .unwrap_or(false),
+        oauth_server_url: cfg_oauth_server_url,
+        source,
+    })
+    .into_response()
 }
 
 /// Simple URL encoding helper (percent-encode special chars).
@@ -2012,7 +2167,7 @@ async fn oauth_setup_commit(
         }
     };
 
-    if let Err(e) = std::fs::write(&resolved, &new_contents) {
+    if let Err(e) = crate::config::write_config_file(&resolved, &new_contents) {
         return error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             "failed to write config file",
@@ -2091,6 +2246,10 @@ pub fn management_routes(state: ManagementState) -> Router {
         .route(
             "/api/endpoints/{name}/tools/{tool_name}/enable",
             post(enable_tool),
+        )
+        .route(
+            "/api/endpoints/{name}/credentials",
+            get(get_endpoint_credentials).post(set_endpoint_credentials),
         )
         .route("/api/endpoints/{name}/oauth/start", post(oauth_start))
         .route(
@@ -4195,5 +4354,201 @@ command = "echo"
         let expires_in: u64 = 3600;
         let expires_at = now_secs + expires_in;
         assert_eq!(expires_at, 1_700_003_600);
+    }
+
+    // -----------------------------------------------------------------------
+    // /api/endpoints/{name}/credentials route tests (Wave 3a)
+    // -----------------------------------------------------------------------
+
+    /// Build a `ManagementState` with a `TokenManager` rooted in `tmp_dir` and
+    /// a single endpoint named `name` in the config (and no OAuth adapter
+    /// registered — the credentials routes do not require one).
+    async fn test_state_with_token_manager(
+        name: &str,
+        tmp_dir: &std::path::Path,
+        config_secret: Option<&str>,
+        config_oauth_server_url: Option<&str>,
+    ) -> (ManagementState, Arc<TokenManager>) {
+        let token_manager = Arc::new(TokenManager::new(tmp_dir.to_path_buf()));
+        let cfg = Config {
+            relay: RelayConfig {
+                machine_name: "test-machine".to_string(),
+                local_js_execution: None,
+                token_dir: None,
+            },
+            endpoints: vec![EndpointConfig {
+                name: name.to_string(),
+                description: None,
+                tool_prefix: None,
+                transport: Transport::Oauth,
+                command: None,
+                args: None,
+                url: Some("https://mcp.example.com".to_string()),
+                env: None,
+                headers: None,
+                disabled: false,
+                disabled_tools: Vec::new(),
+                oauth_server_url: config_oauth_server_url.map(|s| s.to_string()),
+                client_id: Some("legacy-client-id".to_string()),
+                client_secret: config_secret.map(|s| s.to_string()),
+                scopes: None,
+                token_endpoint: None,
+            }],
+        };
+        let state = ManagementState {
+            registry: Arc::new(AdapterRegistry::new()),
+            config: Arc::new(RwLock::new(cfg)),
+            start_time: Instant::now(),
+            config_path: None,
+            oauth_flow_manager: None,
+            relay_port: 9400,
+            oauth_adapter_inners: None,
+            token_manager: Some(token_manager.clone()),
+            setup_manager: None,
+        };
+        (state, token_manager)
+    }
+
+    #[tokio::test]
+    async fn credentials_endpoint_persists_via_token_manager() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (state, tm) = test_state_with_token_manager("ep1", tmp.path(), None, None).await;
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/ep1/credentials")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "client_id": "new-client",
+                            "client_secret": "new-secret",
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["ok"], true);
+        assert_eq!(body["client_secret_set"], true);
+
+        let loaded = tm.load_dcr("ep1").await.unwrap().unwrap();
+        assert_eq!(loaded.client_id, "new-client");
+        assert_eq!(loaded.client_secret.as_deref(), Some("new-secret"));
+    }
+
+    #[tokio::test]
+    async fn credentials_endpoint_rejects_missing_client_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (state, _tm) = test_state_with_token_manager("ep1", tmp.path(), None, None).await;
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/ep1/credentials")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "client_secret": "x" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn credentials_endpoint_unknown_endpoint_returns_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (state, _tm) = test_state_with_token_manager("ep1", tmp.path(), None, None).await;
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/nope/credentials")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "client_id": "x" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn get_credentials_prefers_dcr_over_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (state, tm) = test_state_with_token_manager(
+            "ep1",
+            tmp.path(),
+            Some("legacy-secret"),
+            Some("https://auth.example.com"),
+        )
+        .await;
+        // Seed DCR with a different client_id and a secret.
+        tm.save_dcr(
+            "ep1",
+            &DcrCredentials {
+                client_id: "dcr-client".to_string(),
+                client_secret: Some("dcr-secret".to_string()),
+                client_secret_expires_at: 0,
+                registered_at: 1_700_000_000,
+            },
+        )
+        .await
+        .unwrap();
+
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::get("/api/endpoints/ep1/credentials")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["client_id"], "dcr-client");
+        assert_eq!(body["client_secret_set"], true);
+        assert_eq!(body["source"], "dcr");
+        assert_eq!(body["oauth_server_url"], "https://auth.example.com");
+        // Secret value must NOT be returned.
+        assert!(body.get("client_secret").is_none());
+    }
+
+    #[tokio::test]
+    async fn get_credentials_falls_back_to_config_when_no_dcr() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (state, _tm) =
+            test_state_with_token_manager("ep1", tmp.path(), Some("legacy-secret"), None).await;
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::get("/api/endpoints/ep1/credentials")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["client_id"], "legacy-client-id");
+        assert_eq!(body["client_secret_set"], true);
+        assert_eq!(body["source"], "config");
+        assert!(body.get("client_secret").is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn config_toml_written_with_0600_on_unix() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        crate::config::write_config_file(&path, "# placeholder").unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "Expected 0600, got {:o}", mode & 0o777);
     }
 }

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -477,6 +477,48 @@ pub async fn apply_diff_graceful(
     }
 }
 
+/// Resolve the OAuth client credentials for `ep`, preferring the DCR file
+/// (managed by `TokenManager`) over the legacy `EndpointConfig` fields.
+///
+/// Wave 3a routes new credentials through `TokenManager::save_dcr`; the legacy
+/// `client_id`/`client_secret` TOML fields remain readable for backwards
+/// compatibility. When a TOML `client_secret` is the only source we emit a
+/// one-time WARN so operators notice they should re-provision via the new
+/// `POST /api/endpoints/{name}/credentials` route.
+pub(crate) async fn resolve_oauth_client_creds(
+    ep: &EndpointConfig,
+    token_manager: &TokenManager,
+) -> (String, Option<String>) {
+    match token_manager.load_dcr(&ep.name).await {
+        Ok(Some(creds)) => (creds.client_id, creds.client_secret),
+        Ok(None) => {
+            if ep.client_secret.is_some() {
+                warn!(
+                    endpoint = %ep.name,
+                    "Using legacy `client_secret` from config.toml; \
+                     re-provision via POST /api/endpoints/{{name}}/credentials \
+                     to remove the secret from TOML"
+                );
+            }
+            (
+                ep.client_id.clone().unwrap_or_default(),
+                ep.client_secret.clone(),
+            )
+        }
+        Err(e) => {
+            warn!(
+                endpoint = %ep.name,
+                error = %e,
+                "Failed to read DCR credentials; falling back to config.toml"
+            );
+            (
+                ep.client_id.clone().unwrap_or_default(),
+                ep.client_secret.clone(),
+            )
+        }
+    }
+}
+
 /// Create an adapter from an endpoint configuration.
 ///
 /// Always returns an adapter. If initialization fails, returns a [`FailedAdapter`]
@@ -529,6 +571,8 @@ pub(crate) async fn create_adapter(
             }
         }
         Transport::Oauth => {
+            let (client_id, client_secret) =
+                resolve_oauth_client_creds(ep, token_manager.as_ref()).await;
             let oauth_config = OAuthAdapterConfig {
                 endpoint_name: ep.name.clone(),
                 url: ep.url.clone().unwrap_or_default(),
@@ -538,8 +582,8 @@ pub(crate) async fn create_adapter(
                         ep.oauth_server_url.as_deref().unwrap_or_default()
                     )
                 }),
-                client_id: ep.client_id.clone().unwrap_or_default(),
-                client_secret: ep.client_secret.clone(),
+                client_id,
+                client_secret,
                 heartbeat_interval_secs: 30,
                 probe_timeout_secs: 10,
                 probe_failure_threshold: 3,
@@ -1184,5 +1228,79 @@ mod tests {
             entry.tool_cache.read().await.is_some(),
             "old adapter's sender must NOT invalidate the cache after rewire"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // resolve_oauth_client_creds tests (Wave 3a)
+    // -----------------------------------------------------------------------
+
+    fn oauth_endpoint(
+        name: &str,
+        client_id: Option<&str>,
+        client_secret: Option<&str>,
+    ) -> EndpointConfig {
+        EndpointConfig {
+            name: name.to_string(),
+            description: None,
+            tool_prefix: None,
+            transport: Transport::Oauth,
+            command: None,
+            args: None,
+            url: Some("https://mcp.example.com".to_string()),
+            env: None,
+            headers: None,
+            disabled: false,
+            disabled_tools: Vec::new(),
+            oauth_server_url: Some("https://auth.example.com".to_string()),
+            client_id: client_id.map(|s| s.to_string()),
+            client_secret: client_secret.map(|s| s.to_string()),
+            scopes: None,
+            token_endpoint: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn adapter_init_prefers_dcr_file_over_config_secret() {
+        use crate::token_manager::DcrCredentials;
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = TokenManager::new(tmp.path().to_path_buf());
+        tm.save_dcr(
+            "ep",
+            &DcrCredentials {
+                client_id: "dcr-client".to_string(),
+                client_secret: Some("dcr-secret".to_string()),
+                client_secret_expires_at: 0,
+                registered_at: 1_700_000_000,
+            },
+        )
+        .await
+        .unwrap();
+
+        let ep = oauth_endpoint("ep", Some("toml-client"), Some("toml-secret"));
+        let (id, secret) = resolve_oauth_client_creds(&ep, &tm).await;
+        assert_eq!(id, "dcr-client");
+        assert_eq!(secret.as_deref(), Some("dcr-secret"));
+    }
+
+    #[tokio::test]
+    async fn adapter_init_falls_back_to_legacy_toml_secret() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = TokenManager::new(tmp.path().to_path_buf());
+
+        let ep = oauth_endpoint("ep", Some("toml-client"), Some("toml-secret"));
+        let (id, secret) = resolve_oauth_client_creds(&ep, &tm).await;
+        assert_eq!(id, "toml-client");
+        assert_eq!(secret.as_deref(), Some("toml-secret"));
+    }
+
+    #[tokio::test]
+    async fn adapter_init_no_dcr_no_secret_returns_config_client_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = TokenManager::new(tmp.path().to_path_buf());
+
+        let ep = oauth_endpoint("ep", Some("toml-client"), None);
+        let (id, secret) = resolve_oauth_client_creds(&ep, &tm).await;
+        assert_eq!(id, "toml-client");
+        assert!(secret.is_none());
     }
 }

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1303,4 +1303,50 @@ mod tests {
         assert_eq!(id, "toml-client");
         assert!(secret.is_none());
     }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn adapter_init_warns_when_falling_back_to_toml_secret() {
+        use std::io;
+        use std::sync::{Arc, Mutex};
+        use tracing_subscriber::fmt::MakeWriter;
+
+        #[derive(Clone, Default)]
+        struct BufWriter(Arc<Mutex<Vec<u8>>>);
+        impl io::Write for BufWriter {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+        impl<'a> MakeWriter<'a> for BufWriter {
+            type Writer = BufWriter;
+            fn make_writer(&'a self) -> Self::Writer {
+                self.clone()
+            }
+        }
+
+        let buf = BufWriter::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(buf.clone())
+            .with_max_level(tracing::Level::WARN)
+            .with_ansi(false)
+            .finish();
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = TokenManager::new(tmp.path().to_path_buf());
+        let ep = oauth_endpoint("warned-ep", Some("toml-client"), Some("toml-secret"));
+        let (id, secret) = resolve_oauth_client_creds(&ep, &tm).await;
+        assert_eq!(id, "toml-client");
+        assert_eq!(secret.as_deref(), Some("toml-secret"));
+
+        let captured = String::from_utf8(buf.0.lock().unwrap().clone()).unwrap();
+        assert!(
+            captured.contains("legacy `client_secret`") && captured.contains("warned-ep"),
+            "expected WARN log mentioning legacy client_secret and the endpoint name; got: {captured}"
+        );
+    }
 }

--- a/tests/oauth_setup_integration.rs
+++ b/tests/oauth_setup_integration.rs
@@ -1,0 +1,139 @@
+//! Integration test: POST /api/oauth/setup advanced fields.
+//!
+//! Exercises the path where the caller provides explicit `client_id` /
+//! `client_secret` in the setup request, which should bypass DCR entirely.
+
+mod common;
+
+use endara_relay::config::{Config, EndpointConfig, RelayConfig, Transport};
+use endara_relay::management::{management_routes, ManagementState};
+use endara_relay::oauth::{OAuthFlowManager, OAuthSetupManager};
+use endara_relay::registry::AdapterRegistry;
+use serde_json::{json, Value};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::net::TcpListener;
+use tokio::sync::RwLock;
+
+use common::mock_oauth_server::MockOAuthServer;
+
+fn empty_config() -> Config {
+    Config {
+        relay: RelayConfig {
+            machine_name: "test-machine".to_string(),
+            local_js_execution: None,
+            token_dir: None,
+        },
+        endpoints: vec![EndpointConfig {
+            name: "echo".to_string(),
+            description: None,
+            tool_prefix: None,
+            transport: Transport::Stdio,
+            command: Some("echo".to_string()),
+            args: Some(vec!["hello".to_string()]),
+            url: None,
+            env: None,
+            headers: None,
+            disabled: false,
+            disabled_tools: Vec::new(),
+            oauth_server_url: None,
+            client_id: None,
+            client_secret: None,
+            scopes: None,
+            token_endpoint: None,
+        }],
+    }
+}
+
+async fn start_setup_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let registry = Arc::new(AdapterRegistry::new());
+    let state = ManagementState {
+        registry,
+        config: Arc::new(RwLock::new(empty_config())),
+        start_time: Instant::now(),
+        config_path: None,
+        oauth_flow_manager: Some(Arc::new(OAuthFlowManager::new())),
+        relay_port: 9400,
+        oauth_adapter_inners: None,
+        token_manager: None,
+        setup_manager: Some(Arc::new(OAuthSetupManager::new())),
+    };
+
+    let app = management_routes(state);
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.ok();
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    (addr, handle)
+}
+
+#[tokio::test]
+async fn oauth_setup_with_client_id_skips_dcr() {
+    let mock = MockOAuthServer::start().await;
+    let (addr, _handle) = start_setup_server().await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("http://{}/api/oauth/setup", addr))
+        .json(&json!({
+            "name": "manual-creds",
+            "url": mock.base_url(),
+            "client_id": "user-supplied-client",
+            "client_secret": "user-supplied-secret",
+            "scopes": ["read", "write"],
+        }))
+        .send()
+        .await
+        .expect("setup request failed");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: Value = resp.json().await.unwrap();
+
+    assert_eq!(body["status"], "awaiting_auth");
+    assert!(body["session_id"].as_str().is_some());
+    let authorize_url = body["authorize_url"]
+        .as_str()
+        .expect("authorize_url present");
+    assert!(authorize_url.contains("client_id=user-supplied-client"));
+    assert!(authorize_url.contains("response_type=code"));
+    assert!(authorize_url.contains("code_challenge_method=S256"));
+    // Scopes were forwarded (form-urlencoded: spaces become '+')
+    assert!(authorize_url.contains("scope=read+write"));
+    assert_eq!(body["dcr_error"], Value::Null);
+    assert_eq!(body["discovery"]["dcr_used"], false);
+
+    // DCR endpoint must not have been called when client_id is supplied.
+    let register_calls = mock.requests_to("/register").await;
+    assert!(
+        register_calls.is_empty(),
+        "expected DCR /register to be skipped, got {} calls",
+        register_calls.len()
+    );
+}
+
+#[tokio::test]
+async fn oauth_setup_without_client_id_still_uses_dcr() {
+    let mock = MockOAuthServer::start().await;
+    let (addr, _handle) = start_setup_server().await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("http://{}/api/oauth/setup", addr))
+        .json(&json!({
+            "name": "auto-dcr",
+            "url": mock.base_url(),
+        }))
+        .send()
+        .await
+        .expect("setup request failed");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["status"], "awaiting_auth");
+    assert_eq!(body["discovery"]["dcr_used"], true);
+
+    // DCR /register should have been called exactly once
+    let register_calls = mock.requests_to("/register").await;
+    assert_eq!(register_calls.len(), 1);
+}


### PR DESCRIPTION
## Summary

Wave 3a — stop treating OAuth `client_secret` as a static `config.toml` value. New caller-supplied client credentials are persisted via `TokenManager::save_dcr` (the existing DCR file). Adapter initialization prefers the DCR file over `EndpointConfig.client_id` / `client_secret`, falling back to the legacy TOML fields only when no DCR file exists (with a one-line WARN).

> **Stacked on top of #40 (`panghy/oauth-pass-advanced-fields`).** Will auto-retarget to `main` after #40 merges.

## What changed

- `src/management.rs`
  - `POST /api/endpoints/{name}/credentials` — accepts `{ client_id?, client_secret?, oauth_server_url? }`, persists via `TokenManager::save_dcr`. Returns `{ ok: true, client_secret_set }`. Never writes to `config.toml`.
  - `GET /api/endpoints/{name}/credentials` — returns `{ client_id?, client_secret_set, oauth_server_url?, source }`. DCR file first, then `EndpointConfig` fallback. Never returns the secret value.
  - All `config.toml` writes (`delete_endpoint`, `persist_disabled_state`, `oauth_setup_commit`) now go through `crate::config::write_config_file`, which sets `0o600` on Unix.
- `src/config.rs`
  - New `write_config_file(path, contents)` helper.
  - `create_default_config_file` uses it.
  - `EndpointConfig::client_secret` documented as legacy-only with a pointer to the new credentials route.
- `src/main.rs` & `src/watcher.rs::create_adapter`
  - Both call new `watcher::resolve_oauth_client_creds(ep, token_manager)`, which prefers `tm.load_dcr(&ep.name)` and falls back to TOML with a WARN when a TOML `client_secret` is present.
- Watcher reload behaviour is unchanged. The existing adapter restart triggered by other config changes naturally picks up the new DCR file.
- **No migration code, no automatic TOML rewrite.**

## Tests added

- `credentials_endpoint_persists_via_token_manager`
- `credentials_endpoint_rejects_missing_client_id`
- `credentials_endpoint_unknown_endpoint_returns_not_found`
- `get_credentials_prefers_dcr_over_config` (and never returns secret)
- `get_credentials_falls_back_to_config_when_no_dcr`
- `adapter_init_prefers_dcr_file_over_config_secret`
- `adapter_init_falls_back_to_legacy_toml_secret`
- `adapter_init_no_dcr_no_secret_returns_config_client_id`
- `config_toml_written_with_0600_on_unix`

## Verification

```
cd packages/relay
cargo fmt --check && cargo build && cargo test
```
All tests pass locally (505 + 497 + integration suites green). Clippy clean (`cargo clippy --all-targets -- -D warnings`).

## Out of scope

- Desktop UI changes (Wave 3b).
- Monorepo submodule pointer bump (coordinator owns this).


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author