### PR TITLE
chore: bump version to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "endara-relay"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endara-relay"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Local MCP tool aggregator — aggregate multiple MCP servers behind a single endpoint"
 license = "Apache-2.0"


### PR DESCRIPTION
Bumps `endara-relay` to `0.1.3` ahead of cutting the stable `v0.1.3` tag.

- `Cargo.toml` version → `0.1.3`
- `Cargo.lock` refreshed via `cargo check`

User approved direct stable cut (no `-rc` suffix). After merge, `v0.1.3` will be tagged on `main` and the release workflow will publish the GitHub Release, crates.io, and update the Homebrew tap.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author