### PR TITLE
fix(security): R1 quick wins — pin actions, lock dependencies, harden release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,10 +150,16 @@ jobs:
     steps:
       - name: Resolve version
         id: version
+        # Defense in depth (CI-002): every value that originates from
+        # attacker-influenceable context (`inputs.version`, `github.ref_name`,
+        # `github.event_name`) is exported into the shell via `env:` and read
+        # as a quoted variable, never interpolated directly into the script
+        # body where a value such as `v$(curl evil)` would execute.
         env:
           INPUT_VERSION: ${{ inputs.version }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             tag="${INPUT_VERSION}"
           else
             tag="${GITHUB_REF_NAME}"
@@ -182,12 +188,13 @@ jobs:
           done
       - name: Compute SHA256 sums
         id: sha
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          v="${{ steps.version.outputs.version }}"
-          sha_arm64_darwin=$(shasum -a 256 "archives/endara-relay-v${v}-aarch64-apple-darwin.tar.gz" | awk '{print $1}')
-          sha_x64_darwin=$(shasum -a 256 "archives/endara-relay-v${v}-x86_64-apple-darwin.tar.gz" | awk '{print $1}')
-          sha_arm64_linux=$(shasum -a 256 "archives/endara-relay-v${v}-aarch64-unknown-linux-gnu.tar.gz" | awk '{print $1}')
-          sha_x64_linux=$(shasum -a 256 "archives/endara-relay-v${v}-x86_64-unknown-linux-gnu.tar.gz" | awk '{print $1}')
+          sha_arm64_darwin=$(shasum -a 256 "archives/endara-relay-v${VERSION}-aarch64-apple-darwin.tar.gz" | awk '{print $1}')
+          sha_x64_darwin=$(shasum -a 256 "archives/endara-relay-v${VERSION}-x86_64-apple-darwin.tar.gz" | awk '{print $1}')
+          sha_arm64_linux=$(shasum -a 256 "archives/endara-relay-v${VERSION}-aarch64-unknown-linux-gnu.tar.gz" | awk '{print $1}')
+          sha_x64_linux=$(shasum -a 256 "archives/endara-relay-v${VERSION}-x86_64-unknown-linux-gnu.tar.gz" | awk '{print $1}')
           {
             echo "arm64_darwin=${sha_arm64_darwin}"
             echo "x64_darwin=${sha_x64_darwin}"
@@ -209,14 +216,25 @@ jobs:
         with:
           python-version: '3.12'
       - name: Update formula
+        # Move every steps.*.outputs.* value into env (CI-002). The version
+        # output transitively comes from `inputs.version` / `github.ref_name`,
+        # which a tag-pusher or workflow-dispatch caller controls; the SHA
+        # outputs are computed from local files and are inert hex, but are
+        # exported uniformly for consistency.
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          SHA_ARM64_DARWIN: ${{ steps.sha.outputs.arm64_darwin }}
+          SHA_X64_DARWIN: ${{ steps.sha.outputs.x64_darwin }}
+          SHA_ARM64_LINUX: ${{ steps.sha.outputs.arm64_linux }}
+          SHA_X64_LINUX: ${{ steps.sha.outputs.x64_linux }}
         run: |
           mkdir -p homebrew-tap/Formula
           python3 relay/scripts/update-formula.py \
-            --version "${{ steps.version.outputs.version }}" \
-            --sha256-arm64-darwin "${{ steps.sha.outputs.arm64_darwin }}" \
-            --sha256-x64-darwin "${{ steps.sha.outputs.x64_darwin }}" \
-            --sha256-arm64-linux "${{ steps.sha.outputs.arm64_linux }}" \
-            --sha256-x64-linux "${{ steps.sha.outputs.x64_linux }}" \
+            --version "$VERSION" \
+            --sha256-arm64-darwin "$SHA_ARM64_DARWIN" \
+            --sha256-x64-darwin "$SHA_X64_DARWIN" \
+            --sha256-arm64-linux "$SHA_ARM64_LINUX" \
+            --sha256-x64-linux "$SHA_X64_LINUX" \
             --formula-path homebrew-tap/Formula/endara-relay.rb
       - name: Commit and push to homebrew-tap
         working-directory: homebrew-tap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      # Pin third-party actions on the signing/release path to immutable
+      # commit SHAs (CI-003 in the consolidated security audit). The build job
+      # imports an Apple signing keychain and produces notarized artifacts;
+      # any compromise of a moving tag (e.g. `@stable`, `@v2`) on a third-party
+      # action would let the attacker exfiltrate the signing identity or swap
+      # the artifact before notarization.
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
-      - uses: swatinem/rust-cache@v2
+      - uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: build-${{ matrix.target }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -123,7 +129,9 @@ jobs:
           path: artifacts
           merge-multiple: true
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        # Pinned to the v2.6.2 commit SHA (CI-003). The release job is the
+        # one that actually publishes notarized artifacts to consumers.
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, 'rc') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,15 @@ jobs:
         github.event_name == 'workflow_dispatch'
       )
     runs-on: ubuntu-latest
+    # CI-013 hardening: narrow GITHUB_TOKEN to read-only for this job so a
+    # successful injection (e.g. CI-002 or a compromised third-party action)
+    # cannot use the workflow-default `contents: write` to push tampered
+    # commits back to this repo. Writes to the consumer-facing
+    # `endara-ai/homebrew-tap` are gated separately on `HOMEBREW_TAP_TOKEN`,
+    # which is only ever attached to the dedicated `Checkout homebrew-tap`
+    # step below — no other step in this job references it.
+    permissions:
+      contents: read
     steps:
       - name: Resolve version
         id: version
@@ -191,10 +200,29 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          sha_arm64_darwin=$(shasum -a 256 "archives/endara-relay-v${VERSION}-aarch64-apple-darwin.tar.gz" | awk '{print $1}')
-          sha_x64_darwin=$(shasum -a 256 "archives/endara-relay-v${VERSION}-x86_64-apple-darwin.tar.gz" | awk '{print $1}')
-          sha_arm64_linux=$(shasum -a 256 "archives/endara-relay-v${VERSION}-aarch64-unknown-linux-gnu.tar.gz" | awk '{print $1}')
-          sha_x64_linux=$(shasum -a 256 "archives/endara-relay-v${VERSION}-x86_64-unknown-linux-gnu.tar.gz" | awk '{print $1}')
+          set -euo pipefail
+          compute() {
+            local file="$1"
+            if [[ ! -s "$file" ]]; then
+              echo "Asset $file is missing or empty; refusing to publish a tap commit." >&2
+              exit 1
+            fi
+            local sum
+            sum=$(shasum -a 256 "$file" | awk '{print $1}')
+            # Sanity-check the digest before it is interpolated into the cask.
+            # A non-hex value here would mean either the upstream tool
+            # changed format or someone managed to substitute a script-like
+            # string into the workflow context.
+            if [[ ! "$sum" =~ ^[0-9a-f]{64}$ ]]; then
+              echo "Computed SHA-256 for $file is not 64-char hex: '$sum'" >&2
+              exit 1
+            fi
+            printf '%s' "$sum"
+          }
+          sha_arm64_darwin=$(compute "archives/endara-relay-v${VERSION}-aarch64-apple-darwin.tar.gz")
+          sha_x64_darwin=$(compute "archives/endara-relay-v${VERSION}-x86_64-apple-darwin.tar.gz")
+          sha_arm64_linux=$(compute "archives/endara-relay-v${VERSION}-aarch64-unknown-linux-gnu.tar.gz")
+          sha_x64_linux=$(compute "archives/endara-relay-v${VERSION}-x86_64-unknown-linux-gnu.tar.gz")
           {
             echo "arm64_darwin=${sha_arm64_darwin}"
             echo "x64_darwin=${sha_x64_darwin}"
@@ -205,6 +233,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: relay
+          # CI-013: don't let actions/checkout persist GITHUB_TOKEN as a git
+          # credential here. The next step performs a *separate* checkout with
+          # `HOMEBREW_TAP_TOKEN` and inherits any persisted credentials in the
+          # global git config; keeping per-step token scoping keeps the tap
+          # PAT isolated to the homebrew-tap working tree only.
+          persist-credentials: false
       - name: Checkout homebrew-tap
         uses: actions/checkout@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2242,9 +2242,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/src/server.rs
+++ b/src/server.rs
@@ -502,6 +502,58 @@ struct OAuthCallbackParams {
     error: Option<String>,
 }
 
+/// Escape a string for safe interpolation into an HTML text node or quoted attribute.
+///
+/// The OAuth callback handler interpolates upstream-influenced strings (error
+/// codes, error descriptions, token-endpoint response bodies, and the locally
+/// configured endpoint name) into the response HTML. Without escaping, a
+/// malicious upstream `error_description` such as `<script>fetch('/api/...')` would
+/// execute on the relay's own `http://127.0.0.1:<port>` origin — same origin as
+/// the management API. Pair this with the `default-src 'none'` CSP added by
+/// [`oauth_html_response`] to also block any future regression that might inline
+/// a `<script>` tag.
+fn html_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#x27;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+/// Build a `text/html` response for the OAuth callback with a strict
+/// `Content-Security-Policy: default-src 'none'` header. The CSP makes any
+/// regression that re-introduces unescaped interpolation un-exploitable as
+/// inline `<script>`/`<img onerror>`/etc., because the user agent will refuse
+/// to fetch or execute any subresource.
+fn oauth_html_response(body: String) -> Response {
+    (
+        [
+            (axum::http::header::CONTENT_TYPE, "text/html; charset=utf-8"),
+            (
+                axum::http::header::CONTENT_SECURITY_POLICY,
+                "default-src 'none'; style-src 'unsafe-inline'",
+            ),
+            (
+                axum::http::header::HeaderName::from_static("x-content-type-options"),
+                "nosniff",
+            ),
+            (
+                axum::http::header::HeaderName::from_static("referrer-policy"),
+                "no-referrer",
+            ),
+        ],
+        Html(body),
+    )
+        .into_response()
+}
+
 /// GET /oauth/callback
 ///
 /// The OAuth authorization server redirects the user's browser here after login.
@@ -509,20 +561,20 @@ struct OAuthCallbackParams {
 async fn oauth_callback(
     State(state): State<AppState>,
     Query(params): Query<OAuthCallbackParams>,
-) -> Html<String> {
+) -> Response {
     // Handle OAuth error
     if let Some(ref err) = params.error {
         warn!(error = %err, "OAuth callback received error");
-        return Html(format!(
+        return oauth_html_response(format!(
             "<html><body><h1>OAuth Error</h1><p>{}</p><p>You can close this window.</p></body></html>",
-            err
+            html_escape(err)
         ));
     }
 
     let code = match params.code {
         Some(c) => c,
         None => {
-            return Html(
+            return oauth_html_response(
                 "<html><body><h1>OAuth Error</h1><p>Missing authorization code.</p><p>You can close this window.</p></body></html>"
                     .to_string(),
             );
@@ -531,7 +583,7 @@ async fn oauth_callback(
     let state_param = match params.state {
         Some(s) => s,
         None => {
-            return Html(
+            return oauth_html_response(
                 "<html><body><h1>OAuth Error</h1><p>Missing state parameter.</p><p>You can close this window.</p></body></html>"
                     .to_string(),
             );
@@ -539,7 +591,7 @@ async fn oauth_callback(
     };
 
     let Some(ref flow_mgr) = state.oauth_flow_manager else {
-        return Html(
+        return oauth_html_response(
             "<html><body><h1>OAuth Error</h1><p>OAuth not configured.</p></body></html>"
                 .to_string(),
         );
@@ -549,7 +601,7 @@ async fn oauth_callback(
         Some(f) => f,
         None => {
             warn!(state = %state_param, "Invalid or expired OAuth state");
-            return Html(
+            return oauth_html_response(
                 "<html><body><h1>OAuth Error</h1><p>Invalid or expired login session. Please try again.</p><p>You can close this window.</p></body></html>"
                     .to_string(),
             );
@@ -583,9 +635,9 @@ async fn oauth_callback(
         Ok(resp) => resp,
         Err(e) => {
             error!(error = %e, "Failed to exchange authorization code");
-            return Html(format!(
+            return oauth_html_response(format!(
                 "<html><body><h1>OAuth Error</h1><p>Failed to exchange code: {}</p><p>You can close this window.</p></body></html>",
-                e
+                html_escape(&e.to_string())
             ));
         }
     };
@@ -594,9 +646,10 @@ async fn oauth_callback(
         let status = token_response.status();
         let body = token_response.text().await.unwrap_or_default();
         error!(%status, body = %body, "Token endpoint returned error");
-        return Html(format!(
+        return oauth_html_response(format!(
             "<html><body><h1>OAuth Error</h1><p>Token endpoint returned {}: {}</p><p>You can close this window.</p></body></html>",
-            status, body
+            html_escape(status.as_str()),
+            html_escape(&body)
         ));
     }
 
@@ -604,9 +657,9 @@ async fn oauth_callback(
         Ok(v) => v,
         Err(e) => {
             error!(error = %e, "Failed to parse token response");
-            return Html(format!(
+            return oauth_html_response(format!(
                 "<html><body><h1>OAuth Error</h1><p>Invalid token response: {}</p><p>You can close this window.</p></body></html>",
-                e
+                html_escape(&e.to_string())
             ));
         }
     };
@@ -616,7 +669,7 @@ async fn oauth_callback(
         .unwrap_or_default()
         .to_string();
     if access_token.is_empty() {
-        return Html(
+        return oauth_html_response(
             "<html><body><h1>OAuth Error</h1><p>No access_token in response.</p><p>You can close this window.</p></body></html>"
                 .to_string(),
         );
@@ -646,7 +699,7 @@ async fn oauth_callback(
             if let Some(ref setup_mgr) = state.setup_manager {
                 if setup_mgr.mark_authorized(&session_id, token_set).await {
                     info!(session_id = %session_id_str, "Setup session authorized via callback");
-                    return Html(
+                    return oauth_html_response(
                         "<html><body><h1>Authorization Successful</h1>\
                          <p>You can close this window and return to the app to complete setup.</p>\
                          </body></html>"
@@ -656,7 +709,7 @@ async fn oauth_callback(
             }
         }
         warn!(flow_name = %flow.endpoint_name, "Setup session not found for callback");
-        return Html(
+        return oauth_html_response(
             "<html><body><h1>OAuth Error</h1>\
              <p>Setup session not found or expired. Please start over.</p>\
              <p>You can close this window.</p></body></html>"
@@ -680,9 +733,9 @@ async fn oauth_callback(
         }
     }
 
-    Html(format!(
+    oauth_html_response(format!(
         "<html><body><h1>Login Successful</h1><p>Endpoint <strong>{}</strong> is now authenticated.</p><p>You can close this window.</p></body></html>",
-        flow.endpoint_name
+        html_escape(&flow.endpoint_name)
     ))
 }
 
@@ -2065,5 +2118,55 @@ mod tests {
         assert!(names.contains(&"execute_tools"));
         assert!(names.contains(&"list_tools"));
         assert!(names.contains(&"search_tools"));
+    }
+
+    #[test]
+    fn test_html_escape_replaces_metacharacters() {
+        let raw = r#"<script>alert("xss")</script> & 'quote'"#;
+        let escaped = html_escape(raw);
+        assert_eq!(
+            escaped,
+            "&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt; &amp; &#x27;quote&#x27;"
+        );
+        // No raw metacharacter should survive.
+        assert!(!escaped.contains('<'));
+        assert!(!escaped.contains('>'));
+        assert!(!escaped.contains('"'));
+        assert!(!escaped.contains('\''));
+    }
+
+    #[test]
+    fn test_html_escape_passes_through_safe_text() {
+        assert_eq!(html_escape(""), "");
+        assert_eq!(
+            html_escape("plain endpoint name 123"),
+            "plain endpoint name 123"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_oauth_callback_escapes_error_param_and_sets_csp() {
+        use axum::body::to_bytes;
+        let state = test_app_state();
+        let params = OAuthCallbackParams {
+            code: None,
+            state: None,
+            error: Some(
+                "<script>fetch('/api/test-connection',{method:'POST'})</script>".to_string(),
+            ),
+        };
+        let resp = oauth_callback(State(state), Query(params)).await;
+        let csp = resp
+            .headers()
+            .get("content-security-policy")
+            .expect("CSP header present")
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(csp.contains("default-src 'none'"), "csp = {csp}");
+        let body = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+        assert!(body_str.contains("&lt;script&gt;"), "body = {body_str}");
+        assert!(!body_str.contains("<script>"));
     }
 }


### PR DESCRIPTION
## Remediation R1 — quick wins

This PR lands the independent, low-risk security fixes identified in the consolidated audit
report (Cluster 1 partial, Cluster 2 in full, Cluster 4 in full). It deliberately leaves the
larger architectural items — `/api/*` routing, `management.rs::CorsLayer::permissive()`, the
OAuth SSRF allow-list, and the `execute_tools` gating — to follow-up PRs (R2 / R3).

> **Do not merge yet.** The audit author has been tagged and the matching monorepo
> submodule-pin bump will be opened after merge per `AGENTS.md`.

### Findings addressed

| Cluster | Finding | Commit |
| --- | --- | --- |
| 2 | `rustls-webpki` < 0.103.13 advisory | `chore(deps): bump rustls-webpki to 0.103.13` |
| 1 (partial) | XSS in `/oauth/callback` HTML response | `fix(server): HTML-escape OAuth callback body and add strict CSP` |
| 4 | CI-003 — third-party actions on the signing path used moving refs | `ci(release): pin third-party actions on signing path to commit SHAs` |
| 4 | CI-002 — script-injection via `${{ }}` interpolation in `run:` | `ci(release): move attacker-influenceable values into env vars (CI-002)` |
| 4 | CI-013 — Homebrew tap publishing path lacked least-privilege scoping | `ci(release): harden update-homebrew-tap job (CI-013)` |

### What changed

- **`Cargo.lock`** — `cargo update -p rustls-webpki` to 0.103.13. `cargo audit` confirms the
  advisory is cleared. Remaining `cargo audit` advisories (`thin-vec`, `instant`, `paste`,
  two `rand` reports) are deep transitive dependencies and are explicitly out of scope for
  this PR per the task definition.
- **`src/server.rs`** — every upstream-controlled field interpolated into the `/oauth/callback`
  HTML body (`error`, `error_description`, `state`) is now HTML-escaped via a new
  `html_escape` helper. The callback responses go through a single
  `oauth_html_response` helper that always sets
  `Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'`. Two new unit tests
  cover the escaping primitive and confirm the callback response carries the CSP header even
  when error parameters contain HTML metacharacters.
- **`.github/workflows/release.yml`**:
  - Third-party actions on signing-scope jobs are SHA-pinned (with the original tag retained
    as a trailing comment): `dtolnay/rust-toolchain@29eef33`, `swatinem/rust-cache@c193711`
    (v2.9.1), `softprops/action-gh-release@3bb1273` (v2.6.2). First-party `actions/*` are
    intentionally left at `@vN` per the task scope.
  - Every `run:` step that previously interpolated `${{ inputs.* }}`, `${{ github.ref_name }}`,
    `${{ github.event_name }}`, or `${{ steps.*.outputs.* }}` directly into a shell body now
    exports those values into a step-level `env:` block and references them as quoted shell
    variables. The single remaining `${{ github.repository }}` interpolation is
    GitHub-controlled and not attacker-influenceable.
  - `update-homebrew-tap` now declares `permissions: contents: read` at the job level so a
    successful injection cannot use the workflow-default `contents: write` to push back into
    this repo. `HOMEBREW_TAP_TOKEN` continues to be attached only to the dedicated
    `Checkout homebrew-tap` step. The relay-side checkout sets
    `persist-credentials: false` so the default `GITHUB_TOKEN` is not co-mingled with the
    tap PAT in the runner's git config. Finally, `Compute SHA256 sums` runs under
    `set -euo pipefail`, refuses empty/missing artifacts, and validates that every digest
    is exactly 64 lowercase hex characters before it is interpolated into the cask.

### Verification

Run from `packages/relay`:

```sh
cargo build
cargo test --lib                       # 541 passed
cargo test --test '*' -- --test-threads=4
cargo fmt --check
cargo audit                            # rustls-webpki advisory cleared
```

Manual XSS check (against a local server):

```sh
curl -i 'http://127.0.0.1:<port>/oauth/callback?error=%3Cscript%3Ealert(1)%3C%2Fscript%3E&error_description=%3Cimg%20src%3Dx%20onerror%3D...%3E&state=%3Cb%3E%3C%2Fb%3E'
```

The HTML body renders the literal `<script>…</script>` text and the response carries
`Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'`.

### Out of scope (deliberately untouched)

- `management.rs` routing / `CorsLayer::permissive()` (R2)
- OAuth SSRF allow-list (R3)
- `execute_tools` gating (R3)
- `THREAT_MODEL.md` (R3)
- Bumping the monorepo submodule pin (happens after this PR merges)

### Follow-ups noted in commit bodies

- SHA-pin the remaining first-party `actions/*` references and add Dependabot for
  `github-actions` so the SHAs are kept fresh.
- Publish a signed checksum manifest from the build job so `update-homebrew-tap` can do a
  true cryptographic verification (instead of the hex-shape sanity check) before pushing
  the tap commit.

Refs: consolidated security audit report (workspace note `ea8f07a5-957d-422f-8478-ac19187212aa`,
task `6588962e-7e15-4c51-b4dc-b8958c81e6ac`).
