### PR TITLE
fix(adapter): de-duplicate endpoint name in OAuth/HTTP tracing output

### DIFF
--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -128,7 +128,10 @@ impl HttpAdapter {
 
     /// Create a new HttpAdapter with a pre-built reqwest::Client.
     ///
-    /// Used by OAuthAdapter to inject a client with Bearer token headers.
+    /// Top-level constructor kept for completeness; OAuth wrapping uses
+    /// [`HttpAdapter::new_with_client_inner`] instead so the inner adapter
+    /// does not create its own `endpoint` tracing span.
+    #[allow(dead_code)]
     pub fn new_with_client(config: HttpConfig, client: Client) -> Self {
         let span = tracing::info_span!(
             "endpoint",
@@ -136,6 +139,20 @@ impl HttpAdapter {
             transport = "http",
             server_type = tracing::field::Empty,
         );
+        Self::with_span(config, client, span)
+    }
+
+    /// Create a new HttpAdapter intended to be wrapped by another adapter
+    /// (currently `OAuthAdapter`) that already owns the per-endpoint
+    /// `endpoint` tracing span. The inner adapter uses `tracing::Span::none()`
+    /// so its `.instrument(self.span.clone())` calls become no-ops and events
+    /// are attached to the enclosing wrapper's span instead, avoiding a
+    /// duplicated `endpoint=<name>` field.
+    pub fn new_with_client_inner(config: HttpConfig, client: Client) -> Self {
+        Self::with_span(config, client, tracing::Span::none())
+    }
+
+    fn with_span(config: HttpConfig, client: Client, span: tracing::Span) -> Self {
         Self {
             config,
             client,

--- a/src/adapter/oauth/heartbeat.rs
+++ b/src/adapter/oauth/heartbeat.rs
@@ -136,13 +136,11 @@ async fn apply_probe_action(
     threshold: u32,
     oauth_state: &OAuthState,
 ) {
-    let endpoint = &adapter.config.endpoint_name;
     match action {
         ProbeAction::MarkHealthy => {
             *adapter.inner_health.write().await = HealthStatus::Healthy;
             adapter.metrics.inc_heartbeat_healthy();
             trace!(
-                endpoint = %endpoint,
                 oauth_state = ?oauth_state,
                 result = "healthy",
                 "heartbeat probe succeeded"
@@ -150,7 +148,6 @@ async fn apply_probe_action(
         }
         ProbeAction::BelowThreshold { failures, reason } => {
             debug!(
-                endpoint = %endpoint,
                 oauth_state = ?oauth_state,
                 result = "transient",
                 failures = failures,
@@ -164,7 +161,6 @@ async fn apply_probe_action(
                 HealthStatus::Unhealthy("upstream unreachable".into());
             adapter.metrics.inc_heartbeat_unhealthy();
             warn!(
-                endpoint = %endpoint,
                 oauth_state = ?oauth_state,
                 result = "unhealthy",
                 threshold = threshold,
@@ -175,7 +171,6 @@ async fn apply_probe_action(
         ProbeAction::AuthFailed => {
             adapter.metrics.inc_heartbeat_unhealthy();
             warn!(
-                endpoint = %endpoint,
                 oauth_state = ?oauth_state,
                 result = "unhealthy",
                 "heartbeat probe got 401, transitioning to AuthRequired"

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -188,7 +188,7 @@ impl OAuthAdapterInner {
         let mut http_config = HttpConfig::new(url);
         http_config.server_type_override = server_type_override;
         http_config.endpoint_name = endpoint_name;
-        HttpAdapter::new_with_client(http_config, client)
+        HttpAdapter::new_with_client_inner(http_config, client)
     }
 
     /// Transition to a new `OAuthState`.
@@ -203,7 +203,6 @@ impl OAuthAdapterInner {
         let old = do_transition(&mut state, new_state.clone(), reason, &mut history);
         self.metrics.inc_state_transition();
         info!(
-            endpoint = %self.config.endpoint_name,
             from = ?old,
             to = ?new_state,
             oauth_state = ?new_state,
@@ -285,7 +284,6 @@ impl OAuthAdapterInner {
                 Some(rt) => rt,
                 None => {
                     warn!(
-                        endpoint = %self.config.endpoint_name,
                         correlation_id = %correlation_id,
                         "No refresh token available"
                     );
@@ -300,7 +298,6 @@ impl OAuthAdapterInner {
         };
 
         info!(
-            endpoint = %self.config.endpoint_name,
             correlation_id = %correlation_id,
             "Starting token refresh"
         );
@@ -330,7 +327,6 @@ impl OAuthAdapterInner {
             TokenPostOutcome::Success(token_set) => {
                 self.metrics.inc_refresh_success();
                 info!(
-                    endpoint = %self.config.endpoint_name,
                     correlation_id = %correlation_id,
                     "Token refresh successful"
                 );
@@ -342,7 +338,6 @@ impl OAuthAdapterInner {
             }
             TokenPostOutcome::HttpError { status, body } => {
                 error!(
-                    endpoint = %self.config.endpoint_name,
                     correlation_id = %correlation_id,
                     %status,
                     body = %body,
@@ -355,7 +350,6 @@ impl OAuthAdapterInner {
             }
             TokenPostOutcome::Network(e) => {
                 error!(
-                    endpoint = %self.config.endpoint_name,
                     correlation_id = %correlation_id,
                     error = %e,
                     "Token refresh network error"
@@ -367,7 +361,6 @@ impl OAuthAdapterInner {
             }
             TokenPostOutcome::InvalidJson(e) => {
                 error!(
-                    endpoint = %self.config.endpoint_name,
                     correlation_id = %correlation_id,
                     error = %e,
                     "Token refresh JSON parse error"
@@ -404,7 +397,6 @@ impl OAuthAdapterInner {
         // Discovery is only feasible if we know the resource URL.
         if self.config.url.is_empty() {
             warn!(
-                endpoint = %self.config.endpoint_name,
                 correlation_id = %correlation_id,
                 %status,
                 "Token refresh got 404 but resource URL is empty; skipping discovery fallback"
@@ -416,7 +408,6 @@ impl OAuthAdapterInner {
         }
 
         info!(
-            endpoint = %self.config.endpoint_name,
             correlation_id = %correlation_id,
             %status,
             attempted_url = %initial_url,
@@ -428,7 +419,6 @@ impl OAuthAdapterInner {
                 Ok(d) => d,
                 Err(e) => {
                     warn!(
-                        endpoint = %self.config.endpoint_name,
                         correlation_id = %correlation_id,
                         error = %e,
                         "OAuth discovery fallback failed; returning original 404"
@@ -442,7 +432,6 @@ impl OAuthAdapterInner {
 
         if disc.token_endpoint == initial_url {
             warn!(
-                endpoint = %self.config.endpoint_name,
                 correlation_id = %correlation_id,
                 token_endpoint = %disc.token_endpoint,
                 "OAuth discovery returned the same token endpoint that just 404'd; not retrying"
@@ -454,7 +443,6 @@ impl OAuthAdapterInner {
         }
 
         info!(
-            endpoint = %self.config.endpoint_name,
             correlation_id = %correlation_id,
             old_token_endpoint = %initial_url,
             new_token_endpoint = %disc.token_endpoint,
@@ -469,7 +457,6 @@ impl OAuthAdapterInner {
             TokenPostOutcome::Success(token_set) => {
                 self.metrics.inc_refresh_success();
                 info!(
-                    endpoint = %self.config.endpoint_name,
                     correlation_id = %correlation_id,
                     "Token refresh successful after rediscovery"
                 );
@@ -477,7 +464,6 @@ impl OAuthAdapterInner {
             }
             other => {
                 warn!(
-                    endpoint = %self.config.endpoint_name,
                     correlation_id = %correlation_id,
                     retry_outcome = ?other.short_label(),
                     "Token refresh retry after rediscovery failed; returning original 404"
@@ -576,7 +562,7 @@ impl OAuthAdapterInner {
 
         // 1. Persist to disk
         if let Err(e) = self.token_manager.save(endpoint, &token_set).await {
-            error!(endpoint = %endpoint, error = %e, "Failed to persist tokens");
+            error!(error = %e, "Failed to persist tokens");
         }
 
         // 2. Abort old refresh task
@@ -650,7 +636,7 @@ impl OAuthAdapterInner {
         //    with `issued_at: None` (it's `#[serde(default)]`), but still
         //    deserve a proactive refresh.
         let deadline = if !has_refresh_token {
-            info!(endpoint = %endpoint, "No refresh token, skipping proactive refresh");
+            info!("No refresh token, skipping proactive refresh");
             None
         } else if let Some(expires) = expires_at_secs {
             let now_secs = std::time::SystemTime::now()
@@ -676,10 +662,7 @@ impl OAuthAdapterInner {
                 }
             }
         } else {
-            info!(
-                endpoint = %endpoint,
-                "No expires_at on token, skipping proactive refresh"
-            );
+            info!("No expires_at on token, skipping proactive refresh");
             None
         };
 
@@ -688,7 +671,7 @@ impl OAuthAdapterInner {
             let refresh_span = self.span.clone();
             let fut = async move {
                 tokio::time::sleep_until(deadline).await;
-                info!(endpoint = %inner.config.endpoint_name, "Proactive refresh timer fired");
+                info!("Proactive refresh timer fired");
                 // Detach our own handle from the slot before re-entering
                 // `apply_tokens`. Step 2 of `apply_tokens_inner`
                 // (`refresh_task_handle.take()` followed by `h.abort()`)
@@ -709,14 +692,12 @@ impl OAuthAdapterInner {
                         let state = inner.state.read().await.clone();
                         if matches!(state, OAuthState::Refreshing) {
                             warn!(
-                                endpoint = %inner.config.endpoint_name,
                                 "Proactive refresh recursive apply_tokens returned with state still Refreshing — possible regression"
                             );
                         }
                     }
                     Err(e) => {
                         warn!(
-                            endpoint = %inner.config.endpoint_name,
                             error = %e,
                             "Proactive refresh failed, retrying in 60s"
                         );
@@ -736,7 +717,6 @@ impl OAuthAdapterInner {
                                 let state = inner.state.read().await.clone();
                                 if matches!(state, OAuthState::Refreshing) {
                                     warn!(
-                                        endpoint = %inner.config.endpoint_name,
                                         "Proactive refresh retry recursive apply_tokens returned with state still Refreshing — possible regression"
                                     );
                                 }
@@ -750,7 +730,6 @@ impl OAuthAdapterInner {
                                 // (auth-style failure) or ConnectionFailed
                                 // (network/JSON failure).
                                 warn!(
-                                    endpoint = %inner.config.endpoint_name,
                                     error = %retry_err,
                                     "Proactive refresh retry also failed"
                                 );
@@ -828,12 +807,12 @@ impl OAuthAdapterInner {
 
         // Delete tokens from disk
         if let Err(e) = self.token_manager.delete(endpoint).await {
-            error!(endpoint = %endpoint, error = %e, "Failed to delete tokens from disk");
+            error!(error = %e, "Failed to delete tokens from disk");
         }
 
         // Delete DCR credentials from disk
         if let Err(e) = self.token_manager.delete_dcr(endpoint).await {
-            error!(endpoint = %endpoint, error = %e, "Failed to delete DCR credentials from disk");
+            error!(error = %e, "Failed to delete DCR credentials from disk");
         }
 
         // Set state
@@ -905,16 +884,10 @@ impl McpAdapter for OAuthAdapter {
 
             if let Ok(Some(token_set)) = loaded {
                 if token_set.is_valid() {
-                    info!(
-                        endpoint = %self.inner.config.endpoint_name,
-                        "Loaded valid OAuth tokens from disk"
-                    );
+                    info!("Loaded valid OAuth tokens from disk");
                     self.inner.apply_tokens(token_set).await;
                 } else if token_set.refresh_token.is_some() {
-                    info!(
-                        endpoint = %self.inner.config.endpoint_name,
-                        "Loaded expired tokens with refresh token, attempting refresh"
-                    );
+                    info!("Loaded expired tokens with refresh token, attempting refresh");
                     // Store expired tokens so refresh can use the refresh_token
                     *self.inner.tokens.write().await = Some(token_set);
                     match self.inner.do_token_refresh().await {
@@ -923,7 +896,6 @@ impl McpAdapter for OAuthAdapter {
                         }
                         Err(e) => {
                             warn!(
-                                endpoint = %self.inner.config.endpoint_name,
                                 error = %e,
                                 "Token refresh at startup failed"
                             );
@@ -975,10 +947,7 @@ impl McpAdapter for OAuthAdapter {
                             // Drop the read lock before refreshing
                             drop(guard);
 
-                            info!(
-                                endpoint = %self.inner.config.endpoint_name,
-                                "Got 401 on list_tools, attempting token refresh"
-                            );
+                            info!("Got 401 on list_tools, attempting token refresh");
 
                             match self.inner.do_token_refresh().await {
                                 Ok(new_tokens) => {
@@ -992,7 +961,6 @@ impl McpAdapter for OAuthAdapter {
                                 }
                                 Err(e) => {
                                     warn!(
-                                        endpoint = %self.inner.config.endpoint_name,
                                         error = %e,
                                         "Token refresh after 401 on list_tools failed"
                                     );
@@ -1037,10 +1005,7 @@ impl McpAdapter for OAuthAdapter {
                     // Drop the read lock before refreshing
                     drop(guard);
 
-                    info!(
-                        endpoint = %self.inner.config.endpoint_name,
-                        "Got 401, attempting token refresh"
-                    );
+                    info!("Got 401, attempting token refresh");
 
                     match self.inner.do_token_refresh().await {
                         Ok(new_tokens) => {
@@ -1056,7 +1021,6 @@ impl McpAdapter for OAuthAdapter {
                         }
                         Err(e) => {
                             warn!(
-                                endpoint = %self.inner.config.endpoint_name,
                                 error = %e,
                                 "Token refresh after 401 failed"
                             );


### PR DESCRIPTION
## Summary

Fixes log noise where each OAuth-wrapped endpoint's name was rendered twice in the desktop log viewer — e.g. `endpoint:endpoint: ... Drive Drive` for the Google Drive endpoint.

## Root cause

Two independent sources of duplication in `src/adapter/`:

1. **Redundant event-level fields.** Many `info!/warn!/error!/debug!/trace!` sites in `oauth/mod.rs` and `oauth/heartbeat.rs` explicitly added `endpoint = %config.endpoint_name` even though the surrounding `tracing::info_span!("endpoint", endpoint = ...)` already carried it. Every event therefore emitted `endpoint=<name>` twice.
2. **Nested `endpoint` spans.** When `OAuthAdapter` wrapped an inner `HttpAdapter` via `build_inner_adapter`, both adapters built their own top-level `tracing::info_span!("endpoint", endpoint = ..., transport = ...)`. Events from the inner HTTP transport ran under both spans, producing the `endpoint:endpoint:` doubled span-name prefix and a second `endpoint=<name>` field value.

## Changes

Two commits, one per root cause:

- **`fix(adapter/http): add new_with_client_inner using Span::none for OAuth wrapping`** — new sibling constructor `HttpAdapter::new_with_client_inner` that builds the adapter with `tracing::Span::none()`. Used by `OAuthAdapter::build_inner_adapter` so the inner HTTP adapter does not stack a second `endpoint` span. Standalone `HttpAdapter::new` is unchanged. Shared body extracted into a private `with_span()` helper.
- **`fix(adapter/oauth): drop redundant event-level endpoint fields`** — remove the explicit `endpoint = %…endpoint_name` field at 25 call sites in `oauth/mod.rs` and 4 sites in `oauth/heartbeat.rs`. The five per-adapter `info_span!` definitions in `oauth/mod.rs`, `http.rs`, `sse.rs`, `stdio.rs` remain the single source of truth for the field. Also drops a now-unused `let endpoint = ...` binding in `apply_probe_action` to keep clippy quiet. Wires `build_inner_adapter` over to the new inner constructor (continuation of the http.rs commit).

## Before / after

Before (e.g. proactive refresh on the Drive endpoint):

```
endpoint: endara_relay::adapter::oauth: Proactive refresh timer fired Drive Drive
endpoint:endpoint: endara_relay::adapter::http: HTTP MCP adapter initialized Drive Drive
```

After:

```
endpoint: endara_relay::adapter::oauth: Proactive refresh timer fired Drive
endpoint: endara_relay::adapter::http: HTTP MCP adapter initialized Drive
```

The OAuth-wrapped HTTP events now run under exactly one `endpoint` span — the OAuth one — with a single `endpoint=<name>` field.

## Verification

From `packages/relay/` (all PASS):

- `cargo fmt --check`
- `cargo build`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` — 1442 passed, 0 failed

## Scope / risk

- Diff localized to `src/adapter/http.rs`, `src/adapter/oauth/mod.rs`, `src/adapter/oauth/heartbeat.rs`.
- No public trait or `McpAdapter` surface change.
- One new `pub` constructor `HttpAdapter::new_with_client_inner`; could be tightened to `pub(crate)` in a future cleanup (only in-crate caller today).
- Behavior change is limited to tracing output. No protocol, persistence, or wire-format change.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author