### PR TITLE
ci(release): pin aarch64-apple-darwin to macos-14 (macos-latest broken)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,9 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             binary: endara-relay
+          # pinned to macos-14 — macos-latest (macos-15) ships a rustup-init shim that breaks 'cargo build' in our notarized release path; CI.yml on macos-latest stays unaffected. See burned tags v0.1.6-rc.{2,3,4} (run 25841684545).
           - target: aarch64-apple-darwin
-            os: macos-latest
+            os: macos-14
             binary: endara-relay
           - target: x86_64-pc-windows-msvc
             os: windows-latest


### PR DESCRIPTION
## Why

The release workflow's macOS leg has been failing on `macos-latest` for v0.1.6-rc.{2,3,4}.

Failing run: https://github.com/endara-ai/endara-relay/actions/runs/25841684545

`macos-latest` currently resolves to **macos-15**, which ships a `rustup-init` shim in `/usr/local/bin/cargo`. When the release workflow tries to invoke `cargo build` after `dtolnay/rust-toolchain` installs a stable toolchain, the shim intercepts the call and fails in our notarized release path (which doesn't have an interactive TTY to drive `rustup-init`).

## What

Pin the `aarch64-apple-darwin` matrix entry in `.github/workflows/release.yml` to `macos-14` (which ships macos-14/Sonoma without the shim). A YAML comment documents the reason and references the burned rc tags.

The CI workflow (`.github/workflows/ci.yml`) is **not** changed — it continues to run on `macos-latest` and is unaffected because it doesn't go through the notarized release path.

## Scope

- Single-file change: `.github/workflows/release.yml`
- 1 line value change (`macos-latest` → `macos-14`) plus 1 explanatory comment line.
- Diff: `1 file changed, 2 insertions(+), 1 deletion(-)`

## Note

This is a **temporary pin** (Option A in the coordinator's plan). A follow-up may unpin once the runner image or rustup setup is fixed upstream. Once merged, v0.1.6-rc.5 will be cut against this commit.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author