### PR TITLE
ci(release): clear rustup-init shim before cargo build on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,18 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
+      # macos-latest (and sometimes pinned macOS images) ship a rustup-init
+      # shim at /usr/local/bin/cargo that wins on PATH over the
+      # dtolnay-installed ~/.cargo/bin/cargo. The shim rejects 'cargo build'
+      # with "error: unexpected argument 'build' found" and burned
+      # v0.1.6-rc.6 (run 25864172650). Remove the shims so the toolchain
+      # cargo wins.
+      - name: Clear rustup-init shim (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          sudo rm -f /usr/local/bin/cargo /usr/local/bin/rustc /usr/local/bin/rustup
+          which cargo
+          cargo --version
       - uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: build-${{ matrix.target }}


### PR DESCRIPTION
## Problem

The `Build release` step on the macOS leg of the release workflow has been failing because GitHub-hosted macOS runners ship a **rustup-init shim** at `/usr/local/bin/cargo` that wins on `PATH` over the dtolnay-installed `~/.cargo/bin/cargo`. The shim only understands `rustup`-style invocations, so a plain `cargo build` produces:

```
error: unexpected argument 'build' found
```

Failing run that burned `v0.1.6-rc.6`: https://github.com/endara-ai/endara-relay/actions/runs/25864172650

The `aarch64-apple-darwin` / `macos-14` job invoked `/usr/local/bin/cargo` (the shim) instead of the toolchain cargo from `dtolnay/rust-toolchain`.

## Fix

Add a step right after `dtolnay/rust-toolchain` (and before `swatinem/rust-cache` / `Build release`) that removes the shim binaries on macOS only, then prints `which cargo` / `cargo --version` for visibility:

```yaml
- name: Clear rustup-init shim (macOS)
  if: runner.os == 'macOS'
  run: |
    sudo rm -f /usr/local/bin/cargo /usr/local/bin/rustc /usr/local/bin/rustup
    which cargo
    cargo --version
```

Gated to `runner.os == 'macOS'` so it never runs on the Linux/Windows matrix legs.

## Relationship to PR #62

PR #62 worked around this by pinning the macOS runner to `macos-14` (since `macos-latest` / `macos-15` is where the shim regression first showed up). This PR fixes the underlying shim-vs-toolchain conflict directly and supersedes that workaround.

**This PR intentionally keeps the `macos-14` pin in place.** Unpinning back to `macos-latest` is a separate cleanup we should do once we confirm the shim fix works on `rc.7`.

## Verification

- YAML parses (`python3 -c 'import yaml; yaml.safe_load(open(...))'` — OK).
- No other workflow or file changes.
- Will be exercised on the next rc tag push.

## Do not merge

Leaving this open for review; the release agent will pick it up before cutting `v0.1.6-rc.7`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author