### PR TITLE
feat: convert JSON tool responses to TOON format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml",
+ "toon-format",
  "tower",
  "tower-http",
  "tracing",
@@ -2362,6 +2363,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -2823,6 +2825,18 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toon-format"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1dae994fe9adfb44bdc74fc17546651604a59af32136256515bc1218850832"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "tower"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ thiserror = "1"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 toml = "0.8"
+toon-format = { version = "0.4", default-features = false }
 tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.6", features = ["cors"] }
 tracing = "0.1"

--- a/src/advertise.rs
+++ b/src/advertise.rs
@@ -151,12 +151,23 @@ pub async fn instructions(registry: &AdapterRegistry) -> Option<String> {
     }
 }
 
+/// Hint appended to the `search_tools` description when TOON output is
+/// enabled. Tells the model that tool responses arrive in TOON (Token-Oriented
+/// Object Notation) instead of JSON, so it doesn't try to `JSON.parse()` them.
+pub const TOON_OUTPUT_HINT: &str = "Tool responses are returned in TOON format (Token-Oriented Object Notation) for reduced token usage. TOON is a compact alternative to JSON — indentation-based, no braces, tabular arrays. Parse it like structured text.";
+
 /// Build the `search_tools` description. Appends `\n\nConnected server types: {list}`
-/// when at least one registered adapter has a rendered `server_type`.
-pub async fn search_tools_description(registry: &AdapterRegistry) -> String {
-    match ServerTypeList::new(registry).render().await {
+/// when at least one registered adapter has a rendered `server_type`, and
+/// the TOON hint when `toon_enabled` is true.
+pub async fn search_tools_description(registry: &AdapterRegistry, toon_enabled: bool) -> String {
+    let base = match ServerTypeList::new(registry).render().await {
         Some(list) => format!("{}\n\nConnected server types: {}", SEARCH_TOOLS_BASE, list),
         None => SEARCH_TOOLS_BASE.to_string(),
+    };
+    if toon_enabled {
+        format!("{}\n\n{}", base, TOON_OUTPUT_HINT)
+    } else {
+        base
     }
 }
 
@@ -425,7 +436,7 @@ mod tests {
     #[tokio::test]
     async fn search_tools_description_no_servers() {
         let reg = AdapterRegistry::new();
-        let desc = search_tools_description(&reg).await;
+        let desc = search_tools_description(&reg, false).await;
         assert_eq!(desc, SEARCH_TOOLS_BASE);
     }
 
@@ -434,9 +445,35 @@ mod tests {
         let reg = AdapterRegistry::new();
         register(&reg, "ep1", MockAdapter::ready("github")).await;
         register(&reg, "ep2", MockAdapter::ready("gmail")).await;
-        let desc = search_tools_description(&reg).await;
+        let desc = search_tools_description(&reg, false).await;
         assert!(desc.starts_with(SEARCH_TOOLS_BASE));
         assert!(desc.ends_with("\n\nConnected server types: github, gmail"));
+    }
+
+    #[tokio::test]
+    async fn search_tools_description_appends_toon_hint_when_enabled() {
+        let reg = AdapterRegistry::new();
+        let desc = search_tools_description(&reg, true).await;
+        assert!(desc.starts_with(SEARCH_TOOLS_BASE));
+        assert!(desc.ends_with(TOON_OUTPUT_HINT));
+        assert!(desc.contains("TOON format"));
+    }
+
+    #[tokio::test]
+    async fn search_tools_description_omits_toon_hint_when_disabled() {
+        let reg = AdapterRegistry::new();
+        let desc = search_tools_description(&reg, false).await;
+        assert!(!desc.contains("TOON"));
+    }
+
+    #[tokio::test]
+    async fn search_tools_description_combines_servers_and_toon_hint() {
+        let reg = AdapterRegistry::new();
+        register(&reg, "ep1", MockAdapter::ready("github")).await;
+        let desc = search_tools_description(&reg, true).await;
+        assert!(desc.starts_with(SEARCH_TOOLS_BASE));
+        assert!(desc.contains("Connected server types: github"));
+        assert!(desc.ends_with(TOON_OUTPUT_HINT));
     }
 
     #[tokio::test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,12 @@ pub struct RelayConfig {
     /// confused-deputy attacks against the host running the relay.
     #[serde(default)]
     pub allow_insecure_oauth: Option<bool>,
+    /// Convert JSON tool-call responses to TOON (Token-Oriented Object
+    /// Notation) before they reach the MCP client. Defaults to `true` when
+    /// omitted; set to `false` (or pass `--no-toon` on the command line) to
+    /// restore raw JSON pass-through.
+    #[serde(default)]
+    pub toon_output: Option<bool>,
 }
 
 /// Transport type for an endpoint.
@@ -209,6 +215,7 @@ pub fn default_config() -> Config {
             local_js_execution: None,
             token_dir: None,
             allow_insecure_oauth: None,
+            toon_output: None,
         },
         endpoints: Vec::new(),
     }
@@ -1071,6 +1078,7 @@ command = "echo"
                 local_js_execution: None,
                 token_dir: None,
                 allow_insecure_oauth: None,
+                toon_output: None,
             },
             endpoints,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod server;
 pub mod shell_env;
 pub mod token_manager;
 pub mod token_security;
+pub mod toon_convert;
 pub mod watcher;
 
 use adapter::oauth::OAuthAdapterInner;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod prefix;
 mod registry;
 mod server;
 mod shell_env;
+mod toon_convert;
 
 use adapter::oauth::{OAuthAdapter, OAuthAdapterConfig, OAuthAdapterInner};
 use adapter::{FailedAdapter, McpAdapter, StartingAdapter};
@@ -70,6 +71,12 @@ enum Commands {
         /// EnvFilter directive for the file log layer (default: debug,endara_relay=trace)
         #[arg(long)]
         file_log_level: Option<String>,
+
+        /// Disable TOON (Token-Oriented Object Notation) conversion of JSON
+        /// tool responses. Overrides `relay.toon_output` from config.toml.
+        /// When unset, TOON conversion defaults to on.
+        #[arg(long, default_value_t = false)]
+        no_toon: bool,
     },
 }
 
@@ -162,6 +169,7 @@ async fn main() {
             log_format,
             color,
             file_log_level,
+            no_toon,
         } => {
             let data_dir_path = expand_tilde(&data_dir);
             let log_dir = data_dir_path.join("logs");
@@ -438,6 +446,15 @@ async fn main() {
                 Duration::from_secs(30),
             ));
             let setup_manager = Arc::new(OAuthSetupManager::new());
+            // TOON output: CLI `--no-toon` forces off; otherwise honour
+            // `relay.toon_output` from config.toml; default on when neither
+            // is set.
+            let toon_enabled = if no_toon {
+                false
+            } else {
+                cfg.relay.toon_output.unwrap_or(true)
+            };
+            info!(toon_enabled, "TOON output conversion configured");
             let state = AppState {
                 registry: (*registry).clone(),
                 js_execution_mode: js_execution_mode.clone(),
@@ -447,6 +464,7 @@ async fn main() {
                 oauth_adapter_inners: Some(oauth_adapter_inners.clone()),
                 setup_manager: Some(setup_manager.clone()),
                 started_at: std::time::Instant::now(),
+                toon_enabled,
             };
             let mgmt_state = management::ManagementState {
                 registry: registry.clone(),

--- a/src/management.rs
+++ b/src/management.rs
@@ -2664,6 +2664,7 @@ mod tests {
                 local_js_execution: None,
                 token_dir: None,
                 allow_insecure_oauth: None,
+                toon_output: None,
             },
             endpoints: vec![EndpointConfig {
                 name: "echo".to_string(),
@@ -4623,6 +4624,7 @@ command = "echo"
                 local_js_execution: None,
                 token_dir: None,
                 allow_insecure_oauth: None,
+                toon_output: None,
             },
             endpoints: vec![EndpointConfig {
                 name: name.to_string(),
@@ -4819,6 +4821,7 @@ command = "echo"
                 local_js_execution: None,
                 token_dir: None,
                 allow_insecure_oauth: Some(true),
+                toon_output: None,
             },
             endpoints: vec![EndpointConfig {
                 name: name.to_string(),
@@ -5228,6 +5231,7 @@ command = "echo"
                 local_js_execution: None,
                 token_dir: None,
                 allow_insecure_oauth: Some(allow_insecure_oauth),
+                toon_output: None,
             },
             endpoints: vec![EndpointConfig {
                 name: name.to_string(),
@@ -5340,6 +5344,7 @@ client_id = "client123"
                 local_js_execution: None,
                 token_dir: None,
                 allow_insecure_oauth: Some(false),
+                toon_output: None,
             },
             endpoints: vec![],
         };

--- a/src/server.rs
+++ b/src/server.rs
@@ -42,6 +42,10 @@ pub struct AppState {
     pub setup_manager: Option<Arc<OAuthSetupManager>>,
     /// Process start time, used to compute `/healthz` uptime.
     pub started_at: Instant,
+    /// Convert JSON tool-call responses to TOON (Token-Oriented Object
+    /// Notation) before they reach the MCP client. Computed at startup from
+    /// `RelayConfig::toon_output` and the `--no-toon` CLI flag.
+    pub toon_enabled: bool,
 }
 
 /// JSON-RPC request body expected by MCP routes.
@@ -62,12 +66,19 @@ fn jsonrpc_response(id: Option<Value>, result: Value) -> Json<Value> {
     }))
 }
 
-/// Wrap a raw meta-tool result in the MCP `content` array format.
-fn wrap_meta_tool_result(result: Value) -> Value {
+/// Wrap a raw meta-tool result in the MCP `content` array format. When
+/// `toon_enabled` is true, encode JSON objects/arrays to TOON; otherwise
+/// fall back to pretty-printed JSON.
+fn wrap_meta_tool_result(result: Value, toon_enabled: bool) -> Value {
+    let text = if toon_enabled {
+        crate::toon_convert::toonify_value(&result)
+    } else {
+        serde_json::to_string_pretty(&result).unwrap_or_default()
+    };
     json!({
         "content": [{
             "type": "text",
-            "text": serde_json::to_string_pretty(&result).unwrap_or_default()
+            "text": text
         }]
     })
 }
@@ -114,9 +125,13 @@ async fn mcp_initialize(
 /// The descriptions are built dynamically against the supplied [`AdapterRegistry`]
 /// so each `tools/list` response advertises the currently-Healthy server set
 /// (see `crate::advertise`).
-async fn meta_tool_definitions(js_mode: bool, registry: &AdapterRegistry) -> Vec<Value> {
+async fn meta_tool_definitions(
+    js_mode: bool,
+    registry: &AdapterRegistry,
+    toon_enabled: bool,
+) -> Vec<Value> {
     let list_desc = crate::advertise::list_tools_description(registry).await;
-    let search_desc = crate::advertise::search_tools_description(registry).await;
+    let search_desc = crate::advertise::search_tools_description(registry, toon_enabled).await;
     let mut tools = vec![
         json!({
             "name": "list_tools",
@@ -166,7 +181,7 @@ async fn mcp_tools_list(
     Json(body): Json<JsonRpcBody>,
 ) -> Json<Value> {
     let js_mode = state.js_execution_mode.load(Ordering::Relaxed);
-    let meta_tools = meta_tool_definitions(js_mode, &state.registry).await;
+    let meta_tools = meta_tool_definitions(js_mode, &state.registry, state.toon_enabled).await;
 
     let tools: Vec<Value> = if js_mode {
         // JS execution mode: only the 3 meta-tools (incl. execute_tools)
@@ -230,7 +245,12 @@ async fn mcp_tools_call(
                 .and_then(|v| v.as_u64())
                 .map(|v| v as usize);
             match state.meta_tool_handler.list_tools(limit, offset).await {
-                Ok(result) => return Ok(jsonrpc_response(body.id, wrap_meta_tool_result(result))),
+                Ok(result) => {
+                    return Ok(jsonrpc_response(
+                        body.id,
+                        wrap_meta_tool_result(result, state.toon_enabled),
+                    ))
+                }
                 Err(e) => return Err(jsonrpc_error(body.id, -32603, &e.to_string())),
             }
         }
@@ -244,7 +264,12 @@ async fn mcp_tools_call(
                 .and_then(|v| v.as_u64())
                 .map(|v| v as usize);
             match state.meta_tool_handler.search_tools(query, limit).await {
-                Ok(result) => return Ok(jsonrpc_response(body.id, wrap_meta_tool_result(result))),
+                Ok(result) => {
+                    return Ok(jsonrpc_response(
+                        body.id,
+                        wrap_meta_tool_result(result, state.toon_enabled),
+                    ))
+                }
                 Err(e) => return Err(jsonrpc_error(body.id, -32603, &e.to_string())),
             }
         }
@@ -265,7 +290,12 @@ async fn mcp_tools_call(
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
             match state.meta_tool_handler.execute_tools(script).await {
-                Ok(result) => return Ok(jsonrpc_response(body.id, wrap_meta_tool_result(result))),
+                Ok(result) => {
+                    return Ok(jsonrpc_response(
+                        body.id,
+                        wrap_meta_tool_result(result, state.toon_enabled),
+                    ))
+                }
                 Err(e) => return Err(jsonrpc_error(body.id, -32603, &e.to_string())),
             }
         }
@@ -282,7 +312,14 @@ async fn mcp_tools_call(
     }
 
     match state.registry.route_tool_call(tool_name, arguments).await {
-        Ok(result) => Ok(jsonrpc_response(body.id, result)),
+        Ok(result) => {
+            let result = if state.toon_enabled {
+                crate::toon_convert::toonify_call_result(result)
+            } else {
+                result
+            };
+            Ok(jsonrpc_response(body.id, result))
+        }
         Err(e) => Err(jsonrpc_error(body.id, -32603, &e.to_string())),
     }
 }
@@ -1085,6 +1122,7 @@ mod tests {
             oauth_adapter_inners: None,
             setup_manager: None,
             started_at: Instant::now(),
+            toon_enabled: false,
         }
     }
 
@@ -1147,7 +1185,7 @@ mod tests {
     #[tokio::test]
     async fn meta_tool_definitions_contains_expected_tools() {
         let registry = AdapterRegistry::new();
-        let defs = meta_tool_definitions(true, &registry).await;
+        let defs = meta_tool_definitions(true, &registry, false).await;
         assert_eq!(defs.len(), 3);
 
         let names: Vec<&str> = defs.iter().map(|d| d["name"].as_str().unwrap()).collect();
@@ -1167,7 +1205,7 @@ mod tests {
     #[tokio::test]
     async fn meta_tool_definitions_hides_execute_tools_when_js_off() {
         let registry = AdapterRegistry::new();
-        let defs = meta_tool_definitions(false, &registry).await;
+        let defs = meta_tool_definitions(false, &registry, false).await;
         let names: Vec<&str> = defs.iter().map(|d| d["name"].as_str().unwrap()).collect();
         assert!(names.contains(&"list_tools"));
         assert!(names.contains(&"search_tools"));
@@ -1180,7 +1218,7 @@ mod tests {
     #[tokio::test]
     async fn test_list_tools_description_documents_return_format() {
         let registry = AdapterRegistry::new();
-        let defs = meta_tool_definitions(true, &registry).await;
+        let defs = meta_tool_definitions(true, &registry, false).await;
         let list_desc = defs.iter().find(|d| d["name"] == "list_tools").unwrap()["description"]
             .as_str()
             .unwrap();
@@ -1209,7 +1247,7 @@ mod tests {
     #[tokio::test]
     async fn test_search_tools_description_documents_behavior() {
         let registry = AdapterRegistry::new();
-        let defs = meta_tool_definitions(true, &registry).await;
+        let defs = meta_tool_definitions(true, &registry, false).await;
         let search_desc = defs.iter().find(|d| d["name"] == "search_tools").unwrap()["description"]
             .as_str()
             .unwrap();
@@ -1232,7 +1270,7 @@ mod tests {
     #[tokio::test]
     async fn test_execute_tools_description_has_examples() {
         let registry = AdapterRegistry::new();
-        let defs = meta_tool_definitions(true, &registry).await;
+        let defs = meta_tool_definitions(true, &registry, false).await;
         let exec_desc = defs.iter().find(|d| d["name"] == "execute_tools").unwrap()["description"]
             .as_str()
             .unwrap();
@@ -1397,6 +1435,133 @@ mod tests {
                 // An error response is acceptable for empty script
             }
         }
+    }
+
+    // §5 row 16: `list_tools` response text is TOON when `toon_enabled` is on.
+    #[tokio::test]
+    async fn list_tools_response_is_toon_when_enabled() {
+        let mut state = test_app_state();
+        state.toon_enabled = true;
+        let body = JsonRpcBody {
+            jsonrpc: Some("2.0".to_string()),
+            method: Some("tools/call".to_string()),
+            params: Some(json!({"name": "list_tools", "arguments": {}})),
+            id: Some(json!(1)),
+        };
+        let Json(resp) = mcp_tools_call(State(state), Json(body)).await.unwrap();
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        // TOON output for the `{ tools, total, limit, offset }` envelope is
+        // never valid JSON — it starts with field declarations, not `{`.
+        assert!(
+            serde_json::from_str::<Value>(text).is_err(),
+            "expected TOON, got JSON-parseable text: {text}"
+        );
+        assert!(
+            text.contains("total:"),
+            "expected TOON field syntax in: {text}"
+        );
+    }
+
+    // §5 row 15: `execute_tools` response text is TOON when `toon_enabled`
+    // is on and the script returns a JSON object.
+    #[tokio::test]
+    async fn execute_tools_response_is_toon_when_enabled() {
+        let mut state = test_app_state();
+        state.toon_enabled = true;
+        state.js_execution_mode.store(true, Ordering::Relaxed);
+        let body = JsonRpcBody {
+            jsonrpc: Some("2.0".to_string()),
+            method: Some("tools/call".to_string()),
+            params: Some(json!({
+                "name": "execute_tools",
+                "arguments": {
+                    "script": "return { users: [{ id: 1, name: 'a' }, { id: 2, name: 'b' }] };"
+                }
+            })),
+            id: Some(json!(2)),
+        };
+        let Json(resp) = mcp_tools_call(State(state), Json(body)).await.unwrap();
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(
+            serde_json::from_str::<Value>(text).is_err(),
+            "expected TOON, got JSON-parseable text: {text}"
+        );
+        assert!(
+            text.contains("users"),
+            "expected \"users\" key in TOON: {text}"
+        );
+    }
+
+    // §5 row 11: `toon_enabled = false` keeps JSON pass-through for meta-tool
+    // responses (covers the config-flag-off branch end-to-end).
+    #[tokio::test]
+    async fn list_tools_response_is_json_when_disabled() {
+        let state = test_app_state();
+        assert!(!state.toon_enabled);
+        let body = JsonRpcBody {
+            jsonrpc: Some("2.0".to_string()),
+            method: Some("tools/call".to_string()),
+            params: Some(json!({"name": "list_tools", "arguments": {}})),
+            id: Some(json!(1)),
+        };
+        let Json(resp) = mcp_tools_call(State(state), Json(body)).await.unwrap();
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        let parsed: Value = serde_json::from_str(text).expect("JSON when toon disabled");
+        assert!(parsed["tools"].is_array());
+    }
+
+    // §5 row 17: server advertising description includes the TOON hint when
+    // enabled and omits it when disabled.
+    #[tokio::test]
+    async fn search_tools_advertising_includes_toon_hint_when_enabled() {
+        let registry = AdapterRegistry::new();
+        let defs_on = meta_tool_definitions(true, &registry, true).await;
+        let search_desc = defs_on
+            .iter()
+            .find(|d| d["name"] == "search_tools")
+            .unwrap()["description"]
+            .as_str()
+            .unwrap();
+        assert!(
+            search_desc.contains("TOON format"),
+            "expected TOON hint in: {search_desc}"
+        );
+
+        let defs_off = meta_tool_definitions(true, &registry, false).await;
+        let search_desc_off = defs_off
+            .iter()
+            .find(|d| d["name"] == "search_tools")
+            .unwrap()["description"]
+            .as_str()
+            .unwrap();
+        assert!(
+            !search_desc_off.contains("TOON"),
+            "expected no TOON hint when disabled, got: {search_desc_off}"
+        );
+    }
+
+    // §5 row 14: tools/call native route applies TOON to upstream tool
+    // response text. Exercised via a route_tool_call stand-in: we go through
+    // wrap_meta_tool_result with toon_enabled=true and verify the envelope
+    // shape and TOON content match.
+    #[test]
+    fn wrap_meta_tool_result_emits_toon_when_enabled() {
+        let val = json!({ "rows": [{"id": 1}, {"id": 2}] });
+        let wrapped = wrap_meta_tool_result(val.clone(), true);
+        let text = wrapped["content"][0]["text"].as_str().unwrap();
+        assert!(
+            serde_json::from_str::<Value>(text).is_err(),
+            "expected TOON, got: {text}"
+        );
+    }
+
+    #[test]
+    fn wrap_meta_tool_result_emits_json_when_disabled() {
+        let val = json!({ "rows": [{"id": 1}, {"id": 2}] });
+        let wrapped = wrap_meta_tool_result(val.clone(), false);
+        let text = wrapped["content"][0]["text"].as_str().unwrap();
+        let parsed: Value = serde_json::from_str(text).expect("valid JSON");
+        assert_eq!(parsed, val);
     }
 
     /// Helper: send a JSON-RPC POST to `/mcp` via the router and return the response.

--- a/src/toon_convert.rs
+++ b/src/toon_convert.rs
@@ -1,0 +1,265 @@
+//! Convert JSON tool responses to TOON (Token-Oriented Object Notation) format
+//! before they reach the MCP client. See the Engineering WSpec for the full
+//! design; conversion rules live in §3.4.
+
+use serde_json::Value;
+use toon_format::encode_default;
+
+/// Convert JSON text content in a `CallToolResult` envelope to TOON where
+/// possible. Returns the original value unchanged if the envelope doesn't
+/// match, the response is an error, or individual entries are not
+/// JSON-convertible.
+pub fn toonify_call_result(mut result: Value) -> Value {
+    // Don't convert error responses — models may need the exact JSON
+    // structure to understand what went wrong.
+    if result
+        .get("isError")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        return result;
+    }
+
+    let Some(content) = result.get_mut("content").and_then(|v| v.as_array_mut()) else {
+        return result;
+    };
+
+    for item in content.iter_mut() {
+        // Only convert TextContent entries.
+        if item.get("type").and_then(|v| v.as_str()) != Some("text") {
+            continue;
+        }
+
+        let Some(text) = item.get("text").and_then(|v| v.as_str()) else {
+            continue;
+        };
+
+        // Try to parse as JSON. Non-JSON text (plain text, markdown, …)
+        // passes through untouched.
+        let Ok(json_val) = serde_json::from_str::<Value>(text) else {
+            continue;
+        };
+
+        // Skip scalars — TOON shines on objects/arrays, not "42" or "hello".
+        if !json_val.is_object() && !json_val.is_array() {
+            continue;
+        }
+
+        // Encode to TOON; silently keep original JSON text on failure.
+        if let Ok(toon_text) = encode_default(&json_val) {
+            item["text"] = Value::String(toon_text);
+        }
+    }
+
+    result
+}
+
+/// Convert a JS execution result to TOON for `wrap_meta_tool_result`.
+/// Returns the TOON string, falling back to pretty-printed JSON on failure or
+/// when given a scalar input.
+pub fn toonify_value(val: &Value) -> String {
+    if !val.is_object() && !val.is_array() {
+        return serde_json::to_string_pretty(val).unwrap_or_default();
+    }
+
+    encode_default(val).unwrap_or_else(|_| serde_json::to_string_pretty(val).unwrap_or_default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use toon_format::decode_default;
+
+    // §5 row 1: toonify_call_result converts JSON object in TextContent.text
+    // to TOON.
+    #[test]
+    fn converts_json_object_in_text_content() {
+        let input = json!({
+            "content": [{
+                "type": "text",
+                "text": "{\"name\":\"Alice\",\"age\":30}"
+            }],
+            "isError": false
+        });
+        let out = toonify_call_result(input);
+        let text = out["content"][0]["text"].as_str().unwrap();
+        assert_ne!(text, "{\"name\":\"Alice\",\"age\":30}");
+        // Round-trip back to JSON to confirm fidelity.
+        let decoded: Value = decode_default(text).unwrap();
+        assert_eq!(decoded, json!({"name": "Alice", "age": 30}));
+    }
+
+    // §5 row 2: toonify_call_result converts JSON array in TextContent.text
+    // to TOON.
+    #[test]
+    fn converts_json_array_in_text_content() {
+        let input = json!({
+            "content": [{
+                "type": "text",
+                "text": "[{\"id\":1,\"name\":\"a\"},{\"id\":2,\"name\":\"b\"}]"
+            }]
+        });
+        let out = toonify_call_result(input);
+        let text = out["content"][0]["text"].as_str().unwrap();
+        // TOON arrays start with `[N]{fields}:` — not valid JSON.
+        assert!(
+            serde_json::from_str::<Value>(text).is_err(),
+            "expected TOON, got JSON: {text}"
+        );
+        let decoded: Value = decode_default(text).unwrap();
+        assert_eq!(
+            decoded,
+            json!([{"id": 1, "name": "a"}, {"id": 2, "name": "b"}])
+        );
+    }
+
+    // §5 row 3: toonify_call_result leaves plain text (non-JSON) TextContent
+    // unchanged.
+    #[test]
+    fn leaves_plain_text_unchanged() {
+        let input = json!({
+            "content": [{
+                "type": "text",
+                "text": "Hello, world! This is # not JSON."
+            }]
+        });
+        let out = toonify_call_result(input.clone());
+        assert_eq!(out, input);
+    }
+
+    // §5 row 4: toonify_call_result leaves ImageContent entries unchanged.
+    #[test]
+    fn leaves_image_content_unchanged() {
+        let input = json!({
+            "content": [{
+                "type": "image",
+                "data": "iVBORw0KGgoAAAANSUhEUg==",
+                "mimeType": "image/png"
+            }]
+        });
+        let out = toonify_call_result(input.clone());
+        assert_eq!(out, input);
+    }
+
+    // §5 row 5: toonify_call_result leaves isError: true responses unchanged.
+    #[test]
+    fn leaves_error_responses_unchanged() {
+        let input = json!({
+            "content": [{
+                "type": "text",
+                "text": "{\"error\":\"boom\",\"code\":500}"
+            }],
+            "isError": true
+        });
+        let out = toonify_call_result(input.clone());
+        assert_eq!(out, input);
+    }
+
+    // §5 row 6: toonify_call_result leaves JSON scalar TextContent unchanged.
+    #[test]
+    fn leaves_json_scalar_text_unchanged() {
+        for scalar in ["42", "\"hello\"", "true", "null", "3.14"] {
+            let input = json!({
+                "content": [{ "type": "text", "text": scalar }]
+            });
+            let out = toonify_call_result(input.clone());
+            assert_eq!(out, input, "scalar {scalar} should pass through unchanged");
+        }
+    }
+
+    // §5 row 7: toonify_call_result handles mixed content array
+    // (text + JSON + image).
+    #[test]
+    fn handles_mixed_content_array() {
+        let input = json!({
+            "content": [
+                { "type": "text", "text": "Summary line, not JSON." },
+                { "type": "text", "text": "{\"k\":\"v\"}" },
+                {
+                    "type": "image",
+                    "data": "abc",
+                    "mimeType": "image/png"
+                }
+            ]
+        });
+        let out = toonify_call_result(input);
+        // Plain text untouched.
+        assert_eq!(out["content"][0]["text"], "Summary line, not JSON.");
+        // JSON converted.
+        let toon = out["content"][1]["text"].as_str().unwrap();
+        assert_ne!(toon, "{\"k\":\"v\"}");
+        let decoded: Value = decode_default(toon).unwrap();
+        assert_eq!(decoded, json!({"k": "v"}));
+        // Image untouched.
+        assert_eq!(out["content"][2]["type"], "image");
+        assert_eq!(out["content"][2]["data"], "abc");
+    }
+
+    // §5 row 8: toonify_call_result handles content with no text field
+    // gracefully.
+    #[test]
+    fn handles_text_entry_without_text_field() {
+        let input = json!({
+            "content": [{ "type": "text" }]
+        });
+        let out = toonify_call_result(input.clone());
+        assert_eq!(out, input);
+
+        // Also gracefully handles missing `content` arrays entirely.
+        let no_content = json!({ "isError": false });
+        let out2 = toonify_call_result(no_content.clone());
+        assert_eq!(out2, no_content);
+
+        // And non-array `content` values.
+        let weird = json!({ "content": "not-an-array" });
+        let out3 = toonify_call_result(weird.clone());
+        assert_eq!(out3, weird);
+    }
+
+    // §5 row 9: toonify_value converts JSON object to TOON string.
+    #[test]
+    fn toonify_value_converts_object_to_toon() {
+        let val = json!({ "users": [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}] });
+        let out = toonify_value(&val);
+        // TOON encodes a tabular array with `[2]` header for two-row uniform
+        // arrays — anything ending the prefix-only form is acceptable here as
+        // long as a round-trip restores the original JSON.
+        let decoded: Value = decode_default(&out).unwrap();
+        assert_eq!(decoded, val);
+    }
+
+    // §5 row 10: toonify_value falls back to pretty JSON on scalar input.
+    #[test]
+    fn toonify_value_falls_back_on_scalar() {
+        assert_eq!(toonify_value(&json!(42)), "42");
+        assert_eq!(toonify_value(&json!("hello")), "\"hello\"");
+        assert_eq!(toonify_value(&json!(true)), "true");
+        assert_eq!(toonify_value(&json!(null)), "null");
+    }
+
+    // §5 row 13: Round-trip — decode(encode(json)) == json for
+    // representative tool responses.
+    #[test]
+    fn round_trip_preserves_representative_payloads() {
+        let cases = vec![
+            json!({"name": "Alice", "age": 30, "active": true}),
+            json!([1, 2, 3, 4, 5]),
+            json!({
+                "users": [
+                    {"id": 1, "name": "Alice", "active": true},
+                    {"id": 2, "name": "Bob", "active": false},
+                    {"id": 3, "name": "Carol", "active": true}
+                ]
+            }),
+            json!({"nested": {"inner": {"deep": [1, 2, 3]}}}),
+            json!({"empty_obj": {}, "empty_arr": []}),
+            json!({"mixed": [1, "two", true, null, {"k": "v"}]}),
+        ];
+        for case in cases {
+            let toon = encode_default(&case).expect("encode succeeds");
+            let back: Value = decode_default(&toon).expect("decode succeeds");
+            assert_eq!(back, case, "round-trip lost data: {case}");
+        }
+    }
+}

--- a/tests/advertise.rs
+++ b/tests/advertise.rs
@@ -202,7 +202,7 @@ async fn instructions_and_descriptions_reflect_healthy_server() {
     );
     let search_desc = meta_tool_description(&tools, "search_tools");
     assert!(
-        search_desc.ends_with("\n\nConnected server types: bad"),
+        search_desc.contains("\n\nConnected server types: bad"),
         "search_tools description missing Connected server types footer: {search_desc}"
     );
 }
@@ -252,7 +252,7 @@ async fn failed_adapter_with_override_included_in_advertised_list() {
     );
     let search_desc = meta_tool_description(&tools, "search_tools");
     assert!(
-        search_desc.ends_with("\n\nConnected server types: bad, broken"),
+        search_desc.contains("\n\nConnected server types: bad, broken"),
         "search_tools description must include the Failed adapter's override: {search_desc}"
     );
 }
@@ -301,7 +301,7 @@ async fn multi_distinct_types_rendered_in_alphabetical_order() {
     );
     let search_desc = meta_tool_description(&tools, "search_tools");
     assert!(
-        search_desc.ends_with(&format!("\n\nConnected server types: {}", expected_list)),
+        search_desc.contains(&format!("\n\nConnected server types: {}", expected_list)),
         "search_tools description does not end with full alphabetised list: {search_desc}"
     );
     // execute_tools is hidden when JS mode is off; covered separately.
@@ -339,7 +339,7 @@ async fn hot_reload_kill_endpoint_drops_from_advertised_list() {
     let tools = raw_tools_list(&harness).await;
     let search_desc = meta_tool_description(&tools, "search_tools");
     assert!(
-        search_desc.ends_with("\n\nConnected server types: alpha, zebra"),
+        search_desc.contains("\n\nConnected server types: alpha, zebra"),
         "expected mango to be removed from search_tools description: {search_desc}"
     );
     let init = raw_initialize(&harness).await;
@@ -384,7 +384,7 @@ async fn hot_reload_add_endpoint_appears_in_advertised_list() {
     let tools = raw_tools_list(&harness).await;
     let search_desc = meta_tool_description(&tools, "search_tools");
     assert!(
-        search_desc.ends_with("\n\nConnected server types: alpha, mango, zebra"),
+        search_desc.contains("\n\nConnected server types: alpha, mango, zebra"),
         "expected mango to appear in alphabetised list: {search_desc}"
     );
 }
@@ -427,7 +427,7 @@ async fn duplicate_type_dedupes_but_count_includes_both() {
     );
     let search_desc = meta_tool_description(&tools, "search_tools");
     assert!(
-        search_desc.ends_with("\n\nConnected server types: alpha"),
+        search_desc.contains("\n\nConnected server types: alpha"),
         "search_tools description should carry deduplicated single entry: {search_desc}"
     );
 }

--- a/tests/common/config.rs
+++ b/tests/common/config.rs
@@ -19,6 +19,7 @@ struct EndpointEntry {
 pub struct ConfigBuilder {
     endpoints: Vec<EndpointEntry>,
     js_execution_mode: bool,
+    toon_output: Option<bool>,
 }
 
 impl ConfigBuilder {
@@ -26,6 +27,7 @@ impl ConfigBuilder {
         Self {
             endpoints: Vec::new(),
             js_execution_mode: false,
+            toon_output: None,
         }
     }
 
@@ -156,6 +158,13 @@ impl ConfigBuilder {
         self
     }
 
+    /// Explicitly set the `toon_output` flag. `None` (default) emits no
+    /// `toon_output` line, so the relay's own default (`true`) wins.
+    pub fn toon_output(mut self, enabled: bool) -> Self {
+        self.toon_output = Some(enabled);
+        self
+    }
+
     /// Serialize the config to a TOML string.
     pub fn build(self) -> String {
         let mut out = String::new();
@@ -167,6 +176,9 @@ impl ConfigBuilder {
         out.push_str("allow_insecure_oauth = true\n");
         if self.js_execution_mode {
             out.push_str("local_js_execution = true\n");
+        }
+        if let Some(toon) = self.toon_output {
+            out.push_str(&format!("toon_output = {}\n", toon));
         }
         out.push('\n');
 

--- a/tests/health_endpoint_integration.rs
+++ b/tests/health_endpoint_integration.rs
@@ -24,6 +24,7 @@ async fn setup_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
         oauth_adapter_inners: None,
         setup_manager: None,
         started_at: std::time::Instant::now(),
+        toon_enabled: false,
     };
     let router = build_router(state);
     let addr: SocketAddr = ([127, 0, 0, 1], 0).into();

--- a/tests/hot_reload_integration.rs
+++ b/tests/hot_reload_integration.rs
@@ -60,6 +60,7 @@ async fn test_config_diff_add_endpoint() {
             local_js_execution: None,
             token_dir: None,
             allow_insecure_oauth: None,
+            toon_output: None,
         },
         endpoints: vec![config::EndpointConfig {
             name: "echo-ep".to_string(),
@@ -88,6 +89,7 @@ async fn test_config_diff_add_endpoint() {
             local_js_execution: None,
             token_dir: None,
             allow_insecure_oauth: None,
+            toon_output: None,
         },
         endpoints: vec![
             config::EndpointConfig {
@@ -215,6 +217,7 @@ async fn test_config_diff_remove_endpoint() {
             local_js_execution: None,
             token_dir: None,
             allow_insecure_oauth: None,
+            toon_output: None,
         },
         endpoints: vec![
             config::EndpointConfig {
@@ -264,6 +267,7 @@ async fn test_config_diff_remove_endpoint() {
             local_js_execution: None,
             token_dir: None,
             allow_insecure_oauth: None,
+            toon_output: None,
         },
         endpoints: vec![config::EndpointConfig {
             name: "echo-ep".to_string(),

--- a/tests/js_execution_integration.rs
+++ b/tests/js_execution_integration.rs
@@ -55,6 +55,7 @@ async fn setup_js_server(js_mode: bool) -> (SocketAddr, tokio::task::JoinHandle<
         oauth_adapter_inners: None,
         setup_manager: None,
         started_at: std::time::Instant::now(),
+        toon_enabled: false,
     };
     let router = build_router(state);
     let addr: SocketAddr = ([127, 0, 0, 1], 0).into();

--- a/tests/management_api_integration.rs
+++ b/tests/management_api_integration.rs
@@ -84,6 +84,7 @@ fn test_config() -> Config {
             local_js_execution: None,
             token_dir: None,
             allow_insecure_oauth: None,
+            toon_output: None,
         },
         endpoints: vec![EndpointConfig {
             name: "echo".to_string(),

--- a/tests/mcp_server_integration.rs
+++ b/tests/mcp_server_integration.rs
@@ -50,6 +50,7 @@ async fn setup_server() -> (SocketAddr, AdapterRegistry, tokio::task::JoinHandle
         oauth_adapter_inners: None,
         setup_manager: None,
         started_at: std::time::Instant::now(),
+        toon_enabled: false,
     };
     let router = build_router(state);
     // Bind to port 0 to get a random available port

--- a/tests/mcp_server_integration.rs
+++ b/tests/mcp_server_integration.rs
@@ -1,9 +1,10 @@
+use async_trait::async_trait;
 use endara_relay::adapter::stdio::{StdioAdapter, StdioConfig};
-use endara_relay::adapter::McpAdapter;
+use endara_relay::adapter::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
 use endara_relay::js_sandbox::MetaToolHandler;
 use endara_relay::registry::AdapterRegistry;
 use endara_relay::server::{build_router, start_server, AppState};
-use serde_json::json;
+use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -175,4 +176,152 @@ async fn test_mcp_tools_call_invalid_prefix() {
     assert!(resp.status().is_success());
     let body: serde_json::Value = resp.json().await.unwrap();
     assert!(body["error"].is_object(), "expected error response");
+}
+
+/// Mock adapter whose `call_tool` returns a `CallToolResult` envelope with
+/// a JSON-serialized object in its single TextContent entry. Used by the
+/// route-level integration tests for the native `tools/call` branch
+/// (§5 row 14) to verify TOON gating end-to-end.
+struct JsonPayloadAdapter;
+
+#[async_trait]
+impl McpAdapter for JsonPayloadAdapter {
+    async fn initialize(&mut self) -> Result<(), AdapterError> {
+        Ok(())
+    }
+    async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
+        Ok(vec![ToolInfo {
+            name: "json_tool".to_string(),
+            description: Some("returns a JSON object in TextContent".to_string()),
+            input_schema: json!({"type": "object"}),
+            annotations: None,
+        }])
+    }
+    async fn call_tool(&self, _name: &str, _args: Value) -> Result<Value, AdapterError> {
+        Ok(json!({
+            "content": [{
+                "type": "text",
+                "text": "{\"users\":[{\"id\":1,\"name\":\"a\"},{\"id\":2,\"name\":\"b\"}]}"
+            }]
+        }))
+    }
+    fn health(&self) -> HealthStatus {
+        HealthStatus::Healthy
+    }
+    async fn shutdown(&mut self) -> Result<(), AdapterError> {
+        Ok(())
+    }
+}
+
+/// Build a relay server backed by a single `JsonPayloadAdapter`, with the
+/// requested `toon_enabled` flag. Returns the bound HTTP address.
+async fn setup_native_toon_server(toon_enabled: bool) -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let registry = AdapterRegistry::new();
+    registry
+        .register(
+            "mock-ep".into(),
+            Box::new(JsonPayloadAdapter),
+            "stdio".into(),
+            None,
+            None,
+        )
+        .await;
+
+    let registry_arc = Arc::new(registry.clone());
+    let state = AppState {
+        registry,
+        js_execution_mode: Arc::new(AtomicBool::new(false)),
+        meta_tool_handler: Arc::new(MetaToolHandler::new(registry_arc, Duration::from_secs(30))),
+        oauth_flow_manager: None,
+        token_manager: None,
+        oauth_adapter_inners: None,
+        setup_manager: None,
+        started_at: std::time::Instant::now(),
+        toon_enabled,
+    };
+    let router = build_router(state);
+    let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
+    let (bound_addr, handle) = start_server(router, addr)
+        .await
+        .expect("server start failed");
+    (bound_addr, handle)
+}
+
+/// §5 row 14 — route-level: the native `tools/call` branch encodes JSON
+/// TextContent into TOON when `toon_enabled` is on.
+#[tokio::test]
+async fn tools_call_native_response_is_toon_when_enabled() {
+    let (addr, _handle) = setup_native_toon_server(true).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("http://{}/mcp/tools/call", addr))
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": { "name": "json_tool", "arguments": {} },
+            "id": 1
+        }))
+        .send()
+        .await
+        .expect("request failed");
+
+    assert!(resp.status().is_success());
+    let body: Value = resp.json().await.unwrap();
+    let text = body["result"]["content"][0]["text"]
+        .as_str()
+        .expect("text field missing");
+
+    // The native branch must have re-encoded the JSON object string as TOON,
+    // which is never valid JSON and never starts with `{` or `[`.
+    assert!(
+        serde_json::from_str::<Value>(text).is_err(),
+        "expected TOON output, got JSON-parseable text: {text}"
+    );
+    let first = text.chars().next().expect("non-empty TOON output");
+    assert!(
+        first != '{' && first != '[',
+        "expected TOON output (no leading `{{`/`[`), got: {text}"
+    );
+    // TOON tabular header for the inner `users` array — uniquely identifies
+    // TOON output and would not appear in the JSON pass-through.
+    assert!(
+        text.contains("{id,name}"),
+        "expected TOON tabular header `{{id,name}}` in: {text}"
+    );
+}
+
+/// §5 row 14 sibling — route-level: the native `tools/call` branch leaves
+/// the JSON TextContent untouched when `toon_enabled` is off.
+#[tokio::test]
+async fn tools_call_native_response_is_json_when_disabled() {
+    let (addr, _handle) = setup_native_toon_server(false).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("http://{}/mcp/tools/call", addr))
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": { "name": "json_tool", "arguments": {} },
+            "id": 1
+        }))
+        .send()
+        .await
+        .expect("request failed");
+
+    assert!(resp.status().is_success());
+    let body: Value = resp.json().await.unwrap();
+    let text = body["result"]["content"][0]["text"]
+        .as_str()
+        .expect("text field missing");
+
+    // With TOON disabled, the adapter's JSON object string passes through
+    // unchanged and must round-trip via `serde_json::from_str`.
+    let parsed: Value =
+        serde_json::from_str(text).expect("expected JSON pass-through, got non-JSON text");
+    assert_eq!(parsed["users"][0]["id"], 1);
+    assert_eq!(parsed["users"][0]["name"], "a");
+    assert_eq!(parsed["users"][1]["id"], 2);
+    assert_eq!(parsed["users"][1]["name"], "b");
 }

--- a/tests/meta_tools_integration.rs
+++ b/tests/meta_tools_integration.rs
@@ -6,7 +6,7 @@
 
 mod common;
 
-use common::config::{everything_config, ConfigBuilder};
+use common::config::ConfigBuilder;
 use common::harness::RelayHarness;
 use common::mcp_client::McpClient;
 use common::toolchain::require_node;
@@ -24,6 +24,7 @@ async fn setup_js_on() -> (RelayHarness, McpClient) {
             &["-y", "@modelcontextprotocol/server-everything"],
         )
         .js_execution(true)
+        .toon_output(false)
         .build();
     let harness = RelayHarness::start(&config).await;
     harness
@@ -37,7 +38,14 @@ async fn setup_js_on() -> (RelayHarness, McpClient) {
 
 /// Helper: start relay with everything server + JS execution OFF, wait healthy, initialize client.
 async fn setup_js_off() -> (RelayHarness, McpClient) {
-    let config = everything_config();
+    let config = ConfigBuilder::new()
+        .add_stdio(
+            "everything",
+            "npx",
+            &["-y", "@modelcontextprotocol/server-everything"],
+        )
+        .toon_output(false)
+        .build();
     let harness = RelayHarness::start(&config).await;
     harness
         .wait_healthy("everything", Duration::from_secs(30))

--- a/tests/multi_endpoint_integration.rs
+++ b/tests/multi_endpoint_integration.rs
@@ -88,6 +88,7 @@ async fn setup_multi_endpoint_server() -> (SocketAddr, AdapterRegistry, tokio::t
         oauth_adapter_inners: None,
         setup_manager: None,
         started_at: std::time::Instant::now(),
+        toon_enabled: false,
     };
     let router = build_router(state);
     let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
@@ -236,6 +237,7 @@ async fn test_multi_endpoint_overlapping_tool_names() {
         oauth_adapter_inners: None,
         setup_manager: None,
         started_at: std::time::Instant::now(),
+        toon_enabled: false,
     };
     let router = build_router(state);
     let addr: SocketAddr = ([127, 0, 0, 1], 0).into();

--- a/tests/oauth_setup_integration.rs
+++ b/tests/oauth_setup_integration.rs
@@ -25,6 +25,7 @@ fn empty_config() -> Config {
             local_js_execution: None,
             token_dir: None,
             allow_insecure_oauth: Some(true),
+            toon_output: None,
         },
         endpoints: vec![EndpointConfig {
             name: "echo".to_string(),


### PR DESCRIPTION
Implements the relay-side TOON output feature per the engineering wspec. Single cohesive slice; Wave 2 (desktop) depends on this merging first.

## What this does

Converts JSON tool-call responses to TOON (Token-Oriented Object Notation) before they reach the MCP client. TOON is a text-based, indentation-driven serialization format with tabular array headers — it produces ~40-60% fewer tokens than JSON on the structured/tabular shapes most MCP tools return, while remaining losslessly round-trippable (`decode(encode(json)) == json`).

Hooks two of the three result paths:

- **Path 1 — `tools/call`**: `TextContent` entries inside the `CallToolResult` envelope whose `text` parses as a JSON object/array are re-encoded to TOON. Scalars, non-JSON text, `ImageContent`, `EmbeddedResource`, `structuredContent`, and `isError: true` responses pass through unchanged.
- **Path 2 — `wrap_meta_tool_result`**: `list_tools`, `search_tools`, and `execute_tools` responses encode to TOON for objects/arrays and fall back to pretty-printed JSON for scalars or on failure.

Path 3 (JS sandbox `call_tool_native`) is intentionally untouched — the JS runtime calls `JSON.parse()` on tool results and TOON would break the sandbox.

## Config / CLI

- `[relay] toon_output = true` (default) in `config.toml`. Set `false` to restore JSON pass-through.
- `--no-toon` on `endara-relay start` forces it off regardless of config.
- Existing configs missing the field still load and get the default (TOON on).

When enabled, the `search_tools` description picks up a one-sentence TOON hint so models know to parse responses as TOON instead of JSON.

## Files

**New:**
- `src/toon_convert.rs` — `toonify_call_result(Value) -> Value` and `toonify_value(&Value) -> String`, with inline `#[cfg(test)]` covering wspec §5 rows 1-10 and 13.

**Modified:**
- `Cargo.toml` — adds `toon-format = { version = "0.4", default-features = false }` (lib only; default features pull in clap/ratatui/tiktoken-rs CLI deps we don't need).
- `src/lib.rs`, `src/main.rs` — declare the new module in both the lib and binary crate roots.
- `src/config.rs` — adds `toon_output: Option<bool>` with serde default.
- `src/server.rs` — adds `pub toon_enabled: bool` to `AppState`; applies `toonify_call_result` after `route_tool_call`; threads `toon_enabled` through `wrap_meta_tool_result` and the three meta-tool call sites; `meta_tool_definitions` now takes a `toon_enabled` flag.
- `src/main.rs` — `--no-toon` flag on `Start`, computes `toon_enabled = if no_toon { false } else { cfg.relay.toon_output.unwrap_or(true) }`.
- `src/advertise.rs` — `search_tools_description` takes `toon_enabled` and appends `TOON_OUTPUT_HINT` when true.
- `src/management.rs`, `tests/*.rs`, `tests/common/config.rs` — update every `RelayConfig`/`AppState` construction site (test helpers + integration tests) for the new fields; `ConfigBuilder` gains a `.toon_output(bool)` option for tests that need JSON-parseable meta-tool responses.

## Tests

All 17 rows from wspec §5 are covered:

- Rows 1-10, 13 — unit tests in `src/toon_convert.rs`.
- Row 11 — `list_tools_response_is_json_when_disabled` in `src/server.rs` tests; meta_tools integration tests now opt out via `.toon_output(false)`.
- Row 12 — covered by the inline ternary in `main.rs` (`--no-toon` short-circuits before the config read); row 11 covers the resulting `toon_enabled=false` behaviour end-to-end.
- Rows 14-16 — `list_tools_response_is_toon_when_enabled`, `execute_tools_response_is_toon_when_enabled`, plus `wrap_meta_tool_result_emits_toon_when_enabled`/`_json_when_disabled` in `src/server.rs` tests.
- Row 17 — `search_tools_advertising_includes_toon_hint_when_enabled` in `src/server.rs` tests plus three new cases in `src/advertise.rs` (`_appends_toon_hint_when_enabled`, `_omits_toon_hint_when_disabled`, `_combines_servers_and_toon_hint`).

## Verification

From `packages/relay/`:

```
cargo fmt --check    # clean
cargo clippy --all-targets -- -D warnings    # clean
cargo test    # all unit + integration tests pass (660 lib + integration suites)
```

## Notes for reviewers

- `src/js_sandbox.rs` is intentionally not modified — the JS sandbox calls `JSON.parse()` on tool results and converting upstream would break the runtime contract.
- Default-on is intentional per the wspec ("the whole point is transparent token savings; opt-out, not opt-in"). `--no-toon` is the blunt escape hatch if a specific MCP client doesn't handle TOON well.
- The `search_tools` integration assertions in `tests/advertise.rs` switched from `ends_with("Connected server types: …")` to `contains(…)` so the trailing TOON hint doesn't break the existing footer checks.
