### PR TITLE
docs(readme): refresh for v0.1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ The config file is TOML. Here's a complete reference:
 [relay]
 machine_name = "my-laptop"        # Required — identifies this machine
 local_js_execution = true         # Optional — enable JS execution mode (default: false)
+toon_output = true                # Optional — convert JSON tool responses to TOON (default: true)
 
 # STDIO endpoint — spawns a child process
 [[endpoints]]
@@ -218,6 +219,12 @@ return { repos: repos.length, firstRepoIssues: issues };
 ```
 
 The JS sandbox is powered by [boa_engine](https://crates.io/crates/boa_engine) and runs entirely in-process — no external runtime needed.
+
+### TOON tool output
+
+By default, Relay converts JSON tool responses to [TOON](https://crates.io/crates/toon-format) (Token-Oriented Object Notation) before they reach your MCP client. TOON is an indentation-driven format with tabular array headers that produces ~40–60% fewer tokens than JSON on the structured shapes most MCP tools return, while remaining losslessly round-trippable.
+
+Scalars, non-JSON text, image/resource content, `structuredContent`, and error responses pass through unchanged. To opt out, set `toon_output = false` under `[relay]` in your config, or pass `--no-toon` on the command line.
 
 ---
 


### PR DESCRIPTION
Refreshes `README.md` for the v0.1.7 cycle. Targeted at the one user-visible v0.1.7 feature the relay README was silent about: **TOON tool output** (default-on in v0.1.7-rc.4, endara-ai/endara-relay#73).

## Stale references found and updated

- **`Configuration` → `[relay]` reference block** — added `toon_output = true` so the "complete reference" snippet actually lists every `[relay]` field the binary now reads. Without this, users copying the snippet wouldn't see that TOON conversion is on by default.
- **`Features` section** — added a new `### TOON tool output` subsection covering: default-on behavior, what passes through unchanged (scalars, non-JSON text, image/resource content, `structuredContent`, errors), and the two opt-out paths (`toon_output = false` in config, or `--no-toon` on the CLI).

## What was *not* changed

Cross-referenced every v0.1.7 rc against the README; the remaining items were not stale:

- rc.1 (#71) — OAuth re-authorization fix. Internal bug fix, no README claim broken.
- rc.2 (#72) — OAuth token-endpoint discovery via RFC 8414. Internal mechanism; the README's "OAuth managed for you" bullet is still accurate.
- rc.3/rc.5 — desktop-only changes.

## Verification

README-only edit — no code paths touched. Diff is +7 / -0 lines.
