### PR TITLE
fix(oauth): self-heal token endpoint on refresh-time 404

### DIFF
--- a/src/adapter/oauth/heartbeat.rs
+++ b/src/adapter/oauth/heartbeat.rs
@@ -312,6 +312,7 @@ mod tests {
             probe_timeout_secs: 10,
             probe_failure_threshold: threshold,
             server_type_override: None,
+            allow_insecure_oauth: false,
         }
     }
 

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -9,6 +9,7 @@ use self::metrics::{generate_correlation_id, OAuthMetrics};
 use super::http::{HttpAdapter, HttpConfig};
 use super::server_type_resolution::effective_server_type;
 use super::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
+use crate::oauth::discovery::{discover_oauth_server, DiscoveryResult};
 use crate::oauth::OAuthError;
 use crate::token_manager::{TokenManager, TokenSet};
 use async_trait::async_trait;
@@ -68,6 +69,43 @@ pub struct OAuthAdapterConfig {
     /// Optional override for the advertised `server_type` name. Forwarded to
     /// the inner [`HttpAdapter`] when it is constructed.
     pub server_type_override: Option<String>,
+    /// Permit HTTP and loopback / link-local addresses when running OAuth
+    /// discovery against the resource URL during the refresh-time fallback.
+    /// Mirrors `config.relay.allow_insecure_oauth`; defaults to `false` for
+    /// production callers and is set to `true` only by tests that mock the
+    /// well-known endpoints on `127.0.0.1`.
+    pub allow_insecure_oauth: bool,
+}
+
+/// Outcome of a single POST to the OAuth token endpoint. Returned by
+/// `OAuthAdapterInner::execute_token_post` so the caller can special-case
+/// HTTP 404 (which triggers the discovery fallback) without prematurely
+/// transitioning the adapter state machine.
+#[derive(Debug)]
+enum TokenPostOutcome {
+    Success(TokenSet),
+    NotFound {
+        status: reqwest::StatusCode,
+        body: String,
+    },
+    HttpError {
+        status: reqwest::StatusCode,
+        body: String,
+    },
+    Network(reqwest::Error),
+    InvalidJson(reqwest::Error),
+}
+
+impl TokenPostOutcome {
+    fn short_label(&self) -> &'static str {
+        match self {
+            TokenPostOutcome::Success(_) => "success",
+            TokenPostOutcome::NotFound { .. } => "not_found",
+            TokenPostOutcome::HttpError { .. } => "http_error",
+            TokenPostOutcome::Network(_) => "network",
+            TokenPostOutcome::InvalidJson(_) => "invalid_json",
+        }
+    }
 }
 
 /// Shared inner state for an OAuth adapter, wrapped in `Arc` so it can be
@@ -79,6 +117,13 @@ pub struct OAuthAdapterInner {
     pub tokens: RwLock<Option<TokenSet>>,
     /// Static configuration.
     pub config: OAuthAdapterConfig,
+    /// In-memory override of `config.token_endpoint_url`. Populated when a
+    /// refresh-time RFC 9728 → RFC 8414 rediscovery turns up a different
+    /// token endpoint than the one persisted in `config.toml`, so subsequent
+    /// refreshes skip the discovery round-trip and post directly to the new
+    /// URL. Cleared only on adapter reconstruction; not persisted to disk
+    /// (that is handled separately by the startup-time migration path).
+    token_endpoint_override: RwLock<Option<String>>,
     /// The inner HTTP/SSE adapter that talks to the upstream MCP server.
     inner_adapter: RwLock<Option<HttpAdapter>>,
     /// Token persistence layer.
@@ -167,11 +212,36 @@ impl OAuthAdapterInner {
         );
     }
 
+    /// Resolve the URL that the next token-refresh POST should target.
+    ///
+    /// Returns the in-memory `token_endpoint_override` if a previous refresh
+    /// rediscovered a new endpoint, otherwise the URL persisted in
+    /// `config.token_endpoint_url`. Checked at the top of every refresh
+    /// attempt so that the second and subsequent refreshes after a successful
+    /// rediscovery go straight to the new URL without re-running discovery.
+    pub async fn effective_token_endpoint(&self) -> String {
+        if let Some(url) = self.token_endpoint_override.read().await.clone() {
+            url
+        } else {
+            self.config.token_endpoint_url.clone()
+        }
+    }
+
     /// Perform a token refresh using the refresh_token grant.
     ///
-    /// POSTs to the token endpoint with grant_type=refresh_token.
-    /// On success, calls `apply_tokens_inner` with the new token set.
-    /// On failure, transitions to `AuthRequired`.
+    /// POSTs to the token endpoint (using `effective_token_endpoint`) with
+    /// grant_type=refresh_token. On success, returns the new `TokenSet`. On
+    /// failure, transitions to `AuthRequired` or `ConnectionFailed` to match
+    /// the failure category.
+    ///
+    /// When the POST returns HTTP 404, the adapter runs RFC 9728 → RFC 8414
+    /// discovery against `self.config.url` and, if the rediscovered token
+    /// endpoint differs from the one we just hit, updates the in-memory
+    /// override and retries the POST exactly once. If discovery is not
+    /// feasible (empty `config.url`), discovery fails, returns the same URL,
+    /// or the retry also fails, the original 404 error is returned and the
+    /// adapter transitions to `AuthRequired` (matching the pre-existing
+    /// non-2xx behavior).
     pub async fn do_token_refresh(self: &Arc<Self>) -> Result<TokenSet, OAuthError> {
         // Snapshot the current access token before acquiring the mutex.
         // If it changes while we wait, another concurrent refresh succeeded.
@@ -240,18 +310,38 @@ impl OAuthAdapterInner {
             .extend_pairs(form_parts.iter())
             .finish();
 
-        let resp = match self
-            .http_client
-            .post(&self.config.token_endpoint_url)
-            .header("Content-Type", "application/x-www-form-urlencoded")
-            .body(form_body)
-            .send()
+        let initial_url = self.effective_token_endpoint().await;
+        match self
+            .execute_token_post(&form_body, &initial_url, &correlation_id)
             .await
         {
-            Ok(r) => r,
-            Err(e) => {
-                // Network/timeout error during refresh — leave Refreshing
-                // for ConnectionFailed so the state machine doesn't hang.
+            TokenPostOutcome::Success(token_set) => {
+                self.metrics.inc_refresh_success();
+                info!(
+                    endpoint = %self.config.endpoint_name,
+                    correlation_id = %correlation_id,
+                    "Token refresh successful"
+                );
+                Ok(token_set)
+            }
+            TokenPostOutcome::NotFound { status, body } => {
+                self.handle_refresh_404(&form_body, &initial_url, &correlation_id, status, body)
+                    .await
+            }
+            TokenPostOutcome::HttpError { status, body } => {
+                error!(
+                    endpoint = %self.config.endpoint_name,
+                    correlation_id = %correlation_id,
+                    %status,
+                    body = %body,
+                    "Token refresh failed"
+                );
+                self.metrics.inc_refresh_failure();
+                self.transition_to(OAuthState::AuthRequired, "token refresh failed")
+                    .await;
+                Err(OAuthError::RefreshFailed { status, body })
+            }
+            TokenPostOutcome::Network(e) => {
                 error!(
                     endpoint = %self.config.endpoint_name,
                     correlation_id = %correlation_id,
@@ -261,33 +351,9 @@ impl OAuthAdapterInner {
                 self.metrics.inc_refresh_failure();
                 self.transition_to(OAuthState::ConnectionFailed, "token refresh network error")
                     .await;
-                return Err(OAuthError::Http(e));
+                Err(OAuthError::Http(e))
             }
-        };
-
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            error!(
-                endpoint = %self.config.endpoint_name,
-                correlation_id = %correlation_id,
-                %status,
-                body = %body,
-                "Token refresh failed"
-            );
-            self.metrics.inc_refresh_failure();
-            self.transition_to(OAuthState::AuthRequired, "token refresh failed")
-                .await;
-            return Err(OAuthError::RefreshFailed { status, body });
-        }
-
-        let token_json: serde_json::Value = match resp.json().await {
-            Ok(v) => v,
-            Err(e) => {
-                // Upstream returned 200 but the body is not parseable JSON.
-                // Treat as a transient connection-quality issue (retry may
-                // recover) and leave Refreshing for ConnectionFailed so the
-                // state machine doesn't hang.
+            TokenPostOutcome::InvalidJson(e) => {
                 error!(
                     endpoint = %self.config.endpoint_name,
                     correlation_id = %correlation_id,
@@ -300,8 +366,153 @@ impl OAuthAdapterInner {
                     "token refresh response not JSON",
                 )
                 .await;
-                return Err(OAuthError::Http(e));
+                Err(OAuthError::Http(e))
             }
+        }
+    }
+
+    /// Drive the discovery-and-retry fallback for an HTTP 404 from the token
+    /// POST. Returns the refreshed `TokenSet` if rediscovery yields a new
+    /// endpoint and the retry succeeds; otherwise returns the original
+    /// `RefreshFailed` error (the retry-failure path also transitions to
+    /// `AuthRequired`, matching the pre-existing non-2xx behavior).
+    async fn handle_refresh_404(
+        self: &Arc<Self>,
+        form_body: &str,
+        initial_url: &str,
+        correlation_id: &str,
+        status: reqwest::StatusCode,
+        body: String,
+    ) -> Result<TokenSet, OAuthError> {
+        let original_err = OAuthError::RefreshFailed {
+            status,
+            body: body.clone(),
+        };
+
+        // Discovery is only feasible if we know the resource URL.
+        if self.config.url.is_empty() {
+            warn!(
+                endpoint = %self.config.endpoint_name,
+                correlation_id = %correlation_id,
+                %status,
+                "Token refresh got 404 but resource URL is empty; skipping discovery fallback"
+            );
+            self.metrics.inc_refresh_failure();
+            self.transition_to(OAuthState::AuthRequired, "token refresh failed")
+                .await;
+            return Err(original_err);
+        }
+
+        info!(
+            endpoint = %self.config.endpoint_name,
+            correlation_id = %correlation_id,
+            %status,
+            attempted_url = %initial_url,
+            "Token endpoint returned 404; attempting OAuth discovery fallback"
+        );
+
+        let disc: DiscoveryResult =
+            match discover_oauth_server(&self.config.url, self.config.allow_insecure_oauth).await {
+                Ok(d) => d,
+                Err(e) => {
+                    warn!(
+                        endpoint = %self.config.endpoint_name,
+                        correlation_id = %correlation_id,
+                        error = %e,
+                        "OAuth discovery fallback failed; returning original 404"
+                    );
+                    self.metrics.inc_refresh_failure();
+                    self.transition_to(OAuthState::AuthRequired, "token refresh failed")
+                        .await;
+                    return Err(original_err);
+                }
+            };
+
+        if disc.token_endpoint == initial_url {
+            warn!(
+                endpoint = %self.config.endpoint_name,
+                correlation_id = %correlation_id,
+                token_endpoint = %disc.token_endpoint,
+                "OAuth discovery returned the same token endpoint that just 404'd; not retrying"
+            );
+            self.metrics.inc_refresh_failure();
+            self.transition_to(OAuthState::AuthRequired, "token refresh failed")
+                .await;
+            return Err(original_err);
+        }
+
+        info!(
+            endpoint = %self.config.endpoint_name,
+            correlation_id = %correlation_id,
+            old_token_endpoint = %initial_url,
+            new_token_endpoint = %disc.token_endpoint,
+            "OAuth discovery rediscovered a new token endpoint; retrying refresh once"
+        );
+        *self.token_endpoint_override.write().await = Some(disc.token_endpoint.clone());
+
+        match self
+            .execute_token_post(form_body, &disc.token_endpoint, correlation_id)
+            .await
+        {
+            TokenPostOutcome::Success(token_set) => {
+                self.metrics.inc_refresh_success();
+                info!(
+                    endpoint = %self.config.endpoint_name,
+                    correlation_id = %correlation_id,
+                    "Token refresh successful after rediscovery"
+                );
+                Ok(token_set)
+            }
+            other => {
+                warn!(
+                    endpoint = %self.config.endpoint_name,
+                    correlation_id = %correlation_id,
+                    retry_outcome = ?other.short_label(),
+                    "Token refresh retry after rediscovery failed; returning original 404"
+                );
+                self.metrics.inc_refresh_failure();
+                self.transition_to(OAuthState::AuthRequired, "token refresh failed")
+                    .await;
+                Err(original_err)
+            }
+        }
+    }
+
+    /// Execute a single POST to the token endpoint, returning a structured
+    /// outcome so callers can special-case HTTP 404. State transitions and
+    /// metric updates are intentionally NOT done here — the caller is
+    /// responsible for that so the rediscovery fallback can swallow a 404
+    /// without leaking a `RefreshFailed` transition.
+    async fn execute_token_post(
+        &self,
+        form_body: &str,
+        target_url: &str,
+        _correlation_id: &str,
+    ) -> TokenPostOutcome {
+        let resp = match self
+            .http_client
+            .post(target_url)
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .body(form_body.to_string())
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => return TokenPostOutcome::Network(e),
+        };
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            if status == reqwest::StatusCode::NOT_FOUND {
+                return TokenPostOutcome::NotFound { status, body };
+            }
+            return TokenPostOutcome::HttpError { status, body };
+        }
+
+        let token_json: serde_json::Value = match resp.json().await {
+            Ok(v) => v,
+            Err(e) => return TokenPostOutcome::InvalidJson(e),
         };
         let now_secs = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -335,13 +546,7 @@ impl OAuthAdapterInner {
             issued_at: Some(now_secs),
         };
 
-        self.metrics.inc_refresh_success();
-        info!(
-            endpoint = %self.config.endpoint_name,
-            correlation_id = %correlation_id,
-            "Token refresh successful"
-        );
-        Ok(new_token_set)
+        TokenPostOutcome::Success(new_token_set)
     }
 
     /// Apply a new token set: update in-memory state, persist to disk,
@@ -648,6 +853,7 @@ impl OAuthAdapter {
                 state: RwLock::new(OAuthState::NeedsLogin),
                 tokens: RwLock::new(None),
                 config,
+                token_endpoint_override: RwLock::new(None),
                 inner_adapter: RwLock::new(None),
                 token_manager,
                 http_client: Client::builder()
@@ -956,6 +1162,7 @@ mod tests {
             probe_timeout_secs: 10,
             probe_failure_threshold: 3,
             server_type_override: None,
+            allow_insecure_oauth: false,
         }
     }
 
@@ -2024,5 +2231,315 @@ mod tests {
             !recv_tick(&mut outer_rx, Duration::from_millis(150)).await,
             "no tick should reach outer subscriber after forwarder disabled"
         );
+    }
+
+    // --- Refresh-time token endpoint discovery fallback tests ---
+
+    /// Shared in/out counters and canned responses for the discovery test
+    /// fixture. `None` for any of the metadata fields means "respond 404".
+    #[derive(Clone, Default)]
+    struct DiscoveryFixtureOpts {
+        new_token_count: Arc<std::sync::atomic::AtomicUsize>,
+        old_token_count: Arc<std::sync::atomic::AtomicUsize>,
+        pr_count: Arc<std::sync::atomic::AtomicUsize>,
+        as_count: Arc<std::sync::atomic::AtomicUsize>,
+        pr_metadata: Option<serde_json::Value>,
+        as_metadata: Option<serde_json::Value>,
+        new_token_response: Option<serde_json::Value>,
+    }
+
+    /// Build a `DiscoveryFixtureOpts` pre-populated with a valid protected-
+    /// resource document pointing at the fixture's own host as the
+    /// authorization server, and a valid AS metadata document whose
+    /// `token_endpoint` is the fixture's `/new/token` URL.
+    fn happy_discovery_opts(base: &str) -> DiscoveryFixtureOpts {
+        use serde_json::json;
+        DiscoveryFixtureOpts {
+            pr_metadata: Some(json!({
+                "resource": base,
+                "authorization_servers": [base],
+            })),
+            as_metadata: Some(json!({
+                "issuer": base,
+                "authorization_endpoint": format!("{}/authorize", base),
+                "token_endpoint": format!("{}/new/token", base),
+                "code_challenge_methods_supported": ["S256"],
+            })),
+            new_token_response: Some(json!({
+                "access_token": "rediscovered-access",
+                "token_type": "Bearer",
+                "expires_in": 3600u64,
+                "refresh_token": "rediscovered-refresh",
+            })),
+            ..Default::default()
+        }
+    }
+
+    /// Bind a TCP listener on an ephemeral port without consuming it so we
+    /// know the URL the fixture will use before we spawn the server. The
+    /// listener is returned and dropped only when the caller hands it to the
+    /// fixture's `spawn_on`.
+    async fn reserve_port() -> (tokio::net::TcpListener, String) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        (listener, format!("http://127.0.0.1:{}", addr.port()))
+    }
+
+    /// Variant of `spawn_discovery_fixture` that takes a pre-bound listener
+    /// so the test can build URLs referencing the eventual base URL before
+    /// the server starts.
+    async fn spawn_discovery_fixture_on(
+        listener: tokio::net::TcpListener,
+        opts: DiscoveryFixtureOpts,
+    ) -> tokio::task::JoinHandle<()> {
+        use axum::http::StatusCode;
+        use axum::{extract::State, response::IntoResponse, routing::post, Json, Router};
+        use serde_json::Value;
+
+        #[derive(Clone)]
+        struct Fx {
+            new_token_count: Arc<std::sync::atomic::AtomicUsize>,
+            old_token_count: Arc<std::sync::atomic::AtomicUsize>,
+            pr_count: Arc<std::sync::atomic::AtomicUsize>,
+            as_count: Arc<std::sync::atomic::AtomicUsize>,
+            pr_metadata: Arc<Option<Value>>,
+            as_metadata: Arc<Option<Value>>,
+            new_token_response: Arc<Option<Value>>,
+        }
+
+        async fn old_token(State(fx): State<Fx>) -> impl IntoResponse {
+            fx.old_token_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            (StatusCode::NOT_FOUND, "not found").into_response()
+        }
+        async fn new_token(State(fx): State<Fx>) -> impl IntoResponse {
+            fx.new_token_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            match fx.new_token_response.as_ref() {
+                Some(v) => (StatusCode::OK, Json(v.clone())).into_response(),
+                None => (StatusCode::NOT_FOUND, "not found").into_response(),
+            }
+        }
+        async fn pr_meta(State(fx): State<Fx>) -> axum::response::Response {
+            fx.pr_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            match fx.pr_metadata.as_ref() {
+                Some(v) => (StatusCode::OK, Json(v.clone())).into_response(),
+                None => (StatusCode::NOT_FOUND, "not found").into_response(),
+            }
+        }
+        async fn as_meta(State(fx): State<Fx>) -> axum::response::Response {
+            fx.as_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            match fx.as_metadata.as_ref() {
+                Some(v) => (StatusCode::OK, Json(v.clone())).into_response(),
+                None => (StatusCode::NOT_FOUND, "not found").into_response(),
+            }
+        }
+
+        let fx = Fx {
+            new_token_count: opts.new_token_count,
+            old_token_count: opts.old_token_count,
+            pr_count: opts.pr_count,
+            as_count: opts.as_count,
+            pr_metadata: Arc::new(opts.pr_metadata),
+            as_metadata: Arc::new(opts.as_metadata),
+            new_token_response: Arc::new(opts.new_token_response),
+        };
+
+        let router = Router::new()
+            .route("/old/token", post(old_token))
+            .route("/new/token", post(new_token))
+            .route(
+                "/.well-known/oauth-protected-resource",
+                axum::routing::get(pr_meta),
+            )
+            .route(
+                "/.well-known/oauth-authorization-server",
+                axum::routing::get(as_meta),
+            )
+            .with_state(fx);
+
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        handle
+    }
+
+    /// Happy path: the configured token endpoint returns 404, discovery
+    /// succeeds, the rediscovered endpoint differs, and the retry succeeds.
+    /// The new tokens are returned and the in-memory override is populated.
+    #[tokio::test]
+    async fn refresh_discovery_fallback_success() {
+        let (listener, base) = reserve_port().await;
+        let opts = happy_discovery_opts(&base);
+        let server = spawn_discovery_fixture_on(listener, opts).await;
+
+        let mut config = make_config();
+        config.url = format!("{}/mcp", base);
+        config.token_endpoint_url = format!("{}/old/token", base);
+        config.allow_insecure_oauth = true;
+        let adapter = make_adapter_with_refresh_token(config).await;
+
+        let token_set = adapter
+            .inner
+            .do_token_refresh()
+            .await
+            .expect("refresh should succeed after rediscovery");
+        assert_eq!(token_set.access_token, "rediscovered-access");
+
+        let override_url = adapter.inner.token_endpoint_override.read().await.clone();
+        assert_eq!(override_url, Some(format!("{}/new/token", base)));
+
+        server.abort();
+    }
+
+    /// Discovery itself fails (no protected-resource metadata served).
+    /// The original 404 must be surfaced to the caller and the override must
+    /// remain unset so we don't poison subsequent refreshes.
+    #[tokio::test]
+    async fn refresh_discovery_fallback_failure_discovery_fails() {
+        let (listener, base) = reserve_port().await;
+        let opts = DiscoveryFixtureOpts {
+            pr_metadata: None,
+            as_metadata: None,
+            ..Default::default()
+        };
+        let server = spawn_discovery_fixture_on(listener, opts).await;
+
+        let mut config = make_config();
+        config.url = format!("{}/mcp", base);
+        config.token_endpoint_url = format!("{}/old/token", base);
+        config.allow_insecure_oauth = true;
+        let adapter = make_adapter_with_refresh_token(config).await;
+
+        let result = adapter.inner.do_token_refresh().await;
+        assert!(
+            matches!(result, Err(OAuthError::RefreshFailed { ref body, .. }) if body.contains("not found")),
+            "expected original 404 RefreshFailed, got {:?}",
+            result
+        );
+        assert!(adapter.inner.token_endpoint_override.read().await.is_none());
+
+        let state = adapter.inner.state.read().await.clone();
+        assert_eq!(state, OAuthState::AuthRequired);
+
+        server.abort();
+    }
+
+    /// Discovery succeeds but returns the same token endpoint URL we just
+    /// hit. The adapter must NOT retry (that would just 404 again) and must
+    /// surface the original 404.
+    #[tokio::test]
+    async fn refresh_discovery_fallback_failure_no_token_endpoint() {
+        use serde_json::json;
+        let (listener, base) = reserve_port().await;
+        let opts = DiscoveryFixtureOpts {
+            pr_metadata: Some(json!({
+                "resource": base,
+                "authorization_servers": [base.clone()],
+            })),
+            as_metadata: Some(json!({
+                "issuer": base,
+                "authorization_endpoint": format!("{}/authorize", base),
+                // Discovery returns the SAME URL we just got a 404 from.
+                "token_endpoint": format!("{}/old/token", base),
+                "code_challenge_methods_supported": ["S256"],
+            })),
+            ..Default::default()
+        };
+        let server = spawn_discovery_fixture_on(listener, opts).await;
+
+        let mut config = make_config();
+        config.url = format!("{}/mcp", base);
+        config.token_endpoint_url = format!("{}/old/token", base);
+        config.allow_insecure_oauth = true;
+        let adapter = make_adapter_with_refresh_token(config).await;
+
+        let result = adapter.inner.do_token_refresh().await;
+        assert!(
+            matches!(result, Err(OAuthError::RefreshFailed { .. })),
+            "expected RefreshFailed, got {:?}",
+            result
+        );
+        assert!(adapter.inner.token_endpoint_override.read().await.is_none());
+        server.abort();
+    }
+
+    /// Memoization: after a successful rediscovery the override is cached, so
+    /// a second refresh posts directly to the new endpoint without re-running
+    /// discovery (and without touching the old endpoint).
+    #[tokio::test]
+    async fn refresh_discovery_fallback_memoized() {
+        let (listener, base) = reserve_port().await;
+        let opts = happy_discovery_opts(&base);
+        let pr_count = opts.pr_count.clone();
+        let as_count = opts.as_count.clone();
+        let new_token_count = opts.new_token_count.clone();
+        let old_token_count = opts.old_token_count.clone();
+        let server = spawn_discovery_fixture_on(listener, opts).await;
+
+        let mut config = make_config();
+        config.url = format!("{}/mcp", base);
+        config.token_endpoint_url = format!("{}/old/token", base);
+        config.allow_insecure_oauth = true;
+        let adapter = make_adapter_with_refresh_token(config).await;
+
+        // First refresh: discovery runs, override is populated.
+        let first = adapter
+            .inner
+            .do_token_refresh()
+            .await
+            .expect("first refresh");
+        assert_eq!(first.access_token, "rediscovered-access");
+        let pr_after_first = pr_count.load(std::sync::atomic::Ordering::SeqCst);
+        let as_after_first = as_count.load(std::sync::atomic::Ordering::SeqCst);
+        let new_token_after_first = new_token_count.load(std::sync::atomic::Ordering::SeqCst);
+        let old_token_after_first = old_token_count.load(std::sync::atomic::Ordering::SeqCst);
+        assert!(pr_after_first >= 1, "discovery must hit protected-resource");
+        assert!(
+            as_after_first >= 1,
+            "discovery must hit auth-server metadata"
+        );
+        assert_eq!(
+            new_token_after_first, 1,
+            "new token endpoint must be POSTed exactly once"
+        );
+        assert_eq!(
+            old_token_after_first, 1,
+            "old token endpoint must be POSTed exactly once"
+        );
+
+        // Second refresh: must use the cached override; no new discovery hits
+        // and no hit on the old endpoint.
+        let second = adapter
+            .inner
+            .do_token_refresh()
+            .await
+            .expect("second refresh uses cached override");
+        assert_eq!(second.access_token, "rediscovered-access");
+        assert_eq!(
+            pr_count.load(std::sync::atomic::Ordering::SeqCst),
+            pr_after_first,
+            "second refresh must not re-run protected-resource discovery"
+        );
+        assert_eq!(
+            as_count.load(std::sync::atomic::Ordering::SeqCst),
+            as_after_first,
+            "second refresh must not re-run auth-server discovery"
+        );
+        assert_eq!(
+            old_token_count.load(std::sync::atomic::Ordering::SeqCst),
+            old_token_after_first,
+            "second refresh must not POST to the stale old token endpoint"
+        );
+        assert_eq!(
+            new_token_count.load(std::sync::atomic::Ordering::SeqCst),
+            new_token_after_first + 1,
+            "second refresh must POST to the new token endpoint once"
+        );
+
+        server.abort();
     }
 }

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -2542,4 +2542,160 @@ mod tests {
 
         server.abort();
     }
+
+    // --- PR #69 audit gap 1 & 5: discovery short-circuits -------------------
+
+    /// Gap 1: when the resource URL is empty, a 404 from the token endpoint
+    /// must NOT trigger RFC 9728 / 8414 discovery (discovery would have
+    /// nothing to discover against). The original 404 is surfaced.
+    #[tokio::test]
+    async fn refresh_404_with_empty_config_url_skips_discovery() {
+        let (listener, base) = reserve_port().await;
+        // Serve PR/AS metadata so we can prove they were NOT requested.
+        let opts = happy_discovery_opts(&base);
+        let pr_count = opts.pr_count.clone();
+        let as_count = opts.as_count.clone();
+        let new_token_count = opts.new_token_count.clone();
+        let old_token_count = opts.old_token_count.clone();
+        let server = spawn_discovery_fixture_on(listener, opts).await;
+
+        let mut config = make_config();
+        // `url` empty triggers the early-return branch in `handle_refresh_404`.
+        config.url = String::new();
+        config.token_endpoint_url = format!("{}/old/token", base);
+        config.allow_insecure_oauth = true;
+        let adapter = make_adapter_with_refresh_token(config).await;
+
+        let result = adapter.inner.do_token_refresh().await;
+        assert!(
+            matches!(result, Err(OAuthError::RefreshFailed { ref body, .. }) if body.contains("not found")),
+            "expected original 404 RefreshFailed, got {:?}",
+            result
+        );
+        assert!(adapter.inner.token_endpoint_override.read().await.is_none());
+
+        let state = adapter.inner.state.read().await.clone();
+        assert_eq!(state, OAuthState::AuthRequired);
+
+        assert_eq!(
+            old_token_count.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "old token endpoint must be hit exactly once"
+        );
+        assert_eq!(
+            pr_count.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "protected-resource discovery must NOT run when config.url is empty"
+        );
+        assert_eq!(
+            as_count.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "auth-server discovery must NOT run when config.url is empty"
+        );
+        assert_eq!(
+            new_token_count.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "new token endpoint must NOT be POSTed without discovery"
+        );
+
+        server.abort();
+    }
+
+    /// Gap 5: non-404 HTTP errors (5xx, 4xx other than 404) must NOT trigger
+    /// the discovery fallback — the original status is surfaced as-is and no
+    /// PR/AS metadata requests are issued.
+    #[tokio::test]
+    async fn refresh_5xx_does_not_trigger_discovery() {
+        use axum::http::StatusCode;
+        use axum::{response::IntoResponse, routing::get, routing::post, Router};
+
+        // Counters: token POSTs, plus would-be discovery hits.
+        let token_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let pr_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let as_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        #[derive(Clone)]
+        struct Fx {
+            token_count: Arc<std::sync::atomic::AtomicUsize>,
+            pr_count: Arc<std::sync::atomic::AtomicUsize>,
+            as_count: Arc<std::sync::atomic::AtomicUsize>,
+        }
+
+        async fn token_500(
+            axum::extract::State(fx): axum::extract::State<Fx>,
+        ) -> impl IntoResponse {
+            fx.token_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            (StatusCode::INTERNAL_SERVER_ERROR, "upstream broke")
+        }
+        async fn pr(axum::extract::State(fx): axum::extract::State<Fx>) -> impl IntoResponse {
+            fx.pr_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            (StatusCode::NOT_FOUND, "")
+        }
+        async fn r#as(axum::extract::State(fx): axum::extract::State<Fx>) -> impl IntoResponse {
+            fx.as_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            (StatusCode::NOT_FOUND, "")
+        }
+
+        let fx = Fx {
+            token_count: token_count.clone(),
+            pr_count: pr_count.clone(),
+            as_count: as_count.clone(),
+        };
+        let router = Router::new()
+            .route("/token", post(token_500))
+            .route("/.well-known/oauth-protected-resource", get(pr))
+            .route("/.well-known/oauth-authorization-server", get(r#as))
+            .with_state(fx);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let base = format!("http://127.0.0.1:{}", addr.port());
+
+        let mut config = make_config();
+        config.url = format!("{}/mcp", base);
+        config.token_endpoint_url = format!("{}/token", base);
+        config.allow_insecure_oauth = true;
+        let adapter = make_adapter_with_refresh_token(config).await;
+
+        let result = adapter.inner.do_token_refresh().await;
+        match result {
+            Err(OAuthError::RefreshFailed { status, .. }) => {
+                assert_eq!(
+                    status,
+                    reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+                    "non-404 status must surface unchanged"
+                );
+            }
+            other => panic!("expected RefreshFailed(500), got {:?}", other),
+        }
+
+        assert_eq!(
+            token_count.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "token endpoint must be POSTed exactly once (no retry)"
+        );
+        assert_eq!(
+            pr_count.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "5xx must NOT trigger protected-resource discovery"
+        );
+        assert_eq!(
+            as_count.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "5xx must NOT trigger auth-server discovery"
+        );
+        assert!(adapter.inner.token_endpoint_override.read().await.is_none());
+
+        let state = adapter.inner.state.read().await.clone();
+        assert_eq!(state, OAuthState::AuthRequired);
+
+        server.abort();
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -410,12 +410,14 @@ async fn main() {
             let registry = Arc::new(registry);
 
             // Spawn background initialization for deferred endpoints
+            let allow_insecure_oauth = cfg.relay.allow_insecure_oauth.unwrap_or(false);
             for ep in deferred_init {
                 let reg = registry.clone();
                 let tm = token_manager.clone();
                 let oai = oauth_adapter_inners.clone();
                 tokio::spawn(async move {
-                    let adapter = watcher::create_adapter(&ep, &tm, &oai).await;
+                    let adapter =
+                        watcher::create_adapter(&ep, &tm, &oai, allow_insecure_oauth).await;
                     let mut entries = reg.entries().write().await;
                     if let Some(entry) = entries.get_mut(ep.name.as_str()) {
                         entry.adapter = adapter;

--- a/src/main.rs
+++ b/src/main.rs
@@ -349,6 +349,11 @@ async fn main() {
                         probe_timeout_secs: 10,
                         probe_failure_threshold: 3,
                         server_type_override: ep.server_type_override.clone(),
+                        // Mirror the global SSRF posture for the refresh-time
+                        // discovery fallback so operators who already opted into
+                        // `relay.allow_insecure_oauth` for the initial discovery
+                        // see consistent behavior on rediscovery.
+                        allow_insecure_oauth: cfg.relay.allow_insecure_oauth.unwrap_or(false),
                     };
 
                     let mut adapter = OAuthAdapter::new(oauth_config, token_manager.clone());

--- a/src/management.rs
+++ b/src/management.rs
@@ -4967,6 +4967,272 @@ command = "echo"
         assert_eq!(flow.token_endpoint, explicit_token);
     }
 
+    // -----------------------------------------------------------------------
+    // PR #69 audit gap 2b: oauth_start with a trailing-slash oauth_server_url
+    // must not produce a double-slash well-known URL during AS discovery.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn oauth_start_with_trailing_slash_oauth_server_url_no_double_slash_discovery() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        // Counters for both possible request shapes. The trailing-slash
+        // oauth_server_url must produce `/.well-known/...`; a buggy
+        // concatenation would produce `//.well-known/...`.
+        let well_known_hits = Arc::new(AtomicUsize::new(0));
+        let bad_double_slash_hits = Arc::new(AtomicUsize::new(0));
+        let wk = well_known_hits.clone();
+        let bad = bad_double_slash_hits.clone();
+
+        let well_known_handler = move || {
+            let wk = wk.clone();
+            async move {
+                wk.fetch_add(1, Ordering::SeqCst);
+                Json(serde_json::json!({
+                    "issuer": "http://example.test",
+                    "authorization_endpoint": "http://example.test/discovered-auth",
+                    "token_endpoint": "http://example.test/discovered-token",
+                    "code_challenge_methods_supported": ["S256"],
+                }))
+            }
+        };
+        let bad_handler = move || {
+            let bad = bad.clone();
+            async move {
+                bad.fetch_add(1, Ordering::SeqCst);
+                StatusCode::IM_A_TEAPOT
+            }
+        };
+        let router = Router::new()
+            .route(
+                "/.well-known/oauth-authorization-server",
+                get(well_known_handler),
+            )
+            // A double-slash path would route to this matcher if the bug
+            // re-appeared; bumping the counter makes the failure explicit.
+            .route("//.well-known/oauth-authorization-server", get(bad_handler));
+        let (base_url, _server) = spawn_mock_as(router).await;
+
+        // Trailing slash, exactly like `https://accounts.google.com/`.
+        let trailing = format!("{}/", base_url);
+        let (state, flow_mgr) = test_state_oauth_start("ep1", &trailing, None);
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/ep1/oauth/start")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let authorize_url = body["authorize_url"].as_str().unwrap();
+        assert!(
+            authorize_url.starts_with("http://example.test/discovered-auth?"),
+            "expected discovered authorization_endpoint, got: {}",
+            authorize_url
+        );
+        // The discovered token endpoint must be registered with the pending
+        // flow, proving discovery succeeded against the trailing-slash URL.
+        let state_param = extract_state_param(authorize_url);
+        let flow = flow_mgr
+            .consume_flow(&state_param)
+            .await
+            .expect("pending flow was registered");
+        assert_eq!(flow.token_endpoint, "http://example.test/discovered-token");
+        // Exact counter assertions pin down the bug shape.
+        assert_eq!(
+            well_known_hits.load(Ordering::SeqCst),
+            1,
+            "well-known endpoint must be hit exactly once"
+        );
+        assert_eq!(
+            bad_double_slash_hits.load(Ordering::SeqCst),
+            0,
+            "double-slash well-known path must NOT be hit"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // PR #69 audit gap 4: allow_insecure_oauth threading through
+    // restart_endpoint and reload_config (mirrors the existing watcher tests
+    // for apply_diff / apply_diff_graceful).
+    // -----------------------------------------------------------------------
+
+    /// Wait for `name` to appear in the OAuthAdapterInners map, returning the
+    /// shared inner. Panics on timeout.
+    async fn wait_for_inner(
+        inners: &OAuthAdapterInners,
+        name: &str,
+    ) -> Arc<crate::adapter::oauth::OAuthAdapterInner> {
+        let stop = Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            if let Some(inner) = inners.read().await.get(name).cloned() {
+                return inner;
+            }
+            if Instant::now() >= stop {
+                panic!("OAuthAdapterInner for `{}` was never registered", name);
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+    }
+
+    /// Build a config containing a single OAuth endpoint with the given
+    /// `allow_insecure_oauth` toggle. Used by the threading tests below.
+    fn oauth_config_with_insecure(name: &str, allow_insecure_oauth: bool) -> Config {
+        Config {
+            relay: RelayConfig {
+                machine_name: "test-machine".to_string(),
+                local_js_execution: None,
+                token_dir: None,
+                allow_insecure_oauth: Some(allow_insecure_oauth),
+            },
+            endpoints: vec![EndpointConfig {
+                name: name.to_string(),
+                description: None,
+                tool_prefix: None,
+                transport: Transport::Oauth,
+                command: None,
+                args: None,
+                url: Some("http://127.0.0.1:5000/mcp".to_string()),
+                env: None,
+                headers: None,
+                disabled: false,
+                disabled_tools: Vec::new(),
+                oauth_server_url: Some("http://127.0.0.1:5001".to_string()),
+                client_id: Some("client123".to_string()),
+                client_secret: None,
+                scopes: None,
+                token_endpoint: None,
+                server_type_override: None,
+            }],
+        }
+    }
+
+    #[tokio::test]
+    async fn restart_endpoint_threads_allow_insecure_oauth_to_rebuilt_adapter() {
+        let tmp = tempfile::tempdir().unwrap();
+        let token_manager = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let oauth_inners: OAuthAdapterInners =
+            Arc::new(RwLock::new(std::collections::HashMap::new()));
+
+        // Seed the registry with a placeholder MockAdapter under the OAuth
+        // endpoint's name. restart_endpoint will replace it via
+        // watcher::create_adapter, which reads allow_insecure_oauth from
+        // state.config.relay.
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "oauth_restart_ep".to_string(),
+                Box::new(MockAdapter::healthy_with_tools(vec![])),
+                "oauth".to_string(),
+                None,
+                Some("oauth_restart_ep".to_string()),
+            )
+            .await;
+
+        let state = ManagementState {
+            registry: Arc::new(registry),
+            config: Arc::new(RwLock::new(oauth_config_with_insecure(
+                "oauth_restart_ep",
+                true,
+            ))),
+            start_time: Instant::now(),
+            config_path: None,
+            oauth_flow_manager: None,
+            relay_port: 9400,
+            oauth_adapter_inners: Some(oauth_inners.clone()),
+            token_manager: Some(token_manager),
+            setup_manager: None,
+        };
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/oauth_restart_ep/restart")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let inner = wait_for_inner(&oauth_inners, "oauth_restart_ep").await;
+        assert!(
+            inner.config.allow_insecure_oauth,
+            "restart_endpoint must thread allow_insecure_oauth=true into the rebuilt OAuthAdapterConfig"
+        );
+    }
+
+    #[tokio::test]
+    async fn reload_config_threads_allow_insecure_oauth_to_new_adapter() {
+        // Write a config file on disk whose [relay] section has
+        // allow_insecure_oauth = true and a single OAuth endpoint. The
+        // in-memory baseline starts with NO endpoints, so the reload sees
+        // the OAuth endpoint as "added" and routes it through
+        // apply_diff_graceful -> create_adapter with the flag.
+        let tmp = tempfile::tempdir().unwrap();
+        let token_dir = tmp.path().join("tokens");
+        std::fs::create_dir_all(&token_dir).unwrap();
+        let config_path = tmp.path().join("config.toml");
+        let toml = r#"
+[relay]
+machine_name = "test-machine"
+allow_insecure_oauth = true
+
+[[endpoints]]
+name = "oauth_reload_ep"
+transport = "oauth"
+url = "http://127.0.0.1:5000/mcp"
+oauth_server_url = "http://127.0.0.1:5001"
+client_id = "client123"
+"#;
+        std::fs::write(&config_path, toml).unwrap();
+
+        let token_manager = Arc::new(TokenManager::new(token_dir));
+        let oauth_inners: OAuthAdapterInners =
+            Arc::new(RwLock::new(std::collections::HashMap::new()));
+
+        let baseline = Config {
+            relay: RelayConfig {
+                machine_name: "test-machine".to_string(),
+                local_js_execution: None,
+                token_dir: None,
+                allow_insecure_oauth: Some(false),
+            },
+            endpoints: vec![],
+        };
+        let state = ManagementState {
+            registry: Arc::new(AdapterRegistry::new()),
+            config: Arc::new(RwLock::new(baseline)),
+            start_time: Instant::now(),
+            config_path: Some(config_path),
+            oauth_flow_manager: None,
+            relay_port: 9400,
+            oauth_adapter_inners: Some(oauth_inners.clone()),
+            token_manager: Some(token_manager),
+            setup_manager: None,
+        };
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/config/reload")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["ok"], true);
+
+        let inner = wait_for_inner(&oauth_inners, "oauth_reload_ep").await;
+        assert!(
+            inner.config.allow_insecure_oauth,
+            "reload_config must thread allow_insecure_oauth=true from the on-disk config into the new OAuthAdapterConfig"
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn config_toml_written_with_0600_on_unix() {

--- a/src/management.rs
+++ b/src/management.rs
@@ -339,12 +339,15 @@ async fn restart_endpoint(
         }
 
         // Look up the endpoint config to decide between rebuild and re-init.
-        let ep_config = {
+        let (ep_config, allow_insecure_oauth) = {
             let cfg = config.read().await;
-            cfg.endpoints
-                .iter()
-                .find(|ep| ep.name == task_name)
-                .cloned()
+            (
+                cfg.endpoints
+                    .iter()
+                    .find(|ep| ep.name == task_name)
+                    .cloned(),
+                cfg.relay.allow_insecure_oauth.unwrap_or(false),
+            )
         };
 
         let new_adapter: Box<dyn McpAdapter> = if let Some(ep) = ep_config {
@@ -354,7 +357,7 @@ async fn restart_endpoint(
                 )))
             });
             let oai = oauth_adapter_inners.unwrap_or_else(|| Arc::new(RwLock::new(HashMap::new())));
-            crate::watcher::create_adapter(&ep, &tm, &oai).await
+            crate::watcher::create_adapter(&ep, &tm, &oai, allow_insecure_oauth).await
         } else {
             // Endpoint not in config: re-initialize the previous adapter in
             // place. On failure, surface the error via FailedAdapter so the
@@ -556,6 +559,7 @@ async fn reload_config(State(state): State<ManagementState>) -> Json<ActionRespo
         &warned_names,
         &token_manager,
         &oauth_adapter_inners,
+        new_config.relay.allow_insecure_oauth.unwrap_or(false),
     )
     .await;
 

--- a/src/management.rs
+++ b/src/management.rs
@@ -983,18 +983,43 @@ async fn oauth_start(
         discovered_scopes,
         auth_server_label,
     ) = if let Some(ref server_url) = oauth_server_url {
-        // Convention-based: derive from the configured base URL
-        let base = server_url.trim_end_matches('/');
-        let token_url = config_token_endpoint
-            .clone()
-            .unwrap_or_else(|| format!("{}/token", base));
-        (
-            format!("{}/authorize", base),
-            token_url,
-            None::<String>,
-            Vec::<String>::new(),
-            None::<String>,
-        )
+        // Prefer RFC 8414 discovery against the configured AS URL. If it
+        // succeeds, use the discovered endpoints (explicit token_endpoint
+        // config still wins). On any error, fall back to the legacy
+        // convention-based construction so behavior is unchanged for
+        // servers that don't expose AS metadata.
+        match discovery::discover_authorization_server(server_url, allow_insecure_oauth).await {
+            Ok(disc) => {
+                let token_url = config_token_endpoint
+                    .clone()
+                    .unwrap_or_else(|| disc.token_endpoint.clone());
+                (
+                    disc.authorization_endpoint,
+                    token_url,
+                    disc.registration_endpoint,
+                    disc.scopes_supported,
+                    Some(disc.auth_server_url),
+                )
+            }
+            Err(e) => {
+                warn!(
+                    endpoint = %name,
+                    error = %e,
+                    "RFC 8414 discovery against oauth_server_url failed; falling back to convention-based endpoints"
+                );
+                let base = server_url.trim_end_matches('/');
+                let token_url = config_token_endpoint
+                    .clone()
+                    .unwrap_or_else(|| format!("{}/token", base));
+                (
+                    format!("{}/authorize", base),
+                    token_url,
+                    None::<String>,
+                    Vec::<String>::new(),
+                    None::<String>,
+                )
+            }
+        }
     } else {
         // Try RFC 9728 discovery (URL guard + per-host pinned client live inside)
         match discovery::discover_oauth_server(&endpoint_url, allow_insecure_oauth).await {
@@ -4748,6 +4773,198 @@ command = "echo"
         assert_eq!(body["client_secret_set"], true);
         assert_eq!(body["source"], "config");
         assert!(body.get("client_secret").is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // oauth_start: AS discovery when oauth_server_url is set
+    // -----------------------------------------------------------------------
+
+    /// Spawn a Router on 127.0.0.1:0 and return its base URL.
+    async fn spawn_mock_as(router: Router) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        // Tiny delay to let the server start accepting connections.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        (format!("http://127.0.0.1:{}", addr.port()), handle)
+    }
+
+    /// Build a ManagementState wired for `oauth_start` against a mock AS.
+    fn test_state_oauth_start(
+        name: &str,
+        oauth_server_url: &str,
+        token_endpoint: Option<&str>,
+    ) -> (ManagementState, Arc<OAuthFlowManager>) {
+        let flow_mgr = Arc::new(OAuthFlowManager::new());
+        let cfg = Config {
+            relay: RelayConfig {
+                machine_name: "test-machine".to_string(),
+                local_js_execution: None,
+                token_dir: None,
+                allow_insecure_oauth: Some(true),
+            },
+            endpoints: vec![EndpointConfig {
+                name: name.to_string(),
+                description: None,
+                tool_prefix: None,
+                transport: Transport::Oauth,
+                command: None,
+                args: None,
+                url: Some("http://127.0.0.1:9/mcp".to_string()),
+                env: None,
+                headers: None,
+                disabled: false,
+                disabled_tools: Vec::new(),
+                oauth_server_url: Some(oauth_server_url.to_string()),
+                client_id: Some("test-client".to_string()),
+                client_secret: None,
+                scopes: None,
+                token_endpoint: token_endpoint.map(|s| s.to_string()),
+                server_type_override: None,
+            }],
+        };
+        let state = ManagementState {
+            registry: Arc::new(AdapterRegistry::new()),
+            config: Arc::new(RwLock::new(cfg)),
+            start_time: Instant::now(),
+            config_path: None,
+            oauth_flow_manager: Some(flow_mgr.clone()),
+            relay_port: 9400,
+            oauth_adapter_inners: None,
+            token_manager: None,
+            setup_manager: None,
+        };
+        (state, flow_mgr)
+    }
+
+    /// Extract the `state` query parameter from an authorize URL.
+    fn extract_state_param(authorize_url: &str) -> String {
+        let url = url::Url::parse(authorize_url).expect("valid authorize URL");
+        url.query_pairs()
+            .find(|(k, _)| k == "state")
+            .map(|(_, v)| v.into_owned())
+            .expect("authorize URL has state param")
+    }
+
+    #[tokio::test]
+    async fn oauth_start_with_oauth_server_url_uses_discovery_when_available() {
+        // Mock AS: serve real-looking endpoints at /.well-known/oauth-authorization-server.
+        // Discovered URLs intentionally differ from the convention `{base}/authorize`
+        // and `{base}/token`.
+        async fn well_known() -> Json<Value> {
+            Json(serde_json::json!({
+                "issuer": "http://example.test",
+                "authorization_endpoint": "http://example.test/discovered-auth",
+                "token_endpoint": "http://example.test/discovered-token",
+                "code_challenge_methods_supported": ["S256"],
+            }))
+        }
+        let router =
+            Router::new().route("/.well-known/oauth-authorization-server", get(well_known));
+        let (base_url, _server) = spawn_mock_as(router).await;
+
+        let (state, _flow_mgr) = test_state_oauth_start("ep1", &base_url, None);
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/ep1/oauth/start")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let authorize_url = body["authorize_url"].as_str().unwrap();
+        assert!(
+            authorize_url.starts_with("http://example.test/discovered-auth?"),
+            "expected discovered authorization_endpoint, got: {}",
+            authorize_url
+        );
+        assert_eq!(body["discovery"]["auth_server"], base_url);
+    }
+
+    #[tokio::test]
+    async fn oauth_start_with_oauth_server_url_falls_back_to_convention_on_404() {
+        // Mock AS: return 404 for the well-known. Discovery should fail and
+        // oauth_start should fall back to the convention `{base}/authorize`.
+        async fn not_found() -> StatusCode {
+            StatusCode::NOT_FOUND
+        }
+        let router = Router::new().route("/.well-known/oauth-authorization-server", get(not_found));
+        let (base_url, _server) = spawn_mock_as(router).await;
+
+        let (state, _flow_mgr) = test_state_oauth_start("ep1", &base_url, None);
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/ep1/oauth/start")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        // Flow still proceeds — fallback is transparent to the caller.
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let authorize_url = body["authorize_url"].as_str().unwrap();
+        let expected_prefix = format!("{}/authorize?", base_url);
+        assert!(
+            authorize_url.starts_with(&expected_prefix),
+            "expected convention-constructed authorize URL `{}…`, got: {}",
+            expected_prefix,
+            authorize_url
+        );
+        // No discovery metadata on the fallback path.
+        assert!(body.get("discovery").is_none() || body["discovery"].is_null());
+    }
+
+    #[tokio::test]
+    async fn oauth_start_with_explicit_token_endpoint_overrides_discovery() {
+        // Mock AS: discovery succeeds but advertises a token_endpoint that
+        // differs from the operator-configured explicit override. The
+        // override must win.
+        async fn well_known() -> Json<Value> {
+            Json(serde_json::json!({
+                "issuer": "http://example.test",
+                "authorization_endpoint": "http://example.test/discovered-auth",
+                "token_endpoint": "http://example.test/discovered-token",
+                "code_challenge_methods_supported": ["S256"],
+            }))
+        }
+        let router =
+            Router::new().route("/.well-known/oauth-authorization-server", get(well_known));
+        let (base_url, _server) = spawn_mock_as(router).await;
+
+        let explicit_token = "http://example.test/explicit-token";
+        let (state, flow_mgr) = test_state_oauth_start("ep1", &base_url, Some(explicit_token));
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/ep1/oauth/start")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let authorize_url = body["authorize_url"].as_str().unwrap();
+        // Authorization endpoint still comes from discovery.
+        assert!(
+            authorize_url.starts_with("http://example.test/discovered-auth?"),
+            "expected discovered authorization_endpoint, got: {}",
+            authorize_url
+        );
+        // The registered pending flow must carry the EXPLICIT token endpoint.
+        let state_param = extract_state_param(authorize_url);
+        let flow = flow_mgr
+            .consume_flow(&state_param)
+            .await
+            .expect("pending flow was registered");
+        assert_eq!(flow.token_endpoint, explicit_token);
     }
 
     #[cfg(unix)]

--- a/src/management.rs
+++ b/src/management.rs
@@ -3597,6 +3597,7 @@ command = "echo"
             probe_timeout_secs: 10,
             probe_failure_threshold: 3,
             server_type_override: None,
+            allow_insecure_oauth: false,
         }
     }
 

--- a/src/oauth/discovery.rs
+++ b/src/oauth/discovery.rs
@@ -667,4 +667,158 @@ mod tests {
             vec!["search:read.public", "chat:write"]
         );
     }
+
+    // --- PR #69 audit gap 2a: trailing-slash regression ---------------------
+
+    /// `build_well_known_url` must collapse a trailing slash on the base URL
+    /// rather than producing `…//.well-known/…`. The originally reported bug
+    /// was against `https://accounts.google.com/`.
+    #[test]
+    fn test_build_well_known_url_trailing_slash_no_path() {
+        let url =
+            build_well_known_url("https://accounts.google.com/", "oauth-authorization-server")
+                .unwrap();
+        assert_eq!(
+            url,
+            "https://accounts.google.com/.well-known/oauth-authorization-server"
+        );
+    }
+
+    // --- PR #69 audit gap 3: discover_authorization_server direct tests -----
+
+    /// Spawn an axum server on `127.0.0.1:0` that serves AS metadata. Returns
+    /// `(base_url, handle)`. The `path_status` controls what the path-shaped
+    /// well-known URL returns; the root well-known URL always serves
+    /// `root_body` when provided.
+    async fn spawn_as_fixture(
+        path_status: axum::http::StatusCode,
+        root_body: Option<serde_json::Value>,
+        path_body: Option<serde_json::Value>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        use axum::extract::{Path as AxPath, State};
+        use axum::http::StatusCode;
+        use axum::{response::IntoResponse, routing::get, Json, Router};
+
+        #[derive(Clone)]
+        struct Fx {
+            path_status: StatusCode,
+            root_body: std::sync::Arc<Option<serde_json::Value>>,
+            path_body: std::sync::Arc<Option<serde_json::Value>>,
+        }
+
+        async fn root(State(fx): State<Fx>) -> axum::response::Response {
+            match fx.root_body.as_ref() {
+                Some(v) => (StatusCode::OK, Json(v.clone())).into_response(),
+                None => (StatusCode::NOT_FOUND, "not found").into_response(),
+            }
+        }
+        async fn path_handler(
+            State(fx): State<Fx>,
+            AxPath(_): AxPath<String>,
+        ) -> axum::response::Response {
+            if fx.path_status == StatusCode::OK {
+                match fx.path_body.as_ref() {
+                    Some(v) => (StatusCode::OK, Json(v.clone())).into_response(),
+                    None => (StatusCode::OK, "{}").into_response(),
+                }
+            } else {
+                (fx.path_status, "not found").into_response()
+            }
+        }
+
+        let fx = Fx {
+            path_status,
+            root_body: std::sync::Arc::new(root_body),
+            path_body: std::sync::Arc::new(path_body),
+        };
+
+        let router = Router::new()
+            .route("/.well-known/oauth-authorization-server", get(root))
+            .route(
+                "/.well-known/oauth-authorization-server/{*tail}",
+                get(path_handler),
+            )
+            .with_state(fx);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        // Tiny delay so the server is accepting connections.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        (format!("http://127.0.0.1:{}", addr.port()), handle)
+    }
+
+    /// 3a. URL has a path → path-shaped well-known 404 → root-only fallback
+    /// returns the parsed metadata.
+    #[tokio::test]
+    async fn discover_authorization_server_path_404_falls_back_to_root() {
+        use serde_json::json;
+        let root_meta = json!({
+            "issuer": "https://example.com",
+            "authorization_endpoint": "https://example.com/authorize",
+            "token_endpoint": "https://example.com/token",
+            "code_challenge_methods_supported": ["S256"],
+        });
+        let (base, server) = spawn_as_fixture(
+            axum::http::StatusCode::NOT_FOUND,
+            Some(root_meta.clone()),
+            None,
+        )
+        .await;
+
+        // Input URL has a path so build_well_known_url emits the path variant
+        // first; the fixture returns 404 there and the root fallback hits.
+        let url = format!("{}/some/path", base);
+        let result = discover_authorization_server(&url, true)
+            .await
+            .expect("root fallback must succeed");
+        assert_eq!(
+            result.authorization_endpoint,
+            "https://example.com/authorize"
+        );
+        assert_eq!(result.token_endpoint, "https://example.com/token");
+        assert_eq!(result.auth_server_url, url);
+
+        server.abort();
+    }
+
+    /// 3b. AS metadata advertises only `plain` (no `S256`) → S256NotSupported.
+    #[tokio::test]
+    async fn discover_authorization_server_rejects_when_s256_missing() {
+        use serde_json::json;
+        let root_meta = json!({
+            "issuer": "https://example.com",
+            "authorization_endpoint": "https://example.com/authorize",
+            "token_endpoint": "https://example.com/token",
+            "code_challenge_methods_supported": ["plain"],
+        });
+        // URL has no path so the first fetch hits the root well-known route;
+        // serve the metadata there.
+        let (base, server) =
+            spawn_as_fixture(axum::http::StatusCode::OK, Some(root_meta), None).await;
+
+        let result = discover_authorization_server(&base, true).await;
+        assert!(
+            matches!(result, Err(DiscoveryError::S256NotSupported)),
+            "expected S256NotSupported, got {:?}",
+            result.err()
+        );
+
+        server.abort();
+    }
+
+    /// 3c. SSRF guard rejects a loopback URL when `allow_insecure=false`,
+    /// surfaced as `DiscoveryError::UrlGuard`.
+    #[tokio::test]
+    async fn discover_authorization_server_ssrf_guard_rejects_loopback() {
+        // 127.0.0.1 is loopback → guard rejects when allow_insecure=false.
+        let result = discover_authorization_server("http://127.0.0.1:1/", false).await;
+        match result {
+            Err(DiscoveryError::UrlGuard(_)) => {}
+            Err(other) => panic!("expected DiscoveryError::UrlGuard, got {:?}", other),
+            Ok(_) => panic!("expected DiscoveryError::UrlGuard, got Ok(_)"),
+        }
+    }
 }

--- a/src/oauth/discovery.rs
+++ b/src/oauth/discovery.rs
@@ -178,36 +178,58 @@ pub async fn discover_oauth_server(
         .ok_or(DiscoveryError::NoAuthorizationServer)?
         .clone();
 
-    // Step 2: Fetch authorization server metadata using a client pinned to
-    // the (potentially different and server-supplied) auth-server host.
-    let as_well_known = build_well_known_url(&auth_server_url, "oauth-authorization-server")
+    // Step 2: Fetch authorization server metadata (RFC 8414).
+    discover_authorization_server(&auth_server_url, allow_insecure).await
+}
+
+/// Discover OAuth authorization server metadata directly (RFC 8414 only).
+///
+/// Unlike [`discover_oauth_server`], this skips the RFC 9728 protected
+/// resource step and fetches the AS metadata against `auth_server_url`
+/// itself:
+///
+/// 1. `{origin}/.well-known/oauth-authorization-server{path}`
+///    - Falls back to `{origin}/.well-known/oauth-authorization-server`
+///      if 404 and `auth_server_url` has a path component.
+/// 2. Validates S256 PKCE support.
+///
+/// The input URL is validated through [`url_guard`] before any HTTP
+/// request is sent, and the request uses a per-host pinned client.
+///
+/// The returned `DiscoveryResult.auth_server_url` is set to the input
+/// `auth_server_url` so callers can label discovery output consistently.
+pub async fn discover_authorization_server(
+    auth_server_url: &str,
+    allow_insecure: bool,
+) -> Result<DiscoveryResult, DiscoveryError> {
+    let as_well_known = build_well_known_url(auth_server_url, "oauth-authorization-server")
         .map_err(|_| DiscoveryError::AuthServerMetadataNotFound {
-            url: auth_server_url.clone(),
+            url: auth_server_url.to_string(),
         })?;
     let as_client = url_guard::validated_client(&as_well_known, allow_insecure).await?;
 
-    let as_meta: AuthorizationServerMetadata =
-        match fetch_well_known(&as_client, &as_well_known).await {
-            Ok(resp) => resp.json().await?,
-            Err(DiscoveryError::MetadataNotFound { .. }) if has_path(&auth_server_url) => {
-                let root_url =
-                    build_well_known_url_root(&auth_server_url, "oauth-authorization-server")
-                        .map_err(|_| DiscoveryError::AuthServerMetadataNotFound {
-                            url: auth_server_url.clone(),
-                        })?;
-                fetch_well_known(&as_client, &root_url)
-                    .await
-                    .map_err(|_| DiscoveryError::AuthServerMetadataNotFound {
-                        url: as_well_known.clone(),
-                    })?
-                    .json()
-                    .await?
-            }
-            Err(DiscoveryError::MetadataNotFound { url }) => {
-                return Err(DiscoveryError::AuthServerMetadataNotFound { url });
-            }
-            Err(e) => return Err(e),
-        };
+    let as_meta: AuthorizationServerMetadata = match fetch_well_known(&as_client, &as_well_known)
+        .await
+    {
+        Ok(resp) => resp.json().await?,
+        Err(DiscoveryError::MetadataNotFound { .. }) if has_path(auth_server_url) => {
+            let root_url = build_well_known_url_root(auth_server_url, "oauth-authorization-server")
+                .map_err(|_| DiscoveryError::AuthServerMetadataNotFound {
+                    url: auth_server_url.to_string(),
+                })?;
+            fetch_well_known(&as_client, &root_url)
+                .await
+                .map_err(|_| DiscoveryError::AuthServerMetadataNotFound {
+                    url: as_well_known.clone(),
+                })?
+                .json()
+                .await?
+        }
+        Err(DiscoveryError::MetadataNotFound { url }) => {
+            return Err(DiscoveryError::AuthServerMetadataNotFound { url });
+        }
+        Err(e) => return Err(e),
+    };
 
     // Validate S256 is supported (required for PKCE)
     if !as_meta.code_challenge_methods_supported.is_empty()
@@ -219,7 +241,7 @@ pub async fn discover_oauth_server(
     }
 
     Ok(DiscoveryResult {
-        auth_server_url,
+        auth_server_url: auth_server_url.to_string(),
         authorization_endpoint: as_meta.authorization_endpoint,
         token_endpoint: as_meta.token_endpoint,
         registration_endpoint: as_meta.registration_endpoint,

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -609,6 +609,13 @@ pub(crate) async fn create_adapter(
                 probe_timeout_secs: 10,
                 probe_failure_threshold: 3,
                 server_type_override: ep.server_type_override.clone(),
+                // Refresh-time discovery fallback uses the same SSRF posture as
+                // production OAuth callers: HTTPS-only, no loopback. Threading
+                // the `relay.allow_insecure_oauth` flag through `create_adapter`
+                // would be a wider refactor; tests construct `OAuthAdapterConfig`
+                // directly and set this to `true` when they need to mock against
+                // 127.0.0.1.
+                allow_insecure_oauth: false,
             };
 
             let mut adapter = OAuthAdapter::new(oauth_config, token_manager.clone());

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -139,6 +139,7 @@ async fn watch_loop(
             &warned_names,
             &token_manager,
             &oauth_adapter_inners,
+            new_config.relay.allow_insecure_oauth.unwrap_or(false),
         )
         .await;
 
@@ -166,6 +167,7 @@ pub async fn apply_diff(
     registry: &AdapterRegistry,
     token_manager: &Arc<TokenManager>,
     oauth_adapter_inners: &OAuthAdapterInners,
+    allow_insecure_oauth: bool,
 ) {
     // Remove endpoints
     for name in &diff.removed {
@@ -222,7 +224,7 @@ pub async fn apply_diff(
         let tm = token_manager.clone();
         let oai = oauth_adapter_inners.clone();
         tokio::spawn(async move {
-            let adapter = create_adapter(&ep_clone, &tm, &oai).await;
+            let adapter = create_adapter(&ep_clone, &tm, &oai, allow_insecure_oauth).await;
             let mut entries = reg.entries().write().await;
             if let Some(entry) = entries.get_mut(name_clone.as_str()) {
                 entry.adapter = adapter;
@@ -265,7 +267,7 @@ pub async fn apply_diff(
         let tm = token_manager.clone();
         let oai = oauth_adapter_inners.clone();
         tokio::spawn(async move {
-            let adapter = create_adapter(&ep_clone, &tm, &oai).await;
+            let adapter = create_adapter(&ep_clone, &tm, &oai, allow_insecure_oauth).await;
             let mut entries = reg.entries().write().await;
             if let Some(entry) = entries.get_mut(ep_clone.name.as_str()) {
                 entry.adapter = adapter;
@@ -297,6 +299,7 @@ pub async fn apply_diff_graceful(
     warned_names: &std::collections::HashSet<String>,
     token_manager: &Arc<TokenManager>,
     oauth_adapter_inners: &OAuthAdapterInners,
+    allow_insecure_oauth: bool,
 ) {
     // Build warning message map
     let warning_messages: std::collections::HashMap<String, String> = {
@@ -392,7 +395,7 @@ pub async fn apply_diff_graceful(
         let tm = token_manager.clone();
         let oai = oauth_adapter_inners.clone();
         tokio::spawn(async move {
-            let adapter = create_adapter(&ep_clone, &tm, &oai).await;
+            let adapter = create_adapter(&ep_clone, &tm, &oai, allow_insecure_oauth).await;
             let mut entries = reg.entries().write().await;
             if let Some(entry) = entries.get_mut(name_clone.as_str()) {
                 entry.adapter = adapter;
@@ -462,7 +465,7 @@ pub async fn apply_diff_graceful(
         let tm = token_manager.clone();
         let oai = oauth_adapter_inners.clone();
         tokio::spawn(async move {
-            let adapter = create_adapter(&ep_clone, &tm, &oai).await;
+            let adapter = create_adapter(&ep_clone, &tm, &oai, allow_insecure_oauth).await;
             let mut entries = reg.entries().write().await;
             if let Some(entry) = entries.get_mut(ep_clone.name.as_str()) {
                 entry.adapter = adapter;
@@ -533,6 +536,7 @@ pub(crate) async fn create_adapter(
     ep: &EndpointConfig,
     token_manager: &Arc<TokenManager>,
     oauth_adapter_inners: &OAuthAdapterInners,
+    allow_insecure_oauth: bool,
 ) -> Box<dyn McpAdapter> {
     match ep.transport {
         Transport::Stdio => {
@@ -609,13 +613,7 @@ pub(crate) async fn create_adapter(
                 probe_timeout_secs: 10,
                 probe_failure_threshold: 3,
                 server_type_override: ep.server_type_override.clone(),
-                // Refresh-time discovery fallback uses the same SSRF posture as
-                // production OAuth callers: HTTPS-only, no loopback. Threading
-                // the `relay.allow_insecure_oauth` flag through `create_adapter`
-                // would be a wider refactor; tests construct `OAuthAdapterConfig`
-                // directly and set this to `true` when they need to mock against
-                // 127.0.0.1.
-                allow_insecure_oauth: false,
+                allow_insecure_oauth,
             };
 
             let mut adapter = OAuthAdapter::new(oauth_config, token_manager.clone());
@@ -790,7 +788,7 @@ mod tests {
             )
             .await;
 
-        apply_diff(&empty_diff(), &registry, &tm, &inners).await;
+        apply_diff(&empty_diff(), &registry, &tm, &inners, false).await;
 
         // Existing adapter should still be there, not shut down
         assert!(!shutdown.load(std::sync::atomic::Ordering::SeqCst));
@@ -817,7 +815,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &inners).await;
+        apply_diff(&diff, &registry, &tm, &inners, false).await;
 
         assert!(shutdown.load(std::sync::atomic::Ordering::SeqCst));
         assert!(registry.merged_catalog().await.is_empty());
@@ -833,7 +831,7 @@ mod tests {
         };
 
         // Should not panic
-        apply_diff(&diff, &registry, &tm, &inners).await;
+        apply_diff(&diff, &registry, &tm, &inners, false).await;
     }
 
     #[tokio::test]
@@ -877,7 +875,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &inners).await;
+        apply_diff(&diff, &registry, &tm, &inners, false).await;
 
         // Old adapter should have been shut down
         assert!(shutdown.load(std::sync::atomic::Ordering::SeqCst));
@@ -912,7 +910,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &inners).await;
+        apply_diff(&diff, &registry, &tm, &inners, false).await;
 
         // Wait for background initialization to complete
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -964,7 +962,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &inners).await;
+        apply_diff(&diff, &registry, &tm, &inners, false).await;
 
         // "keep" should still be alive
         assert!(!shutdown_keep.load(std::sync::atomic::Ordering::SeqCst));
@@ -1005,7 +1003,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &inners).await;
+        apply_diff(&diff, &registry, &tm, &inners, false).await;
 
         // Wait for background initialization to complete
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -1045,6 +1043,59 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn apply_diff_threads_allow_insecure_oauth_to_oauth_adapter_config() {
+        let registry = Arc::new(AdapterRegistry::new());
+        let (tm, inners) = test_oauth_infra();
+
+        let new_ep = EndpointConfig {
+            name: "oauth_insecure_ep".to_string(),
+            description: None,
+            tool_prefix: None,
+            transport: Transport::Oauth,
+            command: None,
+            args: None,
+            url: Some("http://127.0.0.1:5000/mcp".to_string()),
+            env: None,
+            headers: None,
+            disabled: false,
+            disabled_tools: Vec::new(),
+            oauth_server_url: Some("http://127.0.0.1:5001".to_string()),
+            client_id: Some("client123".to_string()),
+            client_secret: None,
+            scopes: None,
+            token_endpoint: None,
+            server_type_override: None,
+        };
+        let diff = ConfigDiff {
+            added: vec![new_ep],
+            ..empty_diff()
+        };
+
+        apply_diff(&diff, &registry, &tm, &inners, true).await;
+
+        // Wait for background initialization to register the OAuth adapter inner.
+        let stop = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            if inners.read().await.contains_key("oauth_insecure_ep") {
+                break;
+            }
+            if std::time::Instant::now() >= stop {
+                panic!("OAuthAdapterInner was never registered");
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+
+        let inner_map = inners.read().await;
+        let inner = inner_map
+            .get("oauth_insecure_ep")
+            .expect("inner registered");
+        assert!(
+            inner.config.allow_insecure_oauth,
+            "create_adapter must thread allow_insecure_oauth=true into OAuthAdapterConfig"
+        );
+    }
+
     // ---- G1: apply_diff_graceful direct coverage ------------------------
 
     #[tokio::test]
@@ -1060,7 +1111,16 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff_graceful(&diff, &registry, &[], &Default::default(), &tm, &inners).await;
+        apply_diff_graceful(
+            &diff,
+            &registry,
+            &[],
+            &Default::default(),
+            &tm,
+            &inners,
+            false,
+        )
+        .await;
 
         // Wait for the background spawn to swap StartingAdapter for the
         // (Failed) adapter produced by create_adapter.
@@ -1105,7 +1165,7 @@ mod tests {
         let warned: std::collections::HashSet<String> =
             warnings.iter().map(|w| w.endpoint_name.clone()).collect();
 
-        apply_diff_graceful(&diff, &registry, &warnings, &warned, &tm, &inners).await;
+        apply_diff_graceful(&diff, &registry, &warnings, &warned, &tm, &inners, false).await;
 
         // No background spawn for warned endpoints — entry is final immediately.
         let entries = registry.entries().read().await;
@@ -1155,7 +1215,7 @@ mod tests {
         }];
         let warned: std::collections::HashSet<String> = ["ep".to_string()].into_iter().collect();
 
-        apply_diff_graceful(&diff, &registry, &warnings, &warned, &tm, &inners).await;
+        apply_diff_graceful(&diff, &registry, &warnings, &warned, &tm, &inners, false).await;
 
         // Old adapter shut down synchronously.
         assert!(shutdown.load(std::sync::atomic::Ordering::SeqCst));

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1229,6 +1229,66 @@ mod tests {
         assert!(entry.disabled_tools.contains("preexisting"));
     }
 
+    /// PR #69 audit gap 4: apply_diff_graceful must thread
+    /// `allow_insecure_oauth` into the OAuth adapter config for added OAuth
+    /// endpoints, exactly like `apply_diff` does. Without this, the watcher's
+    /// graceful path could silently drop the flag and any subsequent
+    /// loopback-targeting refresh would be rejected by the SSRF guard.
+    #[tokio::test]
+    async fn apply_diff_graceful_threads_allow_insecure_oauth_to_oauth_adapter_config() {
+        let registry = Arc::new(AdapterRegistry::new());
+        let (tm, inners) = test_oauth_infra();
+
+        let new_ep = EndpointConfig {
+            name: "oauth_graceful_insecure".to_string(),
+            description: None,
+            tool_prefix: None,
+            transport: Transport::Oauth,
+            command: None,
+            args: None,
+            url: Some("http://127.0.0.1:5000/mcp".to_string()),
+            env: None,
+            headers: None,
+            disabled: false,
+            disabled_tools: Vec::new(),
+            oauth_server_url: Some("http://127.0.0.1:5001".to_string()),
+            client_id: Some("client123".to_string()),
+            client_secret: None,
+            scopes: None,
+            token_endpoint: None,
+            server_type_override: None,
+        };
+        let diff = ConfigDiff {
+            added: vec![new_ep],
+            ..empty_diff()
+        };
+        let warnings: Vec<config::EndpointValidationWarning> = vec![];
+        let warned: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+        apply_diff_graceful(&diff, &registry, &warnings, &warned, &tm, &inners, true).await;
+
+        // Wait for background initialization to register the OAuth adapter inner.
+        let stop = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            if inners.read().await.contains_key("oauth_graceful_insecure") {
+                break;
+            }
+            if std::time::Instant::now() >= stop {
+                panic!("OAuthAdapterInner was never registered");
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+
+        let inner_map = inners.read().await;
+        let inner = inner_map
+            .get("oauth_graceful_insecure")
+            .expect("inner registered");
+        assert!(
+            inner.config.allow_insecure_oauth,
+            "apply_diff_graceful must thread allow_insecure_oauth=true into OAuthAdapterConfig"
+        );
+    }
+
     // ---- G2: registry rewires tools-changed listener after swap --------
 
     #[tokio::test]

--- a/tests/hot_reload_integration.rs
+++ b/tests/hot_reload_integration.rs
@@ -142,7 +142,14 @@ async fn test_config_diff_add_endpoint() {
     let oauth_adapter_inners: Arc<
         RwLock<HashMap<String, Arc<endara_relay::adapter::oauth::OAuthAdapterInner>>>,
     > = Arc::new(RwLock::new(HashMap::new()));
-    watcher::apply_diff(&diff, &registry, &token_manager, &oauth_adapter_inners).await;
+    watcher::apply_diff(
+        &diff,
+        &registry,
+        &token_manager,
+        &oauth_adapter_inners,
+        false,
+    )
+    .await;
 
     // Wait for background initialization to complete
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
@@ -288,7 +295,14 @@ async fn test_config_diff_remove_endpoint() {
     let oauth_adapter_inners2: Arc<
         RwLock<HashMap<String, Arc<endara_relay::adapter::oauth::OAuthAdapterInner>>>,
     > = Arc::new(RwLock::new(HashMap::new()));
-    watcher::apply_diff(&diff, &registry, &token_manager2, &oauth_adapter_inners2).await;
+    watcher::apply_diff(
+        &diff,
+        &registry,
+        &token_manager2,
+        &oauth_adapter_inners2,
+        false,
+    )
+    .await;
 
     // Verify the endpoint was removed
     let catalog = registry.merged_catalog().await;

--- a/tests/oauth_integration.rs
+++ b/tests/oauth_integration.rs
@@ -1304,3 +1304,203 @@ async fn test_oauth_server_info_name_enforcement() {
         tools.len()
     );
 }
+
+// ---------------------------------------------------------------------------
+// PR #69 audit gap 6: end-to-end refresh discovery fallback against a real
+// `OAuthAdapter`. Mocks the full RFC 9728 + RFC 8414 path with axum and
+// asserts (1) the 404 on `/old/token` rediscovers `/new/token`, (2) the
+// override is memoized, (3) a second refresh skips discovery, (4) the state
+// machine settles in `Ready`.
+// ---------------------------------------------------------------------------
+
+/// Shared counters for the gap-6 mock servers. Each axum route bumps its own
+/// `AtomicU64` so assertions can pin exact call counts.
+struct RefreshFallbackCounters {
+    pr_metadata_hits: AtomicU64,
+    as_metadata_hits: AtomicU64,
+    old_token_hits: AtomicU64,
+    new_token_hits: AtomicU64,
+}
+
+#[tokio::test]
+async fn refresh_404_triggers_discovery_then_caches_new_token_endpoint() {
+    use axum::routing::{get, post};
+    use axum::Router;
+    use endara_relay::adapter::oauth::{OAuthAdapter, OAuthAdapterConfig};
+    use endara_relay::token_manager::{TokenManager, TokenSet};
+
+    let counters = Arc::new(RefreshFallbackCounters {
+        pr_metadata_hits: AtomicU64::new(0),
+        as_metadata_hits: AtomicU64::new(0),
+        old_token_hits: AtomicU64::new(0),
+        new_token_hits: AtomicU64::new(0),
+    });
+
+    // Bind first so the router can self-reference its own URL in discovery
+    // metadata (mirrors how a real AS advertises its endpoints).
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+
+    let pr_base = base.clone();
+    let pr_counters = counters.clone();
+    let pr_metadata = move || {
+        let base = pr_base.clone();
+        let counters = pr_counters.clone();
+        async move {
+            counters.pr_metadata_hits.fetch_add(1, Ordering::SeqCst);
+            axum::Json(json!({
+                "resource": base,
+                "authorization_servers": [base],
+                "bearer_methods_supported": ["header"],
+            }))
+        }
+    };
+
+    let as_base = base.clone();
+    let as_counters = counters.clone();
+    let as_metadata = move || {
+        let base = as_base.clone();
+        let counters = as_counters.clone();
+        async move {
+            counters.as_metadata_hits.fetch_add(1, Ordering::SeqCst);
+            axum::Json(json!({
+                "issuer": base,
+                "authorization_endpoint": format!("{}/authorize", base),
+                "token_endpoint": format!("{}/new/token", base),
+                "code_challenge_methods_supported": ["S256"],
+            }))
+        }
+    };
+
+    let old_counters = counters.clone();
+    let old_token = move || {
+        let counters = old_counters.clone();
+        async move {
+            counters.old_token_hits.fetch_add(1, Ordering::SeqCst);
+            (axum::http::StatusCode::NOT_FOUND, "not found".to_string())
+        }
+    };
+
+    let new_counters = counters.clone();
+    let new_token = move |body: String| {
+        let counters = new_counters.clone();
+        async move {
+            counters.new_token_hits.fetch_add(1, Ordering::SeqCst);
+            let params: HashMap<String, String> = url::form_urlencoded::parse(body.as_bytes())
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect();
+            let n = counters.new_token_hits.load(Ordering::SeqCst);
+            axum::Json(json!({
+                "access_token": format!("new-access-{}", n),
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "refresh_token": params
+                    .get("refresh_token")
+                    .cloned()
+                    .unwrap_or_else(|| "refresh-token".to_string()),
+                "scope": "read write",
+            }))
+        }
+    };
+
+    let app = Router::new()
+        .route("/.well-known/oauth-protected-resource", get(pr_metadata))
+        .route("/.well-known/oauth-authorization-server", get(as_metadata))
+        .route("/old/token", post(old_token))
+        .route("/new/token", post(new_token));
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.ok();
+    });
+
+    // Construct a real OAuthAdapter via the same public constructor that
+    // watcher::create_adapter uses for the OAuth transport.
+    let tmp = tempfile::tempdir().unwrap();
+    let token_manager = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+    let config = OAuthAdapterConfig {
+        endpoint_name: "gap6-e2e".to_string(),
+        url: format!("{}/mcp", base),
+        token_endpoint_url: format!("{}/old/token", base),
+        client_id: "test-client".to_string(),
+        client_secret: None,
+        heartbeat_interval_secs: 30,
+        probe_timeout_secs: 10,
+        probe_failure_threshold: 3,
+        server_type_override: None,
+        // Required for the mock to be reachable via 127.0.0.1 from the
+        // SSRF-aware discovery client.
+        allow_insecure_oauth: true,
+    };
+    let adapter = OAuthAdapter::new(config, token_manager);
+    let inner = adapter.shared_inner();
+
+    // Pre-seed the refresh token the same way the in-tree
+    // `make_adapter_with_refresh_token` helper does, so `do_token_refresh`
+    // has something to send.
+    *inner.tokens.write().await = Some(TokenSet {
+        access_token: "stale-access".to_string(),
+        refresh_token: Some("rt-1".to_string()),
+        expires_at: None,
+        token_type: "Bearer".to_string(),
+        scope: None,
+        issued_at: None,
+    });
+
+    // First refresh: /old/token returns 404 -> discovery -> /new/token.
+    let tokens = inner
+        .do_token_refresh()
+        .await
+        .expect("refresh should succeed via discovery fallback");
+    assert_eq!(tokens.access_token, "new-access-1");
+
+    // Cached override and effective endpoint.
+    let effective = inner.effective_token_endpoint().await;
+    assert_eq!(effective, format!("{}/new/token", base));
+
+    // Tight per-counter assertions on the first refresh.
+    assert_eq!(counters.old_token_hits.load(Ordering::SeqCst), 1);
+    assert_eq!(counters.pr_metadata_hits.load(Ordering::SeqCst), 1);
+    assert_eq!(counters.as_metadata_hits.load(Ordering::SeqCst), 1);
+    assert_eq!(counters.new_token_hits.load(Ordering::SeqCst), 1);
+
+    // `do_token_refresh` is the inner refresh primitive: on success it
+    // returns the `TokenSet` and leaves the state at `Refreshing` for the
+    // outer caller (`refresh()` / startup-restore) to `apply_tokens` and
+    // transition to `Authenticated`. Pin that contract so a future change
+    // to who owns the post-success transition is caught by this test.
+    let state = inner.state.read().await.clone();
+    assert_eq!(
+        state,
+        endara_relay::adapter::oauth::OAuthState::Refreshing,
+        "do_token_refresh must leave the state at Refreshing for the caller to finalize"
+    );
+
+    // Second refresh: must skip discovery entirely and post to /new/token.
+    let tokens2 = inner
+        .do_token_refresh()
+        .await
+        .expect("second refresh should succeed against memoized endpoint");
+    assert_eq!(tokens2.access_token, "new-access-2");
+
+    assert_eq!(
+        counters.old_token_hits.load(Ordering::SeqCst),
+        1,
+        "second refresh must NOT re-hit /old/token"
+    );
+    assert_eq!(
+        counters.pr_metadata_hits.load(Ordering::SeqCst),
+        1,
+        "second refresh must NOT re-run protected-resource discovery"
+    );
+    assert_eq!(
+        counters.as_metadata_hits.load(Ordering::SeqCst),
+        1,
+        "second refresh must NOT re-run authorization-server discovery"
+    );
+    assert_eq!(
+        counters.new_token_hits.load(Ordering::SeqCst),
+        2,
+        "second refresh must hit /new/token directly"
+    );
+
+    server.abort();
+}


### PR DESCRIPTION
## Summary

Fixes a class of OAuth refresh failures where the persisted `token_endpoint` in `config.toml` is missing or malformed and the fallback URL returns 404. The most visible repro is **Google Drive**: when no `token_endpoint` is stored and `oauth_server_url = "https://accounts.google.com/"`, the adapter falls back to `{oauth_server_url}/token`, which resolves to `https://accounts.google.com//token` and 404s. Once the access token expires, refresh is permanently broken until the user hand-edits `config.toml`.

## Fix

When the refresh POST returns **404**, the adapter now self-heals:

1. Re-runs OAuth discovery against the resource URL (RFC 9728 → RFC 8414) to obtain a fresh `token_endpoint`.
2. Caches the discovered endpoint **in-memory on the adapter** (no `config.toml` mutation this round — see non-goals in the spec).
3. Retries the refresh **once** against the discovered endpoint.
4. Subsequent refreshes within the lifetime of the adapter use the cached URL directly, so the cost is paid at most once per process.

The behavior is gated to the 404 case, so the happy path is unchanged.

## Commits

Two commits, intended to be **squash-merged** when merging:

1. **`3f7ce75` — feat(oauth): rediscover token endpoint on 404 during refresh**
   - Adds the 404 → rediscover → cache → retry loop on the adapter.
   - Adds four new `refresh_discovery_fallback_*` unit tests covering: happy retry, missing `token_endpoint` after discovery, discovery error, and second-refresh-uses-cache.

2. **`0fe92ff` — feat(oauth): thread allow_insecure_oauth through watcher create_adapter**
   - Plumbs `allow_insecure_oauth` through `watcher.rs::create_adapter` so the config-reload path matches the startup path (previously it was hard-coded to `false` on reload, which silently diverged from startup behavior). The new discovery call now uses the real value.
   - Adds one new test: `apply_diff_threads_allow_insecure_oauth_to_oauth_adapter_config`.

## Tests

- 4 new `refresh_discovery_fallback_*` tests on the OAuth adapter.
- 1 new `apply_diff_threads_allow_insecure_oauth_to_oauth_adapter_config` test on the watcher.
- Full suite: **619 passed / 0 failed**.
- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅

## Non-goals (deferred)

- Persisting the rediscovered `token_endpoint` back to `config.toml`.
- Startup-time discovery in `watcher.rs`.
- `server_type_override` naming migration (`googledrive` → `google-drive`).
- Catalog / setup-wizard changes.
- Desktop app changes.

## Merge note

Please **squash-merge** — the two commits are intentionally split for review but should land as one logical change.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author