### PR TITLE
ci(release): unpin macos-14 now that rustup shim is cleared explicitly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,9 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             binary: endara-relay
-          # pinned to macos-14 — macos-latest (macos-15) ships a rustup-init shim that breaks 'cargo build' in our notarized release path; CI.yml on macos-latest stays unaffected. See burned tags v0.1.6-rc.{2,3,4} (run 25841684545).
+          # rustup-init shim on macos-latest is cleared explicitly by the 'Clear rustup-init shim (macOS)' step below, so macos-latest is safe again.
           - target: aarch64-apple-darwin
-            os: macos-14
+            os: macos-latest
             binary: endara-relay
           - target: x86_64-pc-windows-msvc
             os: windows-latest


### PR DESCRIPTION
Reverts the temporary `macos-14` pin for the `aarch64-apple-darwin` matrix entry in `.github/workflows/release.yml` back to `macos-latest`.

## Why

- #62 pinned `aarch64-apple-darwin` to `macos-14` as a temporary workaround for the `rustup-init` shim regression on `macos-latest` (the shim at `/usr/local/bin/cargo` would win on `PATH` over the dtolnay-installed `~/.cargo/bin/cargo` and reject `cargo build`).
- #65 added a dedicated `Clear rustup-init shim (macOS)` step that `sudo rm -f`s `/usr/local/bin/{cargo,rustc,rustup}` after `dtolnay/rust-toolchain` installs the toolchain to `~/.cargo/bin`. That step is the durable fix.

With the shim cleared explicitly, the `macos-14` pin is now redundant, so this PR drops it and updates the explanatory comment to point at the clear-shim step instead.

## Changes

- `aarch64-apple-darwin` matrix entry: `os: macos-14` → `os: macos-latest`.
- Replace the burned-rc / shim-workaround comment with a short note that the shim is cleared explicitly by the `Clear rustup-init shim (macOS)` step below.
- No other lines touched. The `Clear rustup-init shim (macOS)` step from #65 is preserved.

## Verification

- `rg "macos-14" .github/workflows/release.yml` → zero hits.
- `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/release.yml"))'` → parses cleanly.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author