### PR TITLE
ci(release): pin x86_64-apple-darwin to macos-13 (macos-latest is now arm64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
             os: ubuntu-latest
             binary: endara-relay
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-13
             binary: endara-relay
           - target: aarch64-apple-darwin
             os: macos-latest


### PR DESCRIPTION
GitHub-hosted `macos-latest` flipped to arm64 runners, which broke the intel mac build of the relay release. The `aarch64-apple-darwin` matrix row stays on `macos-latest` (now arm64-native, which is what we want for that target).

**Failing run for context:** https://github.com/endara-ai/endara-relay/actions/runs/25837802327

**Failure mode:** `rustup-init` bootstrapping the `x86_64-apple-darwin` toolchain on the new arm64 `macos-latest` runner was hitting a corrupt-download / unsupported-host failure, so the cross build couldn't even start. Pinning `x86_64-apple-darwin` to `macos-13` (the last x86_64 GitHub-hosted mac image) restores a native x86_64 build host.

**Diff:** single line — `os: macos-latest` → `os: macos-13` for the `x86_64-apple-darwin` matrix row only.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author