### PR TITLE
fix(oauth): discover token endpoint at adapter init; slash-safe fallback; propagate from /oauth/callback

### DIFF
--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -227,6 +227,18 @@ impl OAuthAdapterInner {
         }
     }
 
+    /// Install (or replace) the in-memory token endpoint override.
+    ///
+    /// Used by the management `/oauth/callback` handler to propagate the
+    /// token endpoint freshly discovered via RFC 8414 during an
+    /// authorization-code exchange, so that the next proactive refresh POSTs
+    /// to the discovered URL instead of any stale `config.token_endpoint_url`
+    /// baked in at startup. Mirrors the override-write path in
+    /// `handle_refresh_404`.
+    pub async fn set_token_endpoint_override(&self, url: String) {
+        *self.token_endpoint_override.write().await = Some(url);
+    }
+
     /// Perform a token refresh using the refresh_token grant.
     ///
     /// POSTs to the token endpoint (using `effective_token_endpoint`) with

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -1266,6 +1266,42 @@ mod tests {
         assert_eq!(adapter.health(), HealthStatus::Stopped);
     }
 
+    /// `set_token_endpoint_override` populates the in-memory override so that
+    /// `effective_token_endpoint` returns the new URL on the next refresh.
+    /// Covers the management `/oauth/callback` propagation path (the bug
+    /// where a freshly discovered token endpoint was not seen by the
+    /// proactive refresh fired ~45 minutes later).
+    #[tokio::test]
+    async fn set_token_endpoint_override_takes_effect() {
+        let adapter = make_adapter(make_config());
+        // Before the override is set, `effective_token_endpoint` returns the
+        // URL from `config.token_endpoint_url`.
+        assert_eq!(
+            adapter.inner.effective_token_endpoint().await,
+            "http://localhost/token"
+        );
+
+        adapter
+            .inner
+            .set_token_endpoint_override("https://oauth2.googleapis.com/token".to_string())
+            .await;
+
+        assert_eq!(
+            adapter.inner.effective_token_endpoint().await,
+            "https://oauth2.googleapis.com/token"
+        );
+
+        // Replacing again overwrites the previous value (idempotent setter).
+        adapter
+            .inner
+            .set_token_endpoint_override("https://oauth2.googleapis.com/v2/token".to_string())
+            .await;
+        assert_eq!(
+            adapter.inner.effective_token_endpoint().await,
+            "https://oauth2.googleapis.com/v2/token"
+        );
+    }
+
     #[tokio::test]
     async fn apply_tokens_then_disconnect() {
         let tmp = tempfile::tempdir().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -333,16 +333,15 @@ async fn main() {
 
                 // OAuth endpoints initialize inline (always fast)
                 if ep.transport == config::Transport::Oauth {
-                    let base = ep.oauth_server_url.as_deref().unwrap_or_default();
+                    let allow_insecure_oauth = cfg.relay.allow_insecure_oauth.unwrap_or(false);
                     let (client_id, client_secret) =
                         watcher::resolve_oauth_client_creds(ep, token_manager.as_ref()).await;
+                    let token_endpoint_url =
+                        watcher::resolve_oauth_token_endpoint(ep, allow_insecure_oauth).await;
                     let oauth_config = OAuthAdapterConfig {
                         endpoint_name: ep.name.clone(),
                         url: ep.url.clone().unwrap_or_default(),
-                        token_endpoint_url: ep
-                            .token_endpoint
-                            .clone()
-                            .unwrap_or_else(|| format!("{}/token", base)),
+                        token_endpoint_url,
                         client_id,
                         client_secret,
                         heartbeat_interval_secs: 30,
@@ -353,7 +352,7 @@ async fn main() {
                         // discovery fallback so operators who already opted into
                         // `relay.allow_insecure_oauth` for the initial discovery
                         // see consistent behavior on rediscovery.
-                        allow_insecure_oauth: cfg.relay.allow_insecure_oauth.unwrap_or(false),
+                        allow_insecure_oauth,
                     };
 
                     let mut adapter = OAuthAdapter::new(oauth_config, token_manager.clone());

--- a/src/server.rs
+++ b/src/server.rs
@@ -736,12 +736,23 @@ async fn oauth_callback(
         }
     }
 
-    // Apply tokens to the adapter's shared inner state
+    // Apply tokens to the adapter's shared inner state. Also propagate the
+    // freshly discovered token endpoint used for this code exchange into the
+    // adapter's in-memory override so the next proactive refresh POSTs to
+    // the same URL we just succeeded against — without depending on whether
+    // startup-time discovery ran or returned the same result.
     if let Some(ref inners) = state.oauth_adapter_inners {
         let inners = inners.read().await;
         if let Some(inner) = inners.get(&flow.endpoint_name) {
+            inner
+                .set_token_endpoint_override(flow.token_endpoint.clone())
+                .await;
             inner.apply_tokens(token_set.clone()).await;
-            info!(endpoint = %flow.endpoint_name, "Tokens applied to OAuth adapter");
+            info!(
+                endpoint = %flow.endpoint_name,
+                token_endpoint = %flow.token_endpoint,
+                "Tokens applied to OAuth adapter; token endpoint override updated"
+            );
         }
     }
 

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -494,6 +494,72 @@ pub async fn apply_diff_graceful(
 /// compatibility. When a TOML `client_secret` is the only source we emit a
 /// one-time WARN so operators notice they should re-provision via the new
 /// `POST /api/endpoints/{name}/credentials` route.
+/// Build the conventional `{oauth_server_url}/token` endpoint, trimming a
+/// single trailing slash on the base so that `https://accounts.google.com/`
+/// produces `https://accounts.google.com/token` (not `…//token`). Used as
+/// the defense-in-depth fallback when no explicit `token_endpoint` is
+/// configured AND RFC 8414 discovery has not produced a URL.
+pub(crate) fn conventional_token_endpoint(oauth_server_url: &str) -> String {
+    format!("{}/token", oauth_server_url.trim_end_matches('/'))
+}
+
+/// Resolve the URL that an OAuth adapter should target for refresh-token
+/// POSTs at construction time.
+///
+/// Priority:
+/// 1. Explicit `ep.token_endpoint` from config (always wins).
+/// 2. RFC 8414 discovery against `ep.oauth_server_url` — same code path the
+///    management auth flow uses (`management.rs`).
+/// 3. Slash-safe `{oauth_server_url}/token` conventional fallback.
+///
+/// Called from `main.rs` (initial endpoint registration) and from
+/// `create_adapter` (config-watcher reconciliation). On discovery failure
+/// emits a WARN matching the management flow style and continues with the
+/// conventional URL so adapter construction never blocks indefinitely.
+pub(crate) async fn resolve_oauth_token_endpoint(
+    ep: &EndpointConfig,
+    allow_insecure_oauth: bool,
+) -> String {
+    if let Some(explicit) = ep
+        .token_endpoint
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        return explicit.to_string();
+    }
+
+    let Some(base) = ep
+        .oauth_server_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    else {
+        return conventional_token_endpoint("");
+    };
+
+    match crate::oauth::discovery::discover_authorization_server(base, allow_insecure_oauth).await {
+        Ok(disc) => {
+            info!(
+                endpoint = %ep.name,
+                token_endpoint = %disc.token_endpoint,
+                "RFC 8414 discovery resolved token endpoint at adapter init"
+            );
+            disc.token_endpoint
+        }
+        Err(e) => {
+            let fallback = conventional_token_endpoint(base);
+            warn!(
+                endpoint = %ep.name,
+                error = %e,
+                fallback = %fallback,
+                "RFC 8414 discovery against oauth_server_url failed at adapter init; falling back to convention-based token endpoint"
+            );
+            fallback
+        }
+    }
+}
+
 pub(crate) async fn resolve_oauth_client_creds(
     ep: &EndpointConfig,
     token_manager: &TokenManager,

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -664,15 +664,11 @@ pub(crate) async fn create_adapter(
         Transport::Oauth => {
             let (client_id, client_secret) =
                 resolve_oauth_client_creds(ep, token_manager.as_ref()).await;
+            let token_endpoint_url = resolve_oauth_token_endpoint(ep, allow_insecure_oauth).await;
             let oauth_config = OAuthAdapterConfig {
                 endpoint_name: ep.name.clone(),
                 url: ep.url.clone().unwrap_or_default(),
-                token_endpoint_url: ep.token_endpoint.clone().unwrap_or_else(|| {
-                    format!(
-                        "{}/token",
-                        ep.oauth_server_url.as_deref().unwrap_or_default()
-                    )
-                }),
+                token_endpoint_url,
                 client_id,
                 client_secret,
                 heartbeat_interval_secs: 30,
@@ -1568,5 +1564,112 @@ mod tests {
             captured.contains("legacy `client_secret`") && captured.contains("warned-ep"),
             "expected WARN log mentioning legacy client_secret and the endpoint name; got: {captured}"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // resolve_oauth_token_endpoint / conventional_token_endpoint tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: build an OAuth endpoint with explicit `oauth_server_url` and
+    /// optional explicit `token_endpoint`. Used by the resolver tests below.
+    fn oauth_endpoint_with(
+        name: &str,
+        oauth_server_url: Option<&str>,
+        token_endpoint: Option<&str>,
+    ) -> EndpointConfig {
+        EndpointConfig {
+            name: name.to_string(),
+            description: None,
+            tool_prefix: None,
+            transport: Transport::Oauth,
+            command: None,
+            args: None,
+            url: Some("https://mcp.example.com".to_string()),
+            env: None,
+            headers: None,
+            disabled: false,
+            disabled_tools: Vec::new(),
+            oauth_server_url: oauth_server_url.map(|s| s.to_string()),
+            client_id: Some("cid".to_string()),
+            client_secret: None,
+            scopes: None,
+            token_endpoint: token_endpoint.map(|s| s.to_string()),
+            server_type_override: None,
+        }
+    }
+
+    /// `conventional_token_endpoint` must trim a single trailing slash on the
+    /// base so that `https://accounts.google.com/` does NOT produce the
+    /// malformed `https://accounts.google.com//token` URL that triggers the
+    /// Google `invalid_request` refresh failures called out in the spec.
+    #[test]
+    fn conventional_token_endpoint_strips_trailing_slash() {
+        assert_eq!(
+            conventional_token_endpoint("https://accounts.google.com/"),
+            "https://accounts.google.com/token"
+        );
+        assert_eq!(
+            conventional_token_endpoint("https://accounts.google.com"),
+            "https://accounts.google.com/token"
+        );
+        // Multiple trailing slashes also collapse (defense-in-depth).
+        assert_eq!(
+            conventional_token_endpoint("https://example.com///"),
+            "https://example.com/token"
+        );
+    }
+
+    /// Explicit `ep.token_endpoint` always wins — discovery must NOT run when
+    /// the operator has configured the endpoint URL directly.
+    #[tokio::test]
+    async fn resolve_oauth_token_endpoint_prefers_explicit() {
+        let ep = oauth_endpoint_with(
+            "ep",
+            Some("https://accounts.google.com/"),
+            Some("https://oauth2.googleapis.com/token"),
+        );
+        let resolved = resolve_oauth_token_endpoint(&ep, false).await;
+        assert_eq!(resolved, "https://oauth2.googleapis.com/token");
+    }
+
+    /// Whitespace-only `token_endpoint` is treated as "not set" so we fall
+    /// through to discovery / convention rather than POSTing to an empty URL.
+    #[tokio::test]
+    async fn resolve_oauth_token_endpoint_treats_blank_explicit_as_unset() {
+        let ep = oauth_endpoint_with("ep", Some("https://accounts.google.com/"), Some("   "));
+        // Discovery against accounts.google.com would hit the network; use a
+        // loopback URL instead which the SSRF guard rejects fast so we reach
+        // the conventional fallback deterministically. Replace oauth_server_url.
+        let mut ep = ep;
+        ep.oauth_server_url = Some("http://127.0.0.1:1/".to_string());
+        let resolved = resolve_oauth_token_endpoint(&ep, false).await;
+        assert_eq!(resolved, "http://127.0.0.1:1/token");
+    }
+
+    /// When discovery fails (here: SSRF guard rejects loopback with
+    /// `allow_insecure=false`), the resolver falls back to
+    /// `conventional_token_endpoint(oauth_server_url)` and the result must NOT
+    /// contain a `//token` segment — this is the regression the spec calls
+    /// out for Google Drive's trailing-slash `oauth_server_url`.
+    #[tokio::test]
+    async fn resolve_oauth_token_endpoint_falls_back_slash_safely_on_discovery_failure() {
+        let ep = oauth_endpoint_with("ep", Some("http://127.0.0.1:1/"), None);
+        let resolved = resolve_oauth_token_endpoint(&ep, false).await;
+        assert_eq!(resolved, "http://127.0.0.1:1/token");
+        assert!(
+            !resolved.contains("//token"),
+            "fallback must not produce //token; got: {resolved}"
+        );
+    }
+
+    /// Missing `oauth_server_url` AND missing `token_endpoint` produces
+    /// `"/token"` — preserving the prior empty-base behaviour so existing
+    /// misconfigured endpoints fail the same way they did before this change
+    /// (rather than panicking or hanging on discovery).
+    #[tokio::test]
+    async fn resolve_oauth_token_endpoint_empty_base_returns_slash_token() {
+        let ep = oauth_endpoint_with("ep", None, None);
+        let resolved = resolve_oauth_token_endpoint(&ep, false).await;
+        assert_eq!(resolved, "/token");
     }
 }


### PR DESCRIPTION
## Summary

Fix Google Drive OAuth refresh failures caused by a malformed token endpoint URL containing `//token`.

When an endpoint declares `oauth_server_url` with a trailing slash (e.g. Google Drive's `https://accounts.google.com/`) and no explicit `token_endpoint`, the prior convention-only fallback produced `https://accounts.google.com//token`. Google rejects POSTs to that URL with HTTP 400 `invalid_request`, so the proactive refresh fired ~45 minutes after a successful login fails and the endpoint goes Unhealthy.

Three coordinated changes (shipping together):

1. **RFC 8414 discovery at adapter init** — New `watcher::resolve_oauth_token_endpoint` runs the same discovery code path the management auth flow uses, with a slash-safe `{base}/token` conventional fallback on failure. Wired into both `main.rs` (initial registration) and `watcher::create_adapter` (config reconciliation) so `token_endpoint_url` is correct from the very first refresh — no need to wait for the existing refresh-time 404 self-heal.
2. **Trailing-slash safe fallback** — `conventional_token_endpoint` trims trailing slashes on the base so even when discovery is bypassed the fallback URL is well-formed.
3. **Propagation from `/oauth/callback`** — The management callback handler now installs the freshly discovered token endpoint into the adapter's in-memory override via the new `OAuthAdapterInner::set_token_endpoint_override`, so the next proactive refresh uses the exact URL that succeeded for the authorization-code exchange.

## Tests

Six new unit tests, all run offline (loopback + SSRF guard rejection — no network):

- `set_token_endpoint_override_takes_effect`
- `conventional_token_endpoint_strips_trailing_slash`
- `resolve_oauth_token_endpoint_prefers_explicit`
- `resolve_oauth_token_endpoint_treats_blank_explicit_as_unset`
- `resolve_oauth_token_endpoint_falls_back_slash_safely_on_discovery_failure`
- `resolve_oauth_token_endpoint_empty_base_returns_slash_token`

Full suite: `cargo test --lib` → 640 passed, 0 failed.
`cargo fmt --check` clean.

## Verification matrix

| Scenario | Result |
|---|---|
| (a) Discovery succeeds at adapter init | Adapter uses discovered URL |
| (b) Discovery fails at adapter init | Adapter falls back to slash-safe convention URL (WARN logged) |
| (c) `oauth_server_url` has trailing slash, no discovery | Fallback never produces `//token` |
| (d) Management `/oauth/callback` completes | Override is installed; next proactive refresh uses the discovered URL |
