### PR TITLE
chore: bump version to 0.1.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "endara-relay"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endara-relay"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "Local MCP tool aggregator — aggregate multiple MCP servers behind a single endpoint"
 license = "Apache-2.0"


### PR DESCRIPTION
Bump the relay base version from `0.1.6` to `0.1.7` to start the next release cycle per AGENTS.md § Release versioning → Scenario 3 (stable `v0.1.6` shipped, now bumping base).

- `Cargo.toml`: `version = "0.1.7"`
- `Cargo.lock`: regenerated by `cargo check`

No feature changes. Mirror desktop bump PR will follow.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author