### PR TITLE
ci(release): drop x86_64-apple-darwin (Apple Silicon only for macOS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,6 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-          - target: x86_64-apple-darwin
-            os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,6 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             binary: endara-relay
-          - target: x86_64-apple-darwin
-            os: macos-latest
-            binary: endara-relay
           - target: aarch64-apple-darwin
             os: macos-latest
             binary: endara-relay
@@ -187,7 +184,7 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           mkdir -p archives
-          for target in aarch64-apple-darwin x86_64-apple-darwin aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu; do
+          for target in aarch64-apple-darwin aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu; do
             asset="endara-relay-v${VERSION}-${target}.tar.gz"
             echo "Downloading ${asset} from release ${TAG}..."
             gh release download "${TAG}" \
@@ -220,12 +217,10 @@ jobs:
             printf '%s' "$sum"
           }
           sha_arm64_darwin=$(compute "archives/endara-relay-v${VERSION}-aarch64-apple-darwin.tar.gz")
-          sha_x64_darwin=$(compute "archives/endara-relay-v${VERSION}-x86_64-apple-darwin.tar.gz")
           sha_arm64_linux=$(compute "archives/endara-relay-v${VERSION}-aarch64-unknown-linux-gnu.tar.gz")
           sha_x64_linux=$(compute "archives/endara-relay-v${VERSION}-x86_64-unknown-linux-gnu.tar.gz")
           {
             echo "arm64_darwin=${sha_arm64_darwin}"
-            echo "x64_darwin=${sha_x64_darwin}"
             echo "arm64_linux=${sha_arm64_linux}"
             echo "x64_linux=${sha_x64_linux}"
           } >> "$GITHUB_OUTPUT"
@@ -258,7 +253,6 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
           SHA_ARM64_DARWIN: ${{ steps.sha.outputs.arm64_darwin }}
-          SHA_X64_DARWIN: ${{ steps.sha.outputs.x64_darwin }}
           SHA_ARM64_LINUX: ${{ steps.sha.outputs.arm64_linux }}
           SHA_X64_LINUX: ${{ steps.sha.outputs.x64_linux }}
         run: |
@@ -266,7 +260,6 @@ jobs:
           python3 relay/scripts/update-formula.py \
             --version "$VERSION" \
             --sha256-arm64-darwin "$SHA_ARM64_DARWIN" \
-            --sha256-x64-darwin "$SHA_X64_DARWIN" \
             --sha256-arm64-linux "$SHA_ARM64_LINUX" \
             --sha256-x64-linux "$SHA_X64_LINUX" \
             --formula-path homebrew-tap/Formula/endara-relay.rb

--- a/scripts/update-formula.py
+++ b/scripts/update-formula.py
@@ -25,10 +25,6 @@ class EndaraRelay < Formula
       url "https://github.com/endara-ai/endara-relay/releases/download/v#{{version}}/endara-relay-v#{{version}}-aarch64-apple-darwin.tar.gz"
       sha256 "{sha_arm64_darwin}"
     end
-    on_intel do
-      url "https://github.com/endara-ai/endara-relay/releases/download/v#{{version}}/endara-relay-v#{{version}}-x86_64-apple-darwin.tar.gz"
-      sha256 "{sha_x64_darwin}"
-    end
   end
 
   on_linux do
@@ -56,14 +52,12 @@ end
 def render(
     version: str,
     sha_arm64_darwin: str,
-    sha_x64_darwin: str,
     sha_arm64_linux: str,
     sha_x64_linux: str,
 ) -> str:
     return FORMULA_TEMPLATE.format(
         version=version,
         sha_arm64_darwin=sha_arm64_darwin,
-        sha_x64_darwin=sha_x64_darwin,
         sha_arm64_linux=sha_arm64_linux,
         sha_x64_linux=sha_x64_linux,
     )
@@ -73,7 +67,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--version", required=True, help="Version without leading 'v', e.g. 0.1.1")
     parser.add_argument("--sha256-arm64-darwin", required=True, dest="sha_arm64_darwin")
-    parser.add_argument("--sha256-x64-darwin", required=True, dest="sha_x64_darwin")
     parser.add_argument("--sha256-arm64-linux", required=True, dest="sha_arm64_linux")
     parser.add_argument("--sha256-x64-linux", required=True, dest="sha_x64_linux")
     parser.add_argument(
@@ -93,7 +86,6 @@ def main(argv: list[str] | None = None) -> int:
     rendered = render(
         version=args.version,
         sha_arm64_darwin=args.sha_arm64_darwin,
-        sha_x64_darwin=args.sha_x64_darwin,
         sha_arm64_linux=args.sha_arm64_linux,
         sha_x64_linux=args.sha_x64_linux,
     )


### PR DESCRIPTION
## Summary

Remove every reference to `x86_64-apple-darwin` from the relay release pipeline so v0.1.6-rc.4 only builds + ships `aarch64-apple-darwin` for macOS. Linux (x86_64 + aarch64) and Windows (x86_64) targets are untouched.

## Why

GitHub deprecated the Intel `macos-latest` runner image and `macos-13` (the previous Intel image) is on its way out. Two release candidates burned trying to chase the moving image:

- `v0.1.6-rc.2` failed when `macos-latest` flipped to arm64 and the `x86_64-apple-darwin` job suddenly cross-compiled in an environment that doesn't support our notarization flow.
- `v0.1.6-rc.3` failed similarly after pinning to `macos-13`, which is itself approaching retirement.
- PR #60 (the `macos-13` pin attempt) has been closed in favor of dropping Intel macOS entirely.

Rather than continue to chase Apple's Intel runner deprecation, drop the target. Apple Silicon is the only macOS architecture we ship going forward; users on Intel Macs can continue running the previously released v0.1.5 binaries.

## Changes

- `.github/workflows/release.yml` — drop the `x86_64-apple-darwin` build matrix entry, the homebrew tap download/SHA computation for that asset, and the `--sha256-x64-darwin` argument passed to `update-formula.py`.
- `.github/workflows/ci.yml` — drop the `x86_64-apple-darwin` build matrix entry. `aarch64-apple-darwin` remains.
- `scripts/update-formula.py` — remove the `on_intel` block from the macOS section of the Homebrew formula template, the `sha_x64_darwin` parameter, and the `--sha256-x64-darwin` argparse flag.

The Homebrew formula no longer has an `on_intel` block under `on_macos`; Homebrew handles unsupported architectures gracefully (it errors with a clear unsupported-platform message rather than silently installing the wrong build).

## Verification

- `git grep x86_64-apple-darwin` → 0 hits.
- `python3 scripts/update-formula.py --version 0.1.6-rc.4 --sha256-arm64-darwin … --sha256-arm64-linux … --sha256-x64-linux … --formula-path /tmp/test-formula.rb` produces a valid formula; `ruby -c /tmp/test-formula.rb` reports `Syntax OK`.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` all green (this PR doesn't touch Rust code, but verified anyway).

## Out of scope

Tagging / publishing v0.1.6-rc.4 is handled separately after this PR merges.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author