### PR TITLE
feat(server): forward notifications/tools/list_changed to /mcp/sse clients

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -99,6 +99,14 @@ pub struct AdapterRegistry {
     /// cache) can use this as an authoritative invalidation signal without
     /// needing to diff catalog contents.
     catalog_generation: Arc<AtomicU64>,
+    /// Relay-wide tools-changed broadcast. Fan-in for every per-endpoint
+    /// `subscribe_tools_changed` tick observed by
+    /// [`AdapterRegistry::tools_changed_listener_loop`]. Downstream consumers
+    /// (e.g. the `/mcp/sse` handler) subscribe via
+    /// [`AdapterRegistry::subscribe_tools_changed`] to forward
+    /// `notifications/tools/list_changed` to connected MCP clients without
+    /// caring which upstream endpoint emitted the change.
+    tools_changed_tx: broadcast::Sender<()>,
 }
 
 impl Default for AdapterRegistry {
@@ -110,11 +118,31 @@ impl Default for AdapterRegistry {
 impl AdapterRegistry {
     /// Create a new, empty adapter registry.
     pub fn new() -> Self {
+        let (tools_changed_tx, _) = broadcast::channel(16);
         Self {
             adapters: Arc::new(RwLock::new(HashMap::new())),
             catalog_cache: Arc::new(RwLock::new(None)),
             catalog_generation: Arc::new(AtomicU64::new(0)),
+            tools_changed_tx,
         }
+    }
+
+    /// Subscribe to the relay-wide tools-changed broadcast. Each `recv()`
+    /// represents at least one `notifications/tools/list_changed` tick from
+    /// some registered adapter since the previous receive. Mirrors the
+    /// per-adapter [`McpAdapter::subscribe_tools_changed`] policy: `Lagged`
+    /// is also surfaced as a tick by the fan-in loop, and `Closed` only
+    /// happens when the registry itself is dropped.
+    pub fn subscribe_tools_changed(&self) -> broadcast::Receiver<()> {
+        self.tools_changed_tx.subscribe()
+    }
+
+    /// Send a synthetic tools-changed tick on the relay-wide broadcast.
+    /// Test-only escape hatch so server-side handler tests can exercise the
+    /// fan-out path without standing up a real adapter and listener task.
+    #[cfg(test)]
+    pub(crate) fn tick_tools_changed_for_test(&self) {
+        let _ = self.tools_changed_tx.send(());
     }
 
     /// Register an adapter under the given endpoint name.
@@ -184,7 +212,10 @@ impl AdapterRegistry {
     /// Listener loop driven by `subscribe_tools_changed`. Each successful tick
     /// — as well as a `Lagged` error (treated as a missed-but-coalesced tick)
     /// — invalidates the per-endpoint tools cache followed by the merged
-    /// catalog cache. A `Closed` receiver terminates the loop.
+    /// catalog cache, then fans the tick into the relay-wide
+    /// `tools_changed_tx` so downstream consumers (e.g. the `/mcp/sse`
+    /// handler) can forward `notifications/tools/list_changed` to connected
+    /// MCP clients. A `Closed` receiver terminates the loop.
     async fn tools_changed_listener_loop(
         registry: Self,
         endpoint: String,
@@ -195,6 +226,7 @@ impl AdapterRegistry {
                 Ok(()) => {
                     registry.invalidate_endpoint_tool_cache(&endpoint).await;
                     registry.invalidate_catalog_cache().await;
+                    let _ = registry.tools_changed_tx.send(());
                 }
                 Err(broadcast::error::RecvError::Lagged(skipped)) => {
                     debug!(
@@ -204,6 +236,7 @@ impl AdapterRegistry {
                     );
                     registry.invalidate_endpoint_tool_cache(&endpoint).await;
                     registry.invalidate_catalog_cache().await;
+                    let _ = registry.tools_changed_tx.send(());
                 }
                 Err(broadcast::error::RecvError::Closed) => {
                     debug!(endpoint = %endpoint, "tools-changed listener channel closed");
@@ -1962,6 +1995,35 @@ mod tests {
             registry.catalog_generation(),
             gen_before,
             "no listener should remain to bump the generation"
+        );
+    }
+
+    /// A per-endpoint adapter tick must also fan into the relay-wide
+    /// `subscribe_tools_changed` channel so server-side consumers (e.g. the
+    /// `/mcp/sse` handler) can forward `notifications/tools/list_changed`
+    /// to MCP clients.
+    #[tokio::test]
+    async fn test_tools_changed_tick_fans_in_to_relay_subscribers() {
+        let registry = AdapterRegistry::new();
+        let mut relay_rx = registry.subscribe_tools_changed();
+        let (adapter, _calls, tx) = NotifyingAdapter::new(vec![make_tool("a")], 8);
+        registry
+            .register(
+                "ep".into(),
+                Box::new(adapter),
+                "stdio".into(),
+                None,
+                Some("ep".into()),
+            )
+            .await;
+
+        // Drive a per-endpoint tick; the listener loop should observe it and
+        // fan it into the relay-wide broadcast.
+        tx.send(()).unwrap();
+        let recv = tokio::time::timeout(std::time::Duration::from_secs(1), relay_rx.recv()).await;
+        assert!(
+            matches!(recv, Ok(Ok(()))),
+            "relay-wide tools-changed subscriber should receive the fanned-in tick (got {recv:?})"
         );
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -102,7 +102,7 @@ async fn mcp_initialize(
     let mut result = json!({
         "protocolVersion": "2025-03-26",
         "capabilities": {
-            "tools": {}
+            "tools": { "listChanged": true }
         },
         "serverInfo": {
             "name": "Endara Relay",
@@ -530,14 +530,44 @@ async fn mcp_unified(
     }
 }
 
-/// GET /mcp/sse — basic SSE transport (sends a connection ack, then keeps alive)
-async fn mcp_sse() -> Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>> {
+/// GET /mcp/sse — basic SSE transport.
+///
+/// Sends the initial `endpoint` event (`data: /mcp`) so legacy SSE clients
+/// learn where to POST JSON-RPC requests, then forwards every
+/// `notifications/tools/list_changed` tick from the registry-wide broadcast
+/// as a JSON-RPC notification frame so subscribers can re-fetch
+/// `tools/list`. An Axum keep-alive layer prevents idle proxies from
+/// dropping the connection.
+///
+/// Caveat: clients that only POST to `/mcp` (the unified request/response
+/// endpoint, no SSE subscription) will not receive these notifications even
+/// though `mcp_initialize` advertises `tools.listChanged: true`. That is
+/// intentional — `listChanged` describes server capability, not per-
+/// transport delivery — and POST-only clients are expected to re-fetch
+/// `tools/list` on their own cadence.
+async fn mcp_sse(
+    State(state): State<AppState>,
+) -> Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>> {
+    use tokio::sync::broadcast::error::RecvError;
+
     let (tx, rx) = tokio::sync::mpsc::channel(16);
+    let mut tools_rx = state.registry.subscribe_tools_changed();
 
     tokio::spawn(async move {
-        let _ = tx
+        if tx
             .send(Ok(Event::default().event("endpoint").data("/mcp")))
-            .await;
+            .await
+            .is_err()
+        {
+            return;
+        }
+        while let Ok(()) | Err(RecvError::Lagged(_)) = tools_rx.recv().await {
+            let frame = Event::default()
+                .data(r#"{"jsonrpc":"2.0","method":"notifications/tools/list_changed"}"#);
+            if tx.send(Ok(frame)).await.is_err() {
+                break;
+            }
+        }
     });
 
     Sse::new(ReceiverStream::new(rx)).keep_alive(KeepAlive::default())
@@ -2389,5 +2419,121 @@ mod tests {
         let body_str = String::from_utf8(body.to_vec()).unwrap();
         assert!(body_str.contains("&lt;script&gt;"), "body = {body_str}");
         assert!(!body_str.contains("<script>"));
+    }
+
+    // --- /mcp/sse + initialize tools.listChanged capability ---
+
+    /// `initialize` must advertise `tools.listChanged: true` so MCP clients
+    /// know to consume `notifications/tools/list_changed` over `/mcp/sse`.
+    #[tokio::test]
+    async fn mcp_initialize_advertises_tools_list_changed() {
+        let state = test_app_state();
+        let body = JsonRpcBody {
+            jsonrpc: Some("2.0".to_string()),
+            method: Some("initialize".to_string()),
+            params: None,
+            id: Some(json!(7)),
+        };
+        let Json(resp) = mcp_initialize(State(state), Json(body)).await;
+        assert_eq!(
+            resp["result"]["capabilities"]["tools"]["listChanged"], true,
+            "initialize must advertise tools.listChanged: true (got {resp})"
+        );
+    }
+
+    /// Helper: read the SSE response body as a UTF-8 string, accumulating
+    /// chunks until `predicate` returns true or `timeout` elapses. Returns
+    /// the accumulated text either way so tests can produce useful failure
+    /// messages.
+    async fn read_sse_until<F: Fn(&str) -> bool>(
+        resp: axum::response::Response,
+        timeout: Duration,
+        predicate: F,
+    ) -> String {
+        use futures_util::StreamExt;
+        let mut stream = resp.into_body().into_data_stream();
+        let mut collected = String::new();
+        let deadline = tokio::time::Instant::now() + timeout;
+        while tokio::time::Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            match tokio::time::timeout(remaining, stream.next()).await {
+                Ok(Some(Ok(chunk))) => {
+                    collected.push_str(&String::from_utf8_lossy(&chunk));
+                    if predicate(&collected) {
+                        break;
+                    }
+                }
+                Ok(Some(Err(_))) | Ok(None) | Err(_) => break,
+            }
+        }
+        collected
+    }
+
+    /// `mcp_sse` emits the initial `endpoint` event with `data: /mcp` so
+    /// legacy SSE clients learn where to POST JSON-RPC requests.
+    #[tokio::test]
+    async fn mcp_sse_emits_initial_endpoint_event() {
+        use axum::body::Body;
+        use tower::ServiceExt;
+        let state = test_app_state();
+        let router = build_router(state);
+        let request = axum::http::Request::builder()
+            .method("GET")
+            .uri("/mcp/sse")
+            .header("accept", "text/event-stream")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.oneshot(request).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let text = read_sse_until(resp, Duration::from_secs(2), |s| {
+            s.contains("event: endpoint") && s.contains("data: /mcp")
+        })
+        .await;
+        assert!(
+            text.contains("event: endpoint") && text.contains("data: /mcp"),
+            "first SSE frame should be the endpoint event (got: {text:?})"
+        );
+    }
+
+    /// `mcp_sse` forwards every relay-wide tools-changed tick as a JSON-RPC
+    /// `notifications/tools/list_changed` SSE frame.
+    #[tokio::test]
+    async fn mcp_sse_forwards_tools_changed_notification() {
+        use axum::body::Body;
+        use tower::ServiceExt;
+        let state = test_app_state();
+        let registry = state.registry.clone();
+        let router = build_router(state);
+        let request = axum::http::Request::builder()
+            .method("GET")
+            .uri("/mcp/sse")
+            .header("accept", "text/event-stream")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.oneshot(request).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Drive a tick once the spawned forwarder is wired up. The forwarder
+        // subscribes synchronously inside the handler, but the broadcast send
+        // races with the subscriber, so retry the tick until the frame lands.
+        let driver = tokio::spawn(async move {
+            for _ in 0..40 {
+                registry.tick_tools_changed_for_test();
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        });
+        let text = read_sse_until(resp, Duration::from_secs(2), |s| {
+            s.contains("notifications/tools/list_changed")
+        })
+        .await;
+        driver.abort();
+        assert!(
+            text.contains("notifications/tools/list_changed"),
+            "expected tools/list_changed frame within timeout (got: {text:?})"
+        );
+        assert!(
+            text.contains("\"jsonrpc\":\"2.0\""),
+            "frame should be a JSON-RPC notification (got: {text:?})"
+        );
     }
 }


### PR DESCRIPTION
## What

Push upstream `notifications/tools/list_changed` ticks downstream to MCP clients connected over `GET /mcp/sse`, and advertise the capability in the `initialize` handshake.

## How

- **Registry fan-in** (`src/registry.rs`):
  - `AdapterRegistry` owns a relay-wide `broadcast::Sender<()>` whose ticks are produced by the existing per-endpoint `tools_changed_listener_loop` (both the `Ok` and `Lagged` arms fan in, matching the per-adapter policy).
  - New `pub fn subscribe_tools_changed(&self) -> broadcast::Receiver<()>` exposes the channel to downstream consumers.
  - Test-only `tick_tools_changed_for_test()` (`#[cfg(test)] pub(crate)`) so server handler tests can drive a tick without spinning up a real adapter and listener task. Keeps the production surface clean.

- **SSE handler** (`src/server.rs`):
  - `mcp_sse` now takes `State<AppState>`, still emits the initial `endpoint` event (`data: /mcp`) so existing clients keep working, then forwards every relay-wide tools-changed tick as a JSON-RPC notification frame: `{"jsonrpc":"2.0","method":"notifications/tools/list_changed"}`. `Lagged` is forwarded as a tick (clients re-fetch anyway); `Closed` ends the stream cleanly. The existing `keep_alive` layer is preserved.
  - Handler doc-comment calls out that POST-only `/mcp` clients won't receive these notifications even though `tools.listChanged: true` is advertised — `listChanged` describes server capability, not per-transport delivery, and POST-only clients are expected to re-fetch `tools/list` on their own cadence.

- **`initialize` capability** (`src/server.rs`):
  - `mcp_initialize` now returns `"capabilities": { "tools": { "listChanged": true } }`.

## Tests added (all pass)

- `server::tests::mcp_initialize_advertises_tools_list_changed` — capability snapshot.
- `server::tests::mcp_sse_emits_initial_endpoint_event` — first SSE frame is the `endpoint` event with `data: /mcp`.
- `server::tests::mcp_sse_forwards_tools_changed_notification` — driving the registry-wide tick produces a `notifications/tools/list_changed` JSON-RPC SSE frame at the client.
- `registry::tests::test_tools_changed_tick_fans_in_to_relay_subscribers` — per-endpoint adapter tick fans into the relay-wide `subscribe_tools_changed` channel.

## Verification

```
cargo fmt --check          # clean
cargo clippy --all-targets -- -D warnings   # clean
cargo test                 # 1450 passed; 0 failed; 5 ignored (Node-dependent integration tests)
```

## Relationship to other PRs

Pairs with / depends on the upstream-side HTTP-adapter PR endara-ai/endara-relay#79 (which makes the HTTP adapter actually surface upstream `notifications/tools/list_changed` ticks the registry fans in here). Without #79, this PR still safely no-ops for HTTP endpoints; with #79, end-to-end propagation works from upstream HTTP server → relay → SSE-subscribed MCP client.
