### PR TITLE
chore: bump version to 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "endara-relay"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endara-relay"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Local MCP tool aggregator — aggregate multiple MCP servers behind a single endpoint"
 license = "Apache-2.0"


### PR DESCRIPTION
Version bump from 0.1.3 → 0.1.4 ahead of the v0.1.4 stable release.

## Changes

- `Cargo.toml`: `version = "0.1.4"`
- `Cargo.lock`: regenerated for the new version.

Nothing else touched.

## What's new in 0.1.4

Since [v0.1.3](https://github.com/endara-ai/endara-relay/releases/tag/v0.1.3) (`5a85290`):

- [#45](https://github.com/endara-ai/endara-relay/pull/45) `docs(js-sandbox)`: rewrite `execute_tools` examples to teach `call()` unwrapping. Documentation-only change to the LLM-facing tool description — leads with `call()` returning the unwrapped result, frames `tools["name"](args)` as the raw-envelope escape hatch, and replaces the manual-unwrap example with simple / chained / retry / raw-envelope examples.

## Verification

`cargo fmt --check` ✅ · `cargo clippy --all-targets -- -D warnings` ✅ · `cargo test --lib` 538/538 ✅ · `cargo test --test js_execution_integration` 3/3 ✅.

## Next steps

After merge, the `v0.1.4` tag will be pushed to `main` and the release workflow auto-publishes binaries. Desktop bump follows.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author