### PR TITLE
docs(threat-model): drop release / date framing

### DIFF
--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -1,8 +1,7 @@
 # Endara Relay — Threat Model
 
 This document describes the trust boundaries, in-scope threats, and intentional
-non-goals for the Endara Relay process. It complements the consolidated security
-audit and the R1 + R2 hardening work landed in May 2026.
+non-goals for the Endara Relay process.
 
 ## Trust model
 
@@ -48,7 +47,7 @@ audit and the R1 + R2 hardening work landed in May 2026.
 - Side-channel and supply-chain attacks against the Rust toolchain or its
   standard library.
 
-## Protections (as of R1 + R2)
+## Protections
 
 ### Network surface
 


### PR DESCRIPTION
Removes the 'R1+R2 hardening work landed in May 2026' line and any other release-specific framing. The project is not live yet; the threat model describes current state in plain present tense.

Changes:
- Drop the `It complements the consolidated security audit and the R1 + R2 hardening work landed in May 2026.` sentence from the preamble.
- Rename `## Protections (as of R1 + R2)` heading to `## Protections`.

Verified with:
```
grep -i -E 'R1|R2|May 2026|landed|previously|no longer|as of [A-Z]|hardening work|consolidated audit' THREAT_MODEL.md
```
→ zero hits.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author