### PR TITLE
feat(relay): tracing/logging overhaul — color, per-endpoint spans, tool-call events

### DIFF
--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
 use tokio::time::Instant;
-use tracing::{error, info, trace, warn};
+use tracing::{error, info, trace, warn, Instrument};
 
 /// Configuration for the HTTP MCP adapter.
 #[derive(Debug, Clone)]
@@ -26,6 +26,10 @@ pub struct HttpConfig {
     /// Optional override for the advertised `server_type` name. See
     /// [`crate::adapter::server_type_resolution::effective_server_type`].
     pub server_type_override: Option<String>,
+    /// Endpoint name (used as the `endpoint` field on the adapter's
+    /// per-endpoint `tracing` span). Defaults to empty for direct test
+    /// construction; production paths set this from `EndpointConfig::name`.
+    pub endpoint_name: String,
 }
 
 impl HttpConfig {
@@ -35,6 +39,7 @@ impl HttpConfig {
             timeout_secs: 30,
             headers: HashMap::new(),
             server_type_override: None,
+            endpoint_name: String::new(),
         }
     }
 
@@ -60,6 +65,10 @@ pub struct HttpAdapter {
     upstream_server_name: Arc<RwLock<Option<String>>>,
     /// Ring buffer recording tool call activity.
     activity_log: Arc<RwLock<RingBuffer>>,
+    /// Per-endpoint tracing span. Every adapter method instruments its async
+    /// body with this span so events carry `endpoint`/`transport` (and
+    /// `server_type` once the MCP handshake completes).
+    span: tracing::Span,
 }
 
 impl HttpAdapter {
@@ -99,6 +108,12 @@ impl HttpAdapter {
             .build()
             .expect("failed to build HTTP client");
 
+        let span = tracing::info_span!(
+            "endpoint",
+            endpoint = %config.endpoint_name,
+            transport = "http",
+            server_type = tracing::field::Empty,
+        );
         Self {
             config,
             client,
@@ -107,6 +122,7 @@ impl HttpAdapter {
             server_type: Arc::new(RwLock::new(None)),
             upstream_server_name: Arc::new(RwLock::new(None)),
             activity_log: Arc::new(RwLock::new(RingBuffer::new(1000))),
+            span,
         }
     }
 
@@ -114,6 +130,12 @@ impl HttpAdapter {
     ///
     /// Used by OAuthAdapter to inject a client with Bearer token headers.
     pub fn new_with_client(config: HttpConfig, client: Client) -> Self {
+        let span = tracing::info_span!(
+            "endpoint",
+            endpoint = %config.endpoint_name,
+            transport = "http",
+            server_type = tracing::field::Empty,
+        );
         Self {
             config,
             client,
@@ -122,6 +144,7 @@ impl HttpAdapter {
             server_type: Arc::new(RwLock::new(None)),
             upstream_server_name: Arc::new(RwLock::new(None)),
             activity_log: Arc::new(RwLock::new(RingBuffer::new(1000))),
+            span,
         }
     }
 
@@ -306,118 +329,148 @@ impl HttpAdapter {
 #[async_trait]
 impl McpAdapter for HttpAdapter {
     async fn initialize(&mut self) -> Result<(), AdapterError> {
-        *self.health.write().await = HealthStatus::Starting;
+        async {
+            *self.health.write().await = HealthStatus::Starting;
 
-        let params = json!({
-            "protocolVersion": "2025-03-26",
-            "capabilities": {},
-            "clientInfo": {
-                "name": "endara-relay",
-                "version": env!("CARGO_PKG_VERSION")
-            }
-        });
+            let params = json!({
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "endara-relay",
+                    "version": env!("CARGO_PKG_VERSION")
+                }
+            });
 
-        let result = match self.send_request("initialize", Some(params)).await {
-            Ok(r) => r,
-            Err(e) => {
-                let msg = e.to_string();
-                *self.health.write().await = HealthStatus::Unhealthy(msg);
-                error!(url = %self.config.url, error = %e, "HTTP MCP adapter initialization failed");
-                return Err(e);
-            }
-        };
+            let result = match self.send_request("initialize", Some(params)).await {
+                Ok(r) => r,
+                Err(e) => {
+                    let msg = e.to_string();
+                    *self.health.write().await = HealthStatus::Unhealthy(msg);
+                    error!(url = %self.config.url, error = %e, "HTTP MCP adapter initialization failed");
+                    return Err(e);
+                }
+            };
 
-        // Extract serverInfo.name — REQUIRED per MCP spec enforcement
-        let raw_name = match result
-            .get("serverInfo")
-            .and_then(|si| si.get("name"))
-            .and_then(|n| n.as_str())
-        {
-            Some(name) => name,
-            None => {
-                let err = ServerNameError::Missing;
-                let msg = err.to_string();
-                error!(url = %self.config.url, error = %msg, "MCP server did not provide serverInfo.name");
-                *self.health.write().await = HealthStatus::Unhealthy(msg.clone());
-                return Err(AdapterError::ProtocolError(msg));
-            }
-        };
+            // Extract serverInfo.name — REQUIRED per MCP spec enforcement
+            let raw_name = match result
+                .get("serverInfo")
+                .and_then(|si| si.get("name"))
+                .and_then(|n| n.as_str())
+            {
+                Some(name) => name,
+                None => {
+                    let err = ServerNameError::Missing;
+                    let msg = err.to_string();
+                    error!(url = %self.config.url, error = %msg, "MCP server did not provide serverInfo.name");
+                    *self.health.write().await = HealthStatus::Unhealthy(msg.clone());
+                    return Err(AdapterError::ProtocolError(msg));
+                }
+            };
 
-        // Validate and sanitize the server name
-        let sanitized = match sanitize_server_name(raw_name) {
-            Ok(s) => s,
-            Err(e) => {
-                let msg = e.to_string();
-                error!(url = %self.config.url, raw_name = %raw_name, error = %msg, "serverInfo.name validation failed");
-                *self.health.write().await = HealthStatus::Unhealthy(msg.clone());
-                return Err(AdapterError::ProtocolError(msg));
-            }
-        };
+            // Validate and sanitize the server name
+            let sanitized = match sanitize_server_name(raw_name) {
+                Ok(s) => s,
+                Err(e) => {
+                    let msg = e.to_string();
+                    error!(url = %self.config.url, raw_name = %raw_name, error = %msg, "serverInfo.name validation failed");
+                    *self.health.write().await = HealthStatus::Unhealthy(msg.clone());
+                    return Err(AdapterError::ProtocolError(msg));
+                }
+            };
 
-        if let Some(ref ov) = self.config.server_type_override {
-            if sanitize_server_name(ov).is_err() {
-                warn!(
-                    override = %ov,
-                    "server_type_override failed sanitization; falling back to upstream-derived name"
-                );
+            if let Some(ref ov) = self.config.server_type_override {
+                if sanitize_server_name(ov).is_err() {
+                    warn!(
+                        override = %ov,
+                        "server_type_override failed sanitization; falling back to upstream-derived name"
+                    );
+                }
             }
+            let effective = effective_server_type(
+                self.config.server_type_override.clone(),
+                Some(sanitized.clone()),
+            );
+            let upstream_stripped = strip_mcp_server_suffix(sanitized.clone());
+
+            info!(url = %self.config.url, raw_name = %raw_name, sanitized = %sanitized, effective = ?effective, "MCP server reported serverInfo.name");
+            if let Some(ref name) = effective {
+                self.span.record("server_type", tracing::field::display(name));
+            }
+            *self.server_type.write().await = effective;
+            *self.upstream_server_name.write().await = Some(upstream_stripped);
+
+            // Per the MCP spec the client MUST send a notifications/initialized
+            // notification after a successful initialize exchange.
+            if let Err(e) = self
+                .send_notification("notifications/initialized", None)
+                .await
+            {
+                warn!(url = %self.config.url, error = %e, "failed to send notifications/initialized");
+            }
+
+            *self.health.write().await = HealthStatus::Healthy;
+            info!(url = %self.config.url, "HTTP MCP adapter initialized");
+            Ok(())
         }
-        let effective = effective_server_type(
-            self.config.server_type_override.clone(),
-            Some(sanitized.clone()),
-        );
-        let upstream_stripped = strip_mcp_server_suffix(sanitized.clone());
-
-        info!(url = %self.config.url, raw_name = %raw_name, sanitized = %sanitized, effective = ?effective, "MCP server reported serverInfo.name");
-        *self.server_type.write().await = effective;
-        *self.upstream_server_name.write().await = Some(upstream_stripped);
-
-        // Per the MCP spec the client MUST send a notifications/initialized
-        // notification after a successful initialize exchange.
-        if let Err(e) = self
-            .send_notification("notifications/initialized", None)
-            .await
-        {
-            warn!(url = %self.config.url, error = %e, "failed to send notifications/initialized");
-        }
-
-        *self.health.write().await = HealthStatus::Healthy;
-        info!(url = %self.config.url, "HTTP MCP adapter initialized");
-        Ok(())
+        .instrument(self.span.clone())
+        .await
     }
 
     async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
-        let result = self.send_request("tools/list", None).await?;
-        let tools_value = result
-            .get("tools")
-            .ok_or_else(|| AdapterError::ProtocolError("missing 'tools' field".into()))?;
-        let tools: Vec<ToolInfo> = serde_json::from_value(tools_value.clone())?;
-        Ok(tools)
+        async {
+            let result = self.send_request("tools/list", None).await?;
+            let tools_value = result
+                .get("tools")
+                .ok_or_else(|| AdapterError::ProtocolError("missing 'tools' field".into()))?;
+            let tools: Vec<ToolInfo> = serde_json::from_value(tools_value.clone())?;
+            Ok(tools)
+        }
+        .instrument(self.span.clone())
+        .await
     }
 
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
-        let params = json!({
-            "name": name,
-            "arguments": arguments,
-        });
-        let start = Instant::now();
-        let result = self.send_request("tools/call", Some(params)).await;
-        let duration_ms = start.elapsed().as_millis();
-        let now = chrono::Utc::now()
-            .format("%Y-%m-%dT%H:%M:%S%.3fZ")
-            .to_string();
-        let log_line = match &result {
-            Ok(_) => format!(
-                "{}  INFO call_tool tool={} status=ok duration={}ms",
-                now, name, duration_ms
-            ),
-            Err(e) => format!(
-                "{}  WARN call_tool tool={} status=error duration={}ms error={}",
-                now, name, duration_ms, e
-            ),
-        };
-        self.activity_log.write().await.push(log_line);
-        result
+        async {
+            let params = json!({
+                "name": name,
+                "arguments": arguments,
+            });
+            let start = Instant::now();
+            let result = self.send_request("tools/call", Some(params)).await;
+            let duration_ms = start.elapsed().as_millis();
+            let now = chrono::Utc::now()
+                .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+                .to_string();
+            let log_line = match &result {
+                Ok(_) => format!(
+                    "{}  INFO call_tool tool={} status=ok duration={}ms",
+                    now, name, duration_ms
+                ),
+                Err(e) => format!(
+                    "{}  WARN call_tool tool={} status=error duration={}ms error={}",
+                    now, name, duration_ms, e
+                ),
+            };
+            self.activity_log.write().await.push(log_line);
+            match &result {
+                Ok(_) => tracing::info!(
+                    tool = %name,
+                    status = "ok",
+                    duration_ms = duration_ms,
+                    "Tool call completed"
+                ),
+                Err(e) => tracing::warn!(
+                    tool = %name,
+                    status = "error",
+                    duration_ms = duration_ms,
+                    error = %e,
+                    "Tool call failed"
+                ),
+            }
+            result
+        }
+        .instrument(self.span.clone())
+        .await
     }
 
     fn health(&self) -> HealthStatus {
@@ -439,9 +492,13 @@ impl McpAdapter for HttpAdapter {
     }
 
     async fn shutdown(&mut self) -> Result<(), AdapterError> {
-        *self.health.write().await = HealthStatus::Stopped;
-        info!(url = %self.config.url, "HTTP MCP adapter shut down");
-        Ok(())
+        async {
+            *self.health.write().await = HealthStatus::Stopped;
+            info!(url = %self.config.url, "HTTP MCP adapter shut down");
+            Ok(())
+        }
+        .instrument(self.span.clone())
+        .await
     }
 
     async fn activity_log(&self) -> Vec<String> {

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio::task::{AbortHandle, JoinHandle};
 use tokio::time::Instant;
-use tracing::{error, info, warn};
+use tracing::{error, info, warn, Instrument};
 
 /// Returns the `Instant` at which a proactive refresh should fire when
 /// `issued_at` is unknown (or nonsensical relative to `expires_at`).
@@ -104,6 +104,12 @@ pub struct OAuthAdapterInner {
     /// Abort handle for the current inner→outer tools-changed forwarder task,
     /// if any. Re-bound on every inner-adapter swap.
     inner_forwarder_handle: Mutex<Option<AbortHandle>>,
+    /// Per-endpoint tracing span. Every adapter method instruments its async
+    /// body with this span so events emitted directly by `OAuthAdapter` /
+    /// `OAuthAdapterInner` (state transitions, refresh, heartbeat) carry
+    /// `endpoint`/`transport="oauth"` (and `server_type` once the inner MCP
+    /// handshake completes).
+    pub span: tracing::Span,
 }
 
 impl OAuthAdapterInner {
@@ -112,6 +118,7 @@ impl OAuthAdapterInner {
         url: &str,
         access_token: &str,
         server_type_override: Option<String>,
+        endpoint_name: String,
     ) -> HttpAdapter {
         let client = Client::builder()
             .timeout(Duration::from_secs(30))
@@ -134,6 +141,7 @@ impl OAuthAdapterInner {
             .expect("failed to build HTTP client");
         let mut http_config = HttpConfig::new(url);
         http_config.server_type_override = server_type_override;
+        http_config.endpoint_name = endpoint_name;
         HttpAdapter::new_with_client(http_config, client)
     }
 
@@ -367,9 +375,18 @@ impl OAuthAdapterInner {
             &self.config.url,
             &access_token,
             self.config.server_type_override.clone(),
+            self.config.endpoint_name.clone(),
         );
         match adapter.initialize().await {
             Ok(()) => {
+                // Mirror the stdio/sse/http adapters: once the inner MCP
+                // handshake reports a `server_type`, record it on the outer
+                // OAuth span so subsequent events render with the resolved
+                // name in the `endpoint:` header.
+                if let Some(name) = adapter.server_type() {
+                    self.span
+                        .record("server_type", tracing::field::display(&name));
+                }
                 // Reflect the freshly initialized inner adapter's health
                 // immediately so health() reports Healthy without waiting for
                 // the next heartbeat tick.
@@ -450,7 +467,8 @@ impl OAuthAdapterInner {
 
         if let Some(deadline) = deadline {
             let inner = self.clone();
-            let handle = tokio::spawn(async move {
+            let refresh_span = self.span.clone();
+            let fut = async move {
                 tokio::time::sleep_until(deadline).await;
                 info!(endpoint = %inner.config.endpoint_name, "Proactive refresh timer fired");
                 // Detach our own handle from the slot before re-entering
@@ -530,7 +548,8 @@ impl OAuthAdapterInner {
                         }
                     }
                 }
-            });
+            };
+            let handle = tokio::spawn(fut.instrument(refresh_span));
             self.refresh_task_handle.lock().await.replace(handle);
         }
     }
@@ -617,6 +636,12 @@ impl OAuthAdapter {
     /// Create a new OAuthAdapter.
     pub fn new(config: OAuthAdapterConfig, token_manager: Arc<TokenManager>) -> Self {
         let (outer_tools_changed_tx, _) = broadcast::channel(16);
+        let span = tracing::info_span!(
+            "endpoint",
+            endpoint = %config.endpoint_name,
+            transport = "oauth",
+            server_type = tracing::field::Empty,
+        );
         Self {
             inner: Arc::new(OAuthAdapterInner {
                 state: RwLock::new(OAuthState::NeedsLogin),
@@ -636,6 +661,7 @@ impl OAuthAdapter {
                 refresh_mutex: Mutex::new(()),
                 outer_tools_changed_tx,
                 inner_forwarder_handle: Mutex::new(None),
+                span,
             }),
         }
     }
@@ -649,174 +675,190 @@ impl OAuthAdapter {
 #[async_trait]
 impl McpAdapter for OAuthAdapter {
     async fn initialize(&mut self) -> Result<(), AdapterError> {
-        // Try to load existing tokens from disk
-        let loaded = self
-            .inner
-            .token_manager
-            .load(&self.inner.config.endpoint_name)
-            .await;
+        let span = self.inner.span.clone();
+        async {
+            // Try to load existing tokens from disk
+            let loaded = self
+                .inner
+                .token_manager
+                .load(&self.inner.config.endpoint_name)
+                .await;
 
-        if let Ok(Some(token_set)) = loaded {
-            if token_set.is_valid() {
-                info!(
-                    endpoint = %self.inner.config.endpoint_name,
-                    "Loaded valid OAuth tokens from disk"
-                );
-                self.inner.apply_tokens(token_set).await;
-            } else if token_set.refresh_token.is_some() {
-                info!(
-                    endpoint = %self.inner.config.endpoint_name,
-                    "Loaded expired tokens with refresh token, attempting refresh"
-                );
-                // Store expired tokens so refresh can use the refresh_token
-                *self.inner.tokens.write().await = Some(token_set);
-                match self.inner.do_token_refresh().await {
-                    Ok(new_tokens) => {
-                        self.inner.apply_tokens(new_tokens).await;
+            if let Ok(Some(token_set)) = loaded {
+                if token_set.is_valid() {
+                    info!(
+                        endpoint = %self.inner.config.endpoint_name,
+                        "Loaded valid OAuth tokens from disk"
+                    );
+                    self.inner.apply_tokens(token_set).await;
+                } else if token_set.refresh_token.is_some() {
+                    info!(
+                        endpoint = %self.inner.config.endpoint_name,
+                        "Loaded expired tokens with refresh token, attempting refresh"
+                    );
+                    // Store expired tokens so refresh can use the refresh_token
+                    *self.inner.tokens.write().await = Some(token_set);
+                    match self.inner.do_token_refresh().await {
+                        Ok(new_tokens) => {
+                            self.inner.apply_tokens(new_tokens).await;
+                        }
+                        Err(e) => {
+                            warn!(
+                                endpoint = %self.inner.config.endpoint_name,
+                                error = %e,
+                                "Token refresh at startup failed"
+                            );
+                            self.inner
+                                .transition_to(OAuthState::AuthRequired, "startup refresh failed")
+                                .await;
+                        }
                     }
-                    Err(e) => {
-                        warn!(
-                            endpoint = %self.inner.config.endpoint_name,
-                            error = %e,
-                            "Token refresh at startup failed"
-                        );
-                        self.inner
-                            .transition_to(OAuthState::AuthRequired, "startup refresh failed")
-                            .await;
-                    }
+                } else {
+                    self.inner
+                        .transition_to(
+                            OAuthState::AuthRequired,
+                            "expired tokens without refresh token",
+                        )
+                        .await;
                 }
             } else {
                 self.inner
-                    .transition_to(
-                        OAuthState::AuthRequired,
-                        "expired tokens without refresh token",
-                    )
+                    .transition_to(OAuthState::NeedsLogin, "no existing tokens at startup")
                     .await;
             }
-        } else {
+
+            // Spawn the heartbeat probe loop, instrumented with the per-endpoint
+            // span so events emitted from `heartbeat::apply_probe_action` render
+            // under the `endpoint:` span header.
+            let weak = Arc::downgrade(&self.inner);
+            let hb_span = self.inner.span.clone();
+            let handle = tokio::spawn(heartbeat::heartbeat_loop(weak).instrument(hb_span));
             self.inner
-                .transition_to(OAuthState::NeedsLogin, "no existing tokens at startup")
-                .await;
+                .heartbeat_task_handle
+                .lock()
+                .await
+                .replace(handle);
+
+            Ok(()) // initialize always succeeds for OAuth
         }
-
-        // Spawn the heartbeat probe loop
-        let weak = Arc::downgrade(&self.inner);
-        let handle = tokio::spawn(heartbeat::heartbeat_loop(weak));
-        self.inner
-            .heartbeat_task_handle
-            .lock()
-            .await
-            .replace(handle);
-
-        Ok(()) // initialize always succeeds for OAuth
+        .instrument(span)
+        .await
     }
 
     async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
-        let guard = self.inner.inner_adapter.read().await;
-        match guard.as_ref() {
-            Some(adapter) => {
-                match adapter.list_tools().await {
-                    Ok(tools) => Ok(tools),
-                    Err(AdapterError::HttpError { status: 401, .. }) => {
-                        // Drop the read lock before refreshing
-                        drop(guard);
+        async {
+            let guard = self.inner.inner_adapter.read().await;
+            match guard.as_ref() {
+                Some(adapter) => {
+                    match adapter.list_tools().await {
+                        Ok(tools) => Ok(tools),
+                        Err(AdapterError::HttpError { status: 401, .. }) => {
+                            // Drop the read lock before refreshing
+                            drop(guard);
 
-                        info!(
-                            endpoint = %self.inner.config.endpoint_name,
-                            "Got 401 on list_tools, attempting token refresh"
-                        );
+                            info!(
+                                endpoint = %self.inner.config.endpoint_name,
+                                "Got 401 on list_tools, attempting token refresh"
+                            );
 
-                        match self.inner.do_token_refresh().await {
-                            Ok(new_tokens) => {
-                                self.inner.apply_tokens(new_tokens).await;
-                                // Retry with new token
-                                let guard = self.inner.inner_adapter.read().await;
-                                match guard.as_ref() {
-                                    Some(adapter) => adapter.list_tools().await,
-                                    None => Ok(vec![]),
+                            match self.inner.do_token_refresh().await {
+                                Ok(new_tokens) => {
+                                    self.inner.apply_tokens(new_tokens).await;
+                                    // Retry with new token
+                                    let guard = self.inner.inner_adapter.read().await;
+                                    match guard.as_ref() {
+                                        Some(adapter) => adapter.list_tools().await,
+                                        None => Ok(vec![]),
+                                    }
+                                }
+                                Err(e) => {
+                                    warn!(
+                                        endpoint = %self.inner.config.endpoint_name,
+                                        error = %e,
+                                        "Token refresh after 401 on list_tools failed"
+                                    );
+                                    self.inner
+                                        .transition_to(
+                                            OAuthState::AuthRequired,
+                                            "401 on list_tools, refresh failed",
+                                        )
+                                        .await;
+                                    Err(AdapterError::AuthenticationRequired {
+                                        endpoint: self.inner.config.endpoint_name.clone(),
+                                        message: "Token expired and refresh failed. Re-authenticate in Endara Desktop.".to_string(),
+                                    })
                                 }
                             }
-                            Err(e) => {
-                                warn!(
-                                    endpoint = %self.inner.config.endpoint_name,
-                                    error = %e,
-                                    "Token refresh after 401 on list_tools failed"
-                                );
-                                self.inner
-                                    .transition_to(
-                                        OAuthState::AuthRequired,
-                                        "401 on list_tools, refresh failed",
-                                    )
-                                    .await;
-                                Err(AdapterError::AuthenticationRequired {
-                                    endpoint: self.inner.config.endpoint_name.clone(),
-                                    message: "Token expired and refresh failed. Re-authenticate in Endara Desktop.".to_string(),
-                                })
-                            }
                         }
+                        Err(other) => Err(other),
                     }
-                    Err(other) => Err(other),
                 }
+                None => Ok(vec![]),
             }
-            None => Ok(vec![]),
         }
+        .instrument(self.inner.span.clone())
+        .await
     }
 
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
-        let guard = self.inner.inner_adapter.read().await;
-        let adapter = match guard.as_ref() {
-            Some(a) => a,
-            None => {
-                return Err(AdapterError::ConnectionFailed(
-                    "not authenticated — complete OAuth login first".to_string(),
-                ));
-            }
-        };
+        async {
+            let guard = self.inner.inner_adapter.read().await;
+            let adapter = match guard.as_ref() {
+                Some(a) => a,
+                None => {
+                    return Err(AdapterError::ConnectionFailed(
+                        "not authenticated — complete OAuth login first".to_string(),
+                    ));
+                }
+            };
 
-        match adapter.call_tool(name, arguments.clone()).await {
-            Ok(result) => Ok(result),
-            Err(AdapterError::HttpError { status: 401, .. }) => {
-                // Drop the read lock before refreshing
-                drop(guard);
+            match adapter.call_tool(name, arguments.clone()).await {
+                Ok(result) => Ok(result),
+                Err(AdapterError::HttpError { status: 401, .. }) => {
+                    // Drop the read lock before refreshing
+                    drop(guard);
 
-                info!(
-                    endpoint = %self.inner.config.endpoint_name,
-                    "Got 401, attempting token refresh"
-                );
+                    info!(
+                        endpoint = %self.inner.config.endpoint_name,
+                        "Got 401, attempting token refresh"
+                    );
 
-                match self.inner.do_token_refresh().await {
-                    Ok(new_tokens) => {
-                        self.inner.apply_tokens(new_tokens).await;
-                        // Retry with new token
-                        let guard = self.inner.inner_adapter.read().await;
-                        let adapter = guard.as_ref().ok_or_else(|| {
-                            AdapterError::ConnectionFailed(
-                                "Adapter lost during refresh".to_string(),
-                            )
-                        })?;
-                        adapter.call_tool(name, arguments).await
-                    }
-                    Err(e) => {
-                        warn!(
-                            endpoint = %self.inner.config.endpoint_name,
-                            error = %e,
-                            "Token refresh after 401 failed"
-                        );
-                        self.inner
-                            .transition_to(
-                                OAuthState::AuthRequired,
-                                "401 on call_tool, refresh failed",
-                            )
-                            .await;
-                        Err(AdapterError::AuthenticationRequired {
-                            endpoint: self.inner.config.endpoint_name.clone(),
-                            message: "Token expired and refresh failed. Re-authenticate in Endara Desktop.".to_string(),
-                        })
+                    match self.inner.do_token_refresh().await {
+                        Ok(new_tokens) => {
+                            self.inner.apply_tokens(new_tokens).await;
+                            // Retry with new token
+                            let guard = self.inner.inner_adapter.read().await;
+                            let adapter = guard.as_ref().ok_or_else(|| {
+                                AdapterError::ConnectionFailed(
+                                    "Adapter lost during refresh".to_string(),
+                                )
+                            })?;
+                            adapter.call_tool(name, arguments).await
+                        }
+                        Err(e) => {
+                            warn!(
+                                endpoint = %self.inner.config.endpoint_name,
+                                error = %e,
+                                "Token refresh after 401 failed"
+                            );
+                            self.inner
+                                .transition_to(
+                                    OAuthState::AuthRequired,
+                                    "401 on call_tool, refresh failed",
+                                )
+                                .await;
+                            Err(AdapterError::AuthenticationRequired {
+                                endpoint: self.inner.config.endpoint_name.clone(),
+                                message: "Token expired and refresh failed. Re-authenticate in Endara Desktop.".to_string(),
+                            })
+                        }
                     }
                 }
+                Err(other) => Err(other),
             }
-            Err(other) => Err(other),
         }
+        .instrument(self.inner.span.clone())
+        .await
     }
 
     fn server_type(&self) -> Option<String> {
@@ -836,31 +878,36 @@ impl McpAdapter for OAuthAdapter {
     }
 
     async fn shutdown(&mut self) -> Result<(), AdapterError> {
-        // Abort heartbeat task
-        {
-            let mut handle = self.inner.heartbeat_task_handle.lock().await;
-            if let Some(h) = handle.take() {
-                h.abort();
+        let span = self.inner.span.clone();
+        async {
+            // Abort heartbeat task
+            {
+                let mut handle = self.inner.heartbeat_task_handle.lock().await;
+                if let Some(h) = handle.take() {
+                    h.abort();
+                }
             }
-        }
-        // Abort refresh task
-        {
-            let mut handle = self.inner.refresh_task_handle.lock().await;
-            if let Some(h) = handle.take() {
-                h.abort();
+            // Abort refresh task
+            {
+                let mut handle = self.inner.refresh_task_handle.lock().await;
+                if let Some(h) = handle.take() {
+                    h.abort();
+                }
             }
+            // Abort inner→outer tools-changed forwarder
+            self.inner.swap_tools_forwarder(None).await;
+            let mut guard = self.inner.inner_adapter.write().await;
+            if let Some(ref mut adapter) = *guard {
+                adapter.shutdown().await?;
+            }
+            *guard = None;
+            self.inner
+                .transition_to(OAuthState::Disconnected, "shutdown")
+                .await;
+            Ok(())
         }
-        // Abort inner→outer tools-changed forwarder
-        self.inner.swap_tools_forwarder(None).await;
-        let mut guard = self.inner.inner_adapter.write().await;
-        if let Some(ref mut adapter) = *guard {
-            adapter.shutdown().await?;
-        }
-        *guard = None;
-        self.inner
-            .transition_to(OAuthState::Disconnected, "shutdown")
-            .await;
-        Ok(())
+        .instrument(span)
+        .await
     }
 
     fn subscribe_tools_changed(&self) -> Option<broadcast::Receiver<()>> {

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{broadcast, Mutex, Notify, RwLock};
 use tokio::time::Instant;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, warn, Instrument};
 
 /// Configuration for the SSE MCP adapter.
 #[derive(Debug, Clone)]
@@ -26,6 +26,10 @@ pub struct SseConfig {
     /// Optional override for the advertised `server_type` name. See
     /// [`crate::adapter::server_type_resolution::effective_server_type`].
     pub server_type_override: Option<String>,
+    /// Endpoint name (used as the `endpoint` field on the adapter's
+    /// per-endpoint `tracing` span). Defaults to empty for direct test
+    /// construction; production paths set this from `EndpointConfig::name`.
+    pub endpoint_name: String,
 }
 
 impl SseConfig {
@@ -35,6 +39,7 @@ impl SseConfig {
             timeout_secs: 30,
             headers: HashMap::new(),
             server_type_override: None,
+            endpoint_name: String::new(),
         }
     }
 
@@ -144,6 +149,10 @@ pub struct SseAdapter {
     /// Broadcast emitter for `notifications/tools/list_changed` events. Each
     /// tick is an opaque cache-invalidation signal consumed by the registry.
     tools_changed_tx: broadcast::Sender<()>,
+    /// Per-endpoint tracing span. Every adapter method instruments its async
+    /// body with this span so events carry `endpoint`/`transport` (and
+    /// `server_type` once the MCP handshake completes).
+    span: tracing::Span,
 }
 
 impl SseAdapter {
@@ -177,6 +186,12 @@ impl SseAdapter {
 
         let (tools_changed_tx, _) = broadcast::channel(16);
 
+        let span = tracing::info_span!(
+            "endpoint",
+            endpoint = %config.endpoint_name,
+            transport = "sse",
+            server_type = tracing::field::Empty,
+        );
         Self {
             config,
             client,
@@ -193,6 +208,7 @@ impl SseAdapter {
             reconnect_notify: Arc::new(Notify::new()),
             shutdown_notify: Arc::new(Notify::new()),
             tools_changed_tx,
+            span,
         }
     }
 
@@ -558,6 +574,10 @@ impl SseAdapter {
         let upstream_stripped = strip_mcp_server_suffix(sanitized.clone());
 
         debug!(url = %self.config.url, raw_name = %raw_name, sanitized = %sanitized, effective = ?effective, "MCP server reported serverInfo.name");
+        if let Some(ref name) = effective {
+            self.span
+                .record("server_type", tracing::field::display(name));
+        }
         *self.server_type.write().await = effective;
         *self.upstream_server_name.write().await = Some(upstream_stripped);
         *self.health.write().await = HealthStatus::Healthy;
@@ -636,48 +656,75 @@ impl SseAdapter {
 #[async_trait]
 impl McpAdapter for SseAdapter {
     async fn initialize(&mut self) -> Result<(), AdapterError> {
-        if let Err(e) = self.connect_and_handshake().await {
-            error!(url = %self.config.url, error = %e, "SSE MCP adapter initialization failed");
-            return Err(e);
-        }
+        async {
+            if let Err(e) = self.connect_and_handshake().await {
+                error!(url = %self.config.url, error = %e, "SSE MCP adapter initialization failed");
+                return Err(e);
+            }
 
-        self.ensure_supervisor_running().await;
-        info!(url = %self.config.url, "SSE MCP adapter initialized");
-        Ok(())
+            self.ensure_supervisor_running().await;
+            info!(url = %self.config.url, "SSE MCP adapter initialized");
+            Ok(())
+        }
+        .instrument(self.span.clone())
+        .await
     }
 
     async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
-        let result = self.send_request("tools/list", None).await?;
-        let tools_value = result
-            .get("tools")
-            .ok_or_else(|| AdapterError::ProtocolError("missing 'tools' field".into()))?;
-        let tools: Vec<ToolInfo> = serde_json::from_value(tools_value.clone())?;
-        Ok(tools)
+        async {
+            let result = self.send_request("tools/list", None).await?;
+            let tools_value = result
+                .get("tools")
+                .ok_or_else(|| AdapterError::ProtocolError("missing 'tools' field".into()))?;
+            let tools: Vec<ToolInfo> = serde_json::from_value(tools_value.clone())?;
+            Ok(tools)
+        }
+        .instrument(self.span.clone())
+        .await
     }
 
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
-        let params = json!({
-            "name": name,
-            "arguments": arguments,
-        });
-        let start = Instant::now();
-        let result = self.send_request("tools/call", Some(params)).await;
-        let duration_ms = start.elapsed().as_millis();
-        let now = chrono::Utc::now()
-            .format("%Y-%m-%dT%H:%M:%S%.3fZ")
-            .to_string();
-        let log_line = match &result {
-            Ok(_) => format!(
-                "{}  INFO call_tool tool={} status=ok duration={}ms",
-                now, name, duration_ms
-            ),
-            Err(e) => format!(
-                "{}  WARN call_tool tool={} status=error duration={}ms error={}",
-                now, name, duration_ms, e
-            ),
-        };
-        self.activity_log.write().await.push(log_line);
-        result
+        async {
+            let params = json!({
+                "name": name,
+                "arguments": arguments,
+            });
+            let start = Instant::now();
+            let result = self.send_request("tools/call", Some(params)).await;
+            let duration_ms = start.elapsed().as_millis();
+            let now = chrono::Utc::now()
+                .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+                .to_string();
+            let log_line = match &result {
+                Ok(_) => format!(
+                    "{}  INFO call_tool tool={} status=ok duration={}ms",
+                    now, name, duration_ms
+                ),
+                Err(e) => format!(
+                    "{}  WARN call_tool tool={} status=error duration={}ms error={}",
+                    now, name, duration_ms, e
+                ),
+            };
+            self.activity_log.write().await.push(log_line);
+            match &result {
+                Ok(_) => tracing::info!(
+                    tool = %name,
+                    status = "ok",
+                    duration_ms = duration_ms,
+                    "Tool call completed"
+                ),
+                Err(e) => tracing::warn!(
+                    tool = %name,
+                    status = "error",
+                    duration_ms = duration_ms,
+                    error = %e,
+                    "Tool call failed"
+                ),
+            }
+            result
+        }
+        .instrument(self.span.clone())
+        .await
     }
 
     fn health(&self) -> HealthStatus {
@@ -703,30 +750,34 @@ impl McpAdapter for SseAdapter {
     }
 
     async fn shutdown(&mut self) -> Result<(), AdapterError> {
-        *self.health.write().await = HealthStatus::Stopped;
+        async {
+            *self.health.write().await = HealthStatus::Stopped;
 
-        // Tell the supervisor to wake up and exit (in case it's sleeping in
-        // backoff or waiting on a reconnect notification).
-        self.shutdown_notify.notify_waiters();
+            // Tell the supervisor to wake up and exit (in case it's sleeping in
+            // backoff or waiting on a reconnect notification).
+            self.shutdown_notify.notify_waiters();
 
-        // Abort the SSE listener task
-        if let Some(handle) = self.sse_handle.lock().await.take() {
-            handle.abort();
+            // Abort the SSE listener task
+            if let Some(handle) = self.sse_handle.lock().await.take() {
+                handle.abort();
+            }
+
+            // Abort the reconnect supervisor task
+            if let Some(handle) = self.reconnect_handle.lock().await.take() {
+                handle.abort();
+            }
+
+            // Clear the endpoint
+            *self.post_endpoint.write().await = None;
+
+            // Drop all pending requests
+            self.pending.lock().await.clear();
+
+            info!(url = %self.config.url, "SSE MCP adapter shut down");
+            Ok(())
         }
-
-        // Abort the reconnect supervisor task
-        if let Some(handle) = self.reconnect_handle.lock().await.take() {
-            handle.abort();
-        }
-
-        // Clear the endpoint
-        *self.post_endpoint.write().await = None;
-
-        // Drop all pending requests
-        self.pending.lock().await.clear();
-
-        info!(url = %self.config.url, "SSE MCP adapter shut down");
-        Ok(())
+        .instrument(self.span.clone())
+        .await
     }
 
     async fn activity_log(&self) -> Vec<String> {

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -13,7 +13,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio::time::{Duration, Instant};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, warn, Instrument};
 
 /// Configuration for spawning a STDIO MCP server.
 #[derive(Debug, Clone, Default)]
@@ -24,6 +24,10 @@ pub struct StdioConfig {
     /// Optional override for the advertised `server_type` name. See
     /// [`crate::adapter::server_type_resolution::effective_server_type`].
     pub server_type_override: Option<String>,
+    /// Endpoint name (used as the `endpoint` field on the adapter's
+    /// per-endpoint `tracing` span). Defaults to empty for direct test
+    /// construction; production paths set this from `EndpointConfig::name`.
+    pub endpoint_name: String,
 }
 
 /// Ring buffer that stores the last N lines of stderr output.
@@ -166,6 +170,10 @@ pub struct StdioAdapter {
     /// observations to subscribers (the registry's listener loop). Capacity is
     /// 16; `SendError` (no subscribers) is intentionally ignored.
     tools_changed_tx: broadcast::Sender<()>,
+    /// Per-endpoint tracing span. Every adapter method instruments its async
+    /// body with this span so events carry `endpoint`/`transport` (and
+    /// `server_type` once the MCP handshake completes).
+    span: tracing::Span,
     // Background task handles
     _stderr_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
     _stdout_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
@@ -175,6 +183,12 @@ impl StdioAdapter {
     /// Create a new StdioAdapter with the given configuration.
     pub fn new(config: StdioConfig) -> Self {
         let (tools_changed_tx, _) = broadcast::channel(16);
+        let span = tracing::info_span!(
+            "endpoint",
+            endpoint = %config.endpoint_name,
+            transport = "stdio",
+            server_type = tracing::field::Empty,
+        );
         Self {
             config,
             child: Arc::new(Mutex::new(None)),
@@ -187,6 +201,7 @@ impl StdioAdapter {
             server_type: Arc::new(RwLock::new(None)),
             upstream_server_name: Arc::new(RwLock::new(None)),
             tools_changed_tx,
+            span,
             _stderr_handle: Arc::new(Mutex::new(None)),
             _stdout_handle: Arc::new(Mutex::new(None)),
         }
@@ -440,6 +455,10 @@ impl StdioAdapter {
         let upstream_stripped = strip_mcp_server_suffix(sanitized.clone());
 
         info!(raw_name = %raw_name, sanitized = %sanitized, effective = ?effective, "MCP server reported serverInfo.name");
+        if let Some(ref name) = effective {
+            self.span
+                .record("server_type", tracing::field::display(name));
+        }
         *self.server_type.write().await = effective;
         *self.upstream_server_name.write().await = Some(upstream_stripped);
 
@@ -451,28 +470,58 @@ impl StdioAdapter {
 #[async_trait]
 impl McpAdapter for StdioAdapter {
     async fn initialize(&mut self) -> Result<(), AdapterError> {
-        self.spawn_process().await?;
-        self.mcp_initialize().await?;
-        *self.health.write().await = HealthStatus::Healthy;
-        self.crash_tracker.lock().await.reset();
-        Ok(())
+        async {
+            self.spawn_process().await?;
+            self.mcp_initialize().await?;
+            *self.health.write().await = HealthStatus::Healthy;
+            self.crash_tracker.lock().await.reset();
+            Ok(())
+        }
+        .instrument(self.span.clone())
+        .await
     }
 
     async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
-        let result = self.send_request("tools/list", None).await?;
-        let tools_value = result
-            .get("tools")
-            .ok_or_else(|| AdapterError::ProtocolError("missing 'tools' field".into()))?;
-        let tools: Vec<ToolInfo> = serde_json::from_value(tools_value.clone())?;
-        Ok(tools)
+        async {
+            let result = self.send_request("tools/list", None).await?;
+            let tools_value = result
+                .get("tools")
+                .ok_or_else(|| AdapterError::ProtocolError("missing 'tools' field".into()))?;
+            let tools: Vec<ToolInfo> = serde_json::from_value(tools_value.clone())?;
+            Ok(tools)
+        }
+        .instrument(self.span.clone())
+        .await
     }
 
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
-        let params = json!({
-            "name": name,
-            "arguments": arguments,
-        });
-        self.send_request("tools/call", Some(params)).await
+        async {
+            let params = json!({
+                "name": name,
+                "arguments": arguments,
+            });
+            let start = Instant::now();
+            let result = self.send_request("tools/call", Some(params)).await;
+            let duration_ms = start.elapsed().as_millis();
+            match &result {
+                Ok(_) => tracing::info!(
+                    tool = %name,
+                    status = "ok",
+                    duration_ms = duration_ms,
+                    "Tool call completed"
+                ),
+                Err(e) => tracing::warn!(
+                    tool = %name,
+                    status = "error",
+                    duration_ms = duration_ms,
+                    error = %e,
+                    "Tool call failed"
+                ),
+            }
+            result
+        }
+        .instrument(self.span.clone())
+        .await
     }
 
     fn health(&self) -> HealthStatus {
@@ -509,53 +558,57 @@ impl McpAdapter for StdioAdapter {
     }
 
     async fn shutdown(&mut self) -> Result<(), AdapterError> {
-        *self.health.write().await = HealthStatus::Stopped;
+        async {
+            *self.health.write().await = HealthStatus::Stopped;
 
-        // Try graceful close via stdin
-        if let Some(stdin) = self.stdin_writer.lock().await.take() {
-            drop(stdin);
-        }
-
-        // Drop all pending request senders — waiting callers will get RecvError
-        {
-            let mut pending = self.pending_requests.lock().await;
-            let count = pending.len();
-            pending.clear();
-            if count > 0 {
-                debug!(count = count, "dropped pending requests during shutdown");
+            // Try graceful close via stdin
+            if let Some(stdin) = self.stdin_writer.lock().await.take() {
+                drop(stdin);
             }
-        }
 
-        // Try to kill the child process
-        if let Some(mut child) = self.child.lock().await.take() {
-            // Send SIGTERM (kill on unix sends SIGKILL, so we use start_kill)
-            let _ = child.start_kill();
-
-            // Wait up to 5 seconds for graceful shutdown
-            match tokio::time::timeout(Duration::from_secs(5), child.wait()).await {
-                Ok(Ok(status)) => {
-                    info!(exit_code = ?status.code(), "MCP server exited");
-                }
-                Ok(Err(e)) => {
-                    warn!(error = %e, "error waiting for MCP server exit");
-                }
-                Err(_) => {
-                    warn!("MCP server did not exit within 5s, force killing");
-                    let _ = child.kill().await;
+            // Drop all pending request senders — waiting callers will get RecvError
+            {
+                let mut pending = self.pending_requests.lock().await;
+                let count = pending.len();
+                pending.clear();
+                if count > 0 {
+                    debug!(count = count, "dropped pending requests during shutdown");
                 }
             }
-        }
 
-        // Abort background tasks
-        if let Some(h) = self._stderr_handle.lock().await.take() {
-            h.abort();
-        }
-        if let Some(h) = self._stdout_handle.lock().await.take() {
-            h.abort();
-        }
+            // Try to kill the child process
+            if let Some(mut child) = self.child.lock().await.take() {
+                // Send SIGTERM (kill on unix sends SIGKILL, so we use start_kill)
+                let _ = child.start_kill();
 
-        info!("STDIO adapter shut down");
-        Ok(())
+                // Wait up to 5 seconds for graceful shutdown
+                match tokio::time::timeout(Duration::from_secs(5), child.wait()).await {
+                    Ok(Ok(status)) => {
+                        info!(exit_code = ?status.code(), "MCP server exited");
+                    }
+                    Ok(Err(e)) => {
+                        warn!(error = %e, "error waiting for MCP server exit");
+                    }
+                    Err(_) => {
+                        warn!("MCP server did not exit within 5s, force killing");
+                        let _ = child.kill().await;
+                    }
+                }
+            }
+
+            // Abort background tasks
+            if let Some(h) = self._stderr_handle.lock().await.take() {
+                h.abort();
+            }
+            if let Some(h) = self._stdout_handle.lock().await.take() {
+                h.abort();
+            }
+
+            info!("STDIO adapter shut down");
+            Ok(())
+        }
+        .instrument(self.span.clone())
+        .await
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ mod shell_env;
 
 use adapter::oauth::{OAuthAdapter, OAuthAdapterConfig, OAuthAdapterInner};
 use adapter::{FailedAdapter, McpAdapter, StartingAdapter};
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use js_sandbox::MetaToolHandler;
 use oauth::{OAuthFlowManager, OAuthSetupManager};
 use registry::AdapterRegistry;
@@ -60,9 +60,24 @@ enum Commands {
         port: u16,
 
         /// Log output format
-        #[arg(long, default_value = "text", value_parser = ["text", "json"])]
+        #[arg(long, default_value = "compact", value_parser = ["text", "compact", "json"])]
         log_format: String,
+
+        /// Colorize stdout logs (auto detects TTY)
+        #[arg(long, default_value = "auto", value_enum)]
+        color: ColorMode,
+
+        /// EnvFilter directive for the file log layer (default: debug,endara_relay=trace)
+        #[arg(long)]
+        file_log_level: Option<String>,
     },
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug)]
+enum ColorMode {
+    Auto,
+    Always,
+    Never,
 }
 
 /// Expand a path string, replacing a leading `~` with the user's home directory.
@@ -78,40 +93,61 @@ fn expand_tilde(path: &str) -> PathBuf {
     }
 }
 
-fn init_tracing(log_format: &str, log_dir: &std::path::Path) {
+fn init_tracing(
+    color_mode: ColorMode,
+    log_format: &str,
+    file_log_level: Option<String>,
+    log_dir: &std::path::Path,
+) {
+    use std::io::IsTerminal;
     use tracing_subscriber::fmt;
     use tracing_subscriber::prelude::*;
-    use tracing_subscriber::EnvFilter;
+    use tracing_subscriber::{EnvFilter, Layer};
 
-    // Default: info for all crates, debug for endara_relay.
-    // Overridable via RUST_LOG env var.
-    let filter = EnvFilter::try_from_default_env()
+    let use_color = match color_mode {
+        ColorMode::Auto => std::io::stdout().is_terminal(),
+        ColorMode::Always => true,
+        ColorMode::Never => false,
+    };
+
+    // Stdout filter: RUST_LOG or default. Independent of the file filter so the
+    // two layers can run at different verbosity levels.
+    let stdout_filter = EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| EnvFilter::new("info,endara_relay=debug"));
+    let file_filter = EnvFilter::new(
+        file_log_level
+            .as_deref()
+            .unwrap_or("debug,endara_relay=trace"),
+    );
 
     let file_appender = tracing_appender::rolling::daily(log_dir, "relay.log");
     let file_layer = fmt::layer()
         .with_writer(file_appender)
         .with_ansi(false)
+        .with_filter(file_filter)
         .boxed();
 
-    match log_format {
-        "json" => {
-            let stdout_layer = fmt::layer().json().with_ansi(false).boxed();
-            tracing_subscriber::registry()
-                .with(filter)
-                .with(stdout_layer)
-                .with(file_layer)
-                .init();
-        }
-        _ => {
-            let stdout_layer = fmt::layer().with_ansi(false).boxed();
-            tracing_subscriber::registry()
-                .with(filter)
-                .with(stdout_layer)
-                .with(file_layer)
-                .init();
-        }
-    }
+    let stdout_layer = match log_format {
+        "json" => fmt::layer()
+            .json()
+            .with_ansi(use_color)
+            .with_filter(stdout_filter)
+            .boxed(),
+        "compact" => fmt::layer()
+            .compact()
+            .with_ansi(use_color)
+            .with_filter(stdout_filter)
+            .boxed(),
+        _ => fmt::layer()
+            .with_ansi(use_color)
+            .with_filter(stdout_filter)
+            .boxed(),
+    };
+
+    tracing_subscriber::registry()
+        .with(stdout_layer)
+        .with(file_layer)
+        .init();
 }
 
 #[tokio::main]
@@ -124,13 +160,15 @@ async fn main() {
             config,
             port,
             log_format,
+            color,
+            file_log_level,
         } => {
             let data_dir_path = expand_tilde(&data_dir);
             let log_dir = data_dir_path.join("logs");
             let config_explicit = config.is_some();
             let config_path = config.unwrap_or_else(|| data_dir_path.join("config.toml"));
 
-            init_tracing(&log_format, &log_dir);
+            init_tracing(color, &log_format, file_log_level, &log_dir);
             info!(config = %config_path.display(), data_dir = %data_dir_path.display(), "Starting endara-relay");
 
             // First-run config copy: when using a non-default data dir without an

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio::task::AbortHandle;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 /// A registered adapter with its metadata.
 pub struct RegisteredAdapter {
@@ -487,6 +487,12 @@ impl AdapterRegistry {
             )));
         }
 
+        info!(
+            tool = %tool,
+            endpoint = %endpoint,
+            prefixed = %prefixed_name,
+            "Routing tool call"
+        );
         entry.adapter.call_tool(tool, arguments).await
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -24,7 +24,7 @@ use tokio::net::TcpListener;
 
 use tokio_stream::wrappers::ReceiverStream;
 use tower_http::cors::{AllowOrigin, CorsLayer};
-use tracing::{error, info, warn};
+use tracing::{error, info, warn, Instrument};
 
 /// Application state shared across all routes.
 #[derive(Clone)]
@@ -290,108 +290,117 @@ async fn mcp_tools_call(
 /// Handle a single JSON-RPC message object, returning `None` for notifications
 /// (which get 202 Accepted) or `Some(Value)` for requests that need a response.
 async fn handle_single_message(state: &AppState, msg: Value, headers_str: &str) -> Option<Value> {
-    let start = Instant::now();
     let method = msg
         .get("method")
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
-    let is_notification = msg.get("id").is_none() || msg.get("id") == Some(&Value::Null);
-    let req_bytes = serde_json::to_string(&msg).map(|s| s.len()).unwrap_or(0);
+    let id_str = msg
+        .get("id")
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| "null".to_string());
+    let span = tracing::info_span!("request", method = %method, id = %id_str);
+    async move {
+        let start = Instant::now();
+        let is_notification = msg.get("id").is_none() || msg.get("id") == Some(&Value::Null);
+        let req_bytes = serde_json::to_string(&msg).map(|s| s.len()).unwrap_or(0);
 
-    // Notifications (no `id` field) get 202 Accepted with no body per MCP spec.
-    if is_notification {
-        let elapsed_ms = start.elapsed().as_millis() as u64;
-        info!(
-            method = %method,
-            elapsed_ms = elapsed_ms,
-            req_bytes = req_bytes,
-            resp_bytes = 0,
-            status = 202,
-            headers = %headers_str,
-            "MCP notification"
-        );
-        return None;
-    }
-
-    // Deserialize as JsonRpcBody for dispatch
-    let body: JsonRpcBody = match serde_json::from_value(msg) {
-        Ok(b) => b,
-        Err(_) => {
-            return Some(json!({
-                "jsonrpc": "2.0",
-                "error": { "code": -32600, "message": "Invalid Request" },
-                "id": null,
-            }));
-        }
-    };
-
-    let result: Result<Json<Value>, (StatusCode, Json<Value>)> = match method.as_str() {
-        "initialize" => Ok(mcp_initialize(State(state.clone()), Json(body)).await),
-        "tools/list" => Ok(mcp_tools_list(State(state.clone()), Json(body)).await),
-        "tools/call" => mcp_tools_call(State(state.clone()), Json(body)).await,
-        _ => Err(jsonrpc_error(
-            body.id,
-            -32601,
-            &format!("method not found: {}", method),
-        )),
-    };
-
-    let elapsed_ms = start.elapsed().as_millis() as u64;
-    let resp_value = match result {
-        Ok(Json(resp)) => {
-            let resp_bytes = serde_json::to_string(&resp).map(|s| s.len()).unwrap_or(0);
+        // Notifications (no `id` field) get 202 Accepted with no body per MCP spec.
+        if is_notification {
+            let elapsed_ms = start.elapsed().as_millis() as u64;
             info!(
                 method = %method,
                 elapsed_ms = elapsed_ms,
                 req_bytes = req_bytes,
-                resp_bytes = resp_bytes,
-                status = 200,
+                resp_bytes = 0,
+                status = 202,
                 headers = %headers_str,
-                "MCP request"
+                "MCP notification"
             );
-            resp
+            return None;
         }
-        Err((status, Json(resp))) => {
-            let resp_bytes = serde_json::to_string(&resp).map(|s| s.len()).unwrap_or(0);
-            let status_code = status.as_u16();
-            if status_code >= 500 {
-                error!(
-                    method = %method,
-                    elapsed_ms = elapsed_ms,
-                    req_bytes = req_bytes,
-                    resp_bytes = resp_bytes,
-                    status = status_code,
-                    headers = %headers_str,
-                    "MCP request"
-                );
-            } else if status_code == 200 {
-                // JSON-RPC 2.0: errors are returned with HTTP 200, not a sign of trouble.
+
+        // Deserialize as JsonRpcBody for dispatch
+        let body: JsonRpcBody = match serde_json::from_value(msg) {
+            Ok(b) => b,
+            Err(_) => {
+                return Some(json!({
+                    "jsonrpc": "2.0",
+                    "error": { "code": -32600, "message": "Invalid Request" },
+                    "id": null,
+                }));
+            }
+        };
+
+        let result: Result<Json<Value>, (StatusCode, Json<Value>)> = match method.as_str() {
+            "initialize" => Ok(mcp_initialize(State(state.clone()), Json(body)).await),
+            "tools/list" => Ok(mcp_tools_list(State(state.clone()), Json(body)).await),
+            "tools/call" => mcp_tools_call(State(state.clone()), Json(body)).await,
+            _ => Err(jsonrpc_error(
+                body.id,
+                -32601,
+                &format!("method not found: {}", method),
+            )),
+        };
+
+        let elapsed_ms = start.elapsed().as_millis() as u64;
+        let resp_value = match result {
+            Ok(Json(resp)) => {
+                let resp_bytes = serde_json::to_string(&resp).map(|s| s.len()).unwrap_or(0);
                 info!(
                     method = %method,
                     elapsed_ms = elapsed_ms,
                     req_bytes = req_bytes,
                     resp_bytes = resp_bytes,
-                    status = status_code,
+                    status = 200,
                     headers = %headers_str,
                     "MCP request"
                 );
-            } else {
-                warn!(
-                    method = %method,
-                    elapsed_ms = elapsed_ms,
-                    req_bytes = req_bytes,
-                    resp_bytes = resp_bytes,
-                    status = status_code,
-                    headers = %headers_str,
-                    "MCP request"
-                );
+                resp
             }
-            resp
-        }
-    };
+            Err((status, Json(resp))) => {
+                let resp_bytes = serde_json::to_string(&resp).map(|s| s.len()).unwrap_or(0);
+                let status_code = status.as_u16();
+                if status_code >= 500 {
+                    error!(
+                        method = %method,
+                        elapsed_ms = elapsed_ms,
+                        req_bytes = req_bytes,
+                        resp_bytes = resp_bytes,
+                        status = status_code,
+                        headers = %headers_str,
+                        "MCP request"
+                    );
+                } else if status_code == 200 {
+                    // JSON-RPC 2.0: errors are returned with HTTP 200, not a sign of trouble.
+                    info!(
+                        method = %method,
+                        elapsed_ms = elapsed_ms,
+                        req_bytes = req_bytes,
+                        resp_bytes = resp_bytes,
+                        status = status_code,
+                        headers = %headers_str,
+                        "MCP request"
+                    );
+                } else {
+                    warn!(
+                        method = %method,
+                        elapsed_ms = elapsed_ms,
+                        req_bytes = req_bytes,
+                        resp_bytes = resp_bytes,
+                        status = status_code,
+                        headers = %headers_str,
+                        "MCP request"
+                    );
+                }
+                resp
+            }
+        };
 
-    Some(resp_value)
+        Some(resp_value)
+    }
+    .instrument(span)
+    .await
 }
 
 /// POST /mcp — Unified Streamable HTTP transport endpoint.
@@ -744,38 +753,48 @@ async fn oauth_callback(
 
 /// Logged wrapper for POST /mcp/initialize (direct route).
 async fn mcp_initialize_logged(state: State<AppState>, body: Json<JsonRpcBody>) -> Json<Value> {
-    let start = Instant::now();
-    let req_bytes = serde_json::to_string(&body.0).map(|s| s.len()).unwrap_or(0);
-    let resp = mcp_initialize(state, body).await;
-    let elapsed_ms = start.elapsed().as_millis() as u64;
-    let resp_bytes = serde_json::to_string(&resp.0).map(|s| s.len()).unwrap_or(0);
-    info!(
-        method = "initialize",
-        elapsed_ms = elapsed_ms,
-        req_bytes = req_bytes,
-        resp_bytes = resp_bytes,
-        status = 200,
-        "MCP request"
-    );
-    resp
+    let span = tracing::info_span!("request", method = "initialize", id = ?body.id);
+    async move {
+        let start = Instant::now();
+        let req_bytes = serde_json::to_string(&body.0).map(|s| s.len()).unwrap_or(0);
+        let resp = mcp_initialize(state, body).await;
+        let elapsed_ms = start.elapsed().as_millis() as u64;
+        let resp_bytes = serde_json::to_string(&resp.0).map(|s| s.len()).unwrap_or(0);
+        info!(
+            method = "initialize",
+            elapsed_ms = elapsed_ms,
+            req_bytes = req_bytes,
+            resp_bytes = resp_bytes,
+            status = 200,
+            "MCP request"
+        );
+        resp
+    }
+    .instrument(span)
+    .await
 }
 
 /// Logged wrapper for POST /mcp/tools/list (direct route).
 async fn mcp_tools_list_logged(state: State<AppState>, body: Json<JsonRpcBody>) -> Json<Value> {
-    let start = Instant::now();
-    let req_bytes = serde_json::to_string(&body.0).map(|s| s.len()).unwrap_or(0);
-    let resp = mcp_tools_list(state, body).await;
-    let elapsed_ms = start.elapsed().as_millis() as u64;
-    let resp_bytes = serde_json::to_string(&resp.0).map(|s| s.len()).unwrap_or(0);
-    info!(
-        method = "tools/list",
-        elapsed_ms = elapsed_ms,
-        req_bytes = req_bytes,
-        resp_bytes = resp_bytes,
-        status = 200,
-        "MCP request"
-    );
-    resp
+    let span = tracing::info_span!("request", method = "tools/list", id = ?body.id);
+    async move {
+        let start = Instant::now();
+        let req_bytes = serde_json::to_string(&body.0).map(|s| s.len()).unwrap_or(0);
+        let resp = mcp_tools_list(state, body).await;
+        let elapsed_ms = start.elapsed().as_millis() as u64;
+        let resp_bytes = serde_json::to_string(&resp.0).map(|s| s.len()).unwrap_or(0);
+        info!(
+            method = "tools/list",
+            elapsed_ms = elapsed_ms,
+            req_bytes = req_bytes,
+            resp_bytes = resp_bytes,
+            status = 200,
+            "MCP request"
+        );
+        resp
+    }
+    .instrument(span)
+    .await
 }
 
 /// Logged wrapper for POST /mcp/tools/call (direct route).
@@ -783,57 +802,62 @@ async fn mcp_tools_call_logged(
     state: State<AppState>,
     body: Json<JsonRpcBody>,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
-    let start = Instant::now();
-    let req_bytes = serde_json::to_string(&body.0).map(|s| s.len()).unwrap_or(0);
-    let result = mcp_tools_call(state, body).await;
-    let elapsed_ms = start.elapsed().as_millis() as u64;
-    match &result {
-        Ok(Json(resp)) => {
-            let resp_bytes = serde_json::to_string(resp).map(|s| s.len()).unwrap_or(0);
-            info!(
-                method = "tools/call",
-                elapsed_ms = elapsed_ms,
-                req_bytes = req_bytes,
-                resp_bytes = resp_bytes,
-                status = 200,
-                "MCP request"
-            );
-        }
-        Err((status, Json(resp))) => {
-            let resp_bytes = serde_json::to_string(resp).map(|s| s.len()).unwrap_or(0);
-            let status_code = status.as_u16();
-            if status_code >= 500 {
-                error!(
-                    method = "tools/call",
-                    elapsed_ms = elapsed_ms,
-                    req_bytes = req_bytes,
-                    resp_bytes = resp_bytes,
-                    status = status_code,
-                    "MCP request"
-                );
-            } else if status_code == 200 {
-                // JSON-RPC 2.0: errors are returned with HTTP 200, not a sign of trouble.
+    let span = tracing::info_span!("request", method = "tools/call", id = ?body.id);
+    async move {
+        let start = Instant::now();
+        let req_bytes = serde_json::to_string(&body.0).map(|s| s.len()).unwrap_or(0);
+        let result = mcp_tools_call(state, body).await;
+        let elapsed_ms = start.elapsed().as_millis() as u64;
+        match &result {
+            Ok(Json(resp)) => {
+                let resp_bytes = serde_json::to_string(resp).map(|s| s.len()).unwrap_or(0);
                 info!(
                     method = "tools/call",
                     elapsed_ms = elapsed_ms,
                     req_bytes = req_bytes,
                     resp_bytes = resp_bytes,
-                    status = status_code,
-                    "MCP request"
-                );
-            } else {
-                warn!(
-                    method = "tools/call",
-                    elapsed_ms = elapsed_ms,
-                    req_bytes = req_bytes,
-                    resp_bytes = resp_bytes,
-                    status = status_code,
+                    status = 200,
                     "MCP request"
                 );
             }
+            Err((status, Json(resp))) => {
+                let resp_bytes = serde_json::to_string(resp).map(|s| s.len()).unwrap_or(0);
+                let status_code = status.as_u16();
+                if status_code >= 500 {
+                    error!(
+                        method = "tools/call",
+                        elapsed_ms = elapsed_ms,
+                        req_bytes = req_bytes,
+                        resp_bytes = resp_bytes,
+                        status = status_code,
+                        "MCP request"
+                    );
+                } else if status_code == 200 {
+                    // JSON-RPC 2.0: errors are returned with HTTP 200, not a sign of trouble.
+                    info!(
+                        method = "tools/call",
+                        elapsed_ms = elapsed_ms,
+                        req_bytes = req_bytes,
+                        resp_bytes = resp_bytes,
+                        status = status_code,
+                        "MCP request"
+                    );
+                } else {
+                    warn!(
+                        method = "tools/call",
+                        elapsed_ms = elapsed_ms,
+                        req_bytes = req_bytes,
+                        resp_bytes = resp_bytes,
+                        status = status_code,
+                        "MCP request"
+                    );
+                }
+            }
         }
+        result
     }
-    result
+    .instrument(span)
+    .await
 }
 
 /// Handler for DELETE /mcp — returns 405 Method Not Allowed.

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -535,6 +535,7 @@ pub(crate) async fn create_adapter(
                 args: ep.args.clone().unwrap_or_default(),
                 env: ep.env.clone().unwrap_or_default(),
                 server_type_override: ep.server_type_override.clone(),
+                endpoint_name: ep.name.clone(),
             };
             let mut adapter = StdioAdapter::new(stdio_config);
             match adapter.initialize().await {
@@ -550,6 +551,7 @@ pub(crate) async fn create_adapter(
             let mut sse_config = SseConfig::new(url);
             sse_config.headers = ep.headers.clone().unwrap_or_default();
             sse_config.server_type_override = ep.server_type_override.clone();
+            sse_config.endpoint_name = ep.name.clone();
             let mut adapter = SseAdapter::new(sse_config);
             match adapter.initialize().await {
                 Ok(()) => Box::new(adapter),
@@ -564,6 +566,7 @@ pub(crate) async fn create_adapter(
             let mut http_config = HttpConfig::new(url);
             http_config.headers = ep.headers.clone().unwrap_or_default();
             http_config.server_type_override = ep.server_type_override.clone();
+            http_config.endpoint_name = ep.name.clone();
             let mut adapter = HttpAdapter::new(http_config);
             match adapter.initialize().await {
                 Ok(()) => Box::new(adapter),

--- a/tests/crash_recovery_integration.rs
+++ b/tests/crash_recovery_integration.rs
@@ -25,6 +25,7 @@ async fn test_crash_server_successful_calls_then_failure() {
         args: vec!["--crash-after".to_string(), "5".to_string()],
         env: HashMap::new(),
         server_type_override: None,
+        endpoint_name: "crash-test-5".into(),
     };
 
     let mut adapter = StdioAdapter::new(config);
@@ -91,6 +92,7 @@ async fn test_crash_server_immediate_crash() {
         args: vec!["--crash-after".to_string(), "2".to_string()],
         env: HashMap::new(),
         server_type_override: None,
+        endpoint_name: "crash-test-2".into(),
     };
 
     let mut adapter = StdioAdapter::new(config);

--- a/tests/hot_reload_integration.rs
+++ b/tests/hot_reload_integration.rs
@@ -35,6 +35,7 @@ async fn test_config_diff_add_endpoint() {
         args: vec![echo_script_path().to_string_lossy().to_string()],
         env: HashMap::new(),
         server_type_override: None,
+        endpoint_name: "echo-ep".into(),
     };
     let mut echo_adapter = StdioAdapter::new(echo_config);
     echo_adapter.initialize().await.expect("echo init failed");
@@ -164,6 +165,7 @@ async fn test_config_diff_remove_endpoint() {
         args: vec![echo_script_path().to_string_lossy().to_string()],
         env: HashMap::new(),
         server_type_override: None,
+        endpoint_name: "echo-ep".into(),
     };
     let mut echo_adapter = StdioAdapter::new(echo_config);
     echo_adapter.initialize().await.expect("echo init failed");
@@ -182,6 +184,7 @@ async fn test_config_diff_remove_endpoint() {
         args: vec![],
         env: HashMap::new(),
         server_type_override: None,
+        endpoint_name: "multi-ep".into(),
     };
     let mut multi_adapter = StdioAdapter::new(multi_config);
     multi_adapter.initialize().await.expect("multi init failed");

--- a/tests/js_execution_integration.rs
+++ b/tests/js_execution_integration.rs
@@ -31,6 +31,7 @@ async fn setup_js_server(js_mode: bool) -> (SocketAddr, tokio::task::JoinHandle<
         args: vec![echo_script_path().to_string_lossy().to_string()],
         env: HashMap::new(),
         server_type_override: None,
+        endpoint_name: "js-test".into(),
     };
     let mut adapter = StdioAdapter::new(config);
     adapter.initialize().await.expect("adapter init failed");

--- a/tests/mcp_server_integration.rs
+++ b/tests/mcp_server_integration.rs
@@ -26,6 +26,7 @@ async fn setup_server() -> (SocketAddr, AdapterRegistry, tokio::task::JoinHandle
         args: vec![fixture_path().to_string_lossy().to_string()],
         env: HashMap::new(),
         server_type_override: None,
+        endpoint_name: "mcp-server-test".into(),
     };
     let mut adapter = StdioAdapter::new(config);
     adapter.initialize().await.expect("adapter init failed");

--- a/tests/multi_endpoint_integration.rs
+++ b/tests/multi_endpoint_integration.rs
@@ -38,6 +38,7 @@ async fn setup_multi_endpoint_server() -> (SocketAddr, AdapterRegistry, tokio::t
         args: vec![echo_script_path().to_string_lossy().to_string()],
         env: HashMap::new(),
         server_type_override: None,
+        endpoint_name: "echo-ep".into(),
     };
     let mut echo_adapter = StdioAdapter::new(echo_config);
     echo_adapter
@@ -60,6 +61,7 @@ async fn setup_multi_endpoint_server() -> (SocketAddr, AdapterRegistry, tokio::t
         args: vec![],
         env: HashMap::new(),
         server_type_override: None,
+        endpoint_name: "multi-ep".into(),
     };
     let mut multi_adapter = StdioAdapter::new(multi_config);
     multi_adapter
@@ -206,6 +208,7 @@ async fn test_multi_endpoint_overlapping_tool_names() {
             args: vec![],
             env: HashMap::new(),
             server_type_override: None,
+            endpoint_name: (*ep_name).into(),
         };
         let mut adapter = endara_relay::adapter::stdio::StdioAdapter::new(config);
         adapter

--- a/tests/stdio_integration.rs
+++ b/tests/stdio_integration.rs
@@ -18,6 +18,7 @@ async fn test_stdio_full_lifecycle() {
         args: vec![fixture_path().to_string_lossy().to_string()],
         env: HashMap::new(),
         server_type_override: None,
+        endpoint_name: "stdio-test".into(),
     };
 
     let mut adapter = StdioAdapter::new(config);
@@ -60,6 +61,7 @@ async fn test_stdio_spawn_nonexistent_command() {
         args: vec![],
         env: HashMap::new(),
         server_type_override: None,
+        endpoint_name: "stdio-nonexistent".into(),
     };
 
     let mut adapter = StdioAdapter::new(config);


### PR DESCRIPTION
## Summary

Upgrades the Endara Relay tracing/logging stack so logs are scannable in a terminal, per-endpoint context propagates automatically via tracing spans, stdout and the rolling file can run at independent verbosity, and tool-call results flow through tracing alongside the existing activity ring buffer.

The activity ring buffer and management API are untouched. No new crate dependencies. Scope is `packages/relay` only.

## What changed

The work landed in four sequential slices, each implemented and verified independently before the next one started.

### Slice A — Color, per-layer filtering, compact format

- New `start` flags: `--color` (`auto`|`always`|`never`, default `auto`), `--file-log-level` (default `debug,endara_relay=trace`), and `--log-format` (default changed to `compact`).
- `init_tracing` builds two independent `EnvFilter`s applied via `Layer::with_filter`, so stdout and the rolling file can run at different verbosity levels.
- Stdout layer respects color via `with_ansi(use_color)` computed from `--color` + `std::io::IsTerminal`; file layer is always `with_ansi(false)`.
- `compact` is the new default; `text` and `json` still selectable.

### Slice B — Per-endpoint spans + routing events

- Every adapter (stdio/http/sse/oauth) carries an `endpoint` span with `endpoint=<name> transport=<type> server_type=<after-handshake>`.
- All four `McpAdapter` trait methods on each adapter wrap their body in `.instrument(self.span.clone()).await`.
- `registry::route_tool_call` emits an INFO `Routing tool call` event with `tool` / `endpoint` / `prefixed` fields.
- The unified `/mcp` dispatcher and the three direct-route logged handlers (`mcp_initialize_logged`, `mcp_tools_list_logged`, `mcp_tools_call_logged`) wrap dispatch in a `request` span carrying `method` and `id`.
- `StdioConfig` gains an explicit `endpoint_name`; integration tests updated accordingly.

### Slice C — Structured tool-call tracing events

- HTTP/SSE `call_tool` emit `tracing::info!`/`warn!` in parallel to the existing activity-log writes with fields `tool`, `status` (`ok` / `error`), `duration_ms`, and `error` on failure.
- STDIO `call_tool` (which had no ring-buffer write) emits the same event with `Instant`-timed duration.
- Events inherit `endpoint` / `transport` / `server_type` from the Slice B adapter span and the `request` span automatically.

### Slice D — OAuth top-level endpoint span

- `OAuthAdapterInner` gains a `span` field built in `OAuthAdapter::new` with `endpoint{endpoint, transport="oauth", server_type=Empty}`.
- All four `McpAdapter` trait methods on `OAuthAdapter` wrap their body in `.instrument(self.inner.span.clone()).await`.
- The proactive-refresh `tokio::spawn` and the `heartbeat::heartbeat_loop` spawn instrument their futures with the inner span, so transitions / refresh / heartbeat / persist events all inherit the span chain.
- `apply_tokens_inner` records `server_type` on the span via `span.record(...)` after the inner adapter initializes successfully.

## Sample output

Against a stdio echo server (compact format, color on):

```
INFO endpoint{endpoint=verify-echo transport="stdio"}: ::adapter::stdio: MCP server process spawned
INFO endpoint{endpoint=verify-echo transport="stdio" server_type=echo}: ::adapter::stdio: MCP initialize handshake complete
INFO request{method=tools/call id=3}: ::registry: Routing tool call tool=echo endpoint=verify-echo prefixed=echo
INFO request{method=tools/call id=3}: ::server: MCP request method=tools/call elapsed_ms=21
```

## Verification

Run from `packages/relay`:

- `cargo fmt --check` → ✅
- `cargo clippy --all-targets -- -D warnings` → ✅ (no warnings)
- `cargo test --all-targets` → ✅ (606 lib unit tests + every integration suite, including 11/11 `oauth_integration`, 7/7 `tool_call_integration`, 6/6 `tool_listing_integration`, 4/4 `sse_adapter_integration`, 2/2 `stdio_integration`; 0 failures)
- `endara-relay start --help` shows the three new flags with the documented defaults.

## Out of scope / non-goals

- Desktop changes — none.
- Management-API changes — none.
- Activity ring buffer behavior — unchanged (still feeds the desktop UI).
- New CLI subcommands — none.

## Follow-ups (not blocking this PR)

- Cosmetic dedupe: the stdio handshake log shows `server_type` once from the span record and once as an explicit field. Harmless; easy cleanup pass.
- Optional `tracing_test` / `with_test_writer` unit test asserting the tool-call event is emitted with the expected fields and span — not required by the acceptance criteria for this overhaul.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author