### PR TITLE
chore: bump version to 0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "endara-relay"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endara-relay"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 description = "Local MCP tool aggregator — aggregate multiple MCP servers behind a single endpoint"
 license = "Apache-2.0"


### PR DESCRIPTION
Scenario 3 post-stable base-version bump from 0.1.7 to 0.1.8. v0.1.7 stable shipped successfully (https://github.com/endara-ai/endara-relay/releases/tag/v0.1.7). No rc suffix — that comes from the tag during the next rc cycle.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author