### PR TITLE
fix(server): bind HTTP listener to 127.0.0.1 instead of 0.0.0.0

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -406,7 +406,8 @@ async fn main() {
                 setup_manager: Some(setup_manager.clone()),
             };
             let router = build_router(state).merge(management::management_routes(mgmt_state));
-            let addr: SocketAddr = ([0, 0, 0, 0], port).into();
+            // Bind to loopback only; the relay is a local-only service.
+            let addr: SocketAddr = ([127, 0, 0, 1], port).into();
 
             match start_server(router, addr).await {
                 Ok((bound_addr, handle)) => {


### PR DESCRIPTION
## What

Bind the relay's HTTP listener to `127.0.0.1` instead of `0.0.0.0`.

## Why

The relay is a local-only service consumed by the desktop app and locally-running MCP clients. Binding to `0.0.0.0` unnecessarily exposed the listener on every network interface; restricting it to the loopback address closes that exposure with no functional change for supported use cases.

## Change

Single-line change to `src/main.rs` (plus a one-line comment).

## Verification

- `cargo fmt --check` ✅
- `cargo build` ✅
- `cargo test` ✅ (all suites pass)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author