### PR TITLE
feat(management): surface upstream server_name_raw on Lifecycle::Ready

### DIFF
--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -1,5 +1,5 @@
 use super::server_name::{sanitize_server_name, ServerNameError};
-use super::server_type_resolution::effective_server_type;
+use super::server_type_resolution::{effective_server_type, strip_mcp_server_suffix};
 use super::stdio::RingBuffer;
 use super::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
 use crate::jsonrpc::{self, JsonRpcResponse};
@@ -53,6 +53,11 @@ pub struct HttpAdapter {
     request_id: AtomicU64,
     /// Sanitized server name from the MCP initialize response.
     server_type: Arc<RwLock<Option<String>>>,
+    /// Upstream-derived server name (sanitized + suffix-stripped), captured
+    /// before any `server_type_override` resolution. Surfaced via
+    /// [`McpAdapter::upstream_server_name`] so the management API can show the
+    /// default name the upstream reports.
+    upstream_server_name: Arc<RwLock<Option<String>>>,
     /// Ring buffer recording tool call activity.
     activity_log: Arc<RwLock<RingBuffer>>,
 }
@@ -100,6 +105,7 @@ impl HttpAdapter {
             health: Arc::new(RwLock::new(HealthStatus::Stopped)),
             request_id: AtomicU64::new(1),
             server_type: Arc::new(RwLock::new(None)),
+            upstream_server_name: Arc::new(RwLock::new(None)),
             activity_log: Arc::new(RwLock::new(RingBuffer::new(1000))),
         }
     }
@@ -114,6 +120,7 @@ impl HttpAdapter {
             health: Arc::new(RwLock::new(HealthStatus::Stopped)),
             request_id: AtomicU64::new(1),
             server_type: Arc::new(RwLock::new(None)),
+            upstream_server_name: Arc::new(RwLock::new(None)),
             activity_log: Arc::new(RwLock::new(RingBuffer::new(1000))),
         }
     }
@@ -359,9 +366,11 @@ impl McpAdapter for HttpAdapter {
             self.config.server_type_override.clone(),
             Some(sanitized.clone()),
         );
+        let upstream_stripped = strip_mcp_server_suffix(sanitized.clone());
 
         info!(url = %self.config.url, raw_name = %raw_name, sanitized = %sanitized, effective = ?effective, "MCP server reported serverInfo.name");
         *self.server_type.write().await = effective;
+        *self.upstream_server_name.write().await = Some(upstream_stripped);
 
         // Per the MCP spec the client MUST send a notifications/initialized
         // notification after a successful initialize exchange.
@@ -420,6 +429,13 @@ impl McpAdapter for HttpAdapter {
 
     fn server_type(&self) -> Option<String> {
         self.server_type.try_read().ok().and_then(|g| g.clone())
+    }
+
+    fn upstream_server_name(&self) -> Option<String> {
+        self.upstream_server_name
+            .try_read()
+            .ok()
+            .and_then(|g| g.clone())
     }
 
     async fn shutdown(&mut self) -> Result<(), AdapterError> {

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -128,6 +128,19 @@ pub trait McpAdapter: Send + Sync {
         None
     }
 
+    /// Upstream-derived server name (sanitized + suffix-stripped) independent
+    /// of any `server_type_override`. Returns `None` until the initialize
+    /// handshake has populated it; adapters that do not capture
+    /// `serverInfo.name` keep the default.
+    ///
+    /// This mirrors what [`McpAdapter::server_type`] would have returned if no
+    /// override were configured, and lets the management API surface the
+    /// "default name the upstream reports" alongside the effective name so the
+    /// desktop UI can show users what they would revert to.
+    fn upstream_server_name(&self) -> Option<String> {
+        None
+    }
+
     /// Subscribe to MCP `notifications/tools/list_changed` ticks emitted by the
     /// underlying server. Each `recv()` represents at least one change
     /// notification observed since the previous receive; the registry treats

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -827,6 +827,14 @@ impl McpAdapter for OAuthAdapter {
             .and_then(|g| g.as_ref().and_then(|a| a.server_type()))
     }
 
+    fn upstream_server_name(&self) -> Option<String> {
+        self.inner
+            .inner_adapter
+            .try_read()
+            .ok()
+            .and_then(|g| g.as_ref().and_then(|a| a.upstream_server_name()))
+    }
+
     async fn shutdown(&mut self) -> Result<(), AdapterError> {
         // Abort heartbeat task
         {

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -1,5 +1,5 @@
 use super::server_name::{sanitize_server_name, ServerNameError};
-use super::server_type_resolution::effective_server_type;
+use super::server_type_resolution::{effective_server_type, strip_mcp_server_suffix};
 use super::stdio::RingBuffer;
 use super::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
 use crate::jsonrpc::{self, JsonRpcResponse};
@@ -129,6 +129,10 @@ pub struct SseAdapter {
     crash_tracker: Arc<Mutex<CrashTracker>>,
     /// Sanitized server name from the MCP initialize response.
     server_type: Arc<RwLock<Option<String>>>,
+    /// Upstream-derived server name (sanitized + suffix-stripped), captured
+    /// before any `server_type_override` resolution. See
+    /// [`McpAdapter::upstream_server_name`].
+    upstream_server_name: Arc<RwLock<Option<String>>>,
     /// Ring buffer recording tool call activity.
     activity_log: Arc<RwLock<RingBuffer>>,
     /// Handle for the background reconnect supervisor task.
@@ -183,6 +187,7 @@ impl SseAdapter {
             sse_handle: Arc::new(Mutex::new(None)),
             crash_tracker: Arc::new(Mutex::new(CrashTracker::new())),
             server_type: Arc::new(RwLock::new(None)),
+            upstream_server_name: Arc::new(RwLock::new(None)),
             activity_log: Arc::new(RwLock::new(RingBuffer::new(1000))),
             reconnect_handle: Arc::new(Mutex::new(None)),
             reconnect_notify: Arc::new(Notify::new()),
@@ -550,9 +555,11 @@ impl SseAdapter {
             self.config.server_type_override.clone(),
             Some(sanitized.clone()),
         );
+        let upstream_stripped = strip_mcp_server_suffix(sanitized.clone());
 
         debug!(url = %self.config.url, raw_name = %raw_name, sanitized = %sanitized, effective = ?effective, "MCP server reported serverInfo.name");
         *self.server_type.write().await = effective;
+        *self.upstream_server_name.write().await = Some(upstream_stripped);
         *self.health.write().await = HealthStatus::Healthy;
         self.crash_tracker.lock().await.reset();
         // Emit a tick after every successful (re)connect + handshake so any
@@ -682,6 +689,13 @@ impl McpAdapter for SseAdapter {
 
     fn server_type(&self) -> Option<String> {
         self.server_type.try_read().ok().and_then(|g| g.clone())
+    }
+
+    fn upstream_server_name(&self) -> Option<String> {
+        self.upstream_server_name
+            .try_read()
+            .ok()
+            .and_then(|g| g.clone())
     }
 
     fn subscribe_tools_changed(&self) -> Option<broadcast::Receiver<()>> {

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -1,5 +1,5 @@
 use super::server_name::{sanitize_server_name, ServerNameError};
-use super::server_type_resolution::effective_server_type;
+use super::server_type_resolution::{effective_server_type, strip_mcp_server_suffix};
 use super::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
 use crate::jsonrpc::{self, JsonRpcResponse};
 use crate::shell_env;
@@ -158,6 +158,10 @@ pub struct StdioAdapter {
     crash_tracker: Arc<Mutex<CrashTracker>>,
     /// Sanitized server name from the MCP initialize response.
     server_type: Arc<RwLock<Option<String>>>,
+    /// Upstream-derived server name (sanitized + suffix-stripped), captured
+    /// before any `server_type_override` resolution. See
+    /// [`McpAdapter::upstream_server_name`].
+    upstream_server_name: Arc<RwLock<Option<String>>>,
     /// Broadcast sender used to fan out `notifications/tools/list_changed`
     /// observations to subscribers (the registry's listener loop). Capacity is
     /// 16; `SendError` (no subscribers) is intentionally ignored.
@@ -181,6 +185,7 @@ impl StdioAdapter {
             request_id: AtomicU64::new(1),
             crash_tracker: Arc::new(Mutex::new(CrashTracker::new())),
             server_type: Arc::new(RwLock::new(None)),
+            upstream_server_name: Arc::new(RwLock::new(None)),
             tools_changed_tx,
             _stderr_handle: Arc::new(Mutex::new(None)),
             _stdout_handle: Arc::new(Mutex::new(None)),
@@ -432,9 +437,11 @@ impl StdioAdapter {
             self.config.server_type_override.clone(),
             Some(sanitized.clone()),
         );
+        let upstream_stripped = strip_mcp_server_suffix(sanitized.clone());
 
         info!(raw_name = %raw_name, sanitized = %sanitized, effective = ?effective, "MCP server reported serverInfo.name");
         *self.server_type.write().await = effective;
+        *self.upstream_server_name.write().await = Some(upstream_stripped);
 
         info!("MCP initialize handshake complete");
         Ok(())
@@ -478,6 +485,13 @@ impl McpAdapter for StdioAdapter {
 
     fn server_type(&self) -> Option<String> {
         self.server_type.try_read().ok().and_then(|g| g.clone())
+    }
+
+    fn upstream_server_name(&self) -> Option<String> {
+        self.upstream_server_name
+            .try_read()
+            .ok()
+            .and_then(|g| g.clone())
     }
 
     fn subscribe_tools_changed(&self) -> Option<broadcast::Receiver<()>> {

--- a/src/management.rs
+++ b/src/management.rs
@@ -70,9 +70,16 @@ pub enum Lifecycle {
     Initializing,
     /// Adapter is ready and healthy.
     Ready {
-        /// Sanitized server name from MCP serverInfo.name.
+        /// Effective server name (after `server_type_override` resolution),
+        /// derived from the sanitized MCP `serverInfo.name`.
         #[serde(skip_serializing_if = "Option::is_none")]
         server_name: Option<String>,
+        /// Upstream-reported server name (sanitized + suffix-stripped),
+        /// independent of any `server_type_override`. Equals `server_name`
+        /// when no override is configured. Surfaced so the desktop UI can
+        /// show the user the default they would revert to.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        server_name_raw: Option<String>,
     },
     /// Adapter failed to initialize or is unhealthy.
     Failed {
@@ -228,11 +235,15 @@ async fn get_endpoints(State(state): State<ManagementState>) -> Json<Vec<Endpoin
                         .map(|t| t.len())
                         .unwrap_or(0);
                     let server_name = entry.adapter.server_type();
+                    let server_name_raw = entry.adapter.upstream_server_name();
                     (
                         "healthy".to_string(),
                         count,
                         None,
-                        Lifecycle::Ready { server_name },
+                        Lifecycle::Ready {
+                            server_name,
+                            server_name_raw,
+                        },
                     )
                 }
                 HealthStatus::Unhealthy(reason) => {

--- a/tests/server_info_name.rs
+++ b/tests/server_info_name.rs
@@ -158,4 +158,53 @@ async fn test_endpoints_api_shows_ready_with_server_name() {
     // Verify the lifecycle structure
     assert_eq!(endpoint["lifecycle"]["state"].as_str(), Some("Ready"));
     assert_eq!(endpoint["lifecycle"]["server_name"].as_str(), Some("bad"));
+    // Without a server_type_override, server_name_raw mirrors server_name
+    // (both derived from the sanitized + suffix-stripped upstream name).
+    assert_eq!(
+        endpoint["lifecycle"]["server_name_raw"].as_str(),
+        Some("bad"),
+        "expected server_name_raw to mirror server_name when no override is set"
+    );
+}
+
+/// Test 7: With `server_type_override` set, `server_name` reflects the override
+/// while `server_name_raw` continues to surface the upstream-derived name.
+#[tokio::test]
+async fn test_endpoints_api_server_name_raw_independent_of_override() {
+    // Build a config inline so we can set `server_type_override` on the
+    // endpoint without extending the shared ConfigBuilder.
+    let bin = bad_server_bin();
+    let config = format!(
+        "[relay]\n\
+         machine_name = \"integration-test\"\n\
+         allow_insecure_oauth = true\n\
+         \n\
+         [[endpoints]]\n\
+         name = \"good-server\"\n\
+         transport = \"stdio\"\n\
+         command = \"{}\"\n\
+         server_type_override = \"custom-name\"\n",
+        bin
+    );
+
+    let harness = RelayHarness::start(&config).await;
+
+    let endpoint =
+        wait_for_lifecycle_state(&harness, "good-server", "Ready", Duration::from_secs(10))
+            .await
+            .expect("endpoint did not enter Ready state");
+
+    assert_eq!(endpoint["lifecycle"]["state"].as_str(), Some("Ready"));
+    // Effective name reflects the override (no `-mcp` strip applied to overrides).
+    assert_eq!(
+        endpoint["lifecycle"]["server_name"].as_str(),
+        Some("custom-name"),
+        "expected server_name to reflect the override"
+    );
+    // Raw name continues to surface the upstream-derived value (`bad-mcp` → `bad`).
+    assert_eq!(
+        endpoint["lifecycle"]["server_name_raw"].as_str(),
+        Some("bad"),
+        "expected server_name_raw to surface the upstream-derived name independent of the override"
+    );
 }


### PR DESCRIPTION
## Summary

The desktop UI needs the **upstream-reported, sanitized-but-not-overridden** server name so it can show the user the default they would revert to when a `server_type_override` is configured. Today `Lifecycle::Ready { server_name }` only returns the *effective* name (post-override), and the relay does not retain the upstream name once the override has been resolved.

This PR plumbs a new `server_name_raw` field through to `/api/endpoints` alongside the existing `server_name`, so the desktop UI can render “Default: foo” next to the override.

## Changes

- **Trait**: `McpAdapter::upstream_server_name(&self) -> Option<String>` with a default of `None` (`src/adapter/mod.rs`).
- **HTTP / SSE / STDIO adapters**: store the sanitized + suffix-stripped upstream name in a new `Arc<RwLock<Option<String>>>` field, populated during `initialize` alongside the existing `server_type` field, and override the trait method.
- **OAuth adapter**: delegates `upstream_server_name()` to its inner adapter, mirroring the existing `server_type()` delegation.
- **Management API**: `Lifecycle::Ready` gains `server_name_raw: Option<String>` (with `skip_serializing_if`), populated by the `get_endpoints` handler from `entry.adapter.upstream_server_name()`.

## Test coverage

- Existing `server_info_name` integration test extended to assert `server_name_raw == server_name` when no override is configured.
- New test `test_endpoints_api_server_name_raw_independent_of_override` exercises an STDIO endpoint with `server_type_override = "custom-name"` and confirms `server_name = "custom-name"` while `server_name_raw = "bad"` (the suffix-stripped upstream name).
- Full `cargo test -p endara-relay` suite passes locally.
- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` are clean.

## Compatibility

`server_name_raw` is `#[serde(skip_serializing_if = "Option::is_none")]`, so existing API consumers see no change for endpoints that have not yet completed initialize. When populated, it sits next to `server_name` and is always equal to it for endpoints without an override.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author