### PR TITLE
fix(advertise): rename "Connected servers" to "Connected server types"

### DIFF
--- a/src/advertise.rs
+++ b/src/advertise.rs
@@ -115,7 +115,7 @@ impl<'a> ServerTypeList<'a> {
     }
 }
 
-/// Lead-in sentence prepended to the `Connected servers: …` line in
+/// Lead-in sentence prepended to the `Connected server types: …` line in
 /// `InitializeResult.instructions`. Per Engineering Spec §3.2, the literal
 /// blank line between the lead-in and the server list is part of the payload.
 pub const INSTRUCTIONS_LEAD_IN: &str =
@@ -125,17 +125,19 @@ pub const INSTRUCTIONS_LEAD_IN: &str =
 /// adapter is currently `Healthy` with a `server_type`, so the field is
 /// omitted from the response (per spec §2.1).
 pub async fn instructions(registry: &AdapterRegistry) -> Option<String> {
-    ServerTypeList::new(registry)
-        .render()
-        .await
-        .map(|list| format!("{}\n\nConnected servers: {}", INSTRUCTIONS_LEAD_IN, list))
+    ServerTypeList::new(registry).render().await.map(|list| {
+        format!(
+            "{}\n\nConnected server types: {}",
+            INSTRUCTIONS_LEAD_IN, list
+        )
+    })
 }
 
-/// Build the `search_tools` description. Appends `\n\nConnected servers: {list}`
+/// Build the `search_tools` description. Appends `\n\nConnected server types: {list}`
 /// when the registry has at least one Healthy adapter with a `server_type`.
 pub async fn search_tools_description(registry: &AdapterRegistry) -> String {
     match ServerTypeList::new(registry).render().await {
-        Some(list) => format!("{}\n\nConnected servers: {}", SEARCH_TOOLS_BASE, list),
+        Some(list) => format!("{}\n\nConnected server types: {}", SEARCH_TOOLS_BASE, list),
         None => SEARCH_TOOLS_BASE.to_string(),
     }
 }
@@ -339,7 +341,7 @@ mod tests {
         register(&reg, "ep2", MockAdapter::ready("gmail")).await;
         let desc = search_tools_description(&reg).await;
         assert!(desc.starts_with(SEARCH_TOOLS_BASE));
-        assert!(desc.ends_with("\n\nConnected servers: github, gmail"));
+        assert!(desc.ends_with("\n\nConnected server types: github, gmail"));
     }
 
     #[tokio::test]

--- a/tests/advertise.rs
+++ b/tests/advertise.rs
@@ -1,7 +1,7 @@
 //! Integration tests for `Advertise Connected Servers to the Model` (spec §5).
 //!
 //! Verifies that:
-//!   * `InitializeResult.instructions` is present with `Connected servers: …`
+//!   * `InitializeResult.instructions` is present with `Connected server types: …`
 //!     when at least one adapter is `Healthy`, and omitted otherwise.
 //!   * The dynamic descriptions for `list_tools`, `search_tools`, and
 //!     `execute_tools` reflect the currently-Healthy server set.
@@ -96,7 +96,7 @@ fn meta_tool_description<'a>(tools: &'a [Value], name: &str) -> &'a str {
 #[tokio::test]
 async fn instructions_omitted_when_no_healthy_servers() {
     // bad-server with `--omit-server-name` enters Failed → registry has zero
-    // Healthy adapters → no instructions field, no `Connected servers:` suffix.
+    // Healthy adapters → no instructions field, no `Connected server types:` suffix.
     let config = ConfigBuilder::new()
         .add_stdio("bad-server", &bad_server_bin(), &["--omit-server-name"])
         .build();
@@ -121,8 +121,8 @@ async fn instructions_omitted_when_no_healthy_servers() {
     );
     let search_desc = meta_tool_description(&tools, "search_tools");
     assert!(
-        !search_desc.contains("Connected servers:"),
-        "search_tools must not append Connected servers list when none are Healthy: {search_desc}"
+        !search_desc.contains("Connected server types:"),
+        "search_tools must not append Connected server types list when none are Healthy: {search_desc}"
     );
 }
 
@@ -148,7 +148,7 @@ async fn instructions_and_descriptions_reflect_healthy_server() {
         .expect("instructions should be present once an adapter is Healthy");
     assert_eq!(
         instructions,
-        format!("{}\n\nConnected servers: bad", INSTRUCTIONS_LEAD_IN),
+        format!("{}\n\nConnected server types: bad", INSTRUCTIONS_LEAD_IN),
         "unexpected instructions string: {instructions}"
     );
 
@@ -162,8 +162,8 @@ async fn instructions_and_descriptions_reflect_healthy_server() {
     );
     let search_desc = meta_tool_description(&tools, "search_tools");
     assert!(
-        search_desc.ends_with("\n\nConnected servers: bad"),
-        "search_tools description missing Connected servers footer: {search_desc}"
+        search_desc.ends_with("\n\nConnected server types: bad"),
+        "search_tools description missing Connected server types footer: {search_desc}"
     );
 }
 
@@ -189,7 +189,7 @@ async fn failed_adapters_are_not_advertised() {
         .expect("instructions should be present");
     assert_eq!(
         instructions,
-        format!("{}\n\nConnected servers: bad", INSTRUCTIONS_LEAD_IN),
+        format!("{}\n\nConnected server types: bad", INSTRUCTIONS_LEAD_IN),
         "Failed adapter should be excluded; got: {instructions}"
     );
 
@@ -232,7 +232,7 @@ async fn multi_distinct_types_rendered_in_alphabetical_order() {
     assert_eq!(
         instructions,
         format!(
-            "{}\n\nConnected servers: {}",
+            "{}\n\nConnected server types: {}",
             INSTRUCTIONS_LEAD_IN, expected_list
         ),
         "instructions string did not match spec §3.2 format: {instructions}"
@@ -248,7 +248,7 @@ async fn multi_distinct_types_rendered_in_alphabetical_order() {
     );
     let search_desc = meta_tool_description(&tools, "search_tools");
     assert!(
-        search_desc.ends_with(&format!("\n\nConnected servers: {}", expected_list)),
+        search_desc.ends_with(&format!("\n\nConnected server types: {}", expected_list)),
         "search_tools description does not end with full alphabetised list: {search_desc}"
     );
     // execute_tools is hidden when JS mode is off; covered separately.
@@ -286,7 +286,7 @@ async fn hot_reload_kill_endpoint_drops_from_advertised_list() {
     let tools = raw_tools_list(&harness).await;
     let search_desc = meta_tool_description(&tools, "search_tools");
     assert!(
-        search_desc.ends_with("\n\nConnected servers: alpha, zebra"),
+        search_desc.ends_with("\n\nConnected server types: alpha, zebra"),
         "expected mango to be removed from search_tools description: {search_desc}"
     );
     let init = raw_initialize(&harness).await;
@@ -331,7 +331,7 @@ async fn hot_reload_add_endpoint_appears_in_advertised_list() {
     let tools = raw_tools_list(&harness).await;
     let search_desc = meta_tool_description(&tools, "search_tools");
     assert!(
-        search_desc.ends_with("\n\nConnected servers: alpha, mango, zebra"),
+        search_desc.ends_with("\n\nConnected server types: alpha, mango, zebra"),
         "expected mango to appear in alphabetised list: {search_desc}"
     );
 }
@@ -360,7 +360,7 @@ async fn duplicate_type_dedupes_but_count_includes_both() {
         .expect("instructions should be present");
     assert_eq!(
         instructions,
-        format!("{}\n\nConnected servers: alpha", INSTRUCTIONS_LEAD_IN),
+        format!("{}\n\nConnected server types: alpha", INSTRUCTIONS_LEAD_IN),
         "duplicate type should dedupe to a single entry: {instructions}"
     );
 
@@ -374,7 +374,7 @@ async fn duplicate_type_dedupes_but_count_includes_both() {
     );
     let search_desc = meta_tool_description(&tools, "search_tools");
     assert!(
-        search_desc.ends_with("\n\nConnected servers: alpha"),
+        search_desc.ends_with("\n\nConnected server types: alpha"),
         "search_tools description should carry deduplicated single entry: {search_desc}"
     );
 }


### PR DESCRIPTION
Renames the user-facing literal `Connected servers:` → `Connected server types:` in `InitializeResult.instructions` and the `search_tools` description.

## Why

The list emitted on this line is built from `ServerTypeList`, which **deduplicates by `server_type`** (e.g. two healthy `gmail` adapters render as a single `gmail` entry). Calling that line `Connected servers:` is misleading — it implies an instance count, but the value is actually the set of distinct server *types*.

The sibling `list_tools` description already advertises the instance count separately as `" N servers connected via Endara Relay …"`. Renaming the type-list line to `Connected server types:` makes the two lines consistent and unambiguous: one is a deduped type list, the other is a Healthy-instance count.

## Scope

User-facing literal swap only. No internal symbols renamed (`ServerTypeList`, `server_type()`, `ready_server_types`, `SEARCH_TOOLS_BASE`, `INSTRUCTIONS_LEAD_IN` all unchanged).

- `src/advertise.rs` — both `format!` sites (`instructions()` and `search_tools_description()`), their doc comments, and the inline `#[cfg(test)]` assertion.
- `tests/advertise.rs` — every assertion + diagnostic message that referenced the old literal, plus the file-level doc comment.

## Verification

Run from `packages/relay`:

- `cargo fmt --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test -p endara-relay` ✅ (all suites pass)
- `rg "Connected servers" packages/relay` → zero hits ✅


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author