### PR TITLE
feat: add server_type_override and strip -mcp-server suffix from upstream-derived names

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,22 @@ url = "http://localhost:3001/sse"  # Required for sse/http — server URL
 name = "http-server"
 transport = "http"
 url = "http://localhost:4000/mcp"  # Required for sse/http — server URL
+
+# Optional — override the advertised server_type
+# By default the relay derives the server_type from the upstream
+# `serverInfo.name`, then strips one of the suffixes
+# `-mcp-server`, `_mcp_server`, `-mcp`, `_mcp` (so `linear-mcp-server`
+# becomes `linear`). When that produces an awkward name, set
+# `server_type_override` to take control of what is advertised to the
+# model. The override is sanitized to a valid identifier but is **never**
+# auto-stripped — what you write is what gets used.
+[[endpoints]]
+name = "drive"
+transport = "oauth"
+url = "https://drivemcp.googleapis.com/mcp/v1"
+oauth_server_url = "https://accounts.google.com"
+client_id = "$GOOGLE_CLIENT_ID"
+server_type_override = "google-drive"  # Optional — overrides upstream-derived server_type
 ```
 
 ### Environment variable resolution

--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -1,4 +1,5 @@
 use super::server_name::{sanitize_server_name, ServerNameError};
+use super::server_type_resolution::effective_server_type;
 use super::stdio::RingBuffer;
 use super::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
 use crate::jsonrpc::{self, JsonRpcResponse};
@@ -22,6 +23,9 @@ pub struct HttpConfig {
     pub timeout_secs: u64,
     /// Custom HTTP headers to include in every request.
     pub headers: HashMap<String, String>,
+    /// Optional override for the advertised `server_type` name. See
+    /// [`crate::adapter::server_type_resolution::effective_server_type`].
+    pub server_type_override: Option<String>,
 }
 
 impl HttpConfig {
@@ -30,6 +34,7 @@ impl HttpConfig {
             url: url.into(),
             timeout_secs: 30,
             headers: HashMap::new(),
+            server_type_override: None,
         }
     }
 
@@ -342,8 +347,21 @@ impl McpAdapter for HttpAdapter {
             }
         };
 
-        info!(url = %self.config.url, raw_name = %raw_name, sanitized = %sanitized, "MCP server reported serverInfo.name");
-        *self.server_type.write().await = Some(sanitized);
+        if let Some(ref ov) = self.config.server_type_override {
+            if sanitize_server_name(ov).is_err() {
+                warn!(
+                    override = %ov,
+                    "server_type_override failed sanitization; falling back to upstream-derived name"
+                );
+            }
+        }
+        let effective = effective_server_type(
+            self.config.server_type_override.clone(),
+            Some(sanitized.clone()),
+        );
+
+        info!(url = %self.config.url, raw_name = %raw_name, sanitized = %sanitized, effective = ?effective, "MCP server reported serverInfo.name");
+        *self.server_type.write().await = effective;
 
         // Per the MCP spec the client MUST send a notifications/initialized
         // notification after a successful initialize exchange.

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -1,6 +1,7 @@
 pub mod http;
 pub mod oauth;
 pub mod server_name;
+pub mod server_type_resolution;
 pub mod sse;
 pub mod stdio;
 

--- a/src/adapter/oauth/heartbeat.rs
+++ b/src/adapter/oauth/heartbeat.rs
@@ -311,6 +311,7 @@ mod tests {
             heartbeat_interval_secs: 30,
             probe_timeout_secs: 10,
             probe_failure_threshold: threshold,
+            server_type_override: None,
         }
     }
 

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -64,6 +64,9 @@ pub struct OAuthAdapterConfig {
     /// `inner_health` to `Unhealthy("upstream unreachable")` (default: 3).
     /// Hysteresis to avoid flapping on a single transient timeout.
     pub probe_failure_threshold: u32,
+    /// Optional override for the advertised `server_type` name. Forwarded to
+    /// the inner [`HttpAdapter`] when it is constructed.
+    pub server_type_override: Option<String>,
 }
 
 /// Shared inner state for an OAuth adapter, wrapped in `Arc` so it can be
@@ -105,7 +108,11 @@ pub struct OAuthAdapterInner {
 
 impl OAuthAdapterInner {
     /// Build an inner HttpAdapter with a Bearer token in the default headers.
-    fn build_inner_adapter(url: &str, access_token: &str) -> HttpAdapter {
+    fn build_inner_adapter(
+        url: &str,
+        access_token: &str,
+        server_type_override: Option<String>,
+    ) -> HttpAdapter {
         let client = Client::builder()
             .timeout(Duration::from_secs(30))
             .default_headers({
@@ -125,7 +132,9 @@ impl OAuthAdapterInner {
             })
             .build()
             .expect("failed to build HTTP client");
-        HttpAdapter::new_with_client(HttpConfig::new(url), client)
+        let mut http_config = HttpConfig::new(url);
+        http_config.server_type_override = server_type_override;
+        HttpAdapter::new_with_client(http_config, client)
     }
 
     /// Transition to a new `OAuthState`.
@@ -354,7 +363,11 @@ impl OAuthAdapterInner {
 
         // 3. Rebuild inner adapter
         let access_token = token_set.access_token.clone();
-        let mut adapter = Self::build_inner_adapter(&self.config.url, &access_token);
+        let mut adapter = Self::build_inner_adapter(
+            &self.config.url,
+            &access_token,
+            self.config.server_type_override.clone(),
+        );
         match adapter.initialize().await {
             Ok(()) => {
                 // Reflect the freshly initialized inner adapter's health
@@ -881,6 +894,7 @@ mod tests {
             heartbeat_interval_secs: 30,
             probe_timeout_secs: 10,
             probe_failure_threshold: 3,
+            server_type_override: None,
         }
     }
 

--- a/src/adapter/server_type_resolution.rs
+++ b/src/adapter/server_type_resolution.rs
@@ -1,0 +1,191 @@
+//! Resolve the effective `server_type` for an adapter from an optional
+//! per-endpoint override and the upstream-sanitized name reported via
+//! `serverInfo.name`.
+//!
+//! Rules:
+//! - If a `server_type_override` is supplied, it is run through
+//!   [`sanitize_server_name`] and used directly. The `-mcp-server` strip is
+//!   **never** applied to overrides — the user is taken at their word.
+//! - If the override is missing **or** fails sanitization, the upstream
+//!   sanitized name is used, with [`strip_mcp_server_suffix`] applied to remove
+//!   one of the placeholder suffixes that upstream servers commonly bake into
+//!   their `serverInfo.name`.
+//! - The strip is a closed list of four suffixes (`-mcp-server`, `_mcp_server`,
+//!   `-mcp`, `_mcp`); strips that would empty the name return the original.
+
+use super::server_name::sanitize_server_name;
+
+/// The closed list of upstream suffixes that are stripped from the
+/// upstream-derived `server_type`. Order matters: longer variants first so
+/// `something-mcp-server` strips down to `something` rather than
+/// `something-mcp`.
+const STRIP_SUFFIXES: &[&str] = &["-mcp-server", "_mcp_server", "-mcp", "_mcp"];
+
+/// Strip a single trailing `-mcp-server` / `_mcp_server` / `-mcp` / `_mcp`
+/// suffix from the upstream-derived sanitized name.
+///
+/// The strip is applied at most once and is skipped if it would reduce the
+/// name to empty (e.g. a pathological `"_mcp"` upstream name keeps as-is).
+pub fn strip_mcp_server_suffix(name: String) -> String {
+    for suffix in STRIP_SUFFIXES {
+        if let Some(stripped) = name.strip_suffix(suffix) {
+            if !stripped.is_empty() {
+                return stripped.to_string();
+            }
+        }
+    }
+    name
+}
+
+/// Resolve the effective `server_type` advertised to connected models.
+///
+/// `override_field` is the user-supplied `server_type_override` from
+/// `EndpointConfig` (already env-resolved). `upstream_sanitized` is the result
+/// of [`sanitize_server_name`] on `serverInfo.name`.
+///
+/// Falls back to the upstream-stripped name when the override fails
+/// sanitization. Adapters should log a warning at the call site when this
+/// fallback is taken so the misconfiguration is visible.
+pub fn effective_server_type(
+    override_field: Option<String>,
+    upstream_sanitized: Option<String>,
+) -> Option<String> {
+    if let Some(o) = override_field {
+        if let Ok(sanitized) = sanitize_server_name(&o) {
+            return Some(sanitized);
+        }
+        // Override was supplied but unusable; fall through to the
+        // upstream-derived name so the endpoint still advertises something.
+    }
+    upstream_sanitized.map(strip_mcp_server_suffix)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- strip_mcp_server_suffix -------------------------------------------
+
+    #[test]
+    fn strip_dash_mcp_server() {
+        assert_eq!(
+            strip_mcp_server_suffix("linear-mcp-server".into()),
+            "linear"
+        );
+    }
+
+    #[test]
+    fn strip_underscore_mcp_server() {
+        assert_eq!(
+            strip_mcp_server_suffix("linear_mcp_server".into()),
+            "linear"
+        );
+    }
+
+    #[test]
+    fn strip_dash_mcp() {
+        assert_eq!(strip_mcp_server_suffix("linear-mcp".into()), "linear");
+    }
+
+    #[test]
+    fn strip_underscore_mcp() {
+        assert_eq!(strip_mcp_server_suffix("linear_mcp".into()), "linear");
+    }
+
+    #[test]
+    fn strip_no_suffix_match_is_noop() {
+        assert_eq!(strip_mcp_server_suffix("linear".into()), "linear");
+        assert_eq!(
+            strip_mcp_server_suffix("statelessserver".into()),
+            "statelessserver"
+        );
+        // Substring (not suffix) is left alone.
+        assert_eq!(
+            strip_mcp_server_suffix("mcp-server-x".into()),
+            "mcp-server-x"
+        );
+    }
+
+    #[test]
+    fn strip_prefers_longest_suffix_first() {
+        // "-mcp-server" is tried before "-mcp", so the result is `linear`,
+        // not `linear-server`.
+        assert_eq!(
+            strip_mcp_server_suffix("linear-mcp-server".into()),
+            "linear"
+        );
+    }
+
+    #[test]
+    fn strip_skipped_when_it_would_empty_the_name() {
+        // Pathological all-suffix names: stripping would leave empty, so the
+        // original is preserved.
+        for s in ["-mcp-server", "_mcp_server", "-mcp", "_mcp"] {
+            assert_eq!(
+                strip_mcp_server_suffix(s.into()),
+                s,
+                "skip-empty for {:?}",
+                s
+            );
+        }
+    }
+
+    #[test]
+    fn strip_is_idempotent() {
+        let first = strip_mcp_server_suffix("foo-mcp-server".into());
+        let second = strip_mcp_server_suffix(first.clone());
+        assert_eq!(first, second);
+        assert_eq!(second, "foo");
+    }
+
+    // --- effective_server_type ---------------------------------------------
+
+    #[test]
+    fn override_happy_path_takes_precedence_over_strip() {
+        // Override wins even when the upstream name would have been stripped,
+        // and the override is taken verbatim (not stripped).
+        let out = effective_server_type(
+            Some("google-drive-mcp-server".into()),
+            Some("statelessserver".into()),
+        );
+        assert_eq!(out, Some("google-drive-mcp-server".into()));
+    }
+
+    #[test]
+    fn override_is_sanitized() {
+        // `Google Drive` sanitizes to `google-drive`.
+        let out = effective_server_type(Some("Google Drive".into()), Some("upstream".into()));
+        assert_eq!(out, Some("google-drive".into()));
+    }
+
+    #[test]
+    fn override_failing_sanitization_falls_back_to_stripped_upstream() {
+        // Pure-emoji override is unsanitizable; we fall back to the
+        // upstream-stripped name rather than returning `None`.
+        let out = effective_server_type(Some("🚀🚀🚀".into()), Some("foo-mcp-server".into()));
+        assert_eq!(out, Some("foo".into()));
+    }
+
+    #[test]
+    fn override_failing_with_no_upstream_returns_none() {
+        let out = effective_server_type(Some("🚀".into()), None);
+        assert_eq!(out, None);
+    }
+
+    #[test]
+    fn no_override_strips_upstream() {
+        let out = effective_server_type(None, Some("linear-mcp-server".into()));
+        assert_eq!(out, Some("linear".into()));
+    }
+
+    #[test]
+    fn no_override_no_upstream_returns_none() {
+        assert_eq!(effective_server_type(None, None), None);
+    }
+
+    #[test]
+    fn no_override_unstripped_upstream_passes_through() {
+        let out = effective_server_type(None, Some("linear".into()));
+        assert_eq!(out, Some("linear".into()));
+    }
+}

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -1,4 +1,5 @@
 use super::server_name::{sanitize_server_name, ServerNameError};
+use super::server_type_resolution::effective_server_type;
 use super::stdio::RingBuffer;
 use super::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
 use crate::jsonrpc::{self, JsonRpcResponse};
@@ -22,6 +23,9 @@ pub struct SseConfig {
     pub timeout_secs: u64,
     /// Custom HTTP headers to include in requests.
     pub headers: HashMap<String, String>,
+    /// Optional override for the advertised `server_type` name. See
+    /// [`crate::adapter::server_type_resolution::effective_server_type`].
+    pub server_type_override: Option<String>,
 }
 
 impl SseConfig {
@@ -30,6 +34,7 @@ impl SseConfig {
             url: url.into(),
             timeout_secs: 30,
             headers: HashMap::new(),
+            server_type_override: None,
         }
     }
 
@@ -533,8 +538,21 @@ impl SseAdapter {
             }
         };
 
-        debug!(url = %self.config.url, raw_name = %raw_name, sanitized = %sanitized, "MCP server reported serverInfo.name");
-        *self.server_type.write().await = Some(sanitized);
+        if let Some(ref ov) = self.config.server_type_override {
+            if sanitize_server_name(ov).is_err() {
+                warn!(
+                    override = %ov,
+                    "server_type_override failed sanitization; falling back to upstream-derived name"
+                );
+            }
+        }
+        let effective = effective_server_type(
+            self.config.server_type_override.clone(),
+            Some(sanitized.clone()),
+        );
+
+        debug!(url = %self.config.url, raw_name = %raw_name, sanitized = %sanitized, effective = ?effective, "MCP server reported serverInfo.name");
+        *self.server_type.write().await = effective;
         *self.health.write().await = HealthStatus::Healthy;
         self.crash_tracker.lock().await.reset();
         // Emit a tick after every successful (re)connect + handshake so any

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -1,4 +1,5 @@
 use super::server_name::{sanitize_server_name, ServerNameError};
+use super::server_type_resolution::effective_server_type;
 use super::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
 use crate::jsonrpc::{self, JsonRpcResponse};
 use crate::shell_env;
@@ -15,11 +16,14 @@ use tokio::time::{Duration, Instant};
 use tracing::{debug, error, info, warn};
 
 /// Configuration for spawning a STDIO MCP server.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct StdioConfig {
     pub command: String,
     pub args: Vec<String>,
     pub env: HashMap<String, String>,
+    /// Optional override for the advertised `server_type` name. See
+    /// [`crate::adapter::server_type_resolution::effective_server_type`].
+    pub server_type_override: Option<String>,
 }
 
 /// Ring buffer that stores the last N lines of stderr output.
@@ -412,8 +416,25 @@ impl StdioAdapter {
             AdapterError::ProtocolError(e.to_string())
         })?;
 
-        info!(raw_name = %raw_name, sanitized = %sanitized, "MCP server reported serverInfo.name");
-        *self.server_type.write().await = Some(sanitized);
+        // Resolve the effective `server_type` from the optional per-endpoint
+        // override and the upstream-stripped sanitized name. Log a warning if
+        // the override was supplied but failed sanitization (the resolver
+        // falls back to the upstream-stripped name in that case).
+        if let Some(ref ov) = self.config.server_type_override {
+            if sanitize_server_name(ov).is_err() {
+                warn!(
+                    override = %ov,
+                    "server_type_override failed sanitization; falling back to upstream-derived name"
+                );
+            }
+        }
+        let effective = effective_server_type(
+            self.config.server_type_override.clone(),
+            Some(sanitized.clone()),
+        );
+
+        info!(raw_name = %raw_name, sanitized = %sanitized, effective = ?effective, "MCP server reported serverInfo.name");
+        *self.server_type.write().await = effective;
 
         info!("MCP initialize handshake complete");
         Ok(())
@@ -775,6 +796,7 @@ for line in sys.stdin:
             command: "python3".to_string(),
             args: vec!["-c".to_string(), script.to_string()],
             env: HashMap::new(),
+            ..Default::default()
         })
     }
 
@@ -856,6 +878,7 @@ for line in sys.stdin:
             command: "python3".to_string(),
             args: vec!["-c".to_string(), "import time; time.sleep(120)".to_string()],
             env: HashMap::new(),
+            ..Default::default()
         });
         adapter.spawn_process().await.unwrap();
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -920,6 +943,7 @@ for line in sys.stdin:
             command: "python3".to_string(),
             args: vec!["-c".to_string(), script.to_string()],
             env: HashMap::new(),
+            ..Default::default()
         });
         adapter.spawn_process().await.unwrap();
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -941,6 +965,7 @@ for line in sys.stdin:
             command: "python3".to_string(),
             args: vec!["-c".to_string(), "pass".to_string()],
             env: HashMap::new(),
+            ..Default::default()
         });
         assert!(
             (&adapter as &dyn McpAdapter)
@@ -976,6 +1001,7 @@ for line in sys.stdin:
             command: "python3".to_string(),
             args: vec!["-c".to_string(), script.to_string()],
             env: HashMap::new(),
+            ..Default::default()
         });
         adapter.spawn_process().await.unwrap();
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -1022,6 +1048,7 @@ for line in sys.stdin:
             command: "python3".to_string(),
             args: vec!["-c".to_string(), script.to_string()],
             env: HashMap::new(),
+            ..Default::default()
         });
         adapter.spawn_process().await.unwrap();
         tokio::time::sleep(Duration::from_millis(100)).await;

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,6 +83,14 @@ pub struct EndpointConfig {
     pub scopes: Option<Vec<String>>,
     #[serde(default)]
     pub token_endpoint: Option<String>,
+    /// Optional override for the advertised `server_type` name. When set,
+    /// this value is sanitized through `sanitize_server_name` and used in
+    /// place of the upstream-derived name in the `instructions` field and
+    /// meta-tool descriptions. The auto-strip of `-mcp-server` and friends
+    /// is **never** applied to overrides — the user is taken at face value.
+    /// Tool-name routing (the `tool_prefix`) is unaffected.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server_type_override: Option<String>,
 }
 
 impl EndpointConfig {
@@ -117,6 +125,7 @@ impl PartialEq for EndpointConfig {
             && self.client_id == other.client_id
             && self.client_secret == other.client_secret
             && self.scopes == other.scopes
+            && self.server_type_override == other.server_type_override
     }
 }
 
@@ -1085,6 +1094,7 @@ command = "echo"
             client_secret: None,
             scopes: None,
             token_endpoint: None,
+            server_type_override: None,
         }
     }
 
@@ -1106,6 +1116,7 @@ command = "echo"
             client_secret: None,
             scopes: None,
             token_endpoint: None,
+            server_type_override: None,
         }
     }
 
@@ -1540,6 +1551,7 @@ scopes = ["openid", "profile", "email"]
             client_secret: None,
             scopes: None,
             token_endpoint: None,
+            server_type_override: None,
         };
 
         let mut ep2 = ep1.clone();
@@ -1554,5 +1566,73 @@ scopes = ["openid", "profile", "email"]
             "OAuth field change should trigger diff"
         );
         assert!(diff.unchanged.is_empty());
+    }
+
+    // --- server_type_override tests ----------------------------------------
+
+    #[test]
+    fn parse_server_type_override_field() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "drive"
+transport = "oauth"
+url = "https://drivemcp.googleapis.com/mcp/v1"
+server_type_override = "google-drive"
+"#;
+        let config = parse_and_validate(toml_str).unwrap();
+        assert_eq!(
+            config.endpoints[0].server_type_override.as_deref(),
+            Some("google-drive")
+        );
+    }
+
+    #[test]
+    fn server_type_override_optional_defaults_to_none() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "echo"
+transport = "stdio"
+command = "echo"
+"#;
+        let config = parse_and_validate(toml_str).unwrap();
+        assert!(config.endpoints[0].server_type_override.is_none());
+    }
+
+    #[test]
+    fn server_type_override_change_triggers_config_diff() {
+        // Hot-reload requirement: changing only the override must restart
+        // the adapter so the new advertised name takes effect.
+        let mut ep1 = sse_ep("remote", "http://localhost:3000/sse");
+        ep1.server_type_override = Some("old-name".to_string());
+        let mut ep2 = sse_ep("remote", "http://localhost:3000/sse");
+        ep2.server_type_override = Some("new-name".to_string());
+
+        let old = make_config(vec![ep1]);
+        let new = make_config(vec![ep2]);
+        let diff = diff_configs(&old, &new);
+        assert_eq!(
+            diff.changed.len(),
+            1,
+            "server_type_override change should trigger diff"
+        );
+        assert!(diff.unchanged.is_empty());
+    }
+
+    #[test]
+    fn server_type_override_added_or_removed_triggers_diff() {
+        let ep1 = sse_ep("remote", "http://localhost:3000/sse");
+        let mut ep2 = sse_ep("remote", "http://localhost:3000/sse");
+        ep2.server_type_override = Some("override".to_string());
+
+        let old = make_config(vec![ep1]);
+        let new = make_config(vec![ep2]);
+        let diff = diff_configs(&old, &new);
+        assert_eq!(diff.changed.len(), 1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -307,6 +307,7 @@ async fn main() {
                         heartbeat_interval_secs: 30,
                         probe_timeout_secs: 10,
                         probe_failure_threshold: 3,
+                        server_type_override: ep.server_type_override.clone(),
                     };
 
                     let mut adapter = OAuthAdapter::new(oauth_config, token_manager.clone());

--- a/src/management.rs
+++ b/src/management.rs
@@ -702,6 +702,7 @@ async fn test_connection(Json(req): Json<TestConnectionRequest>) -> impl IntoRes
                 command: req.command.unwrap_or_default(),
                 args: req.args.unwrap_or_default(),
                 env: req.env.unwrap_or_default(),
+                ..Default::default()
             };
             Box::new(StdioAdapter::new(config))
         }
@@ -2618,6 +2619,7 @@ mod tests {
                 client_secret: None,
                 scopes: None,
                 token_endpoint: None,
+                server_type_override: None,
             }],
         }
     }
@@ -3572,6 +3574,7 @@ command = "echo"
             heartbeat_interval_secs: 30,
             probe_timeout_secs: 10,
             probe_failure_threshold: 3,
+            server_type_override: None,
         }
     }
 
@@ -4405,6 +4408,7 @@ command = "echo"
                 client_secret: config_secret.map(|s| s.to_string()),
                 scopes: None,
                 token_endpoint: None,
+                server_type_override: None,
             }],
         };
         let state = ManagementState {

--- a/src/management.rs
+++ b/src/management.rs
@@ -1609,6 +1609,10 @@ struct OAuthSetupRequest {
     /// If provided, use this URL as the discovery base instead of `url`.
     #[serde(default)]
     oauth_server_url: Option<String>,
+    /// Optional override for the advertised server type. Persisted into the
+    /// resulting `[[endpoints]]` entry as `server_type_override`.
+    #[serde(default)]
+    server_type_override: Option<String>,
 }
 
 /// Response for POST /api/oauth/setup
@@ -1688,6 +1692,7 @@ async fn oauth_setup(
             body.url.clone(),
             scopes_str.clone(),
             body.tool_prefix.clone(),
+            body.server_type_override.clone(),
         )
         .await;
 
@@ -2154,6 +2159,12 @@ async fn oauth_setup_commit(
     }
     if let Some(ref tp) = session.tool_prefix {
         ep_table.insert("tool_prefix".into(), toml::Value::String(tp.clone()));
+    }
+    if let Some(ref sto) = session.server_type_override {
+        ep_table.insert(
+            "server_type_override".into(),
+            toml::Value::String(sto.clone()),
+        );
     }
 
     // Append to the [[endpoints]] array
@@ -3983,7 +3994,7 @@ command = "echo"
         let state = test_state_with_setup().await;
         let setup_mgr = state.setup_manager.as_ref().unwrap();
         let session_id = setup_mgr
-            .create_session("ep".into(), "https://x.com".into(), None, None)
+            .create_session("ep".into(), "https://x.com".into(), None, None, None)
             .await;
 
         let app = management_routes(state);
@@ -4005,7 +4016,7 @@ command = "echo"
         let state = test_state_with_setup().await;
         let setup_mgr = state.setup_manager.as_ref().unwrap();
         let session_id = setup_mgr
-            .create_session("ep".into(), "https://x.com".into(), None, None)
+            .create_session("ep".into(), "https://x.com".into(), None, None, None)
             .await;
 
         // First cancel
@@ -4051,7 +4062,7 @@ command = "echo"
 
         let setup_mgr = state.setup_manager.as_ref().unwrap();
         let session_id = setup_mgr
-            .create_session("ep".into(), "https://x.com".into(), None, None)
+            .create_session("ep".into(), "https://x.com".into(), None, None, None)
             .await;
 
         // Session is in AwaitingCredentials status (not Authorized)
@@ -4074,7 +4085,7 @@ command = "echo"
         let state = test_state_with_setup().await;
         let setup_mgr = state.setup_manager.as_ref().unwrap();
         let session_id = setup_mgr
-            .create_session("ep".into(), "https://x.com".into(), None, None)
+            .create_session("ep".into(), "https://x.com".into(), None, None, None)
             .await;
 
         // Cancel the session
@@ -4098,7 +4109,13 @@ command = "echo"
         let state = test_state_with_setup().await;
         let setup_mgr = state.setup_manager.as_ref().unwrap();
         let session_id = setup_mgr
-            .create_session("my-ep".into(), "https://mcp.example.com".into(), None, None)
+            .create_session(
+                "my-ep".into(),
+                "https://mcp.example.com".into(),
+                None,
+                None,
+                None,
+            )
             .await;
 
         let app = management_routes(state);
@@ -4146,7 +4163,7 @@ command = "echo"
         let state = test_state_with_setup().await;
         let setup_mgr = state.setup_manager.as_ref().unwrap();
         let session_id = setup_mgr
-            .create_session("ep".into(), "https://x.com".into(), None, None)
+            .create_session("ep".into(), "https://x.com".into(), None, None, None)
             .await;
         // Set auth/token endpoints so credential submission can proceed
         setup_mgr
@@ -4195,6 +4212,7 @@ command = "echo"
                 "https://mcp.example.com".into(),
                 Some("read write".into()),
                 Some("newep".into()),
+                None,
             )
             .await;
 
@@ -4239,6 +4257,165 @@ command = "echo"
         assert!(contents.contains("oauth"));
     }
 
+    /// Round-trip: a commit driven by a session created with
+    /// `server_type_override = Some(...)` must write the field to config.toml.
+    #[tokio::test]
+    async fn oauth_setup_commit_persists_server_type_override() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(&config_path, "").unwrap();
+
+        let token_dir = tmp.path().join("tokens");
+        std::fs::create_dir_all(&token_dir).unwrap();
+
+        let mut state = test_state_with_setup().await;
+        state.config_path = Some(config_path.clone());
+        state.token_manager = Some(Arc::new(TokenManager::new(token_dir)));
+
+        let setup_mgr = state.setup_manager.as_ref().unwrap();
+        let session_id = setup_mgr
+            .create_session(
+                "drive-ep".into(),
+                "https://mcp.example.com".into(),
+                None,
+                None,
+                Some("google-drive".into()),
+            )
+            .await;
+
+        setup_mgr
+            .get_session_mut(&session_id, |s| {
+                s.authorization_endpoint = Some("https://auth.example.com/authorize".into());
+                s.token_endpoint = Some("https://auth.example.com/token".into());
+                s.client_id = Some("cid".into());
+                s.status = crate::oauth::SetupSessionStatus::Authorized;
+                s.tokens = Some(crate::token_manager::TokenSet {
+                    access_token: "tok".into(),
+                    refresh_token: None,
+                    expires_at: None,
+                    token_type: "Bearer".into(),
+                    scope: None,
+                    issued_at: None,
+                });
+            })
+            .await;
+
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post(format!("/api/oauth/setup/{}/commit", session_id))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Re-parse the written config and assert the field made it through.
+        // Parse as a raw toml::Table because the test fixture omits the
+        // mandatory `[relay]` section that `Config` deserialization requires.
+        let contents = std::fs::read_to_string(&config_path).unwrap();
+        let parsed: toml::Table = contents.parse().unwrap();
+        let endpoints = parsed
+            .get("endpoints")
+            .and_then(|v| v.as_array())
+            .expect("endpoints array missing from written config");
+        let ep = endpoints
+            .iter()
+            .find(|v| v.get("name").and_then(|n| n.as_str()) == Some("drive-ep"))
+            .expect("committed endpoint missing from config");
+        assert_eq!(
+            ep.get("server_type_override").and_then(|v| v.as_str()),
+            Some("google-drive"),
+            "server_type_override missing from written endpoint entry"
+        );
+    }
+
+    /// Sanity check: when no override is supplied, the commit must not emit a
+    /// `server_type_override` key (avoids polluting config.toml with `None`).
+    #[tokio::test]
+    async fn oauth_setup_commit_omits_server_type_override_when_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(&config_path, "").unwrap();
+
+        let token_dir = tmp.path().join("tokens");
+        std::fs::create_dir_all(&token_dir).unwrap();
+
+        let mut state = test_state_with_setup().await;
+        state.config_path = Some(config_path.clone());
+        state.token_manager = Some(Arc::new(TokenManager::new(token_dir)));
+
+        let setup_mgr = state.setup_manager.as_ref().unwrap();
+        let session_id = setup_mgr
+            .create_session(
+                "plain-ep".into(),
+                "https://mcp.example.com".into(),
+                None,
+                None,
+                None,
+            )
+            .await;
+
+        setup_mgr
+            .get_session_mut(&session_id, |s| {
+                s.authorization_endpoint = Some("https://auth.example.com/authorize".into());
+                s.token_endpoint = Some("https://auth.example.com/token".into());
+                s.client_id = Some("cid".into());
+                s.status = crate::oauth::SetupSessionStatus::Authorized;
+                s.tokens = Some(crate::token_manager::TokenSet {
+                    access_token: "tok".into(),
+                    refresh_token: None,
+                    expires_at: None,
+                    token_type: "Bearer".into(),
+                    scope: None,
+                    issued_at: None,
+                });
+            })
+            .await;
+
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post(format!("/api/oauth/setup/{}/commit", session_id))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let contents = std::fs::read_to_string(&config_path).unwrap();
+        assert!(
+            !contents.contains("server_type_override"),
+            "expected no server_type_override key when override is None, got:\n{}",
+            contents
+        );
+    }
+
+    /// HTTP-layer round-trip: the request body's `server_type_override` field
+    /// must deserialize and be threaded into the resulting setup session.
+    #[tokio::test]
+    async fn oauth_setup_request_threads_server_type_override_into_session() {
+        // Deserialize via the public JSON contract and verify the field lands
+        // on the request struct that the handler uses.
+        let body: OAuthSetupRequest = serde_json::from_value(serde_json::json!({
+            "name": "drive-ep",
+            "url": "https://mcp.example.com",
+            "server_type_override": "google-drive"
+        }))
+        .unwrap();
+        assert_eq!(body.server_type_override.as_deref(), Some("google-drive"));
+
+        // And when omitted, it defaults to None.
+        let body_no_override: OAuthSetupRequest = serde_json::from_value(serde_json::json!({
+            "name": "x",
+            "url": "https://x.com"
+        }))
+        .unwrap();
+        assert!(body_no_override.server_type_override.is_none());
+    }
+
     #[tokio::test]
     async fn oauth_setup_double_commit_returns_not_found() {
         let tmp = tempfile::tempdir().unwrap();
@@ -4254,7 +4431,7 @@ command = "echo"
 
         let setup_mgr = state.setup_manager.as_ref().unwrap();
         let session_id = setup_mgr
-            .create_session("ep".into(), "https://x.com".into(), None, None)
+            .create_session("ep".into(), "https://x.com".into(), None, None, None)
             .await;
 
         // Mark as authorized

--- a/src/oauth/mod.rs
+++ b/src/oauth/mod.rs
@@ -177,6 +177,10 @@ pub struct OAuthSetupSession {
     pub scopes: Option<String>,
     /// Tool prefix override (None = auto-derive from name).
     pub tool_prefix: Option<String>,
+    /// Optional override for the advertised server type. When `Some(_)`, this
+    /// value is sanitized and used in place of the upstream-derived server
+    /// name in `server_type()` and is persisted to `config.toml` on commit.
+    pub server_type_override: Option<String>,
     /// Discovered authorization endpoint.
     pub authorization_endpoint: Option<String>,
     /// Discovered token endpoint.
@@ -220,6 +224,7 @@ impl OAuthSetupManager {
         url: String,
         scopes: Option<String>,
         tool_prefix: Option<String>,
+        server_type_override: Option<String>,
     ) -> Uuid {
         let id = Uuid::new_v4();
         let session = OAuthSetupSession {
@@ -227,6 +232,7 @@ impl OAuthSetupManager {
             url,
             scopes,
             tool_prefix,
+            server_type_override,
             authorization_endpoint: None,
             token_endpoint: None,
             registration_endpoint: None,
@@ -454,6 +460,7 @@ mod tests {
                 "https://mcp.example.com".into(),
                 Some("read write".into()),
                 Some("test".into()),
+                None,
             )
             .await;
 
@@ -489,7 +496,7 @@ mod tests {
     async fn setup_manager_remove_session() {
         let mgr = OAuthSetupManager::new();
         let id = mgr
-            .create_session("ep".into(), "https://x.com".into(), None, None)
+            .create_session("ep".into(), "https://x.com".into(), None, None, None)
             .await;
 
         let removed = mgr.remove_session(&id).await;
@@ -504,7 +511,7 @@ mod tests {
     async fn setup_manager_mark_authorized() {
         let mgr = OAuthSetupManager::new();
         let id = mgr
-            .create_session("ep".into(), "https://x.com".into(), None, None)
+            .create_session("ep".into(), "https://x.com".into(), None, None, None)
             .await;
 
         let tokens = crate::token_manager::TokenSet {
@@ -544,7 +551,7 @@ mod tests {
     async fn setup_manager_expired_session_is_invisible() {
         let mgr = OAuthSetupManager::new();
         let id = mgr
-            .create_session("ep".into(), "https://x.com".into(), None, None)
+            .create_session("ep".into(), "https://x.com".into(), None, None, None)
             .await;
 
         // Manually expire the session
@@ -566,10 +573,10 @@ mod tests {
     async fn setup_manager_cleanup_stale() {
         let mgr = OAuthSetupManager::new();
         let fresh_id = mgr
-            .create_session("fresh".into(), "https://a.com".into(), None, None)
+            .create_session("fresh".into(), "https://a.com".into(), None, None, None)
             .await;
         let stale_id = mgr
-            .create_session("stale".into(), "https://b.com".into(), None, None)
+            .create_session("stale".into(), "https://b.com".into(), None, None, None)
             .await;
 
         // Make one session stale
@@ -592,7 +599,7 @@ mod tests {
     async fn setup_manager_get_session_mut_modifies() {
         let mgr = OAuthSetupManager::new();
         let id = mgr
-            .create_session("ep".into(), "https://x.com".into(), None, None)
+            .create_session("ep".into(), "https://x.com".into(), None, None, None)
             .await;
 
         mgr.get_session_mut(&id, |s| {

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -534,6 +534,7 @@ pub(crate) async fn create_adapter(
                 command: ep.command.clone().unwrap_or_default(),
                 args: ep.args.clone().unwrap_or_default(),
                 env: ep.env.clone().unwrap_or_default(),
+                server_type_override: ep.server_type_override.clone(),
             };
             let mut adapter = StdioAdapter::new(stdio_config);
             match adapter.initialize().await {
@@ -548,6 +549,7 @@ pub(crate) async fn create_adapter(
             let url = ep.url.clone().unwrap_or_default();
             let mut sse_config = SseConfig::new(url);
             sse_config.headers = ep.headers.clone().unwrap_or_default();
+            sse_config.server_type_override = ep.server_type_override.clone();
             let mut adapter = SseAdapter::new(sse_config);
             match adapter.initialize().await {
                 Ok(()) => Box::new(adapter),
@@ -561,6 +563,7 @@ pub(crate) async fn create_adapter(
             let url = ep.url.clone().unwrap_or_default();
             let mut http_config = HttpConfig::new(url);
             http_config.headers = ep.headers.clone().unwrap_or_default();
+            http_config.server_type_override = ep.server_type_override.clone();
             let mut adapter = HttpAdapter::new(http_config);
             match adapter.initialize().await {
                 Ok(()) => Box::new(adapter),
@@ -587,6 +590,7 @@ pub(crate) async fn create_adapter(
                 heartbeat_interval_secs: 30,
                 probe_timeout_secs: 10,
                 probe_failure_threshold: 3,
+                server_type_override: ep.server_type_override.clone(),
             };
 
             let mut adapter = OAuthAdapter::new(oauth_config, token_manager.clone());
@@ -724,6 +728,7 @@ mod tests {
             client_secret: None,
             scopes: None,
             token_endpoint: None,
+            server_type_override: None,
         }
     }
 
@@ -840,6 +845,7 @@ mod tests {
             client_secret: None,
             scopes: None,
             token_endpoint: None,
+            server_type_override: None,
         };
         let diff = ConfigDiff {
             changed: vec![("ep".to_string(), changed_ep)],
@@ -874,6 +880,7 @@ mod tests {
             client_secret: None,
             scopes: None,
             token_endpoint: None,
+            server_type_override: None,
         };
         let diff = ConfigDiff {
             added: vec![new_ep],
@@ -966,6 +973,7 @@ mod tests {
             client_secret: None,
             scopes: None,
             token_endpoint: None,
+            server_type_override: None,
         };
         let diff = ConfigDiff {
             added: vec![new_ep],
@@ -1256,6 +1264,7 @@ mod tests {
             client_secret: client_secret.map(|s| s.to_string()),
             scopes: None,
             token_endpoint: None,
+            server_type_override: None,
         }
     }
 

--- a/tests/advertise.rs
+++ b/tests/advertise.rs
@@ -128,7 +128,8 @@ async fn instructions_omitted_when_no_healthy_servers() {
 
 /// 2 — instructions present and meta-tool descriptions extended once a server
 ///     becomes Healthy. Uses the `bad-server` fixture without flags so it
-///     advertises serverInfo.name = "bad-mcp" and reaches Ready.
+///     advertises serverInfo.name = "bad-mcp"; the relay strips the `-mcp`
+///     suffix and advertises `bad`.
 #[tokio::test]
 async fn instructions_and_descriptions_reflect_healthy_server() {
     let config = ConfigBuilder::new()
@@ -147,7 +148,7 @@ async fn instructions_and_descriptions_reflect_healthy_server() {
         .expect("instructions should be present once an adapter is Healthy");
     assert_eq!(
         instructions,
-        format!("{}\n\nConnected servers: bad-mcp", INSTRUCTIONS_LEAD_IN),
+        format!("{}\n\nConnected servers: bad", INSTRUCTIONS_LEAD_IN),
         "unexpected instructions string: {instructions}"
     );
 
@@ -161,14 +162,15 @@ async fn instructions_and_descriptions_reflect_healthy_server() {
     );
     let search_desc = meta_tool_description(&tools, "search_tools");
     assert!(
-        search_desc.ends_with("\n\nConnected servers: bad-mcp"),
+        search_desc.ends_with("\n\nConnected servers: bad"),
         "search_tools description missing Connected servers footer: {search_desc}"
     );
 }
 
 /// 3 — Failed adapters are excluded from the advertised list even when sitting
 ///     alongside a Healthy one. Two adapters: one good (`good-server`,
-///     reports `bad-mcp`) and one Failed (`broken-server`).
+///     reports `bad-mcp` which is stripped to `bad`) and one Failed
+///     (`broken-server`).
 #[tokio::test]
 async fn failed_adapters_are_not_advertised() {
     let config = ConfigBuilder::new()
@@ -187,7 +189,7 @@ async fn failed_adapters_are_not_advertised() {
         .expect("instructions should be present");
     assert_eq!(
         instructions,
-        format!("{}\n\nConnected servers: bad-mcp", INSTRUCTIONS_LEAD_IN),
+        format!("{}\n\nConnected servers: bad", INSTRUCTIONS_LEAD_IN),
         "Failed adapter should be excluded; got: {instructions}"
     );
 

--- a/tests/crash_recovery_integration.rs
+++ b/tests/crash_recovery_integration.rs
@@ -24,6 +24,7 @@ async fn test_crash_server_successful_calls_then_failure() {
         command: crash_server_bin(),
         args: vec!["--crash-after".to_string(), "5".to_string()],
         env: HashMap::new(),
+        server_type_override: None,
     };
 
     let mut adapter = StdioAdapter::new(config);
@@ -89,6 +90,7 @@ async fn test_crash_server_immediate_crash() {
         command: crash_server_bin(),
         args: vec!["--crash-after".to_string(), "2".to_string()],
         env: HashMap::new(),
+        server_type_override: None,
     };
 
     let mut adapter = StdioAdapter::new(config);

--- a/tests/hot_reload_integration.rs
+++ b/tests/hot_reload_integration.rs
@@ -34,6 +34,7 @@ async fn test_config_diff_add_endpoint() {
         command: "bash".to_string(),
         args: vec![echo_script_path().to_string_lossy().to_string()],
         env: HashMap::new(),
+        server_type_override: None,
     };
     let mut echo_adapter = StdioAdapter::new(echo_config);
     echo_adapter.initialize().await.expect("echo init failed");
@@ -76,6 +77,7 @@ async fn test_config_diff_add_endpoint() {
             client_secret: None,
             scopes: None,
             token_endpoint: None,
+            server_type_override: None,
         }],
     };
 
@@ -104,6 +106,7 @@ async fn test_config_diff_add_endpoint() {
                 client_secret: None,
                 scopes: None,
                 token_endpoint: None,
+                server_type_override: None,
             },
             config::EndpointConfig {
                 name: "multi-ep".to_string(),
@@ -122,6 +125,7 @@ async fn test_config_diff_add_endpoint() {
                 client_secret: None,
                 scopes: None,
                 token_endpoint: None,
+                server_type_override: None,
             },
         ],
     };
@@ -159,6 +163,7 @@ async fn test_config_diff_remove_endpoint() {
         command: "bash".to_string(),
         args: vec![echo_script_path().to_string_lossy().to_string()],
         env: HashMap::new(),
+        server_type_override: None,
     };
     let mut echo_adapter = StdioAdapter::new(echo_config);
     echo_adapter.initialize().await.expect("echo init failed");
@@ -176,6 +181,7 @@ async fn test_config_diff_remove_endpoint() {
         command: multi_tool_bin(),
         args: vec![],
         env: HashMap::new(),
+        server_type_override: None,
     };
     let mut multi_adapter = StdioAdapter::new(multi_config);
     multi_adapter.initialize().await.expect("multi init failed");
@@ -218,6 +224,7 @@ async fn test_config_diff_remove_endpoint() {
                 client_secret: None,
                 scopes: None,
                 token_endpoint: None,
+                server_type_override: None,
             },
             config::EndpointConfig {
                 name: "multi-ep".to_string(),
@@ -236,6 +243,7 @@ async fn test_config_diff_remove_endpoint() {
                 client_secret: None,
                 scopes: None,
                 token_endpoint: None,
+                server_type_override: None,
             },
         ],
     };
@@ -264,6 +272,7 @@ async fn test_config_diff_remove_endpoint() {
             client_secret: None,
             scopes: None,
             token_endpoint: None,
+            server_type_override: None,
         }],
     };
 

--- a/tests/js_execution_integration.rs
+++ b/tests/js_execution_integration.rs
@@ -30,6 +30,7 @@ async fn setup_js_server(js_mode: bool) -> (SocketAddr, tokio::task::JoinHandle<
         command: "bash".to_string(),
         args: vec![echo_script_path().to_string_lossy().to_string()],
         env: HashMap::new(),
+        server_type_override: None,
     };
     let mut adapter = StdioAdapter::new(config);
     adapter.initialize().await.expect("adapter init failed");

--- a/tests/management_api_integration.rs
+++ b/tests/management_api_integration.rs
@@ -102,6 +102,7 @@ fn test_config() -> Config {
             client_secret: None,
             scopes: None,
             token_endpoint: None,
+            server_type_override: None,
         }],
     }
 }

--- a/tests/mcp_server_integration.rs
+++ b/tests/mcp_server_integration.rs
@@ -25,6 +25,7 @@ async fn setup_server() -> (SocketAddr, AdapterRegistry, tokio::task::JoinHandle
         command: "bash".to_string(),
         args: vec![fixture_path().to_string_lossy().to_string()],
         env: HashMap::new(),
+        server_type_override: None,
     };
     let mut adapter = StdioAdapter::new(config);
     adapter.initialize().await.expect("adapter init failed");

--- a/tests/multi_endpoint_integration.rs
+++ b/tests/multi_endpoint_integration.rs
@@ -37,6 +37,7 @@ async fn setup_multi_endpoint_server() -> (SocketAddr, AdapterRegistry, tokio::t
         command: "bash".to_string(),
         args: vec![echo_script_path().to_string_lossy().to_string()],
         env: HashMap::new(),
+        server_type_override: None,
     };
     let mut echo_adapter = StdioAdapter::new(echo_config);
     echo_adapter
@@ -58,6 +59,7 @@ async fn setup_multi_endpoint_server() -> (SocketAddr, AdapterRegistry, tokio::t
         command: multi_tool_bin(),
         args: vec![],
         env: HashMap::new(),
+        server_type_override: None,
     };
     let mut multi_adapter = StdioAdapter::new(multi_config);
     multi_adapter
@@ -203,6 +205,7 @@ async fn test_multi_endpoint_overlapping_tool_names() {
             command: multi_tool_bin(),
             args: vec![],
             env: HashMap::new(),
+            server_type_override: None,
         };
         let mut adapter = endara_relay::adapter::stdio::StdioAdapter::new(config);
         adapter

--- a/tests/oauth_setup_integration.rs
+++ b/tests/oauth_setup_integration.rs
@@ -43,6 +43,7 @@ fn empty_config() -> Config {
             client_secret: None,
             scopes: None,
             token_endpoint: None,
+            server_type_override: None,
         }],
     }
 }

--- a/tests/server_info_name.rs
+++ b/tests/server_info_name.rs
@@ -82,11 +82,12 @@ async fn test_stdio_valid_server_name_enters_ready_state() {
             .await
             .expect("endpoint did not enter Ready state");
 
-    // Verify server_name is present
+    // Verify server_name is present. The upstream advertises `bad-mcp`;
+    // the relay strips the `-mcp` suffix to advertise `bad`.
     assert_eq!(
         endpoint["lifecycle"]["server_name"].as_str(),
-        Some("bad-mcp"),
-        "expected server_name to be 'bad-mcp'"
+        Some("bad"),
+        "expected server_name to be 'bad' (stripped from 'bad-mcp')"
     );
 }
 
@@ -156,8 +157,5 @@ async fn test_endpoints_api_shows_ready_with_server_name() {
 
     // Verify the lifecycle structure
     assert_eq!(endpoint["lifecycle"]["state"].as_str(), Some("Ready"));
-    assert_eq!(
-        endpoint["lifecycle"]["server_name"].as_str(),
-        Some("bad-mcp")
-    );
+    assert_eq!(endpoint["lifecycle"]["server_name"].as_str(), Some("bad"));
 }

--- a/tests/stdio_integration.rs
+++ b/tests/stdio_integration.rs
@@ -17,6 +17,7 @@ async fn test_stdio_full_lifecycle() {
         command: "bash".to_string(),
         args: vec![fixture_path().to_string_lossy().to_string()],
         env: HashMap::new(),
+        server_type_override: None,
     };
 
     let mut adapter = StdioAdapter::new(config);
@@ -58,6 +59,7 @@ async fn test_stdio_spawn_nonexistent_command() {
         command: "/nonexistent/command/that/does/not/exist".to_string(),
         args: vec![],
         env: HashMap::new(),
+        server_type_override: None,
     };
 
     let mut adapter = StdioAdapter::new(config);


### PR DESCRIPTION
## Summary

Adds an optional per-endpoint `server_type_override` config field that lets operators control the name advertised in `InitializeResult.instructions` and the meta-tool descriptions when the upstream-derived value is awkward (e.g. `statelessserver`, generic vendor names).

In the same change, the relay now strips one of a closed-list of suffixes (`-mcp-server`, `_mcp_server`, `-mcp`, `_mcp`) from the upstream-derived sanitized `serverInfo.name`, so `linear-mcp-server` is advertised as `linear`.

## Resolution rules

New `adapter::server_type_resolution` module:

- **Override path**: if `server_type_override` is set, the value is sanitized through `sanitize_server_name` and used verbatim. The auto-strip is **never** applied to overrides — what you write is what gets advertised.
- **Upstream path**: if no override is supplied (or the supplied override fails sanitization), the upstream sanitized `serverInfo.name` is used, with one of `-mcp-server` / `_mcp_server` / `-mcp` / `_mcp` stripped (longest first, single pass). Strips that would empty the name fall back to the original.

## Hot-reload

The new field is included in `EndpointConfig`'s custom `PartialEq` so a config change that touches only the override triggers a diff and restarts the adapter, just like every other endpoint field.

## Scope notes

- Tool-name routing (`tool_prefix`) is unaffected.
- Wired through every transport adapter: stdio, sse, http, oauth (oauth forwards into the inner http adapter).
- README updated with a new example endpoint that uses `server_type_override`.
- Two existing integration tests (`advertise.rs::instructions_and_descriptions_reflect_healthy_server`, `failed_adapters_are_not_advertised`) and two `server_info_name.rs` tests had their expected values updated from `bad-mcp` to `bad` because the test fixture's `serverInfo.name` is now stripped.

## Verification

- `cargo build`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` — full suite green (600 unit + all integration tests)

## Phase 2 / Wave RF.1

This is the relay-side change for Wave RF.1. Per the rollout plan, opening this PR **unmerged** for review. Desktop and monorepo are intentionally untouched.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author