### PR TITLE
chore: bump version to 0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "endara-relay"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endara-relay"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "Local MCP tool aggregator — aggregate multiple MCP servers behind a single endpoint"
 license = "Apache-2.0"


### PR DESCRIPTION
Prepares the `v0.1.6-rc.1` tag.

Follows up on the just-merged #56. Diff is exactly `Cargo.toml` (version line) and `Cargo.lock` (endara-relay entry only).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author