### PR TITLE
fix(management): clear unreachable_code lint and RUSTSEC-2026-0097 (rand)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ dependencies = [
  "once_cell",
  "pollster",
  "portable-atomic",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regress",
  "rustc-hash",
  "ryu-js",
@@ -1788,7 +1788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1925,7 +1925,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1974,9 +1974,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1985,9 +1985,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",

--- a/src/management_listener.rs
+++ b/src/management_listener.rs
@@ -45,6 +45,7 @@ pub fn resolve_api_socket_path(#[allow(unused_variables)] data_dir: &Path) -> Pa
                 return runtime.join("endara-relay").join("api.sock");
             }
         }
+        return data_dir.join("api.sock");
     }
 
     #[cfg(target_os = "macos")]
@@ -62,10 +63,13 @@ pub fn resolve_api_socket_path(#[allow(unused_variables)] data_dir: &Path) -> Pa
         return PathBuf::from(format!(r"\\.\pipe\endara-relay-{session_id}"));
     }
 
-    // Final fallback — reached on Linux when XDG_RUNTIME_DIR is unset, and on
-    // any platform not covered by the cfg branches above. macOS / Windows
-    // branches above always early-return, so they never fall through here.
-    data_dir.join("api.sock")
+    // Final fallback for any other target (e.g. non-macOS unix variants not
+    // covered above). The platform-specific branches above all early-return,
+    // so this is only compiled where it can actually be reached.
+    #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+    {
+        data_dir.join("api.sock")
+    }
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
Bundles two small clean-ups flagged by the security audit.

## 1. `fix(management)` — gate api.sock fallback

The macOS/Windows builds emit a `unreachable_code` warning because both `cfg` blocks end with an unconditional `return`, leaving the function-level `data_dir.join("api.sock")` fallback unreachable on those targets:

```
warning: unreachable expression
  --> src/management_listener.rs:68:5
```

Fix: add an explicit `return data_dir.join("api.sock")` inside the Linux block (where the fallback is actually reachable when `XDG_RUNTIME_DIR` is unset), and gate the function-level tail expression to `#[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]` so it only compiles on platforms that can actually reach it. No `#[allow(unreachable_code)]` used.

No behavior change on any target:
- Linux: unchanged — `$XDG_RUNTIME_DIR/endara-relay/api.sock`, falling back to `<data_dir>/api.sock`.
- macOS: unchanged — `$TMPDIR/endara-relay-<uid>/api.sock`.
- Windows: unchanged — `\\.\pipe\endara-relay-<sessionid>`.

## 2. `chore(deps)` — bump rand to clear RUSTSEC-2026-0097

Lockfile-only bump:
- `rand 0.8.5` → `0.8.6`
- `rand 0.9.2` → `0.9.3`

Relay isn't actually exploitable (advisory requires a custom `log` logger calling `rand::rng()`; relay uses `tracing`, not `log`, and rand is transitive via `reqwest → quinn → quinn-proto`). Clean-up only. `Cargo.toml` untouched.

## Verification (macOS, local)

- `cargo build` — clean, no `unreachable_code` warning.
- `cargo clippy --tests -- -D warnings` — exits 0 (CI's gate).
- `cargo test --lib` — 567 passed, 0 failed.
- `cargo test --lib management_listener` — 7 passed, 0 failed.
- `cargo fmt --check` — clean.
- `cargo audit` — RUSTSEC-2026-0097 no longer reported. (Pre-existing `thin-vec` / `instant` / `paste` advisories unchanged; out of scope here.)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author.

