### PR TITLE
feat(advertise): always advertise all registered server types regardless of health

### DIFF
--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -438,6 +438,11 @@ impl McpAdapter for HttpAdapter {
             .and_then(|g| g.clone())
     }
 
+    fn configured_server_type(&self) -> Option<String> {
+        effective_server_type(self.config.server_type_override.clone(), None)
+            .map(|s| s.to_lowercase())
+    }
+
     async fn shutdown(&mut self) -> Result<(), AdapterError> {
         *self.health.write().await = HealthStatus::Stopped;
         info!(url = %self.config.url, "HTTP MCP adapter shut down");

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -141,6 +141,14 @@ pub trait McpAdapter: Send + Sync {
         None
     }
 
+    /// Returns the configured `server_type_override` (sanitized through the
+    /// existing `effective_server_type` resolver with `None` for the upstream
+    /// value), or `None` if no override is configured. Used by the registry to
+    /// advertise endpoints before their first successful `initialize` handshake.
+    fn configured_server_type(&self) -> Option<String> {
+        None
+    }
+
     /// Subscribe to MCP `notifications/tools/list_changed` ticks emitted by the
     /// underlying server. Each `recv()` represents at least one change
     /// notification observed since the previous receive; the registry treats
@@ -162,12 +170,28 @@ pub trait McpAdapter: Send + Sync {
 /// `initialize()` on the real adapter again (handled by the restart endpoint).
 pub struct FailedAdapter {
     error_message: String,
+    /// Sanitized `server_type_override` carried over from the originating
+    /// `EndpointConfig`. Surfaced via [`McpAdapter::configured_server_type`]
+    /// so endpoints with a configured override still appear in the
+    /// advertisement list when their real adapter fails to initialize.
+    server_type_override: Option<String>,
 }
 
 impl FailedAdapter {
     /// Create a new failed adapter with the error message from initialization.
     pub fn new(error_message: String) -> Self {
-        Self { error_message }
+        Self {
+            error_message,
+            server_type_override: None,
+        }
+    }
+
+    /// Attach the originating endpoint's `server_type_override` so this
+    /// failed adapter still advertises its configured type via
+    /// [`McpAdapter::configured_server_type`].
+    pub fn with_server_type_override(mut self, override_field: Option<String>) -> Self {
+        self.server_type_override = override_field;
+        self
     }
 }
 
@@ -195,6 +219,14 @@ impl McpAdapter for FailedAdapter {
 
     fn health(&self) -> HealthStatus {
         HealthStatus::Unhealthy(self.error_message.clone())
+    }
+
+    fn configured_server_type(&self) -> Option<String> {
+        crate::adapter::server_type_resolution::effective_server_type(
+            self.server_type_override.clone(),
+            None,
+        )
+        .map(|s| s.to_lowercase())
     }
 
     async fn stderr_lines(&self) -> Vec<String> {

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -267,3 +267,28 @@ impl McpAdapter for StartingAdapter {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A validation-failed endpoint registered as a `FailedAdapter` should
+    /// still surface its configured `server_type_override` via
+    /// [`McpAdapter::configured_server_type`], mirroring the bootstrap path in
+    /// `main.rs` and the runtime path in `watcher.rs`.
+    #[test]
+    fn failed_adapter_surfaces_server_type_override() {
+        let adapter = FailedAdapter::new("validation failed".to_string())
+            .with_server_type_override(Some("Broken".to_string()));
+        assert_eq!(adapter.configured_server_type(), Some("broken".to_string()));
+    }
+
+    /// Without an override, `configured_server_type` returns `None` so the
+    /// endpoint is omitted from the advertisement list until it transitions
+    /// to a real adapter that knows its server type.
+    #[test]
+    fn failed_adapter_without_override_returns_none() {
+        let adapter = FailedAdapter::new("validation failed".to_string());
+        assert_eq!(adapter.configured_server_type(), None);
+    }
+}

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -7,6 +7,7 @@ pub use state::{derive_health, do_transition, refresh_deadline, OAuthState, Tran
 
 use self::metrics::{generate_correlation_id, OAuthMetrics};
 use super::http::{HttpAdapter, HttpConfig};
+use super::server_type_resolution::effective_server_type;
 use super::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
 use crate::oauth::OAuthError;
 use crate::token_manager::{TokenManager, TokenSet};
@@ -833,6 +834,11 @@ impl McpAdapter for OAuthAdapter {
             .try_read()
             .ok()
             .and_then(|g| g.as_ref().and_then(|a| a.upstream_server_name()))
+    }
+
+    fn configured_server_type(&self) -> Option<String> {
+        effective_server_type(self.inner.config.server_type_override.clone(), None)
+            .map(|s| s.to_lowercase())
     }
 
     async fn shutdown(&mut self) -> Result<(), AdapterError> {

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -698,6 +698,11 @@ impl McpAdapter for SseAdapter {
             .and_then(|g| g.clone())
     }
 
+    fn configured_server_type(&self) -> Option<String> {
+        effective_server_type(self.config.server_type_override.clone(), None)
+            .map(|s| s.to_lowercase())
+    }
+
     fn subscribe_tools_changed(&self) -> Option<broadcast::Receiver<()>> {
         Some(self.tools_changed_tx.subscribe())
     }

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -494,6 +494,11 @@ impl McpAdapter for StdioAdapter {
             .and_then(|g| g.clone())
     }
 
+    fn configured_server_type(&self) -> Option<String> {
+        effective_server_type(self.config.server_type_override.clone(), None)
+            .map(|s| s.to_lowercase())
+    }
+
     fn subscribe_tools_changed(&self) -> Option<broadcast::Receiver<()>> {
         Some(self.tools_changed_tx.subscribe())
     }

--- a/src/advertise.rs
+++ b/src/advertise.rs
@@ -1,13 +1,19 @@
 //! Server-type advertisement to connected models.
 //!
-//! Renders a deduplicated, alphabetised list of `server_type` values from
-//! adapters currently in [`HealthStatus::Healthy`][crate::adapter::HealthStatus::Healthy]
-//! state, and provides description builders for the meta-tools (`list_tools`,
+//! Renders a deduplicated, alphabetised list of `server_type` values across
+//! **all** currently-registered adapters (regardless of [`HealthStatus`]) and
+//! provides description builders for the meta-tools (`list_tools`,
 //! `search_tools`, `execute_tools`) so each `tools/list` response reflects the
 //! current registry. The same list also feeds `InitializeResult.instructions`.
+//! Each adapter's rendered `server_type` is sourced from the cached upstream
+//! handshake value when available and falls back to the configured
+//! `server_type_override`, so endpoints surface immediately even before their
+//! first successful `initialize`.
 //!
 //! See `Engineering Spec — Advertise Connected Servers to the Model` (§3) for
 //! the full design.
+//!
+//! [`HealthStatus`]: crate::adapter::HealthStatus
 
 use crate::registry::AdapterRegistry;
 
@@ -72,12 +78,13 @@ impl<'a> ServerTypeList<'a> {
         Self { registry }
     }
 
-    /// Returns `Some("a, b, c")` if at least one Healthy adapter has a
-    /// `server_type`; `None` otherwise. The list is enforced under the
+    /// Returns `Some("a, b, c")` if at least one registered adapter has a
+    /// rendered `server_type` (cached upstream value or configured
+    /// override); `None` otherwise. The list is enforced under the
     /// 8KB safety cap; trailing entries are dropped and a `, …` suffix
     /// appended if the cap is exceeded.
     pub async fn render(&self) -> Option<String> {
-        let types = self.registry.ready_server_types().await;
+        let types = self.registry.all_server_types().await;
         if types.is_empty() {
             return None;
         }
@@ -109,9 +116,10 @@ impl<'a> ServerTypeList<'a> {
         Some(out)
     }
 
-    /// Number of `Healthy` adapter instances (NOT deduplicated by type).
+    /// Number of registered adapter instances regardless of health (NOT
+    /// deduplicated by type).
     pub async fn endpoint_count(&self) -> usize {
-        self.registry.ready_endpoint_count().await
+        self.registry.all_endpoint_count().await
     }
 }
 
@@ -121,20 +129,30 @@ impl<'a> ServerTypeList<'a> {
 pub const INSTRUCTIONS_LEAD_IN: &str =
     "Endara Relay aggregates MCP servers behind a single endpoint.";
 
-/// Build the `InitializeResult.instructions` string. Returns `None` when no
-/// adapter is currently `Healthy` with a `server_type`, so the field is
-/// omitted from the response (per spec §2.1).
+/// Build the `InitializeResult.instructions` string.
+///
+/// - Returns `Some("{LEAD_IN}\n\nConnected server types: {list}")` whenever
+///   the rendered list is non-empty.
+/// - Returns `Some("{LEAD_IN}")` (just the lead-in, no `Connected server
+///   types:` line) when the registry has at least one registered adapter but
+///   no rendered server types.
+/// - Returns `None` when the registry has zero registered adapters so the
+///   field is omitted from the response.
 pub async fn instructions(registry: &AdapterRegistry) -> Option<String> {
-    ServerTypeList::new(registry).render().await.map(|list| {
-        format!(
+    let list = ServerTypeList::new(registry).render().await;
+    let count = registry.all_endpoint_count().await;
+    match (list, count) {
+        (Some(list), _) => Some(format!(
             "{}\n\nConnected server types: {}",
             INSTRUCTIONS_LEAD_IN, list
-        )
-    })
+        )),
+        (None, 0) => None,
+        (None, _) => Some(INSTRUCTIONS_LEAD_IN.to_string()),
+    }
 }
 
 /// Build the `search_tools` description. Appends `\n\nConnected server types: {list}`
-/// when the registry has at least one Healthy adapter with a `server_type`.
+/// when at least one registered adapter has a rendered `server_type`.
 pub async fn search_tools_description(registry: &AdapterRegistry) -> String {
     match ServerTypeList::new(registry).render().await {
         Some(list) => format!("{}\n\nConnected server types: {}", SEARCH_TOOLS_BASE, list),
@@ -143,7 +161,7 @@ pub async fn search_tools_description(registry: &AdapterRegistry) -> String {
 }
 
 /// Build the `list_tools` description. Appends `" {count} servers connected …"`
-/// when at least one adapter is `Healthy`.
+/// when the registry has at least one registered adapter.
 pub async fn list_tools_description(registry: &AdapterRegistry) -> String {
     let count = ServerTypeList::new(registry).endpoint_count().await;
     if count > 0 {
@@ -177,11 +195,13 @@ mod tests {
     use async_trait::async_trait;
     use serde_json::Value;
 
-    /// Minimal mock adapter — `health` and `server_type` are configurable; the
-    /// rest is stubbed. Mirrors the pattern in `registry::tests::MockAdapter`.
+    /// Minimal mock adapter — `health`, `server_type`, and
+    /// `configured_server_type` are independently configurable; the rest is
+    /// stubbed. Mirrors the pattern in `registry::tests::MockAdapter`.
     struct MockAdapter {
         health: HealthStatus,
         server_type_val: Option<String>,
+        configured_val: Option<String>,
     }
 
     impl MockAdapter {
@@ -189,6 +209,7 @@ mod tests {
             Self {
                 health: HealthStatus::Healthy,
                 server_type_val: Some(server_type.to_string()),
+                configured_val: None,
             }
         }
 
@@ -196,6 +217,7 @@ mod tests {
             Self {
                 health: HealthStatus::Healthy,
                 server_type_val: None,
+                configured_val: None,
             }
         }
 
@@ -203,6 +225,7 @@ mod tests {
             Self {
                 health: HealthStatus::Unhealthy("test".into()),
                 server_type_val: Some("gmail".into()),
+                configured_val: None,
             }
         }
 
@@ -210,6 +233,29 @@ mod tests {
             Self {
                 health: HealthStatus::Starting,
                 server_type_val: Some("gmail".into()),
+                configured_val: None,
+            }
+        }
+
+        /// `Starting` adapter that has not yet captured an upstream
+        /// `serverInfo.name` but does carry a `server_type_override` — used
+        /// to exercise the override-only render path.
+        fn starting_with_override(override_val: &str) -> Self {
+            Self {
+                health: HealthStatus::Starting,
+                server_type_val: None,
+                configured_val: Some(override_val.to_string()),
+            }
+        }
+
+        /// Adapter with neither an upstream-captured `server_type` nor a
+        /// configured override — exercises the "registered but renders
+        /// nothing" path that drops the `Connected server types:` sub-line.
+        fn starting_no_type() -> Self {
+            Self {
+                health: HealthStatus::Starting,
+                server_type_val: None,
+                configured_val: None,
             }
         }
     }
@@ -231,6 +277,9 @@ mod tests {
         fn server_type(&self) -> Option<String> {
             self.server_type_val.clone()
         }
+        fn configured_server_type(&self) -> Option<String> {
+            self.configured_val.clone()
+        }
         async fn shutdown(&mut self) -> Result<(), AdapterError> {
             Ok(())
         }
@@ -248,19 +297,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn render_returns_none_when_no_healthy_adapters() {
+    async fn render_returns_none_when_registry_empty() {
         let reg = AdapterRegistry::new();
         assert!(ServerTypeList::new(&reg).render().await.is_none());
         assert_eq!(ServerTypeList::new(&reg).endpoint_count().await, 0);
     }
 
     #[tokio::test]
-    async fn render_returns_none_when_only_failed_or_starting() {
+    async fn render_includes_failed_and_starting_adapters_with_known_types() {
         let reg = AdapterRegistry::new();
         register(&reg, "a", MockAdapter::failed()).await;
         register(&reg, "b", MockAdapter::starting()).await;
-        assert!(ServerTypeList::new(&reg).render().await.is_none());
-        assert_eq!(ServerTypeList::new(&reg).endpoint_count().await, 0);
+        // Both adapters have server_type = "gmail" → deduped to a single entry.
+        let list = ServerTypeList::new(&reg).render().await.unwrap();
+        assert_eq!(list, "gmail");
+        // endpoint_count covers all registered adapters regardless of health.
+        assert_eq!(ServerTypeList::new(&reg).endpoint_count().await, 2);
     }
 
     #[tokio::test]
@@ -291,19 +343,62 @@ mod tests {
         register(&reg, "ep2", MockAdapter::ready_no_type()).await;
         let list = ServerTypeList::new(&reg).render().await.unwrap();
         assert_eq!(list, "notion");
-        // endpoint_count counts all Healthy adapters regardless of server_type.
+        // endpoint_count counts all registered adapters regardless of server_type.
         assert_eq!(ServerTypeList::new(&reg).endpoint_count().await, 2);
     }
 
     #[tokio::test]
-    async fn render_excludes_unhealthy_adapters() {
+    async fn render_includes_unhealthy_adapters_in_list_and_count() {
         let reg = AdapterRegistry::new();
         register(&reg, "ep1", MockAdapter::ready("notion")).await;
         register(&reg, "ep2", MockAdapter::failed()).await;
         register(&reg, "ep3", MockAdapter::starting()).await;
         let list = ServerTypeList::new(&reg).render().await.unwrap();
-        assert_eq!(list, "notion");
+        // Failed and Starting both carry server_type = "gmail" → deduped.
+        assert_eq!(list, "gmail, notion");
+        // endpoint_count includes the non-Healthy adapters.
+        assert_eq!(ServerTypeList::new(&reg).endpoint_count().await, 3);
+    }
+
+    /// New scenario: a `Failed` adapter that still has a cached upstream
+    /// `server_type` from an earlier successful handshake is included.
+    #[tokio::test]
+    async fn render_includes_failed_adapter_with_cached_server_type() {
+        let reg = AdapterRegistry::new();
+        register(&reg, "ep-healthy", MockAdapter::ready("notion")).await;
+        // `MockAdapter::failed()` carries `server_type_val = Some("gmail")`,
+        // matching an adapter that handshook successfully and later flipped to
+        // Unhealthy without losing its cached upstream name.
+        register(&reg, "ep-failed", MockAdapter::failed()).await;
+        let list = ServerTypeList::new(&reg).render().await.unwrap();
+        assert_eq!(list, "gmail, notion");
+    }
+
+    /// New scenario: a `Starting` adapter with no upstream value yet but with
+    /// a configured `server_type_override` renders via the override.
+    #[tokio::test]
+    async fn render_includes_starting_adapter_via_configured_override() {
+        let reg = AdapterRegistry::new();
+        register(
+            &reg,
+            "ep-pending",
+            MockAdapter::starting_with_override("gmail"),
+        )
+        .await;
+        let list = ServerTypeList::new(&reg).render().await.unwrap();
+        assert_eq!(list, "gmail");
         assert_eq!(ServerTypeList::new(&reg).endpoint_count().await, 1);
+    }
+
+    /// New scenario: the endpoint count includes non-Healthy adapters.
+    #[tokio::test]
+    async fn endpoint_count_includes_non_healthy_adapters() {
+        let reg = AdapterRegistry::new();
+        register(&reg, "ep1", MockAdapter::ready("notion")).await;
+        register(&reg, "ep2", MockAdapter::failed()).await;
+        register(&reg, "ep3", MockAdapter::starting()).await;
+        register(&reg, "ep4", MockAdapter::ready_no_type()).await;
+        assert_eq!(ServerTypeList::new(&reg).endpoint_count().await, 4);
     }
 
     #[tokio::test]
@@ -384,6 +479,40 @@ mod tests {
             desc.ends_with(" 2 servers connected via Endara Relay \u{2014} use search_tools to discover tools."),
             "unexpected suffix: {}",
             &desc[desc.len().saturating_sub(120)..]
+        );
+    }
+
+    #[tokio::test]
+    async fn instructions_none_when_registry_empty() {
+        let reg = AdapterRegistry::new();
+        assert!(instructions(&reg).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn instructions_lead_in_only_when_registered_but_no_types_render() {
+        let reg = AdapterRegistry::new();
+        // Registered adapter with neither an upstream type nor an override.
+        register(&reg, "ep1", MockAdapter::starting_no_type()).await;
+        let s = instructions(&reg).await.expect("instructions present");
+        assert_eq!(s, INSTRUCTIONS_LEAD_IN);
+        assert!(
+            !s.contains("Connected server types:"),
+            "no list expected when nothing renders: {s}"
+        );
+    }
+
+    #[tokio::test]
+    async fn instructions_full_form_when_types_render() {
+        let reg = AdapterRegistry::new();
+        register(&reg, "ep1", MockAdapter::ready("github")).await;
+        register(&reg, "ep2", MockAdapter::ready("gmail")).await;
+        let s = instructions(&reg).await.expect("instructions present");
+        assert_eq!(
+            s,
+            format!(
+                "{}\n\nConnected server types: github, gmail",
+                INSTRUCTIONS_LEAD_IN
+            )
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,7 +275,10 @@ async fn main() {
                 if warned_names.contains(&ep.name) {
                     let msg = warning_messages.get(&ep.name).cloned().unwrap_or_default();
                     warn!(endpoint = %ep.name, "Registering as failed due to validation error: {}", msg);
-                    let adapter: Box<dyn McpAdapter> = Box::new(FailedAdapter::new(msg));
+                    let adapter: Box<dyn McpAdapter> = Box::new(
+                        FailedAdapter::new(msg)
+                            .with_server_type_override(ep.server_type_override.clone()),
+                    );
                     registry
                         .register(
                             ep.name.clone(),

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -297,6 +297,7 @@ impl AdapterRegistry {
     /// [`BTreeSet`] so the output is sorted. Adapters whose `server_type()`
     /// returns `None` (not yet initialized or transport that does not record
     /// it) are skipped.
+    #[allow(dead_code)] // Superseded by `all_server_types`; kept for potential future Healthy-only callers.
     pub async fn ready_server_types(&self) -> BTreeSet<String> {
         let adapters = self.adapters.read().await;
         adapters
@@ -309,12 +310,44 @@ impl AdapterRegistry {
 
     /// Number of currently `Healthy` adapter instances (NOT deduplicated by
     /// server type — three Gmail accounts count as three).
+    #[allow(dead_code)] // Superseded by `all_endpoint_count`; kept for potential future Healthy-only callers.
     pub async fn ready_endpoint_count(&self) -> usize {
         let adapters = self.adapters.read().await;
         adapters
             .values()
             .filter(|entry| matches!(entry.adapter.health(), HealthStatus::Healthy))
             .count()
+    }
+
+    /// Deduplicated, lower-cased server types across **all** registered
+    /// adapters regardless of health.
+    ///
+    /// For each adapter, prefers the cached upstream-derived `server_type()`
+    /// (populated after a successful `initialize` handshake) and falls back
+    /// to [`McpAdapter::configured_server_type`] (the sanitized
+    /// `server_type_override`) so endpoints with a configured override
+    /// surface immediately, before they ever transition to Healthy.
+    /// Adapters with neither value are skipped.
+    pub async fn all_server_types(&self) -> BTreeSet<String> {
+        let adapters = self.adapters.read().await;
+        adapters
+            .values()
+            .filter_map(|entry| {
+                entry
+                    .adapter
+                    .server_type()
+                    .or_else(|| entry.adapter.configured_server_type())
+            })
+            .map(|s| s.to_lowercase())
+            .collect()
+    }
+
+    /// Total number of registered adapter instances regardless of health
+    /// (NOT deduplicated by server type — three Gmail accounts count as
+    /// three).
+    pub async fn all_endpoint_count(&self) -> usize {
+        let adapters = self.adapters.read().await;
+        adapters.len()
     }
 
     /// Access the underlying adapters map (for management API use).

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -349,7 +349,10 @@ pub async fn apply_diff_graceful(
             registry
                 .register(
                     name.clone(),
-                    Box::new(FailedAdapter::new(msg)),
+                    Box::new(
+                        FailedAdapter::new(msg)
+                            .with_server_type_override(new_ep.server_type_override.clone()),
+                    ),
                     new_ep.transport.to_string(),
                     new_ep.description.clone(),
                     new_ep.resolved_tool_prefix(),
@@ -415,7 +418,10 @@ pub async fn apply_diff_graceful(
             registry
                 .register(
                     ep.name.clone(),
-                    Box::new(FailedAdapter::new(msg)),
+                    Box::new(
+                        FailedAdapter::new(msg)
+                            .with_server_type_override(ep.server_type_override.clone()),
+                    ),
                     ep.transport.to_string(),
                     ep.description.clone(),
                     ep.resolved_tool_prefix(),
@@ -541,7 +547,10 @@ pub(crate) async fn create_adapter(
                 Ok(()) => Box::new(adapter),
                 Err(e) => {
                     warn!(endpoint = %ep.name, error = %e, "Failed to initialize stdio adapter, registering as failed");
-                    Box::new(FailedAdapter::new(e.to_string()))
+                    Box::new(
+                        FailedAdapter::new(e.to_string())
+                            .with_server_type_override(ep.server_type_override.clone()),
+                    )
                 }
             }
         }
@@ -555,7 +564,10 @@ pub(crate) async fn create_adapter(
                 Ok(()) => Box::new(adapter),
                 Err(e) => {
                     warn!(endpoint = %ep.name, error = %e, "Failed to initialize SSE adapter, registering as failed");
-                    Box::new(FailedAdapter::new(e.to_string()))
+                    Box::new(
+                        FailedAdapter::new(e.to_string())
+                            .with_server_type_override(ep.server_type_override.clone()),
+                    )
                 }
             }
         }
@@ -569,7 +581,10 @@ pub(crate) async fn create_adapter(
                 Ok(()) => Box::new(adapter),
                 Err(e) => {
                     warn!(endpoint = %ep.name, error = %e, "Failed to initialize HTTP adapter, registering as failed");
-                    Box::new(FailedAdapter::new(e.to_string()))
+                    Box::new(
+                        FailedAdapter::new(e.to_string())
+                            .with_server_type_override(ep.server_type_override.clone()),
+                    )
                 }
             }
         }

--- a/tests/advertise.rs
+++ b/tests/advertise.rs
@@ -2,9 +2,12 @@
 //!
 //! Verifies that:
 //!   * `InitializeResult.instructions` is present with `Connected server types: …`
-//!     when at least one adapter is `Healthy`, and omitted otherwise.
+//!     when at least one registered adapter has a rendered `server_type`,
+//!     present as just the lead-in when adapters are registered but none have
+//!     a rendered type, and omitted entirely when no adapters are registered.
 //!   * The dynamic descriptions for `list_tools`, `search_tools`, and
-//!     `execute_tools` reflect the currently-Healthy server set.
+//!     `execute_tools` reflect **all** registered adapters (not only the
+//!     `Healthy` ones).
 
 mod common;
 
@@ -92,11 +95,44 @@ fn meta_tool_description<'a>(tools: &'a [Value], name: &str) -> &'a str {
         .unwrap_or_else(|| panic!("'{}' description was not a string", name))
 }
 
-/// 1 — instructions field is omitted entirely when no adapters are Healthy.
+/// 1a — instructions field is omitted entirely when **no adapters at all**
+///       are registered in the relay config.
 #[tokio::test]
-async fn instructions_omitted_when_no_healthy_servers() {
-    // bad-server with `--omit-server-name` enters Failed → registry has zero
-    // Healthy adapters → no instructions field, no `Connected server types:` suffix.
+async fn instructions_omitted_when_no_endpoints_configured() {
+    // No endpoints in config → registry is empty → no instructions field, no
+    // `Connected server types:` suffix, and no count on list_tools.
+    let config = ConfigBuilder::new().build();
+    let harness = RelayHarness::start(&config).await;
+
+    let init = raw_initialize(&harness).await;
+    let result = &init["result"];
+    assert!(
+        result.get("instructions").is_none(),
+        "instructions should be omitted with zero registered adapters; got: {}",
+        result
+    );
+
+    let tools = raw_tools_list(&harness).await;
+    let list_desc = meta_tool_description(&tools, "list_tools");
+    assert!(
+        !list_desc.contains("servers connected"),
+        "list_tools must not advertise connected servers when none are registered: {list_desc}"
+    );
+    let search_desc = meta_tool_description(&tools, "search_tools");
+    assert!(
+        !search_desc.contains("Connected server types:"),
+        "search_tools must not append Connected server types list when none are registered: {search_desc}"
+    );
+}
+
+/// 1b — instructions field carries only the lead-in (no `Connected server
+///       types:` sub-line) when a registered adapter exists but neither
+///       handshook successfully nor carries a `server_type_override`.
+#[tokio::test]
+async fn instructions_lead_in_only_when_registered_adapter_has_no_renderable_type() {
+    // `bad-server --omit-server-name` enters Failed without capturing
+    // `serverInfo.name`; without a `server_type_override` it renders nothing,
+    // but the endpoint is still registered → lead-in present, list omitted.
     let config = ConfigBuilder::new()
         .add_stdio("bad-server", &bad_server_bin(), &["--omit-server-name"])
         .build();
@@ -107,22 +143,26 @@ async fn instructions_omitted_when_no_healthy_servers() {
 
     let init = raw_initialize(&harness).await;
     let result = &init["result"];
-    assert!(
-        result.get("instructions").is_none(),
-        "instructions should be omitted with zero Healthy adapters; got: {}",
-        result
+    let instructions = result["instructions"]
+        .as_str()
+        .expect("instructions should be present once an adapter is registered");
+    assert_eq!(
+        instructions, INSTRUCTIONS_LEAD_IN,
+        "instructions should be lead-in only when no server_type renders: {instructions}"
     );
 
     let tools = raw_tools_list(&harness).await;
     let list_desc = meta_tool_description(&tools, "list_tools");
     assert!(
-        !list_desc.contains("servers connected"),
-        "list_tools must not advertise connected servers when none are Healthy: {list_desc}"
+        list_desc.ends_with(
+            " 1 servers connected via Endara Relay \u{2014} use search_tools to discover tools."
+        ),
+        "list_tools count must include the registered adapter regardless of health: {list_desc}"
     );
     let search_desc = meta_tool_description(&tools, "search_tools");
     assert!(
         !search_desc.contains("Connected server types:"),
-        "search_tools must not append Connected server types list when none are Healthy: {search_desc}"
+        "search_tools must not append Connected server types list when nothing renders: {search_desc}"
     );
 }
 
@@ -167,21 +207,26 @@ async fn instructions_and_descriptions_reflect_healthy_server() {
     );
 }
 
-/// 3 — Failed adapters are excluded from the advertised list even when sitting
-///     alongside a Healthy one. Two adapters: one good (`good-server`,
-///     reports `bad-mcp` which is stripped to `bad`) and one Failed
-///     (`broken-server`).
+/// 3 — Failed adapters with a configured `server_type_override` are now
+///     **included** in the advertised list alongside Healthy ones, and the
+///     endpoint count covers all registered adapters regardless of health.
+///     Two adapters: one good (`good-server`, reports `bad-mcp` which is
+///     stripped to `bad`) and one Failed with override (`broken-server` with
+///     `server_type_override = "broken"`).
 #[tokio::test]
-async fn failed_adapters_are_not_advertised() {
+async fn failed_adapter_with_override_included_in_advertised_list() {
     let config = ConfigBuilder::new()
         .add_stdio("good-server", &bad_server_bin(), &[])
         .add_stdio("broken-server", &bad_server_bin(), &["--omit-server-name"])
+        .with_server_type_override("broken")
         .build();
     let harness = RelayHarness::start(&config).await;
     harness
         .wait_healthy("good-server", Duration::from_secs(10))
         .await
         .expect("good-server did not become healthy");
+    // Give broken-server a moment to attempt initialize and transition to Failed.
+    tokio::time::sleep(Duration::from_millis(500)).await;
 
     let init = raw_initialize(&harness).await;
     let instructions = init["result"]["instructions"]
@@ -189,18 +234,26 @@ async fn failed_adapters_are_not_advertised() {
         .expect("instructions should be present");
     assert_eq!(
         instructions,
-        format!("{}\n\nConnected server types: bad", INSTRUCTIONS_LEAD_IN),
-        "Failed adapter should be excluded; got: {instructions}"
+        format!(
+            "{}\n\nConnected server types: bad, broken",
+            INSTRUCTIONS_LEAD_IN
+        ),
+        "Failed adapter with override should now be included; got: {instructions}"
     );
 
     let tools = raw_tools_list(&harness).await;
     let list_desc = meta_tool_description(&tools, "list_tools");
-    // endpoint_count counts Healthy adapters only → 1, not 2.
+    // endpoint_count covers all registered adapters regardless of health → 2.
     assert!(
         list_desc.ends_with(
-            " 1 servers connected via Endara Relay \u{2014} use search_tools to discover tools."
+            " 2 servers connected via Endara Relay \u{2014} use search_tools to discover tools."
         ),
-        "list_tools count must exclude Failed adapter: {list_desc}"
+        "list_tools count must include the Failed adapter: {list_desc}"
+    );
+    let search_desc = meta_tool_description(&tools, "search_tools");
+    assert!(
+        search_desc.ends_with("\n\nConnected server types: bad, broken"),
+        "search_tools description must include the Failed adapter's override: {search_desc}"
     );
 }
 

--- a/tests/common/config.rs
+++ b/tests/common/config.rs
@@ -12,6 +12,7 @@ struct EndpointEntry {
     oauth_server_url: Option<String>,
     client_id: Option<String>,
     env: Vec<(String, String)>,
+    server_type_override: Option<String>,
 }
 
 /// Builder for generating relay TOML config strings.
@@ -39,6 +40,7 @@ impl ConfigBuilder {
             oauth_server_url: None,
             client_id: None,
             env: Vec::new(),
+            server_type_override: None,
         });
         self
     }
@@ -63,6 +65,7 @@ impl ConfigBuilder {
                 .iter()
                 .map(|(k, v)| (k.to_string(), v.to_string()))
                 .collect(),
+            server_type_override: None,
         });
         self
     }
@@ -78,6 +81,7 @@ impl ConfigBuilder {
             oauth_server_url: None,
             client_id: None,
             env: Vec::new(),
+            server_type_override: None,
         });
         self
     }
@@ -93,6 +97,7 @@ impl ConfigBuilder {
             oauth_server_url: None,
             client_id: None,
             env: Vec::new(),
+            server_type_override: None,
         });
         self
     }
@@ -108,6 +113,7 @@ impl ConfigBuilder {
             oauth_server_url: oauth_server_url.map(|s| s.to_string()),
             client_id: None,
             env: Vec::new(),
+            server_type_override: None,
         });
         self
     }
@@ -129,7 +135,18 @@ impl ConfigBuilder {
             oauth_server_url: oauth_server_url.map(|s| s.to_string()),
             client_id: Some(client_id.to_string()),
             env: Vec::new(),
+            server_type_override: None,
         });
+        self
+    }
+
+    /// Attach a `server_type_override` to the most recently added endpoint.
+    pub fn with_server_type_override(mut self, server_type: &str) -> Self {
+        let last = self
+            .endpoints
+            .last_mut()
+            .expect("with_server_type_override called before any add_* method");
+        last.server_type_override = Some(server_type.to_string());
         self
     }
 
@@ -172,6 +189,9 @@ impl ConfigBuilder {
             }
             if let Some(ref cid) = ep.client_id {
                 out.push_str(&format!("client_id = \"{}\"\n", cid));
+            }
+            if let Some(ref ov) = ep.server_type_override {
+                out.push_str(&format!("server_type_override = \"{}\"\n", ov));
             }
             if !ep.env.is_empty() {
                 out.push_str("env = { ");


### PR DESCRIPTION
## Why

The relay advertises connected `server_type` values to MCP clients in three places: the `search_tools` description, `InitializeResult.instructions`, and the `N servers connected` count in `list_tools` / `execute_tools`. All three were filtered on `HealthStatus::Healthy`.

Most MCP clients (e.g. Claude) cache tool descriptions and don't refresh them on every call. A momentary blip that flips a server to `Failed` or `Starting` would silently drop it from the model's view until the client next pulls `tools/list`. Models would then have no signal that the server even exists, and might stop trying to use it.

## What

Switch advertisement to include **all currently-registered endpoints**, sourced from either the adapter's cached upstream `server_type` or the configured `server_type_override` — so configured types appear immediately even before the first successful handshake.

- New `McpAdapter::configured_server_type()` trait method (default `None`) implemented by `stdio` / `sse` / `http` / `oauth` via the existing `effective_server_type` resolver.
- New `AdapterRegistry::all_server_types()` and `all_endpoint_count()` that do not filter by `HealthStatus`. `ready_*` are retained and marked `#[allow(dead_code)]` for now.
- `advertise.rs` (`ServerTypeList`, `instructions`, `search_tools_description`, `list_tools_description`, `execute_tools_description`) all switch to the `all_*` variants.
- `InitializeResult.instructions` three-branch rule: full string when the list is non-empty, lead-in only when there's ≥1 registered endpoint but the list renders empty, omitted entirely when zero endpoints are registered.
- `FailedAdapter` (in `watcher.rs`) and the bootstrap-validation `FailedAdapter` site in `main.rs` thread `server_type_override` through, so configured types appear even when an endpoint failed to initialise.

## Tests

- Unit tests added in `src/advertise.rs` for: (a) Failed adapter with cached `server_type` still rendered, (b) Starting/non-Healthy adapter advertised via `configured_server_type` override only, (c) endpoint count includes non-Healthy adapters.
- New `FailedAdapter::configured_server_type` unit tests in `adapter/mod.rs` (with and without override).
- Integration tests in `tests/advertise.rs`: previously-asserted "non-Healthy excluded" assertions were inverted, plus a new test exercising the zero-endpoints `instructions`-omitted path.

## Verification (from `packages/relay`)

- `cargo fmt --check` ✅
- `cargo build` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test --lib`: 614 passed, 0 failed
- `cargo test --test advertise`: 9 passed, 0 failed

## Non-goals

- Changing what tools are returned by `tools/list` (still healthy-only for actual routable tools).
- Changing endpoint health state machine, OAuth flow, or watcher behaviour.
- Desktop or website changes.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author