### PR TITLE
feat: advertise connected MCP servers to the model

### DIFF
--- a/src/advertise.rs
+++ b/src/advertise.rs
@@ -115,6 +115,12 @@ impl<'a> ServerTypeList<'a> {
     }
 }
 
+/// Lead-in sentence prepended to the `Connected servers: …` line in
+/// `InitializeResult.instructions`. Per Engineering Spec §3.2, the literal
+/// blank line between the lead-in and the server list is part of the payload.
+pub const INSTRUCTIONS_LEAD_IN: &str =
+    "Endara Relay aggregates MCP servers behind a single endpoint.";
+
 /// Build the `InitializeResult.instructions` string. Returns `None` when no
 /// adapter is currently `Healthy` with a `server_type`, so the field is
 /// omitted from the response (per spec §2.1).
@@ -122,7 +128,7 @@ pub async fn instructions(registry: &AdapterRegistry) -> Option<String> {
     ServerTypeList::new(registry)
         .render()
         .await
-        .map(|list| format!("Connected servers: {}", list))
+        .map(|list| format!("{}\n\nConnected servers: {}", INSTRUCTIONS_LEAD_IN, list))
 }
 
 /// Build the `search_tools` description. Appends `\n\nConnected servers: {list}`
@@ -376,6 +382,29 @@ mod tests {
             desc.ends_with(" 2 servers connected via Endara Relay \u{2014} use search_tools to discover tools."),
             "unexpected suffix: {}",
             &desc[desc.len().saturating_sub(120)..]
+        );
+    }
+
+    /// 50 synthetic distinct server-types render well under 1KB — sanity-check
+    /// the dedup/render path before the 8KB safety cap engages.
+    #[tokio::test]
+    async fn render_50_distinct_types_under_1024_bytes() {
+        let reg = AdapterRegistry::new();
+        for i in 0..50 {
+            let ty = format!("type-{:02}", i);
+            register(&reg, &format!("ep{}", i), MockAdapter::ready(&ty)).await;
+        }
+        let list = ServerTypeList::new(&reg).render().await.unwrap();
+        assert!(
+            list.len() < 1024,
+            "50 distinct types rendered to {} bytes, expected < 1024",
+            list.len()
+        );
+        // Defence in depth: confirm we didn't truncate.
+        assert!(
+            !list.ends_with(", \u{2026}"),
+            "50 types should fit without truncation: {}",
+            list
         );
     }
 }

--- a/src/advertise.rs
+++ b/src/advertise.rs
@@ -1,0 +1,381 @@
+//! Server-type advertisement to connected models.
+//!
+//! Renders a deduplicated, alphabetised list of `server_type` values from
+//! adapters currently in [`HealthStatus::Healthy`][crate::adapter::HealthStatus::Healthy]
+//! state, and provides description builders for the meta-tools (`list_tools`,
+//! `search_tools`, `execute_tools`) so each `tools/list` response reflects the
+//! current registry. The same list also feeds `InitializeResult.instructions`.
+//!
+//! See `Engineering Spec — Advertise Connected Servers to the Model` (§3) for
+//! the full design.
+
+use crate::registry::AdapterRegistry;
+
+/// Safety cap on the rendered server-type list. With deduplication a typical
+/// deployment is well under 1KB, but the cap is retained as defence in depth
+/// per the spec §2.4. When exceeded, trailing entries are truncated and a
+/// `, …` suffix is appended.
+const RENDER_BYTE_CAP: usize = 8 * 1024;
+
+/// Base description for the `list_tools` meta-tool. Kept identical to the
+/// literal in `server.rs` so behaviour is unchanged when no servers are
+/// connected.
+pub const LIST_TOOLS_BASE: &str = "List available tools with pagination. Returns `{ tools, total, limit, offset }`. Each tool has `name`, `description`, and `input_schema`. The `name` is the exact identifier to use when calling tools via `execute_tools`.";
+
+/// Base description for the `search_tools` meta-tool. Kept identical to the
+/// literal in `server.rs`.
+pub const SEARCH_TOOLS_BASE: &str = "Fuzzy search across tool name, description, server endpoint, and input-schema property names. Typo-tolerant (Levenshtein), case-insensitive, and aware of camelCase / snake_case / kebab-case boundaries. Results are ranked by relevance (exact > prefix > substring > fuzzy; name > description > endpoint); tools matching more query tokens rank higher. Returns an array of matching tools, each with `name`, `description`, and `input_schema`.";
+
+/// Base description for the `execute_tools` meta-tool. Kept identical to the
+/// `concat!()` block in `server.rs`.
+pub const EXECUTE_TOOLS_BASE: &str = concat!(
+    "Execute a JavaScript snippet that can call tools. ",
+    "Invoke a tool with `await call(\"tool_name\", { ...args })` — `call()` returns the unwrapped result directly, no manual envelope reading required. ",
+    "Behind the scenes it returns `structuredContent` when the tool provides it, parses `content[0].text` when it begins with `[` or `{`, returns the text as-is otherwise, and throws an `Error` on `isError` envelopes (the message includes the tool name and `content[0].text`). ",
+    "Multi-server tool names use `prefix__name` format (double underscore); single-server mode has no prefix. ",
+    "Use `tools[\"tool_name\"](args)` only when you need the raw MCP envelope (`{ content, structuredContent, isError }`) — for example to inspect `isError` without throwing or to read the literal `content[0].text`. ",
+    "Calling an unknown tool name throws an error that lists the closest matching tools. ",
+    "Pass `{ retry: 3 }` as the third argument (e.g. `await call(\"name\", args, { retry: 3 })`) to retry transient errors on tools whose annotations declare `readOnlyHint` or `idempotentHint`. ",
+    "Use `return` to send data back.\n\n",
+    "Examples:\n",
+    "```js\n",
+    "// call() returns the unwrapped result — no need to read content[0].text yourself.\n",
+    "const tasks = await call(\"todoist__get-tasks\", { limit: 5 });\n",
+    "return tasks;\n",
+    "```\n",
+    "```js\n",
+    "// Chain two tool calls and combine their results.\n",
+    "const projects = await call(\"todoist__get-projects\", {});\n",
+    "const tasks = await call(\"todoist__get-tasks\", { project_id: projects[0].id });\n",
+    "return { projects, tasks };\n",
+    "```\n",
+    "```js\n",
+    "// Opt into retry for read-only / idempotent tools.\n",
+    "const issues = await call(\"github__list-issues\", { repo: \"endara-ai/relay\" }, { retry: 3 });\n",
+    "return issues;\n",
+    "```\n",
+    "```js\n",
+    "// Use the tools[...] indexer when you need the raw MCP envelope.\n",
+    "const r = await tools[\"todoist__get-tasks\"]({ limit: 5 });\n",
+    "return r.structuredContent;\n",
+    "```",
+);
+
+/// Renders the deduplicated, sorted server-type list for a registry.
+pub struct ServerTypeList<'a> {
+    registry: &'a AdapterRegistry,
+}
+
+impl<'a> ServerTypeList<'a> {
+    /// Bind a renderer to the given registry.
+    pub fn new(registry: &'a AdapterRegistry) -> Self {
+        Self { registry }
+    }
+
+    /// Returns `Some("a, b, c")` if at least one Healthy adapter has a
+    /// `server_type`; `None` otherwise. The list is enforced under the
+    /// 8KB safety cap; trailing entries are dropped and a `, …` suffix
+    /// appended if the cap is exceeded.
+    pub async fn render(&self) -> Option<String> {
+        let types = self.registry.ready_server_types().await;
+        if types.is_empty() {
+            return None;
+        }
+
+        let mut out = String::new();
+        const SUFFIX: &str = ", …";
+        let cap_with_suffix = RENDER_BYTE_CAP.saturating_sub(SUFFIX.len());
+        let mut truncated = false;
+
+        for ty in &types {
+            let sep_len = if out.is_empty() { 0 } else { 2 };
+            // Reserve room for the "…" suffix so we can always append it
+            // cleanly when truncation is needed.
+            if out.len() + sep_len + ty.len() > cap_with_suffix {
+                truncated = true;
+                break;
+            }
+            if !out.is_empty() {
+                out.push_str(", ");
+            }
+            out.push_str(ty);
+        }
+
+        if truncated {
+            // If even the first entry didn't fit (extremely pathological),
+            // emit just the suffix so callers can still detect overflow.
+            out.push_str(SUFFIX);
+        }
+        Some(out)
+    }
+
+    /// Number of `Healthy` adapter instances (NOT deduplicated by type).
+    pub async fn endpoint_count(&self) -> usize {
+        self.registry.ready_endpoint_count().await
+    }
+}
+
+/// Build the `InitializeResult.instructions` string. Returns `None` when no
+/// adapter is currently `Healthy` with a `server_type`, so the field is
+/// omitted from the response (per spec §2.1).
+pub async fn instructions(registry: &AdapterRegistry) -> Option<String> {
+    ServerTypeList::new(registry)
+        .render()
+        .await
+        .map(|list| format!("Connected servers: {}", list))
+}
+
+/// Build the `search_tools` description. Appends `\n\nConnected servers: {list}`
+/// when the registry has at least one Healthy adapter with a `server_type`.
+pub async fn search_tools_description(registry: &AdapterRegistry) -> String {
+    match ServerTypeList::new(registry).render().await {
+        Some(list) => format!("{}\n\nConnected servers: {}", SEARCH_TOOLS_BASE, list),
+        None => SEARCH_TOOLS_BASE.to_string(),
+    }
+}
+
+/// Build the `list_tools` description. Appends `" {count} servers connected …"`
+/// when at least one adapter is `Healthy`.
+pub async fn list_tools_description(registry: &AdapterRegistry) -> String {
+    let count = ServerTypeList::new(registry).endpoint_count().await;
+    if count > 0 {
+        format!(
+            "{} {} servers connected via Endara Relay — use search_tools to discover tools.",
+            LIST_TOOLS_BASE, count
+        )
+    } else {
+        LIST_TOOLS_BASE.to_string()
+    }
+}
+
+/// Build the `execute_tools` description. Same suffix as
+/// [`list_tools_description`], appended to the long base block.
+pub async fn execute_tools_description(registry: &AdapterRegistry) -> String {
+    let count = ServerTypeList::new(registry).endpoint_count().await;
+    if count > 0 {
+        format!(
+            "{} {} servers connected via Endara Relay — use search_tools to discover tools.",
+            EXECUTE_TOOLS_BASE, count
+        )
+    } else {
+        EXECUTE_TOOLS_BASE.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapter::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
+    use async_trait::async_trait;
+    use serde_json::Value;
+
+    /// Minimal mock adapter — `health` and `server_type` are configurable; the
+    /// rest is stubbed. Mirrors the pattern in `registry::tests::MockAdapter`.
+    struct MockAdapter {
+        health: HealthStatus,
+        server_type_val: Option<String>,
+    }
+
+    impl MockAdapter {
+        fn ready(server_type: &str) -> Self {
+            Self {
+                health: HealthStatus::Healthy,
+                server_type_val: Some(server_type.to_string()),
+            }
+        }
+
+        fn ready_no_type() -> Self {
+            Self {
+                health: HealthStatus::Healthy,
+                server_type_val: None,
+            }
+        }
+
+        fn failed() -> Self {
+            Self {
+                health: HealthStatus::Unhealthy("test".into()),
+                server_type_val: Some("gmail".into()),
+            }
+        }
+
+        fn starting() -> Self {
+            Self {
+                health: HealthStatus::Starting,
+                server_type_val: Some("gmail".into()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl McpAdapter for MockAdapter {
+        async fn initialize(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+        async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
+            Ok(vec![])
+        }
+        async fn call_tool(&self, _name: &str, _args: Value) -> Result<Value, AdapterError> {
+            Ok(Value::Null)
+        }
+        fn health(&self) -> HealthStatus {
+            self.health.clone()
+        }
+        fn server_type(&self) -> Option<String> {
+            self.server_type_val.clone()
+        }
+        async fn shutdown(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+    }
+
+    async fn register(reg: &AdapterRegistry, name: &str, adapter: MockAdapter) {
+        reg.register(
+            name.into(),
+            Box::new(adapter),
+            "stdio".into(),
+            None,
+            Some(name.into()),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn render_returns_none_when_no_healthy_adapters() {
+        let reg = AdapterRegistry::new();
+        assert!(ServerTypeList::new(&reg).render().await.is_none());
+        assert_eq!(ServerTypeList::new(&reg).endpoint_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn render_returns_none_when_only_failed_or_starting() {
+        let reg = AdapterRegistry::new();
+        register(&reg, "a", MockAdapter::failed()).await;
+        register(&reg, "b", MockAdapter::starting()).await;
+        assert!(ServerTypeList::new(&reg).render().await.is_none());
+        assert_eq!(ServerTypeList::new(&reg).endpoint_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn render_lists_single_healthy_adapter() {
+        let reg = AdapterRegistry::new();
+        register(&reg, "gmail-personal", MockAdapter::ready("gmail")).await;
+        let list = ServerTypeList::new(&reg).render().await.unwrap();
+        assert_eq!(list, "gmail");
+        assert_eq!(ServerTypeList::new(&reg).endpoint_count().await, 1);
+    }
+
+    #[tokio::test]
+    async fn render_dedups_and_sorts_alphabetically() {
+        let reg = AdapterRegistry::new();
+        register(&reg, "ep1", MockAdapter::ready("Gmail")).await;
+        register(&reg, "ep2", MockAdapter::ready("gmail")).await;
+        register(&reg, "ep3", MockAdapter::ready("notion")).await;
+        register(&reg, "ep4", MockAdapter::ready("github")).await;
+        let list = ServerTypeList::new(&reg).render().await.unwrap();
+        assert_eq!(list, "github, gmail, notion");
+        assert_eq!(ServerTypeList::new(&reg).endpoint_count().await, 4);
+    }
+
+    #[tokio::test]
+    async fn render_skips_adapters_without_server_type() {
+        let reg = AdapterRegistry::new();
+        register(&reg, "ep1", MockAdapter::ready("notion")).await;
+        register(&reg, "ep2", MockAdapter::ready_no_type()).await;
+        let list = ServerTypeList::new(&reg).render().await.unwrap();
+        assert_eq!(list, "notion");
+        // endpoint_count counts all Healthy adapters regardless of server_type.
+        assert_eq!(ServerTypeList::new(&reg).endpoint_count().await, 2);
+    }
+
+    #[tokio::test]
+    async fn render_excludes_unhealthy_adapters() {
+        let reg = AdapterRegistry::new();
+        register(&reg, "ep1", MockAdapter::ready("notion")).await;
+        register(&reg, "ep2", MockAdapter::failed()).await;
+        register(&reg, "ep3", MockAdapter::starting()).await;
+        let list = ServerTypeList::new(&reg).render().await.unwrap();
+        assert_eq!(list, "notion");
+        assert_eq!(ServerTypeList::new(&reg).endpoint_count().await, 1);
+    }
+
+    #[tokio::test]
+    async fn render_truncates_above_byte_cap() {
+        let reg = AdapterRegistry::new();
+        // Each entry is ~70 bytes; ~150 entries pushes us above 8KB.
+        for i in 0..200 {
+            let st = format!("server-type-{:04}-padding-padding-padding-padding", i);
+            register(&reg, &format!("ep{}", i), MockAdapter::ready(&st)).await;
+        }
+        let list = ServerTypeList::new(&reg).render().await.unwrap();
+        assert!(
+            list.len() <= RENDER_BYTE_CAP,
+            "rendered list exceeded byte cap: {} bytes",
+            list.len()
+        );
+        assert!(
+            list.ends_with(", \u{2026}"),
+            "expected truncation suffix, got tail: {:?}",
+            &list[list.len().saturating_sub(20)..]
+        );
+    }
+
+    #[tokio::test]
+    async fn search_tools_description_no_servers() {
+        let reg = AdapterRegistry::new();
+        let desc = search_tools_description(&reg).await;
+        assert_eq!(desc, SEARCH_TOOLS_BASE);
+    }
+
+    #[tokio::test]
+    async fn search_tools_description_appends_connected_servers() {
+        let reg = AdapterRegistry::new();
+        register(&reg, "ep1", MockAdapter::ready("github")).await;
+        register(&reg, "ep2", MockAdapter::ready("gmail")).await;
+        let desc = search_tools_description(&reg).await;
+        assert!(desc.starts_with(SEARCH_TOOLS_BASE));
+        assert!(desc.ends_with("\n\nConnected servers: github, gmail"));
+    }
+
+    #[tokio::test]
+    async fn list_tools_description_no_servers() {
+        let reg = AdapterRegistry::new();
+        let desc = list_tools_description(&reg).await;
+        assert_eq!(desc, LIST_TOOLS_BASE);
+    }
+
+    #[tokio::test]
+    async fn list_tools_description_appends_count() {
+        let reg = AdapterRegistry::new();
+        register(&reg, "ep1", MockAdapter::ready("github")).await;
+        register(&reg, "ep2", MockAdapter::ready("gmail")).await;
+        register(&reg, "ep3", MockAdapter::ready("gmail")).await;
+        let desc = list_tools_description(&reg).await;
+        assert!(desc.starts_with(LIST_TOOLS_BASE));
+        assert!(
+            desc.ends_with(" 3 servers connected via Endara Relay \u{2014} use search_tools to discover tools."),
+            "unexpected suffix: {}",
+            desc
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_tools_description_no_servers() {
+        let reg = AdapterRegistry::new();
+        let desc = execute_tools_description(&reg).await;
+        assert_eq!(desc, EXECUTE_TOOLS_BASE);
+    }
+
+    #[tokio::test]
+    async fn execute_tools_description_appends_count() {
+        let reg = AdapterRegistry::new();
+        register(&reg, "ep1", MockAdapter::ready("github")).await;
+        register(&reg, "ep2", MockAdapter::ready("gmail")).await;
+        let desc = execute_tools_description(&reg).await;
+        assert!(desc.starts_with(EXECUTE_TOOLS_BASE));
+        assert!(
+            desc.ends_with(" 2 servers connected via Endara Relay \u{2014} use search_tools to discover tools."),
+            "unexpected suffix: {}",
+            &desc[desc.len().saturating_sub(120)..]
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod adapter;
+pub mod advertise;
 pub mod config;
 pub mod js_sandbox;
 pub mod jsonrpc;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod token_manager;
 mod watcher;
 
 mod adapter;
+mod advertise;
 mod jsonrpc;
 mod prefix;
 mod registry;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,6 +1,6 @@
 use crate::adapter::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
 use crate::prefix;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
@@ -288,6 +288,33 @@ impl AdapterRegistry {
             .filter(|(_, entry)| matches!(entry.adapter.health(), HealthStatus::Healthy))
             .map(|(name, _)| name.clone())
             .collect()
+    }
+
+    /// Deduplicated, lower-cased server types reported by Healthy adapters.
+    ///
+    /// Walks the adapter map, filters to [`HealthStatus::Healthy`], calls
+    /// [`McpAdapter::server_type`], lowercases the result and collects into a
+    /// [`BTreeSet`] so the output is sorted. Adapters whose `server_type()`
+    /// returns `None` (not yet initialized or transport that does not record
+    /// it) are skipped.
+    pub async fn ready_server_types(&self) -> BTreeSet<String> {
+        let adapters = self.adapters.read().await;
+        adapters
+            .values()
+            .filter(|entry| matches!(entry.adapter.health(), HealthStatus::Healthy))
+            .filter_map(|entry| entry.adapter.server_type())
+            .map(|s| s.to_lowercase())
+            .collect()
+    }
+
+    /// Number of currently `Healthy` adapter instances (NOT deduplicated by
+    /// server type — three Gmail accounts count as three).
+    pub async fn ready_endpoint_count(&self) -> usize {
+        let adapters = self.adapters.read().await;
+        adapters
+            .values()
+            .filter(|entry| matches!(entry.adapter.health(), HealthStatus::Healthy))
+            .count()
     }
 
     /// Access the underlying adapters map (for management API use).

--- a/src/server.rs
+++ b/src/server.rs
@@ -84,20 +84,24 @@ fn jsonrpc_error(id: Option<Value>, code: i64, message: &str) -> (StatusCode, Js
 }
 
 /// POST /mcp/initialize
-async fn mcp_initialize(Json(body): Json<JsonRpcBody>) -> Json<Value> {
-    jsonrpc_response(
-        body.id,
-        json!({
-            "protocolVersion": "2025-03-26",
-            "capabilities": {
-                "tools": {}
-            },
-            "serverInfo": {
-                "name": "Endara Relay",
-                "version": env!("CARGO_PKG_VERSION")
-            }
-        }),
-    )
+async fn mcp_initialize(
+    State(state): State<AppState>,
+    Json(body): Json<JsonRpcBody>,
+) -> Json<Value> {
+    let mut result = json!({
+        "protocolVersion": "2025-03-26",
+        "capabilities": {
+            "tools": {}
+        },
+        "serverInfo": {
+            "name": "Endara Relay",
+            "version": env!("CARGO_PKG_VERSION")
+        }
+    });
+    if let Some(instructions) = crate::advertise::instructions(&state.registry).await {
+        result["instructions"] = Value::String(instructions);
+    }
+    jsonrpc_response(body.id, result)
 }
 
 /// Build the meta-tool definitions as JSON values.
@@ -106,12 +110,17 @@ async fn mcp_initialize(Json(body): Json<JsonRpcBody>) -> Json<Value> {
 /// only included when `js_mode` is on — this matches the invocation-side
 /// gate in `mcp_tools_call`, which rejects `execute_tools` calls when
 /// `local_js_execution` is disabled.
-#[allow(unused_mut)]
-fn meta_tool_definitions(js_mode: bool) -> Vec<Value> {
+///
+/// The descriptions are built dynamically against the supplied [`AdapterRegistry`]
+/// so each `tools/list` response advertises the currently-Healthy server set
+/// (see `crate::advertise`).
+async fn meta_tool_definitions(js_mode: bool, registry: &AdapterRegistry) -> Vec<Value> {
+    let list_desc = crate::advertise::list_tools_description(registry).await;
+    let search_desc = crate::advertise::search_tools_description(registry).await;
     let mut tools = vec![
         json!({
             "name": "list_tools",
-            "description": "List available tools with pagination. Returns `{ tools, total, limit, offset }`. Each tool has `name`, `description`, and `input_schema`. The `name` is the exact identifier to use when calling tools via `execute_tools`.",
+            "description": list_desc,
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -122,7 +131,7 @@ fn meta_tool_definitions(js_mode: bool) -> Vec<Value> {
         }),
         json!({
             "name": "search_tools",
-            "description": "Fuzzy search across tool name, description, server endpoint, and input-schema property names. Typo-tolerant (Levenshtein), case-insensitive, and aware of camelCase / snake_case / kebab-case boundaries. Results are ranked by relevance (exact > prefix > substring > fuzzy; name > description > endpoint); tools matching more query tokens rank higher. Returns an array of matching tools, each with `name`, `description`, and `input_schema`.",
+            "description": search_desc,
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -136,48 +145,18 @@ fn meta_tool_definitions(js_mode: bool) -> Vec<Value> {
     if !js_mode {
         return tools;
     }
+    let execute_desc = crate::advertise::execute_tools_description(registry).await;
     tools.push(json!({
-            "name": "execute_tools",
-            "description": concat!(
-                "Execute a JavaScript snippet that can call tools. ",
-                "Invoke a tool with `await call(\"tool_name\", { ...args })` — `call()` returns the unwrapped result directly, no manual envelope reading required. ",
-                "Behind the scenes it returns `structuredContent` when the tool provides it, parses `content[0].text` when it begins with `[` or `{`, returns the text as-is otherwise, and throws an `Error` on `isError` envelopes (the message includes the tool name and `content[0].text`). ",
-                "Multi-server tool names use `prefix__name` format (double underscore); single-server mode has no prefix. ",
-                "Use `tools[\"tool_name\"](args)` only when you need the raw MCP envelope (`{ content, structuredContent, isError }`) — for example to inspect `isError` without throwing or to read the literal `content[0].text`. ",
-                "Calling an unknown tool name throws an error that lists the closest matching tools. ",
-                "Pass `{ retry: 3 }` as the third argument (e.g. `await call(\"name\", args, { retry: 3 })`) to retry transient errors on tools whose annotations declare `readOnlyHint` or `idempotentHint`. ",
-                "Use `return` to send data back.\n\n",
-                "Examples:\n",
-                "```js\n",
-                "// call() returns the unwrapped result — no need to read content[0].text yourself.\n",
-                "const tasks = await call(\"todoist__get-tasks\", { limit: 5 });\n",
-                "return tasks;\n",
-                "```\n",
-                "```js\n",
-                "// Chain two tool calls and combine their results.\n",
-                "const projects = await call(\"todoist__get-projects\", {});\n",
-                "const tasks = await call(\"todoist__get-tasks\", { project_id: projects[0].id });\n",
-                "return { projects, tasks };\n",
-                "```\n",
-                "```js\n",
-                "// Opt into retry for read-only / idempotent tools.\n",
-                "const issues = await call(\"github__list-issues\", { repo: \"endara-ai/relay\" }, { retry: 3 });\n",
-                "return issues;\n",
-                "```\n",
-                "```js\n",
-                "// Use the tools[...] indexer when you need the raw MCP envelope.\n",
-                "const r = await tools[\"todoist__get-tasks\"]({ limit: 5 });\n",
-                "return r.structuredContent;\n",
-                "```",
-            ),
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "script": { "type": "string" }
-                },
-                "required": ["script"]
-            }
-        }));
+        "name": "execute_tools",
+        "description": execute_desc,
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "script": { "type": "string" }
+            },
+            "required": ["script"]
+        }
+    }));
     tools
 }
 
@@ -187,7 +166,7 @@ async fn mcp_tools_list(
     Json(body): Json<JsonRpcBody>,
 ) -> Json<Value> {
     let js_mode = state.js_execution_mode.load(Ordering::Relaxed);
-    let meta_tools = meta_tool_definitions(js_mode);
+    let meta_tools = meta_tool_definitions(js_mode, &state.registry).await;
 
     let tools: Vec<Value> = if js_mode {
         // JS execution mode: only the 3 meta-tools (incl. execute_tools)
@@ -348,7 +327,7 @@ async fn handle_single_message(state: &AppState, msg: Value, headers_str: &str) 
     };
 
     let result: Result<Json<Value>, (StatusCode, Json<Value>)> = match method.as_str() {
-        "initialize" => Ok(mcp_initialize(Json(body)).await),
+        "initialize" => Ok(mcp_initialize(State(state.clone()), Json(body)).await),
         "tools/list" => Ok(mcp_tools_list(State(state.clone()), Json(body)).await),
         "tools/call" => mcp_tools_call(State(state.clone()), Json(body)).await,
         _ => Err(jsonrpc_error(
@@ -764,10 +743,10 @@ async fn oauth_callback(
 }
 
 /// Logged wrapper for POST /mcp/initialize (direct route).
-async fn mcp_initialize_logged(body: Json<JsonRpcBody>) -> Json<Value> {
+async fn mcp_initialize_logged(state: State<AppState>, body: Json<JsonRpcBody>) -> Json<Value> {
     let start = Instant::now();
     let req_bytes = serde_json::to_string(&body.0).map(|s| s.len()).unwrap_or(0);
-    let resp = mcp_initialize(body).await;
+    let resp = mcp_initialize(state, body).await;
     let elapsed_ms = start.elapsed().as_millis() as u64;
     let resp_bytes = serde_json::to_string(&resp.0).map(|s| s.len()).unwrap_or(0);
     info!(
@@ -1107,13 +1086,14 @@ mod tests {
 
     #[tokio::test]
     async fn mcp_initialize_returns_correct_response() {
+        let state = test_app_state();
         let body = JsonRpcBody {
             jsonrpc: Some("2.0".to_string()),
             method: Some("initialize".to_string()),
             params: None,
             id: Some(json!(1)),
         };
-        let Json(resp) = mcp_initialize(Json(body)).await;
+        let Json(resp) = mcp_initialize(State(state), Json(body)).await;
 
         assert_eq!(resp["jsonrpc"], "2.0");
         assert_eq!(resp["id"], 1);
@@ -1125,11 +1105,14 @@ mod tests {
         assert!(!result["serverInfo"]["version"].as_str().unwrap().is_empty());
         // Capabilities must include "tools"
         assert!(result["capabilities"]["tools"].is_object());
+        // No connected adapters → instructions field omitted (spec §2.1).
+        assert!(result.get("instructions").is_none());
     }
 
-    #[test]
-    fn meta_tool_definitions_contains_expected_tools() {
-        let defs = meta_tool_definitions(true);
+    #[tokio::test]
+    async fn meta_tool_definitions_contains_expected_tools() {
+        let registry = AdapterRegistry::new();
+        let defs = meta_tool_definitions(true, &registry).await;
         assert_eq!(defs.len(), 3);
 
         let names: Vec<&str> = defs.iter().map(|d| d["name"].as_str().unwrap()).collect();
@@ -1146,9 +1129,10 @@ mod tests {
         }
     }
 
-    #[test]
-    fn meta_tool_definitions_hides_execute_tools_when_js_off() {
-        let defs = meta_tool_definitions(false);
+    #[tokio::test]
+    async fn meta_tool_definitions_hides_execute_tools_when_js_off() {
+        let registry = AdapterRegistry::new();
+        let defs = meta_tool_definitions(false, &registry).await;
         let names: Vec<&str> = defs.iter().map(|d| d["name"].as_str().unwrap()).collect();
         assert!(names.contains(&"list_tools"));
         assert!(names.contains(&"search_tools"));
@@ -1158,9 +1142,10 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_list_tools_description_documents_return_format() {
-        let defs = meta_tool_definitions(true);
+    #[tokio::test]
+    async fn test_list_tools_description_documents_return_format() {
+        let registry = AdapterRegistry::new();
+        let defs = meta_tool_definitions(true, &registry).await;
         let list_desc = defs.iter().find(|d| d["name"] == "list_tools").unwrap()["description"]
             .as_str()
             .unwrap();
@@ -1186,9 +1171,10 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_search_tools_description_documents_behavior() {
-        let defs = meta_tool_definitions(true);
+    #[tokio::test]
+    async fn test_search_tools_description_documents_behavior() {
+        let registry = AdapterRegistry::new();
+        let defs = meta_tool_definitions(true, &registry).await;
         let search_desc = defs.iter().find(|d| d["name"] == "search_tools").unwrap()["description"]
             .as_str()
             .unwrap();
@@ -1208,9 +1194,10 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_execute_tools_description_has_examples() {
-        let defs = meta_tool_definitions(true);
+    #[tokio::test]
+    async fn test_execute_tools_description_has_examples() {
+        let registry = AdapterRegistry::new();
+        let defs = meta_tool_definitions(true, &registry).await;
         let exec_desc = defs.iter().find(|d| d["name"] == "execute_tools").unwrap()["description"]
             .as_str()
             .unwrap();

--- a/tests/advertise.rs
+++ b/tests/advertise.rs
@@ -17,6 +17,40 @@ fn bad_server_bin() -> String {
     env!("CARGO_BIN_EXE_fixture-bad-server").to_string()
 }
 
+fn multi_tool_bin() -> String {
+    env!("CARGO_BIN_EXE_fixture-multi-tool-server").to_string()
+}
+
+/// Lead-in sentence required at the top of `instructions` per spec §3.2.
+const INSTRUCTIONS_LEAD_IN: &str = "Endara Relay aggregates MCP servers behind a single endpoint.";
+
+/// Poll `tools/list` until the `list_tools` description count suffix reads
+/// `N servers connected …`, or the timeout elapses.
+async fn wait_for_list_tools_count(harness: &RelayHarness, expected: usize, timeout: Duration) {
+    let needle = format!(" {} servers connected via Endara Relay", expected);
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let tools = raw_tools_list(harness).await;
+        if let Some(t) = tools
+            .iter()
+            .find(|t| t["name"].as_str() == Some("list_tools"))
+        {
+            if let Some(d) = t["description"].as_str() {
+                if d.contains(&needle) {
+                    return;
+                }
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for list_tools count to reach {} (needle: {:?})",
+                expected, needle
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+}
+
 /// Run a JSON-RPC `initialize` against the relay using a fresh client. We do
 /// **not** use `McpClient::initialize()` because that helper hard-codes a
 /// session and consumes the response — here we want the raw result.
@@ -112,7 +146,8 @@ async fn instructions_and_descriptions_reflect_healthy_server() {
         .as_str()
         .expect("instructions should be present once an adapter is Healthy");
     assert_eq!(
-        instructions, "Connected servers: bad-mcp",
+        instructions,
+        format!("{}\n\nConnected servers: bad-mcp", INSTRUCTIONS_LEAD_IN),
         "unexpected instructions string: {instructions}"
     );
 
@@ -151,7 +186,8 @@ async fn failed_adapters_are_not_advertised() {
         .as_str()
         .expect("instructions should be present");
     assert_eq!(
-        instructions, "Connected servers: bad-mcp",
+        instructions,
+        format!("{}\n\nConnected servers: bad-mcp", INSTRUCTIONS_LEAD_IN),
         "Failed adapter should be excluded; got: {instructions}"
     );
 
@@ -163,5 +199,208 @@ async fn failed_adapters_are_not_advertised() {
             " 1 servers connected via Endara Relay \u{2014} use search_tools to discover tools."
         ),
         "list_tools count must exclude Failed adapter: {list_desc}"
+    );
+}
+
+/// 4 — §5.3 row 1: three Healthy endpoints with three distinct serverInfo.name
+///     values render verbatim in `initialize.instructions`, `search_tools`, and
+///     count to 3 in `list_tools` / `execute_tools` (JS-mode off → list_tools
+///     count assertion only).
+#[tokio::test]
+async fn multi_distinct_types_rendered_in_alphabetical_order() {
+    let config = ConfigBuilder::new()
+        .add_stdio("ep-zebra", &multi_tool_bin(), &["--name", "zebra"])
+        .add_stdio("ep-alpha", &multi_tool_bin(), &["--name", "alpha"])
+        .add_stdio("ep-mango", &multi_tool_bin(), &["--name", "mango"])
+        .build();
+    let harness = RelayHarness::start(&config).await;
+    for ep in ["ep-zebra", "ep-alpha", "ep-mango"] {
+        harness
+            .wait_healthy(ep, Duration::from_secs(10))
+            .await
+            .unwrap_or_else(|_| panic!("{ep} did not become healthy"));
+    }
+
+    let expected_list = "alpha, mango, zebra";
+
+    let init = raw_initialize(&harness).await;
+    let instructions = init["result"]["instructions"]
+        .as_str()
+        .expect("instructions should be present with 3 Healthy adapters");
+    assert_eq!(
+        instructions,
+        format!(
+            "{}\n\nConnected servers: {}",
+            INSTRUCTIONS_LEAD_IN, expected_list
+        ),
+        "instructions string did not match spec §3.2 format: {instructions}"
+    );
+
+    let tools = raw_tools_list(&harness).await;
+    let list_desc = meta_tool_description(&tools, "list_tools");
+    assert!(
+        list_desc.ends_with(
+            " 3 servers connected via Endara Relay \u{2014} use search_tools to discover tools."
+        ),
+        "list_tools description missing count=3 suffix: {list_desc}"
+    );
+    let search_desc = meta_tool_description(&tools, "search_tools");
+    assert!(
+        search_desc.ends_with(&format!("\n\nConnected servers: {}", expected_list)),
+        "search_tools description does not end with full alphabetised list: {search_desc}"
+    );
+    // execute_tools is hidden when JS mode is off; covered separately.
+}
+
+/// 5 — §5.3 row 4 (kill endpoint): hot-reload removes one of three endpoints
+///     via config rewrite; the relay's file watcher applies the diff and the
+///     advertised type list / count drop accordingly.
+#[tokio::test]
+async fn hot_reload_kill_endpoint_drops_from_advertised_list() {
+    let initial = ConfigBuilder::new()
+        .add_stdio("ep-alpha", &multi_tool_bin(), &["--name", "alpha"])
+        .add_stdio("ep-mango", &multi_tool_bin(), &["--name", "mango"])
+        .add_stdio("ep-zebra", &multi_tool_bin(), &["--name", "zebra"])
+        .build();
+    let harness = RelayHarness::start(&initial).await;
+    for ep in ["ep-alpha", "ep-mango", "ep-zebra"] {
+        harness
+            .wait_healthy(ep, Duration::from_secs(10))
+            .await
+            .unwrap_or_else(|_| panic!("{ep} did not become healthy"));
+    }
+    wait_for_list_tools_count(&harness, 3, Duration::from_secs(5)).await;
+
+    // Rewrite config without ep-mango.
+    let updated = ConfigBuilder::new()
+        .add_stdio("ep-alpha", &multi_tool_bin(), &["--name", "alpha"])
+        .add_stdio("ep-zebra", &multi_tool_bin(), &["--name", "zebra"])
+        .build();
+    std::fs::write(&harness.config_path, updated).expect("failed to rewrite config");
+
+    // Watcher debounce is 500ms; allow extra slack for fs notify + reload.
+    wait_for_list_tools_count(&harness, 2, Duration::from_secs(15)).await;
+
+    let tools = raw_tools_list(&harness).await;
+    let search_desc = meta_tool_description(&tools, "search_tools");
+    assert!(
+        search_desc.ends_with("\n\nConnected servers: alpha, zebra"),
+        "expected mango to be removed from search_tools description: {search_desc}"
+    );
+    let init = raw_initialize(&harness).await;
+    let instructions = init["result"]["instructions"].as_str().unwrap_or("");
+    assert!(
+        !instructions.contains("mango"),
+        "instructions should not mention removed endpoint type: {instructions}"
+    );
+}
+
+/// 6 — §5.3 row 5 (add endpoint): hot-reload adds a new endpoint via config
+///     rewrite; the new type appears in `tools/list` and the count goes up.
+#[tokio::test]
+async fn hot_reload_add_endpoint_appears_in_advertised_list() {
+    let initial = ConfigBuilder::new()
+        .add_stdio("ep-alpha", &multi_tool_bin(), &["--name", "alpha"])
+        .add_stdio("ep-zebra", &multi_tool_bin(), &["--name", "zebra"])
+        .build();
+    let harness = RelayHarness::start(&initial).await;
+    for ep in ["ep-alpha", "ep-zebra"] {
+        harness
+            .wait_healthy(ep, Duration::from_secs(10))
+            .await
+            .unwrap_or_else(|_| panic!("{ep} did not become healthy"));
+    }
+    wait_for_list_tools_count(&harness, 2, Duration::from_secs(5)).await;
+
+    // Rewrite config with an extra endpoint reporting "mango".
+    let updated = ConfigBuilder::new()
+        .add_stdio("ep-alpha", &multi_tool_bin(), &["--name", "alpha"])
+        .add_stdio("ep-zebra", &multi_tool_bin(), &["--name", "zebra"])
+        .add_stdio("ep-mango", &multi_tool_bin(), &["--name", "mango"])
+        .build();
+    std::fs::write(&harness.config_path, updated).expect("failed to rewrite config");
+
+    harness
+        .wait_healthy("ep-mango", Duration::from_secs(15))
+        .await
+        .expect("ep-mango did not become healthy after hot-reload add");
+    wait_for_list_tools_count(&harness, 3, Duration::from_secs(15)).await;
+
+    let tools = raw_tools_list(&harness).await;
+    let search_desc = meta_tool_description(&tools, "search_tools");
+    assert!(
+        search_desc.ends_with("\n\nConnected servers: alpha, mango, zebra"),
+        "expected mango to appear in alphabetised list: {search_desc}"
+    );
+}
+
+/// 7 — §5.3 row 6 (second instance of existing type): two endpoints reporting
+///     the same `serverInfo.name`; the type list deduplicates but the count
+///     reflects both Healthy endpoints.
+#[tokio::test]
+async fn duplicate_type_dedupes_but_count_includes_both() {
+    let config = ConfigBuilder::new()
+        .add_stdio("ep-alpha-1", &multi_tool_bin(), &["--name", "alpha"])
+        .add_stdio("ep-alpha-2", &multi_tool_bin(), &["--name", "alpha"])
+        .build();
+    let harness = RelayHarness::start(&config).await;
+    for ep in ["ep-alpha-1", "ep-alpha-2"] {
+        harness
+            .wait_healthy(ep, Duration::from_secs(10))
+            .await
+            .unwrap_or_else(|_| panic!("{ep} did not become healthy"));
+    }
+    wait_for_list_tools_count(&harness, 2, Duration::from_secs(10)).await;
+
+    let init = raw_initialize(&harness).await;
+    let instructions = init["result"]["instructions"]
+        .as_str()
+        .expect("instructions should be present");
+    assert_eq!(
+        instructions,
+        format!("{}\n\nConnected servers: alpha", INSTRUCTIONS_LEAD_IN),
+        "duplicate type should dedupe to a single entry: {instructions}"
+    );
+
+    let tools = raw_tools_list(&harness).await;
+    let list_desc = meta_tool_description(&tools, "list_tools");
+    assert!(
+        list_desc.ends_with(
+            " 2 servers connected via Endara Relay \u{2014} use search_tools to discover tools."
+        ),
+        "list_tools count must reflect both Healthy endpoints: {list_desc}"
+    );
+    let search_desc = meta_tool_description(&tools, "search_tools");
+    assert!(
+        search_desc.ends_with("\n\nConnected servers: alpha"),
+        "search_tools description should carry deduplicated single entry: {search_desc}"
+    );
+}
+
+/// 8 — JS-execution-mode `execute_tools` carries the count suffix when at
+///     least one adapter is Healthy. Verifies the meta-tool is exposed and
+///     the description is built via `execute_tools_description`.
+#[tokio::test]
+async fn js_mode_execute_tools_carries_count_suffix() {
+    let config = ConfigBuilder::new()
+        .js_execution(true)
+        .add_stdio("ep-alpha", &multi_tool_bin(), &["--name", "alpha"])
+        .build();
+    let harness = RelayHarness::start(&config).await;
+    harness
+        .wait_healthy("ep-alpha", Duration::from_secs(10))
+        .await
+        .expect("ep-alpha did not become healthy");
+    wait_for_list_tools_count(&harness, 1, Duration::from_secs(10)).await;
+
+    let tools = raw_tools_list(&harness).await;
+    // execute_tools is only exposed in JS mode.
+    let exec_desc = meta_tool_description(&tools, "execute_tools");
+    assert!(
+        exec_desc.ends_with(
+            " 1 servers connected via Endara Relay \u{2014} use search_tools to discover tools."
+        ),
+        "execute_tools description missing count suffix in JS mode: ...{}",
+        &exec_desc[exec_desc.len().saturating_sub(160)..]
     );
 }

--- a/tests/advertise.rs
+++ b/tests/advertise.rs
@@ -1,0 +1,167 @@
+//! Integration tests for `Advertise Connected Servers to the Model` (spec §5).
+//!
+//! Verifies that:
+//!   * `InitializeResult.instructions` is present with `Connected servers: …`
+//!     when at least one adapter is `Healthy`, and omitted otherwise.
+//!   * The dynamic descriptions for `list_tools`, `search_tools`, and
+//!     `execute_tools` reflect the currently-Healthy server set.
+
+mod common;
+
+use common::config::ConfigBuilder;
+use common::harness::RelayHarness;
+use serde_json::{json, Value};
+use std::time::Duration;
+
+fn bad_server_bin() -> String {
+    env!("CARGO_BIN_EXE_fixture-bad-server").to_string()
+}
+
+/// Run a JSON-RPC `initialize` against the relay using a fresh client. We do
+/// **not** use `McpClient::initialize()` because that helper hard-codes a
+/// session and consumes the response — here we want the raw result.
+async fn raw_initialize(harness: &RelayHarness) -> Value {
+    harness
+        .rpc(json!({
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "advertise-test", "version": "0.1"}
+            },
+            "id": 1
+        }))
+        .await
+}
+
+async fn raw_tools_list(harness: &RelayHarness) -> Vec<Value> {
+    let resp = harness
+        .rpc(json!({
+            "jsonrpc": "2.0",
+            "method": "tools/list",
+            "id": 2
+        }))
+        .await;
+    resp["result"]["tools"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn meta_tool_description<'a>(tools: &'a [Value], name: &str) -> &'a str {
+    tools
+        .iter()
+        .find(|t| t["name"].as_str() == Some(name))
+        .unwrap_or_else(|| panic!("meta-tool '{}' not found in tools/list", name))["description"]
+        .as_str()
+        .unwrap_or_else(|| panic!("'{}' description was not a string", name))
+}
+
+/// 1 — instructions field is omitted entirely when no adapters are Healthy.
+#[tokio::test]
+async fn instructions_omitted_when_no_healthy_servers() {
+    // bad-server with `--omit-server-name` enters Failed → registry has zero
+    // Healthy adapters → no instructions field, no `Connected servers:` suffix.
+    let config = ConfigBuilder::new()
+        .add_stdio("bad-server", &bad_server_bin(), &["--omit-server-name"])
+        .build();
+    let harness = RelayHarness::start(&config).await;
+
+    // Give the adapter a moment to attempt initialize and transition to Failed.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let init = raw_initialize(&harness).await;
+    let result = &init["result"];
+    assert!(
+        result.get("instructions").is_none(),
+        "instructions should be omitted with zero Healthy adapters; got: {}",
+        result
+    );
+
+    let tools = raw_tools_list(&harness).await;
+    let list_desc = meta_tool_description(&tools, "list_tools");
+    assert!(
+        !list_desc.contains("servers connected"),
+        "list_tools must not advertise connected servers when none are Healthy: {list_desc}"
+    );
+    let search_desc = meta_tool_description(&tools, "search_tools");
+    assert!(
+        !search_desc.contains("Connected servers:"),
+        "search_tools must not append Connected servers list when none are Healthy: {search_desc}"
+    );
+}
+
+/// 2 — instructions present and meta-tool descriptions extended once a server
+///     becomes Healthy. Uses the `bad-server` fixture without flags so it
+///     advertises serverInfo.name = "bad-mcp" and reaches Ready.
+#[tokio::test]
+async fn instructions_and_descriptions_reflect_healthy_server() {
+    let config = ConfigBuilder::new()
+        .add_stdio("good-server", &bad_server_bin(), &[])
+        .build();
+    let harness = RelayHarness::start(&config).await;
+    harness
+        .wait_healthy("good-server", Duration::from_secs(10))
+        .await
+        .expect("good-server did not become healthy");
+
+    let init = raw_initialize(&harness).await;
+    let result = &init["result"];
+    let instructions = result["instructions"]
+        .as_str()
+        .expect("instructions should be present once an adapter is Healthy");
+    assert_eq!(
+        instructions, "Connected servers: bad-mcp",
+        "unexpected instructions string: {instructions}"
+    );
+
+    let tools = raw_tools_list(&harness).await;
+    let list_desc = meta_tool_description(&tools, "list_tools");
+    assert!(
+        list_desc.ends_with(
+            " 1 servers connected via Endara Relay \u{2014} use search_tools to discover tools."
+        ),
+        "list_tools description missing connected-servers suffix: {list_desc}"
+    );
+    let search_desc = meta_tool_description(&tools, "search_tools");
+    assert!(
+        search_desc.ends_with("\n\nConnected servers: bad-mcp"),
+        "search_tools description missing Connected servers footer: {search_desc}"
+    );
+}
+
+/// 3 — Failed adapters are excluded from the advertised list even when sitting
+///     alongside a Healthy one. Two adapters: one good (`good-server`,
+///     reports `bad-mcp`) and one Failed (`broken-server`).
+#[tokio::test]
+async fn failed_adapters_are_not_advertised() {
+    let config = ConfigBuilder::new()
+        .add_stdio("good-server", &bad_server_bin(), &[])
+        .add_stdio("broken-server", &bad_server_bin(), &["--omit-server-name"])
+        .build();
+    let harness = RelayHarness::start(&config).await;
+    harness
+        .wait_healthy("good-server", Duration::from_secs(10))
+        .await
+        .expect("good-server did not become healthy");
+
+    let init = raw_initialize(&harness).await;
+    let instructions = init["result"]["instructions"]
+        .as_str()
+        .expect("instructions should be present");
+    assert_eq!(
+        instructions, "Connected servers: bad-mcp",
+        "Failed adapter should be excluded; got: {instructions}"
+    );
+
+    let tools = raw_tools_list(&harness).await;
+    let list_desc = meta_tool_description(&tools, "list_tools");
+    // endpoint_count counts Healthy adapters only → 1, not 2.
+    assert!(
+        list_desc.ends_with(
+            " 1 servers connected via Endara Relay \u{2014} use search_tools to discover tools."
+        ),
+        "list_tools count must exclude Failed adapter: {list_desc}"
+    );
+}

--- a/tests/fixtures/multi_tool_server.rs
+++ b/tests/fixtures/multi_tool_server.rs
@@ -1,5 +1,8 @@
 //! Multi-tool MCP server fixture — exposes 12 tools with varied input schemas.
-//! Usage: fixture-multi-tool-server
+//!
+//! Usage:
+//!   fixture-multi-tool-server                 # serverInfo.name = "multi-tool-mcp"
+//!   fixture-multi-tool-server --name <NAME>   # serverInfo.name = "<NAME>"
 
 use serde_json::{json, Value};
 use std::io::{self, BufRead, Write};
@@ -111,8 +114,26 @@ fn handle_tool_call(name: &str, args: &Value) -> String {
     }
 }
 
+fn parse_server_name() -> String {
+    let mut args = std::env::args().skip(1);
+    while let Some(a) = args.next() {
+        if a == "--name" {
+            if let Some(v) = args.next() {
+                return v;
+            }
+        } else if let Some(rest) = a.strip_prefix("--name=") {
+            return rest.to_string();
+        }
+    }
+    "multi-tool-mcp".to_string()
+}
+
 fn main() {
-    eprintln!("multi-tool-server: starting with 12 tools");
+    let server_name = parse_server_name();
+    eprintln!(
+        "multi-tool-server: starting with 12 tools (name={})",
+        server_name
+    );
     let stdin = io::stdin();
     let stdout = io::stdout();
 
@@ -138,7 +159,7 @@ fn main() {
         let response = match method {
             "initialize" => json!({"jsonrpc": "2.0", "result": {
                 "protocolVersion": "2024-11-05", "capabilities": {"tools": {}},
-                "serverInfo": {"name": "multi-tool-mcp", "version": "0.1.0"}}, "id": id}),
+                "serverInfo": {"name": server_name.as_str(), "version": "0.1.0"}}, "id": id}),
             "tools/list" => {
                 json!({"jsonrpc": "2.0", "result": {"tools": tool_definitions()}, "id": id})
             }


### PR DESCRIPTION
Implements the **Advertise Connected Servers to the Model** Engineering Spec end-to-end in `packages/relay`.

Dynamically informs the model about the types and count of connected MCP servers via:
1. The `instructions` field on the `initialize` response.
2. The descriptions of the `search_tools`, `list_tools`, and `execute_tools` meta-tools.

## Changes
- **`src/registry.rs`** — added `ready_server_types()` (sorted/deduped `BTreeSet<String>` of Healthy server types, lower-cased) and `ready_endpoint_count()` (count of Healthy adapters, not deduped).
- **`src/advertise.rs`** *(new)* — `ServerTypeList` plus three description builders (`search_tools_description`, `list_tools_description`, `execute_tools_description`). Enforces the 8 KB safety cap from spec §2.4 with a `, …` truncation suffix.
- **`src/server.rs`** —
  - `mcp_initialize` now takes `State<AppState>` and populates `instructions` from the registry. The field is **omitted** entirely (not `null`) when no Healthy adapter has a `server_type`.
  - `meta_tool_definitions` made `async` and registry-driven, so each `tools/list` reflects current registry state.
  - All call sites (`mcp_unified`, `mcp_tools_list`, logged wrappers) updated to await the new signatures.
- **`src/lib.rs`, `src/main.rs`** — declared `pub mod advertise;`.
- **`tests/advertise.rs`** *(new)* — 3 integration scenarios covering instructions omission with no Healthy adapters, instructions + tool-description population once Healthy, and exclusion of Failed adapters from the advertised set.
- **13 inline unit tests** in `src/advertise.rs` covering all rows from spec §5.1 (list rendering, sort, dedup, truncation) and §5.2 (description-builder behavior).

## Verification
```bash
cd packages/relay
cargo fmt --check                              # ✅
cargo clippy --all-targets -- -D warnings      # ✅
cargo test --lib advertise::                   # ✅ 13/13
cargo test --test advertise                    # ✅ 3/3
cargo test                                     # ✅ full suite, 0 failures
```

## Out of scope
- Any `packages/desktop` change.
- Adapter trait changes (`server_type()` already exists).
- Caching, hot-reload, or `notifications/tools/list_changed` plumbing — falls out of existing behavior per Engineering Spec §3.4.
- Per-endpoint description rendering.

**Do not merge** — wait for verifier wave + user approval.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author