### PR TITLE
feat: endpoint profiles (/mcp/{profile})

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,6 +674,7 @@ dependencies = [
  "hyper-util",
  "notify",
  "rand 0.10.1",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",
@@ -2076,6 +2077,18 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ hyper = { version = "1", features = ["server", "http1", "http2"] }
 hyper-util = { version = "0.1", features = ["http1", "http2", "server", "server-auto", "tokio"] }
 notify = "7"
 rand = "0.10.1"
+regex = "1.12.3"
 reqwest = { version = "0.13.2", features = ["json", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/advertise.rs
+++ b/src/advertise.rs
@@ -15,6 +15,9 @@
 //!
 //! [`HealthStatus`]: crate::adapter::HealthStatus
 
+use std::collections::HashSet;
+
+use crate::profile_registry::ProfileRegistryView;
 use crate::registry::AdapterRegistry;
 
 /// Safety cap on the rendered server-type list. With deduplication a typical
@@ -68,23 +71,49 @@ pub const EXECUTE_TOOLS_BASE: &str = concat!(
 );
 
 /// Renders the deduplicated, sorted server-type list for a registry.
+///
+/// When `allowed_endpoints` is `Some`, the rendered list and the endpoint
+/// count are restricted to adapters whose endpoint name is in the set —
+/// this powers the `_for_profile` advertising variants. When `None`, the
+/// renderer reflects every registered adapter (the global `/mcp` path).
 pub struct ServerTypeList<'a> {
     registry: &'a AdapterRegistry,
+    allowed_endpoints: Option<&'a HashSet<String>>,
 }
 
 impl<'a> ServerTypeList<'a> {
-    /// Bind a renderer to the given registry.
+    /// Bind a renderer to the given registry (unfiltered — every
+    /// registered adapter contributes).
     pub fn new(registry: &'a AdapterRegistry) -> Self {
-        Self { registry }
+        Self {
+            registry,
+            allowed_endpoints: None,
+        }
     }
 
-    /// Returns `Some("a, b, c")` if at least one registered adapter has a
+    /// Bind a renderer scoped to a profile's allowed endpoint set. Adapters
+    /// whose endpoint name is not in `allowed_endpoints` are skipped in
+    /// both [`Self::render`] and [`Self::endpoint_count`].
+    pub fn for_profile(
+        registry: &'a AdapterRegistry,
+        allowed_endpoints: &'a HashSet<String>,
+    ) -> Self {
+        Self {
+            registry,
+            allowed_endpoints: Some(allowed_endpoints),
+        }
+    }
+
+    /// Returns `Some("a, b, c")` if at least one in-scope adapter has a
     /// rendered `server_type` (cached upstream value or configured
     /// override); `None` otherwise. The list is enforced under the
     /// 8KB safety cap; trailing entries are dropped and a `, …` suffix
     /// appended if the cap is exceeded.
     pub async fn render(&self) -> Option<String> {
-        let types = self.registry.all_server_types().await;
+        let types = match self.allowed_endpoints {
+            Some(allowed) => self.registry.server_types_in(allowed).await,
+            None => self.registry.all_server_types().await,
+        };
         if types.is_empty() {
             return None;
         }
@@ -116,10 +145,14 @@ impl<'a> ServerTypeList<'a> {
         Some(out)
     }
 
-    /// Number of registered adapter instances regardless of health (NOT
-    /// deduplicated by type).
+    /// Number of in-scope adapter instances regardless of health (NOT
+    /// deduplicated by type). When scoped to a profile, only adapters
+    /// whose endpoint name is in `allowed_endpoints` are counted.
     pub async fn endpoint_count(&self) -> usize {
-        self.registry.all_endpoint_count().await
+        match self.allowed_endpoints {
+            Some(allowed) => self.registry.endpoint_count_in(allowed).await,
+            None => self.registry.all_endpoint_count().await,
+        }
     }
 }
 
@@ -129,7 +162,24 @@ impl<'a> ServerTypeList<'a> {
 pub const INSTRUCTIONS_LEAD_IN: &str =
     "Endara Relay aggregates MCP servers behind a single endpoint.";
 
-/// Build the `InitializeResult.instructions` string.
+/// Shared body of [`instructions`] / [`instructions_for_profile`]. Takes a
+/// pre-bound [`ServerTypeList`] so the same render logic powers the global
+/// `/mcp` path and per-profile `/mcp/{profile}` advertising.
+async fn build_instructions(list: ServerTypeList<'_>) -> Option<String> {
+    let rendered = list.render().await;
+    let count = list.endpoint_count().await;
+    match (rendered, count) {
+        (Some(rendered), _) => Some(format!(
+            "{}\n\nConnected server types: {}",
+            INSTRUCTIONS_LEAD_IN, rendered
+        )),
+        (None, 0) => None,
+        (None, _) => Some(INSTRUCTIONS_LEAD_IN.to_string()),
+    }
+}
+
+/// Build the `InitializeResult.instructions` string for the global `/mcp`
+/// path (every registered adapter contributes).
 ///
 /// - Returns `Some("{LEAD_IN}\n\nConnected server types: {list}")` whenever
 ///   the rendered list is non-empty.
@@ -139,16 +189,20 @@ pub const INSTRUCTIONS_LEAD_IN: &str =
 /// - Returns `None` when the registry has zero registered adapters so the
 ///   field is omitted from the response.
 pub async fn instructions(registry: &AdapterRegistry) -> Option<String> {
-    let list = ServerTypeList::new(registry).render().await;
-    let count = registry.all_endpoint_count().await;
-    match (list, count) {
-        (Some(list), _) => Some(format!(
-            "{}\n\nConnected server types: {}",
-            INSTRUCTIONS_LEAD_IN, list
-        )),
-        (None, 0) => None,
-        (None, _) => Some(INSTRUCTIONS_LEAD_IN.to_string()),
-    }
+    build_instructions(ServerTypeList::new(registry)).await
+}
+
+/// Profile-scoped variant of [`instructions`]. Renders against the profile's
+/// allowed endpoint set so per-profile `InitializeResult.instructions` only
+/// advertises servers the profile is authorised to see — including the
+/// fallback lead-in / `None` shapes that the global helper uses for the
+/// zero-adapter case.
+pub async fn instructions_for_profile(view: &ProfileRegistryView) -> Option<String> {
+    build_instructions(ServerTypeList::for_profile(
+        view.inner(),
+        view.allowed_endpoints(),
+    ))
+    .await
 }
 
 /// Hint appended to the `search_tools` description when TOON output is
@@ -156,12 +210,14 @@ pub async fn instructions(registry: &AdapterRegistry) -> Option<String> {
 /// Object Notation) instead of JSON, so it doesn't try to `JSON.parse()` them.
 pub const TOON_OUTPUT_HINT: &str = "Tool responses are returned in TOON format (Token-Oriented Object Notation) for reduced token usage. TOON is a compact alternative to JSON — indentation-based, no braces, tabular arrays. Parse it like structured text.";
 
-/// Build the `search_tools` description. Appends `\n\nConnected server types: {list}`
-/// when at least one registered adapter has a rendered `server_type`, and
-/// the TOON hint when `toon_enabled` is true.
-pub async fn search_tools_description(registry: &AdapterRegistry, toon_enabled: bool) -> String {
-    let base = match ServerTypeList::new(registry).render().await {
-        Some(list) => format!("{}\n\nConnected server types: {}", SEARCH_TOOLS_BASE, list),
+/// Shared body of [`search_tools_description`] /
+/// [`search_tools_description_for_profile`].
+async fn build_search_tools_description(list: ServerTypeList<'_>, toon_enabled: bool) -> String {
+    let base = match list.render().await {
+        Some(rendered) => format!(
+            "{}\n\nConnected server types: {}",
+            SEARCH_TOOLS_BASE, rendered
+        ),
         None => SEARCH_TOOLS_BASE.to_string(),
     };
     if toon_enabled {
@@ -171,32 +227,74 @@ pub async fn search_tools_description(registry: &AdapterRegistry, toon_enabled: 
     }
 }
 
-/// Build the `list_tools` description. Appends `" {count} servers connected …"`
-/// when the registry has at least one registered adapter.
-pub async fn list_tools_description(registry: &AdapterRegistry) -> String {
-    let count = ServerTypeList::new(registry).endpoint_count().await;
+/// Build the `search_tools` description. Appends `\n\nConnected server types: {list}`
+/// when at least one registered adapter has a rendered `server_type`, and
+/// the TOON hint when `toon_enabled` is true.
+pub async fn search_tools_description(registry: &AdapterRegistry, toon_enabled: bool) -> String {
+    build_search_tools_description(ServerTypeList::new(registry), toon_enabled).await
+}
+
+/// Profile-scoped variant of [`search_tools_description`]. Only adapters in
+/// the profile's allowed endpoint set contribute to the appended
+/// `Connected server types:` line; the TOON hint follows the per-profile
+/// `toon_enabled`.
+pub async fn search_tools_description_for_profile(
+    view: &ProfileRegistryView,
+    toon_enabled: bool,
+) -> String {
+    build_search_tools_description(
+        ServerTypeList::for_profile(view.inner(), view.allowed_endpoints()),
+        toon_enabled,
+    )
+    .await
+}
+
+/// Shared body of [`list_tools_description`] /
+/// [`list_tools_description_for_profile`] and the matching `execute_tools`
+/// helpers — appends `" {count} servers connected …"` to `base` when the
+/// in-scope endpoint count is non-zero.
+async fn build_count_suffix_description(list: ServerTypeList<'_>, base: &str) -> String {
+    let count = list.endpoint_count().await;
     if count > 0 {
         format!(
             "{} {} servers connected via Endara Relay — use search_tools to discover tools.",
-            LIST_TOOLS_BASE, count
+            base, count
         )
     } else {
-        LIST_TOOLS_BASE.to_string()
+        base.to_string()
     }
+}
+
+/// Build the `list_tools` description. Appends `" {count} servers connected …"`
+/// when the registry has at least one registered adapter.
+pub async fn list_tools_description(registry: &AdapterRegistry) -> String {
+    build_count_suffix_description(ServerTypeList::new(registry), LIST_TOOLS_BASE).await
+}
+
+/// Profile-scoped variant of [`list_tools_description`] — the count reflects
+/// only adapters in the profile's allowed endpoint set.
+pub async fn list_tools_description_for_profile(view: &ProfileRegistryView) -> String {
+    build_count_suffix_description(
+        ServerTypeList::for_profile(view.inner(), view.allowed_endpoints()),
+        LIST_TOOLS_BASE,
+    )
+    .await
 }
 
 /// Build the `execute_tools` description. Same suffix as
 /// [`list_tools_description`], appended to the long base block.
 pub async fn execute_tools_description(registry: &AdapterRegistry) -> String {
-    let count = ServerTypeList::new(registry).endpoint_count().await;
-    if count > 0 {
-        format!(
-            "{} {} servers connected via Endara Relay — use search_tools to discover tools.",
-            EXECUTE_TOOLS_BASE, count
-        )
-    } else {
-        EXECUTE_TOOLS_BASE.to_string()
-    }
+    build_count_suffix_description(ServerTypeList::new(registry), EXECUTE_TOOLS_BASE).await
+}
+
+/// Profile-scoped variant of [`execute_tools_description`] — the count
+/// reflects only adapters in the profile's allowed endpoint set.
+pub async fn execute_tools_description_for_profile(view: &ProfileRegistryView) -> String {
+    build_count_suffix_description(
+        ServerTypeList::for_profile(view.inner(), view.allowed_endpoints()),
+        EXECUTE_TOOLS_BASE,
+    )
+    .await
 }
 
 #[cfg(test)]
@@ -573,6 +671,160 @@ mod tests {
             !list.ends_with(", \u{2026}"),
             "50 types should fit without truncation: {}",
             list
+        );
+    }
+
+    // ----------------------------------------------------------------------
+    // Profile-aware advertising (R3.C, matrix row #15).
+    //
+    // The `_for_profile` variants render the same shapes as the global
+    // builders but filter the server-type list and the endpoint count to
+    // adapters in `allowed_endpoints`. The tests below pin both halves of
+    // that contract: only the profile's types appear, the count reflects
+    // only the profile's endpoints, and the empty-profile / TOON-hint
+    // edge cases behave identically to the global helpers.
+    // ----------------------------------------------------------------------
+
+    /// Build a [`ProfileRegistryView`] scoped to `names` for the per-
+    /// profile advertising tests. Mirrors how [`crate::profile_registry::
+    /// ProfileRegistry::rebuild`] constructs views at runtime.
+    fn view_for(reg: &AdapterRegistry, names: &[&str]) -> ProfileRegistryView {
+        let allowed: HashSet<String> = names.iter().map(|s| (*s).to_string()).collect();
+        ProfileRegistryView::new(reg.clone(), allowed)
+    }
+
+    /// Matrix row #15 — happy path. `instructions_for_profile` only mentions
+    /// the profile's server types and uses the profile's endpoint count.
+    #[tokio::test]
+    async fn instructions_for_profile_filters_server_types_and_count() {
+        let reg = AdapterRegistry::new();
+        register(&reg, "gmail", MockAdapter::ready("gmail")).await;
+        register(&reg, "linear", MockAdapter::ready("linear")).await;
+        register(&reg, "todoist", MockAdapter::ready("todoist")).await;
+        register(&reg, "github", MockAdapter::ready("github")).await;
+
+        let view = view_for(&reg, &["gmail", "linear"]);
+        let s = instructions_for_profile(&view)
+            .await
+            .expect("instructions present");
+        assert_eq!(
+            s,
+            format!(
+                "{}\n\nConnected server types: gmail, linear",
+                INSTRUCTIONS_LEAD_IN
+            )
+        );
+        // The unrelated endpoints must not leak into the rendered list.
+        assert!(!s.contains("todoist"));
+        assert!(!s.contains("github"));
+    }
+
+    /// An empty profile (no overlap with any registered endpoint) returns
+    /// `None`, matching the global behaviour for an empty registry. This is
+    /// the "Connected server types: " line guard: a misconfigured profile
+    /// must not advertise the global server list.
+    #[tokio::test]
+    async fn instructions_for_profile_none_when_no_overlap() {
+        let reg = AdapterRegistry::new();
+        register(&reg, "gmail", MockAdapter::ready("gmail")).await;
+        register(&reg, "linear", MockAdapter::ready("linear")).await;
+        let view = view_for(&reg, &["does-not-exist"]);
+        assert!(instructions_for_profile(&view).await.is_none());
+    }
+
+    /// A profile whose endpoints are all registered but none have a rendered
+    /// `server_type` returns the lead-in only — same shape as the global
+    /// `instructions_lead_in_only_when_registered_but_no_types_render` test.
+    #[tokio::test]
+    async fn instructions_for_profile_lead_in_only_when_in_scope_but_no_types() {
+        let reg = AdapterRegistry::new();
+        register(&reg, "pending", MockAdapter::starting_no_type()).await;
+        let view = view_for(&reg, &["pending"]);
+        let s = instructions_for_profile(&view)
+            .await
+            .expect("instructions present");
+        assert_eq!(s, INSTRUCTIONS_LEAD_IN);
+        assert!(!s.contains("Connected server types:"));
+    }
+
+    /// Matrix #15 (description side) — `list_tools_description_for_profile`
+    /// uses the profile's endpoint count, not the registry-wide count.
+    #[tokio::test]
+    async fn list_tools_description_for_profile_counts_only_profile_endpoints() {
+        let reg = AdapterRegistry::new();
+        register(&reg, "gmail", MockAdapter::ready("gmail")).await;
+        register(&reg, "linear", MockAdapter::ready("linear")).await;
+        register(&reg, "todoist", MockAdapter::ready("todoist")).await;
+        let view = view_for(&reg, &["gmail", "linear"]);
+        let desc = list_tools_description_for_profile(&view).await;
+        assert!(desc.starts_with(LIST_TOOLS_BASE));
+        assert!(
+            desc.ends_with(" 2 servers connected via Endara Relay \u{2014} use search_tools to discover tools."),
+            "expected count = 2 for the 2-endpoint profile, got: {}",
+            desc
+        );
+    }
+
+    /// `search_tools_description_for_profile` filters the appended
+    /// `Connected server types:` line and respects the per-profile TOON
+    /// toggle exactly like the global helper.
+    #[tokio::test]
+    async fn search_tools_description_for_profile_filters_types_and_respects_toon() {
+        let reg = AdapterRegistry::new();
+        register(&reg, "gmail", MockAdapter::ready("gmail")).await;
+        register(&reg, "todoist", MockAdapter::ready("todoist")).await;
+        let view = view_for(&reg, &["gmail"]);
+
+        let no_toon = search_tools_description_for_profile(&view, false).await;
+        assert!(no_toon.starts_with(SEARCH_TOOLS_BASE));
+        assert!(no_toon.contains("Connected server types: gmail"));
+        assert!(!no_toon.contains("todoist"));
+        assert!(!no_toon.contains("TOON"));
+
+        let with_toon = search_tools_description_for_profile(&view, true).await;
+        assert!(with_toon.contains("Connected server types: gmail"));
+        assert!(!with_toon.contains("todoist"));
+        assert!(with_toon.ends_with(TOON_OUTPUT_HINT));
+    }
+
+    /// `execute_tools_description_for_profile` mirrors the list-tools
+    /// suffix on the profile's count.
+    #[tokio::test]
+    async fn execute_tools_description_for_profile_counts_only_profile_endpoints() {
+        let reg = AdapterRegistry::new();
+        register(&reg, "gmail", MockAdapter::ready("gmail")).await;
+        register(&reg, "linear", MockAdapter::ready("linear")).await;
+        register(&reg, "todoist", MockAdapter::ready("todoist")).await;
+        let view = view_for(&reg, &["gmail"]);
+        let desc = execute_tools_description_for_profile(&view).await;
+        assert!(desc.starts_with(EXECUTE_TOOLS_BASE));
+        assert!(
+            desc.ends_with(" 1 servers connected via Endara Relay \u{2014} use search_tools to discover tools."),
+            "expected count = 1 for the 1-endpoint profile, got tail: {}",
+            &desc[desc.len().saturating_sub(120)..]
+        );
+    }
+
+    /// Empty profile: descriptions fall back to the base text with no
+    /// appended suffix — same as the global helper when the registry is
+    /// empty. This is the regression guard against accidentally appending
+    /// "0 servers connected …" to misconfigured profiles.
+    #[tokio::test]
+    async fn description_for_profile_no_overlap_returns_base() {
+        let reg = AdapterRegistry::new();
+        register(&reg, "gmail", MockAdapter::ready("gmail")).await;
+        let view = view_for(&reg, &["nope"]);
+        assert_eq!(
+            list_tools_description_for_profile(&view).await,
+            LIST_TOOLS_BASE
+        );
+        assert_eq!(
+            execute_tools_description_for_profile(&view).await,
+            EXECUTE_TOOLS_BASE
+        );
+        assert_eq!(
+            search_tools_description_for_profile(&view, false).await,
+            SEARCH_TOOLS_BASE
         );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,12 @@ pub struct Config {
     pub relay: RelayConfig,
     #[serde(default)]
     pub endpoints: Vec<EndpointConfig>,
+    /// Named subsets of `endpoints` served at `/mcp/{path}` with their own
+    /// JS-execution and TOON-output toggles. `None` and `Some(empty)` are
+    /// equivalent: no profiles configured. Per recon §D1, the TOML key is
+    /// plural `[[profiles]]` to match the existing `[[endpoints]]` convention.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profiles: Option<Vec<ProfileConfig>>,
 }
 
 /// Relay-specific configuration.
@@ -63,6 +69,123 @@ impl fmt::Display for Transport {
             Transport::Http => write!(f, "http"),
             Transport::Oauth => write!(f, "oauth"),
         }
+    }
+}
+
+/// Reserved profile paths — would collide with existing relay routes
+/// (`/mcp/sse`, `/mcp/initialize`, `/mcp/tools/...`, `/oauth/...`, `/healthz`).
+/// Matched case-insensitively per spec §2.3.
+pub const RESERVED_PROFILE_PATHS: &[&str] = &["sse", "initialize", "tools", "oauth", "healthz"];
+
+/// Configuration for a named endpoint profile.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ProfileConfig {
+    /// Human-friendly display name (freeform string).
+    pub name: String,
+    /// URL path segment — the profile is served at `/mcp/{path}`. Must
+    /// satisfy [`validate_profile_path`].
+    pub path: String,
+    /// Endpoint names (matching [`EndpointConfig::name`]) included in this
+    /// profile. Order is cosmetic — the merged catalog is sorted by the
+    /// registry layer.
+    #[serde(default)]
+    pub endpoints: Vec<String>,
+    /// Per-profile JS-execution mode. When `Some(true)`, this profile's
+    /// `/mcp/{path}` exposes the meta-tools (`list_tools`, `search_tools`,
+    /// `execute_tools`) and hides direct tool calls. When `None`, inherits
+    /// from [`RelayConfig::local_js_execution`].
+    #[serde(default)]
+    pub js_execution: Option<bool>,
+    /// Per-profile TOON output. When `Some(true)`, tool responses on this
+    /// profile are converted to TOON. When `None`, inherits from
+    /// [`RelayConfig::toon_output`].
+    #[serde(default)]
+    pub toon_output: Option<bool>,
+}
+
+/// Validate a profile path slug.
+///
+/// A valid path:
+/// 1. Matches `^[a-zA-Z0-9][a-zA-Z0-9_-]*$` (starts alphanumeric, then
+///    alphanumeric / underscore / hyphen).
+/// 2. Is not in [`RESERVED_PROFILE_PATHS`] (case-insensitive).
+///
+/// Returns `Err(message)` on failure; the message is suitable for surfacing
+/// to the user.
+pub fn validate_profile_path(path: &str) -> Result<(), String> {
+    if path.is_empty() {
+        return Err("profile path must not be empty".into());
+    }
+    static PATH_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    let re = PATH_RE.get_or_init(|| regex::Regex::new(r"^[a-zA-Z0-9][a-zA-Z0-9_-]*$").unwrap());
+    if !re.is_match(path) {
+        return Err(format!(
+            "profile path '{}' contains invalid characters — \
+             use letters, digits, hyphens, or underscores (must start with a letter or digit)",
+            path
+        ));
+    }
+    if RESERVED_PROFILE_PATHS
+        .iter()
+        .any(|r| r.eq_ignore_ascii_case(path))
+    {
+        return Err(format!("profile path '{}' is reserved by the relay", path));
+    }
+    Ok(())
+}
+
+/// Validate the top-level `profiles` block.
+///
+/// Fail-fast: any invalid path, duplicate path (case-insensitive), duplicate
+/// profile name, or reference to an unknown endpoint becomes a hard startup
+/// error per spec §2.4. Empty `endpoints` lists are allowed (a profile may
+/// exist with no members and simply serve an empty catalog).
+pub fn validate_profiles(config: &Config) -> Result<(), Vec<String>> {
+    let profiles = match &config.profiles {
+        Some(p) if !p.is_empty() => p,
+        _ => return Ok(()),
+    };
+
+    let mut errors: Vec<String> = Vec::new();
+    let mut seen_paths: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut seen_names: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    let endpoint_names: std::collections::HashSet<&str> =
+        config.endpoints.iter().map(|e| e.name.as_str()).collect();
+
+    for profile in profiles {
+        if profile.name.trim().is_empty() {
+            errors.push("Profile name must not be empty".to_string());
+        } else if !seen_names.insert(profile.name.clone()) {
+            errors.push(format!("Duplicate profile name: '{}'", profile.name));
+        }
+
+        if let Err(msg) = validate_profile_path(&profile.path) {
+            errors.push(format!("Profile '{}': {}", profile.name, msg));
+        } else {
+            let path_key = profile.path.to_ascii_lowercase();
+            if !seen_paths.insert(path_key) {
+                errors.push(format!(
+                    "Duplicate profile path '{}' (paths are case-insensitive)",
+                    profile.path
+                ));
+            }
+        }
+
+        for ep_name in &profile.endpoints {
+            if !endpoint_names.contains(ep_name.as_str()) {
+                errors.push(format!(
+                    "Profile '{}' references unknown endpoint '{}'",
+                    profile.name, ep_name
+                ));
+            }
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
     }
 }
 
@@ -230,6 +353,7 @@ pub fn default_config() -> Config {
             startup_init_timeout_secs: None,
         },
         endpoints: Vec::new(),
+        profiles: None,
     }
 }
 
@@ -277,6 +401,7 @@ pub fn parse_and_validate(contents: &str) -> Result<Config, ConfigError> {
     let mut config: Config = toml::from_str(contents)?;
     resolve_env_vars(&mut config)?;
     validate(&config)?;
+    validate_profiles(&config).map_err(|errors| ConfigError::ValidationError(errors.join("; ")))?;
     Ok(config)
 }
 
@@ -298,6 +423,11 @@ pub fn parse_and_validate_graceful(
 
     // Validate per-endpoint, collecting failures as warnings
     validate_graceful(&config, &mut warnings);
+
+    // Profile validation is fail-fast (per spec §2.4): invalid paths,
+    // duplicate paths, and missing endpoint refs are hard startup errors,
+    // never per-endpoint warnings.
+    validate_profiles(&config).map_err(|errors| ConfigError::ValidationError(errors.join("; ")))?;
 
     Ok((config, warnings))
 }
@@ -1113,6 +1243,237 @@ command = "echo"
         assert!(errors.iter().any(|e| e.contains("Duplicate tool_prefix")));
     }
 
+    // --- Profile validation tests (spec §11 rows #1–#6) ---
+
+    /// §11 row #1 — valid paths.
+    #[test]
+    fn profile_path_accepts_valid() {
+        for p in &["work", "my-project", "A1", "abc_123", "0", "a", "Project-2"] {
+            assert!(
+                validate_profile_path(p).is_ok(),
+                "expected '{}' to be a valid profile path",
+                p
+            );
+        }
+    }
+
+    /// §11 row #2 — invalid paths.
+    #[test]
+    fn profile_path_rejects_invalid_chars() {
+        for p in &[
+            "",
+            "-leading-hyphen",
+            "_leads_underscore",
+            "has space",
+            "café",
+        ] {
+            assert!(
+                validate_profile_path(p).is_err(),
+                "expected '{}' to be rejected",
+                p
+            );
+        }
+    }
+
+    /// §11 row #3 — reserved paths (case-insensitive).
+    #[test]
+    fn profile_path_rejects_reserved() {
+        for p in &[
+            "sse",
+            "SSE",
+            "Sse",
+            "initialize",
+            "INITIALIZE",
+            "tools",
+            "Tools",
+            "oauth",
+            "OAuth",
+            "healthz",
+            "Healthz",
+        ] {
+            let err = validate_profile_path(p)
+                .err()
+                .unwrap_or_else(|| panic!("'{}' should be reserved", p));
+            assert!(
+                err.contains("reserved"),
+                "error for '{}' should mention 'reserved': {}",
+                p,
+                err
+            );
+        }
+    }
+
+    /// §11 row #4 — TOML with `[[profiles]]` parses correctly.
+    #[test]
+    fn profile_toml_parses() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "gmail"
+transport = "stdio"
+command = "echo"
+
+[[endpoints]]
+name = "linear"
+transport = "stdio"
+command = "cat"
+
+[[profiles]]
+name = "Work"
+path = "work"
+endpoints = ["gmail", "linear"]
+js_execution = true
+toon_output = true
+
+[[profiles]]
+name = "Personal"
+path = "personal"
+endpoints = ["gmail"]
+"#;
+        let config = parse_and_validate(toml_str).expect("config should parse");
+        let profiles = config.profiles.expect("profiles should be present");
+        assert_eq!(profiles.len(), 2);
+        assert_eq!(profiles[0].name, "Work");
+        assert_eq!(profiles[0].path, "work");
+        assert_eq!(profiles[0].endpoints, vec!["gmail", "linear"]);
+        assert_eq!(profiles[0].js_execution, Some(true));
+        assert_eq!(profiles[0].toon_output, Some(true));
+        assert_eq!(profiles[1].js_execution, None);
+        assert_eq!(profiles[1].toon_output, None);
+    }
+
+    /// §11 row #5 — profile referencing a non-existent endpoint is a startup error.
+    #[test]
+    fn profile_missing_endpoint_ref_errors() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "gmail"
+transport = "stdio"
+command = "echo"
+
+[[profiles]]
+name = "Work"
+path = "work"
+endpoints = ["gmail", "ghost"]
+"#;
+        let err = parse_and_validate(toml_str).unwrap_err();
+        match err {
+            ConfigError::ValidationError(msg) => {
+                assert!(
+                    msg.contains("ghost"),
+                    "error should mention 'ghost': {}",
+                    msg
+                );
+                assert!(
+                    msg.to_lowercase().contains("unknown endpoint"),
+                    "error should mention unknown endpoint: {}",
+                    msg
+                );
+            }
+            other => panic!("Expected ValidationError, got: {:?}", other),
+        }
+    }
+
+    /// §11 row #6 — duplicate paths (case-insensitive) are a startup error.
+    #[test]
+    fn profile_duplicate_paths_error() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[profiles]]
+name = "Lower"
+path = "shared"
+
+[[profiles]]
+name = "Upper"
+path = "SHARED"
+"#;
+        let err = parse_and_validate(toml_str).unwrap_err();
+        match err {
+            ConfigError::ValidationError(msg) => {
+                assert!(
+                    msg.to_lowercase().contains("duplicate profile path"),
+                    "error should flag duplicate profile path: {}",
+                    msg
+                );
+            }
+            other => panic!("Expected ValidationError, got: {:?}", other),
+        }
+    }
+
+    /// Graceful path also enforces profile validation as a hard error.
+    #[test]
+    fn profile_validation_is_hard_error_on_graceful_path() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[profiles]]
+name = "Bad"
+path = "sse"
+"#;
+        let err = parse_and_validate_graceful(toml_str).unwrap_err();
+        match err {
+            ConfigError::ValidationError(msg) => {
+                assert!(
+                    msg.contains("reserved"),
+                    "error should mention reserved: {}",
+                    msg
+                );
+            }
+            other => panic!("Expected ValidationError, got: {:?}", other),
+        }
+    }
+
+    /// Duplicate profile names are also caught.
+    #[test]
+    fn profile_duplicate_names_error() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[profiles]]
+name = "Work"
+path = "work-a"
+
+[[profiles]]
+name = "Work"
+path = "work-b"
+"#;
+        let err = parse_and_validate(toml_str).unwrap_err();
+        match err {
+            ConfigError::ValidationError(msg) => {
+                assert!(
+                    msg.contains("Duplicate profile name"),
+                    "error should flag duplicate name: {}",
+                    msg
+                );
+            }
+            other => panic!("Expected ValidationError, got: {:?}", other),
+        }
+    }
+
+    /// Empty `endpoints` list on a profile is allowed.
+    #[test]
+    fn profile_with_no_endpoints_is_ok() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[profiles]]
+name = "Empty"
+path = "empty"
+"#;
+        let config = parse_and_validate(toml_str).expect("empty profile should be valid");
+        assert_eq!(config.profiles.as_ref().unwrap()[0].endpoints.len(), 0);
+    }
+
     // --- Config diff tests ---
 
     fn make_config(endpoints: Vec<EndpointConfig>) -> Config {
@@ -1126,6 +1487,7 @@ command = "echo"
                 startup_init_timeout_secs: None,
             },
             endpoints,
+            profiles: None,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,17 +90,15 @@ pub struct ProfileConfig {
     /// registry layer.
     #[serde(default)]
     pub endpoints: Vec<String>,
-    /// Per-profile JS-execution mode. When `Some(true)`, this profile's
+    /// Per-profile JS-execution mode. When `true`, this profile's
     /// `/mcp/{path}` exposes the meta-tools (`list_tools`, `search_tools`,
-    /// `execute_tools`) and hides direct tool calls. When `None`, inherits
-    /// from [`RelayConfig::local_js_execution`].
-    #[serde(default)]
-    pub js_execution: Option<bool>,
-    /// Per-profile TOON output. When `Some(true)`, tool responses on this
-    /// profile are converted to TOON. When `None`, inherits from
-    /// [`RelayConfig::toon_output`].
-    #[serde(default)]
-    pub toon_output: Option<bool>,
+    /// `execute_tools`) and hides direct tool calls. Required: the loader
+    /// rejects configs whose profile block omits this field.
+    pub js_execution: bool,
+    /// Per-profile TOON output. When `true`, tool responses on this profile
+    /// are converted to TOON. Required: the loader rejects configs whose
+    /// profile block omits this field.
+    pub toon_output: bool,
 }
 
 /// Validate a profile path slug.
@@ -1331,6 +1329,8 @@ toon_output = true
 name = "Personal"
 path = "personal"
 endpoints = ["gmail"]
+js_execution = false
+toon_output = false
 "#;
         let config = parse_and_validate(toml_str).expect("config should parse");
         let profiles = config.profiles.expect("profiles should be present");
@@ -1338,10 +1338,10 @@ endpoints = ["gmail"]
         assert_eq!(profiles[0].name, "Work");
         assert_eq!(profiles[0].path, "work");
         assert_eq!(profiles[0].endpoints, vec!["gmail", "linear"]);
-        assert_eq!(profiles[0].js_execution, Some(true));
-        assert_eq!(profiles[0].toon_output, Some(true));
-        assert_eq!(profiles[1].js_execution, None);
-        assert_eq!(profiles[1].toon_output, None);
+        assert!(profiles[0].js_execution);
+        assert!(profiles[0].toon_output);
+        assert!(!profiles[1].js_execution);
+        assert!(!profiles[1].toon_output);
     }
 
     /// §11 row #5 — profile referencing a non-existent endpoint is a startup error.
@@ -1360,6 +1360,8 @@ command = "echo"
 name = "Work"
 path = "work"
 endpoints = ["gmail", "ghost"]
+js_execution = false
+toon_output = true
 "#;
         let err = parse_and_validate(toml_str).unwrap_err();
         match err {
@@ -1389,10 +1391,14 @@ machine_name = "test"
 [[profiles]]
 name = "Lower"
 path = "shared"
+js_execution = false
+toon_output = true
 
 [[profiles]]
 name = "Upper"
 path = "SHARED"
+js_execution = false
+toon_output = true
 "#;
         let err = parse_and_validate(toml_str).unwrap_err();
         match err {
@@ -1417,6 +1423,8 @@ machine_name = "test"
 [[profiles]]
 name = "Bad"
 path = "sse"
+js_execution = false
+toon_output = true
 "#;
         let err = parse_and_validate_graceful(toml_str).unwrap_err();
         match err {
@@ -1441,10 +1449,14 @@ machine_name = "test"
 [[profiles]]
 name = "Work"
 path = "work-a"
+js_execution = false
+toon_output = true
 
 [[profiles]]
 name = "Work"
 path = "work-b"
+js_execution = false
+toon_output = true
 "#;
         let err = parse_and_validate(toml_str).unwrap_err();
         match err {
@@ -1469,9 +1481,65 @@ machine_name = "test"
 [[profiles]]
 name = "Empty"
 path = "empty"
+js_execution = false
+toon_output = true
 "#;
         let config = parse_and_validate(toml_str).expect("empty profile should be valid");
         assert_eq!(config.profiles.as_ref().unwrap()[0].endpoints.len(), 0);
+    }
+
+    /// A profile block missing `js_execution` is rejected at parse time —
+    /// the loader treats the omission as a config error rather than silently
+    /// falling back to a default.
+    #[test]
+    fn profile_missing_js_execution_is_parse_error() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[profiles]]
+name = "Work"
+path = "work"
+toon_output = true
+"#;
+        let err = parse_and_validate(toml_str).unwrap_err();
+        match err {
+            ConfigError::ParseError(e) => {
+                let msg = e.to_string();
+                assert!(
+                    msg.contains("js_execution"),
+                    "parse error should mention js_execution: {}",
+                    msg
+                );
+            }
+            other => panic!("Expected ParseError, got: {:?}", other),
+        }
+    }
+
+    /// A profile block missing `toon_output` is rejected at parse time.
+    #[test]
+    fn profile_missing_toon_output_is_parse_error() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[profiles]]
+name = "Work"
+path = "work"
+js_execution = false
+"#;
+        let err = parse_and_validate(toml_str).unwrap_err();
+        match err {
+            ConfigError::ParseError(e) => {
+                let msg = e.to_string();
+                assert!(
+                    msg.contains("toon_output"),
+                    "parse error should mention toon_output: {}",
+                    msg
+                );
+            }
+            other => panic!("Expected ParseError, got: {:?}", other),
+        }
     }
 
     // --- Config diff tests ---

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -14,7 +14,7 @@ use serde_json::Value;
 use tokio::sync::RwLock;
 
 use crate::adapter::{AdapterError, ToolInfo};
-use crate::registry::AdapterRegistry;
+use crate::registry::MetaToolRegistry;
 
 // ---------------------------------------------------------------------------
 // Retry tuning (Wave 3)
@@ -73,7 +73,12 @@ pub enum JsSandboxError {
 // ---------------------------------------------------------------------------
 
 struct SandboxState {
-    registry: Arc<AdapterRegistry>,
+    /// Catalog/routing source for the running script. Per locked decision
+    /// Relay #2 this is `Arc<dyn MetaToolRegistry>` so the sandbox sees the
+    /// same scoped view as its enclosing [`MetaToolHandler`] — global
+    /// (`AdapterRegistry`) for `/mcp` or filtered
+    /// (`ProfileRegistryView`) for `/mcp/{profile}`.
+    registry: Arc<dyn MetaToolRegistry>,
     handle: tokio::runtime::Handle,
     /// Wall-clock deadline for the running script (`now + sandbox_timeout`,
     /// captured when `execute_in_sandbox` enters). The retry loop checks this
@@ -98,7 +103,11 @@ thread_local! {
 
 /// A sandboxed JavaScript execution environment.
 pub struct JsSandbox {
-    registry: Arc<AdapterRegistry>,
+    /// Catalog/routing source the sandbox sees. Held as
+    /// `Arc<dyn MetaToolRegistry>` (locked decision Relay #2) so a profile
+    /// view filters which tools `tools.call()` can reach without changing
+    /// the sandbox's wiring.
+    registry: Arc<dyn MetaToolRegistry>,
     timeout: Duration,
     /// Test-only override that opts a single sandbox into the real backoff
     /// schedule. Production callers leave this at `false` because production
@@ -107,8 +116,30 @@ pub struct JsSandbox {
 }
 
 impl JsSandbox {
-    /// Create a new sandbox backed by the given registry.
-    pub fn new(registry: Arc<AdapterRegistry>, timeout: Duration) -> Self {
+    /// Create a new sandbox backed by the given registry. Accepts any
+    /// `Arc<R>` where `R: MetaToolRegistry + 'static`, so callers can pass
+    /// either `Arc<AdapterRegistry>` (global) or
+    /// `Arc<ProfileRegistryView>` (per-profile) without explicit
+    /// `as Arc<dyn ...>` casting — the trait-object coercion fires at the
+    /// `from_dyn` call site below.
+    ///
+    /// `allow(dead_code)`: production callers reach the sandbox through
+    /// [`MetaToolHandler::execute_tools`], which uses [`Self::from_dyn`]
+    /// directly. This generic convenience constructor is exercised by
+    /// the unit tests in this module and by external lib consumers.
+    #[allow(dead_code)]
+    pub fn new<R>(registry: Arc<R>, timeout: Duration) -> Self
+    where
+        R: MetaToolRegistry + 'static,
+    {
+        Self::from_dyn(registry, timeout)
+    }
+
+    /// Construct directly from an already-typed `Arc<dyn MetaToolRegistry>`.
+    /// Used by `MetaToolHandler::execute_tools`, which holds the trait
+    /// object and forwards it into the sandbox without naming the concrete
+    /// type.
+    pub fn from_dyn(registry: Arc<dyn MetaToolRegistry>, timeout: Duration) -> Self {
         Self {
             registry,
             timeout,
@@ -164,7 +195,7 @@ impl JsSandbox {
 fn execute_in_sandbox(
     script: &str,
     catalog: &[ToolInfo],
-    registry: &Arc<AdapterRegistry>,
+    registry: &Arc<dyn MetaToolRegistry>,
     handle: &tokio::runtime::Handle,
     sandbox_timeout: Duration,
     use_real_backoff: bool,
@@ -404,7 +435,7 @@ fn call_tool_with_retry_native(
         let res = state
             .handle
             .block_on(call_tool_with_retry_loop(
-                &registry,
+                registry.as_ref(),
                 &tool_name,
                 arguments,
                 max_retries,
@@ -440,7 +471,7 @@ fn call_tool_with_retry_native(
 /// the real schedule outside `cfg(test)`. Tests pass `true` to opt back into
 /// real sleeps.
 async fn call_tool_with_retry_loop(
-    registry: &AdapterRegistry,
+    registry: &dyn MetaToolRegistry,
     tool_name: &str,
     arguments: Value,
     max_retries: usize,
@@ -1044,7 +1075,11 @@ impl From<&ToolInfo> for ToolInfoSlim {
 
 /// Handles the three meta-tools: list_tools, search_tools, execute_tools.
 pub struct MetaToolHandler {
-    registry: Arc<AdapterRegistry>,
+    /// Catalog/routing source for the three meta-tools. Held as
+    /// `Arc<dyn MetaToolRegistry>` (locked decision Relay #2) so a profile
+    /// view filters which tools `list_tools`/`search_tools` see and which
+    /// tools `execute_tools` can reach via the JS sandbox.
+    registry: Arc<dyn MetaToolRegistry>,
     sandbox_timeout: Duration,
     /// Memoized per-tool search index reused across `search_tools` calls.
     /// Holds `(generation, docs)` where `generation` is the registry's
@@ -1061,7 +1096,30 @@ pub struct MetaToolHandler {
 }
 
 impl MetaToolHandler {
-    pub fn new(registry: Arc<AdapterRegistry>, sandbox_timeout: Duration) -> Self {
+    /// Build a handler backed by the given registry. Accepts any `Arc<R>`
+    /// where `R: MetaToolRegistry + 'static`, so callers can pass either
+    /// `Arc<AdapterRegistry>` (global `/mcp`) or
+    /// `Arc<ProfileRegistryView>` (per-profile `/mcp/{profile}`) without
+    /// explicit `as Arc<dyn ...>` casting at call sites — the trait-object
+    /// coercion fires at the [`Self::from_dyn`] call site.
+    ///
+    /// `allow(dead_code)`: production code paths build per-profile
+    /// handlers via `MetaToolHandler::new(Arc::new(view.clone()), ...)`
+    /// in `ProfileRegistry::rebuild`, which goes through this generic
+    /// constructor; the bin compilation unit (which doesn't see the
+    /// rebuild path) still flags it without this.
+    #[allow(dead_code)]
+    pub fn new<R>(registry: Arc<R>, sandbox_timeout: Duration) -> Self
+    where
+        R: MetaToolRegistry + 'static,
+    {
+        Self::from_dyn(registry, sandbox_timeout)
+    }
+
+    /// Construct directly from an already-typed `Arc<dyn MetaToolRegistry>`.
+    /// Used internally and by callers that hold the trait object without
+    /// the concrete type in scope.
+    pub fn from_dyn(registry: Arc<dyn MetaToolRegistry>, sandbox_timeout: Duration) -> Self {
         Self {
             registry,
             sandbox_timeout,
@@ -1200,9 +1258,11 @@ impl MetaToolHandler {
         serde_json::to_value(&matches).map_err(|e| JsSandboxError::Internal(e.to_string()))
     }
 
-    /// `execute_tools` — run JS in sandbox.
+    /// `execute_tools` — run JS in sandbox. The sandbox inherits the
+    /// handler's [`MetaToolRegistry`] backing, so a per-profile handler
+    /// gives the script a profile-filtered `tools.call()`.
     pub async fn execute_tools(&self, script: &str) -> Result<Value, JsSandboxError> {
-        let sandbox = JsSandbox::new(self.registry.clone(), self.sandbox_timeout);
+        let sandbox = JsSandbox::from_dyn(self.registry.clone(), self.sandbox_timeout);
         sandbox.execute(script).await
     }
 }
@@ -1215,6 +1275,7 @@ impl MetaToolHandler {
 mod tests {
     use super::*;
     use crate::adapter::{AdapterError, HealthStatus, McpAdapter};
+    use crate::registry::AdapterRegistry;
     use async_trait::async_trait;
     use serde_json::json;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod management;
 pub mod management_listener;
 pub mod oauth;
 pub mod prefix;
+pub mod profile_registry;
 pub mod registry;
 pub mod server;
 pub mod shell_env;

--- a/src/main.rs
+++ b/src/main.rs
@@ -746,6 +746,7 @@ async fn main() {
                         registry.clone(),
                         cfg.relay.machine_name.clone(),
                         js_execution_mode.clone(),
+                        profile_registry.clone(),
                         token_manager.clone(),
                         oauth_flow_manager.clone(),
                         oauth_adapter_inners.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -581,7 +581,7 @@ async fn main() {
             // registry just exposes filtered views of `AdapterRegistry`.
             let profile_registry = Arc::new(ProfileRegistry::new((*registry).clone()));
             profile_registry
-                .rebuild(cfg.profiles.as_deref().unwrap_or(&[]), &cfg.relay)
+                .rebuild(cfg.profiles.as_deref().unwrap_or(&[]))
                 .await;
             let setup_manager = Arc::new(OAuthSetupManager::new());
             // TOON output: CLI `--no-toon` forces off; otherwise honour

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod adapter;
 mod advertise;
 mod jsonrpc;
 mod prefix;
+mod profile_registry;
 mod registry;
 mod server;
 mod shell_env;
@@ -20,6 +21,7 @@ use adapter::{FailedAdapter, McpAdapter, StartingAdapter};
 use clap::{Parser, Subcommand, ValueEnum};
 use js_sandbox::MetaToolHandler;
 use oauth::{OAuthFlowManager, OAuthSetupManager};
+use profile_registry::ProfileRegistry;
 use registry::AdapterRegistry;
 use server::{build_router, start_server, AppState};
 use std::collections::HashMap;
@@ -574,6 +576,13 @@ async fn main() {
                 registry.clone(),
                 Duration::from_secs(30),
             ));
+            // Build the relay-wide profile registry. R3.A will populate
+            // `ProfileContext::meta_tool_handler` per profile; for now the
+            // registry just exposes filtered views of `AdapterRegistry`.
+            let profile_registry = Arc::new(ProfileRegistry::new((*registry).clone()));
+            profile_registry
+                .rebuild(cfg.profiles.as_deref().unwrap_or(&[]), &cfg.relay)
+                .await;
             let setup_manager = Arc::new(OAuthSetupManager::new());
             // TOON output: CLI `--no-toon` forces off; otherwise honour
             // `relay.toon_output` from config.toml; default on when neither
@@ -588,6 +597,7 @@ async fn main() {
                 registry: (*registry).clone(),
                 js_execution_mode: js_execution_mode.clone(),
                 meta_tool_handler,
+                profile_registry: profile_registry.clone(),
                 oauth_flow_manager: Some(oauth_flow_manager.clone()),
                 token_manager: Some(token_manager.clone()),
                 oauth_adapter_inners: Some(oauth_adapter_inners.clone()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -615,6 +615,7 @@ async fn main() {
                 oauth_adapter_inners: Some(oauth_adapter_inners.clone()),
                 token_manager: Some(token_manager.clone()),
                 setup_manager: Some(setup_manager.clone()),
+                profile_registry: Some(profile_registry.clone()),
             };
             // Build the MCP (TCP) and management (UDS / Named Pipe) routers
             // separately. The management API carries credential-bearing routes

--- a/src/management.rs
+++ b/src/management.rs
@@ -2689,6 +2689,7 @@ mod tests {
                 token_endpoint: None,
                 server_type_override: None,
             }],
+            profiles: None,
         }
     }
 
@@ -4647,6 +4648,7 @@ command = "echo"
                 token_endpoint: None,
                 server_type_override: None,
             }],
+            profiles: None,
         };
         let state = ManagementState {
             registry: Arc::new(AdapterRegistry::new()),
@@ -4845,6 +4847,7 @@ command = "echo"
                 token_endpoint: token_endpoint.map(|s| s.to_string()),
                 server_type_override: None,
             }],
+            profiles: None,
         };
         let state = ManagementState {
             registry: Arc::new(AdapterRegistry::new()),
@@ -5256,6 +5259,7 @@ command = "echo"
                 token_endpoint: None,
                 server_type_override: None,
             }],
+            profiles: None,
         }
     }
 
@@ -5352,6 +5356,7 @@ client_id = "client123"
                 startup_init_timeout_secs: None,
             },
             endpoints: vec![],
+            profiles: None,
         };
         let state = ManagementState {
             registry: Arc::new(AdapterRegistry::new()),

--- a/src/management.rs
+++ b/src/management.rs
@@ -2311,16 +2311,18 @@ async fn oauth_setup_cancel(
 // ---------------------------------------------------------------------------
 
 /// Request body for `POST /api/profiles` and `PUT /api/profiles/{path}`.
+///
+/// `js_execution` and `toon_output` are required: requests that omit (or
+/// send `null` for) either field are rejected at deserialization time by
+/// the axum `Json` extractor.
 #[derive(Deserialize)]
 pub struct ProfileRequest {
     pub name: String,
     pub path: String,
     #[serde(default)]
     pub endpoints: Vec<String>,
-    #[serde(default)]
-    pub js_execution: Option<bool>,
-    #[serde(default)]
-    pub toon_output: Option<bool>,
+    pub js_execution: bool,
+    pub toon_output: bool,
 }
 
 /// Summary shape returned by `GET /api/profiles` and `POST /api/profiles`.
@@ -2330,11 +2332,11 @@ pub struct ProfileSummary {
     pub name: String,
     pub path: String,
     pub endpoints: Vec<String>,
-    /// Resolved per-profile JS-execution flag (falls back to
-    /// `RelayConfig::local_js_execution` when the profile leaves it unset).
+    /// Per-profile JS-execution flag (mirror of
+    /// [`crate::config::ProfileConfig::js_execution`]).
     pub js_execution: bool,
-    /// Resolved per-profile TOON output flag (falls back to
-    /// `RelayConfig::toon_output`).
+    /// Per-profile TOON output flag (mirror of
+    /// [`crate::config::ProfileConfig::toon_output`]).
     pub toon_output: bool,
     pub endpoint_count: usize,
     pub tool_count: usize,
@@ -2347,19 +2349,6 @@ pub struct ProfileDetail {
     #[serde(flatten)]
     pub summary: ProfileSummary,
     pub tools: Vec<CatalogEntry>,
-}
-
-/// Resolve a request's `js_execution` / `toon_output` against the same
-/// fallbacks `ProfileRegistry::rebuild` uses, so the JSON shape matches what
-/// the live registry will report.
-fn resolve_profile_flags(profile: &crate::config::ProfileConfig, cfg: &Config) -> (bool, bool) {
-    let js = profile
-        .js_execution
-        .unwrap_or_else(|| cfg.relay.local_js_execution.unwrap_or(false));
-    let toon = profile
-        .toon_output
-        .unwrap_or_else(|| cfg.relay.toon_output.unwrap_or(true));
-    (js, toon)
 }
 
 /// Look up the live tool count for a profile (post-rebuild). Returns 0 when
@@ -2377,17 +2366,15 @@ async fn profile_tool_count(state: &ManagementState, path: &str) -> usize {
 /// Build a [`ProfileSummary`] from a [`crate::config::ProfileConfig`].
 async fn build_profile_summary(
     state: &ManagementState,
-    cfg: &Config,
     profile: &crate::config::ProfileConfig,
 ) -> ProfileSummary {
-    let (js, toon) = resolve_profile_flags(profile, cfg);
     let tool_count = profile_tool_count(state, &profile.path).await;
     ProfileSummary {
         name: profile.name.clone(),
         path: profile.path.clone(),
         endpoints: profile.endpoints.clone(),
-        js_execution: js,
-        toon_output: toon,
+        js_execution: profile.js_execution,
+        toon_output: profile.toon_output,
         endpoint_count: profile.endpoints.len(),
         tool_count,
     }
@@ -2545,17 +2532,16 @@ async fn apply_profiles_change(
     // R4.B will additionally rebuild on file-watcher events; for the
     // self-written change we do it inline so the response reflects the
     // post-write state without waiting on the watcher debounce.
-    let relay_clone = {
+    {
         let mut cfg = state.config.write().await;
         cfg.profiles = if new_profiles.is_empty() {
             None
         } else {
             Some(new_profiles.clone())
         };
-        cfg.relay.clone()
-    };
+    }
     if let Some(ref pr) = state.profile_registry {
-        pr.rebuild(&new_profiles, &relay_clone).await;
+        pr.rebuild(&new_profiles).await;
     }
     Ok(())
 }
@@ -2564,9 +2550,10 @@ async fn apply_profiles_change(
 async fn list_profiles(State(state): State<ManagementState>) -> impl IntoResponse {
     let cfg = state.config.read().await;
     let profiles = cfg.profiles.clone().unwrap_or_default();
+    drop(cfg);
     let mut out: Vec<ProfileSummary> = Vec::with_capacity(profiles.len());
     for p in &profiles {
-        out.push(build_profile_summary(&state, &cfg, p).await);
+        out.push(build_profile_summary(&state, p).await);
     }
     out.sort_by(|a, b| a.name.cmp(&b.name));
     Json(out).into_response()
@@ -2587,8 +2574,7 @@ async fn create_profile(
     if let Err(resp) = apply_profiles_change(&state, profiles).await {
         return *resp;
     }
-    let cfg = state.config.read().await;
-    let summary = build_profile_summary(&state, &cfg, &new_profile).await;
+    let summary = build_profile_summary(&state, &new_profile).await;
     (StatusCode::CREATED, Json(summary)).into_response()
 }
 
@@ -2615,7 +2601,8 @@ async fn get_profile(
         )
         .into_response();
     };
-    let summary = build_profile_summary(&state, &cfg, &profile).await;
+    drop(cfg);
+    let summary = build_profile_summary(&state, &profile).await;
     // Build a profile-scoped CatalogEntry list. When no profile_registry is
     // wired (legacy test fixtures), the catalog is empty.
     let tools: Vec<CatalogEntry> = if let Some(ref pr) = state.profile_registry {
@@ -2696,8 +2683,7 @@ async fn update_profile(
     if let Err(resp) = apply_profiles_change(&state, profiles).await {
         return *resp;
     }
-    let cfg = state.config.read().await;
-    let summary = build_profile_summary(&state, &cfg, &updated).await;
+    let summary = build_profile_summary(&state, &updated).await;
     (StatusCode::OK, Json(summary)).into_response()
 }
 
@@ -5954,7 +5940,7 @@ client_id = "client123"
         std::fs::write(config_file, toml_str).unwrap();
 
         let profile_registry = Arc::new(ProfileRegistry::new((*registry_arc).clone()));
-        profile_registry.rebuild(&[], &cfg.relay).await;
+        profile_registry.rebuild(&[]).await;
 
         ManagementState {
             registry: registry_arc,
@@ -6211,22 +6197,34 @@ client_id = "client123"
         let cases: &[(&str, serde_json::Value, StatusCode)] = &[
             (
                 "empty name",
-                serde_json::json!({ "name": "", "path": "work", "endpoints": [] }),
+                serde_json::json!({
+                    "name": "", "path": "work", "endpoints": [],
+                    "js_execution": false, "toon_output": true,
+                }),
                 StatusCode::BAD_REQUEST,
             ),
             (
                 "reserved path",
-                serde_json::json!({ "name": "X", "path": "sse", "endpoints": [] }),
+                serde_json::json!({
+                    "name": "X", "path": "sse", "endpoints": [],
+                    "js_execution": false, "toon_output": true,
+                }),
                 StatusCode::BAD_REQUEST,
             ),
             (
                 "invalid path characters",
-                serde_json::json!({ "name": "X", "path": "with space", "endpoints": [] }),
+                serde_json::json!({
+                    "name": "X", "path": "with space", "endpoints": [],
+                    "js_execution": false, "toon_output": true,
+                }),
                 StatusCode::BAD_REQUEST,
             ),
             (
                 "unknown endpoint reference",
-                serde_json::json!({ "name": "X", "path": "x", "endpoints": ["nonexistent"] }),
+                serde_json::json!({
+                    "name": "X", "path": "x", "endpoints": ["nonexistent"],
+                    "js_execution": false, "toon_output": true,
+                }),
                 StatusCode::BAD_REQUEST,
             ),
         ];
@@ -6277,6 +6275,8 @@ client_id = "client123"
                             "name": "Ghost",
                             "path": "ghost",
                             "endpoints": [],
+                            "js_execution": false,
+                            "toon_output": true,
                         })
                         .to_string(),
                     ))
@@ -6298,6 +6298,8 @@ client_id = "client123"
                                 "name": name,
                                 "path": path,
                                 "endpoints": [],
+                                "js_execution": false,
+                                "toon_output": true,
                             })
                             .to_string(),
                         ))
@@ -6316,6 +6318,8 @@ client_id = "client123"
                             "name": "B",
                             "path": "ALPHA",
                             "endpoints": [],
+                            "js_execution": false,
+                            "toon_output": true,
                         })
                         .to_string(),
                     ))
@@ -6327,6 +6331,73 @@ client_id = "client123"
             resp.status(),
             StatusCode::CONFLICT,
             "rename onto existing path must 409 (case-insensitive)"
+        );
+    }
+
+    /// `POST /api/profiles` with a body that omits (or nulls out)
+    /// `js_execution` / `toon_output` is rejected by the JSON extractor
+    /// with a 4xx, and never touches `config.toml` on disk.
+    #[tokio::test]
+    async fn management_profiles_post_rejects_missing_js_toon_fields() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_file = tmp.path().join("config.toml");
+        let state = profiles_test_state(&["gmail"], &config_file).await;
+        let app = management_routes(state);
+        let before = std::fs::read_to_string(&config_file).unwrap();
+
+        let cases: &[(&str, serde_json::Value)] = &[
+            (
+                "missing js_execution",
+                serde_json::json!({
+                    "name": "Work", "path": "work", "endpoints": [],
+                    "toon_output": true,
+                }),
+            ),
+            (
+                "missing toon_output",
+                serde_json::json!({
+                    "name": "Work", "path": "work", "endpoints": [],
+                    "js_execution": false,
+                }),
+            ),
+            (
+                "null js_execution",
+                serde_json::json!({
+                    "name": "Work", "path": "work", "endpoints": [],
+                    "js_execution": null, "toon_output": true,
+                }),
+            ),
+            (
+                "null toon_output",
+                serde_json::json!({
+                    "name": "Work", "path": "work", "endpoints": [],
+                    "js_execution": false, "toon_output": null,
+                }),
+            ),
+        ];
+        for (label, body) in cases {
+            let resp = app
+                .clone()
+                .oneshot(
+                    Request::post("/api/profiles")
+                        .header("content-type", "application/json")
+                        .body(Body::from(body.to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            let s = resp.status();
+            assert!(
+                s.is_client_error(),
+                "case '{}' should reject with a 4xx, got {}",
+                label,
+                s
+            );
+        }
+        let after = std::fs::read_to_string(&config_file).unwrap();
+        assert_eq!(
+            before, after,
+            "rejected POSTs must not write to config.toml"
         );
     }
 }

--- a/src/management.rs
+++ b/src/management.rs
@@ -22,6 +22,7 @@ use crate::adapter::stdio::{StdioAdapter, StdioConfig};
 use crate::adapter::{FailedAdapter, HealthStatus, McpAdapter, StartingAdapter};
 use crate::config::Config;
 use crate::oauth::{OAuthFlowManager, OAuthSetupManager, PkceChallenge};
+use crate::profile_registry::ProfileRegistry;
 use crate::registry::AdapterRegistry;
 use crate::token_manager::{DcrCredentials, TokenManager};
 use crate::OAuthAdapterInners;
@@ -48,6 +49,13 @@ pub struct ManagementState {
     pub token_manager: Option<Arc<TokenManager>>,
     /// Transient OAuth setup session manager (preflight flow).
     pub setup_manager: Option<Arc<OAuthSetupManager>>,
+    /// Relay-wide profile registry. Profile CRUD handlers call
+    /// [`ProfileRegistry::rebuild`] directly after a successful TOML
+    /// writeback so the live `/mcp/{profile}` routes reflect the change
+    /// without waiting on `ConfigWatcher` (the watcher path is owned by
+    /// R4.B). `None` is permitted for legacy test fixtures that don't
+    /// exercise the profile routes.
+    pub profile_registry: Option<Arc<ProfileRegistry>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -2299,6 +2307,458 @@ async fn oauth_setup_cancel(
 }
 
 // ---------------------------------------------------------------------------
+// Profile CRUD (R4.A)
+// ---------------------------------------------------------------------------
+
+/// Request body for `POST /api/profiles` and `PUT /api/profiles/{path}`.
+#[derive(Deserialize)]
+pub struct ProfileRequest {
+    pub name: String,
+    pub path: String,
+    #[serde(default)]
+    pub endpoints: Vec<String>,
+    #[serde(default)]
+    pub js_execution: Option<bool>,
+    #[serde(default)]
+    pub toon_output: Option<bool>,
+}
+
+/// Summary shape returned by `GET /api/profiles` and `POST /api/profiles`.
+/// Mirrors the JSON shape documented in Engineering Spec §8.2.
+#[derive(Serialize)]
+pub struct ProfileSummary {
+    pub name: String,
+    pub path: String,
+    pub endpoints: Vec<String>,
+    /// Resolved per-profile JS-execution flag (falls back to
+    /// `RelayConfig::local_js_execution` when the profile leaves it unset).
+    pub js_execution: bool,
+    /// Resolved per-profile TOON output flag (falls back to
+    /// `RelayConfig::toon_output`).
+    pub toon_output: bool,
+    pub endpoint_count: usize,
+    pub tool_count: usize,
+}
+
+/// Detail shape returned by `GET /api/profiles/{path}` — same fields as
+/// [`ProfileSummary`] plus the profile-scoped tool catalog.
+#[derive(Serialize)]
+pub struct ProfileDetail {
+    #[serde(flatten)]
+    pub summary: ProfileSummary,
+    pub tools: Vec<CatalogEntry>,
+}
+
+/// Resolve a request's `js_execution` / `toon_output` against the same
+/// fallbacks `ProfileRegistry::rebuild` uses, so the JSON shape matches what
+/// the live registry will report.
+fn resolve_profile_flags(profile: &crate::config::ProfileConfig, cfg: &Config) -> (bool, bool) {
+    let js = profile
+        .js_execution
+        .unwrap_or_else(|| cfg.relay.local_js_execution.unwrap_or(false));
+    let toon = profile
+        .toon_output
+        .unwrap_or_else(|| cfg.relay.toon_output.unwrap_or(true));
+    (js, toon)
+}
+
+/// Look up the live tool count for a profile (post-rebuild). Returns 0 when
+/// the registry isn't available (legacy test fixtures).
+async fn profile_tool_count(state: &ManagementState, path: &str) -> usize {
+    let Some(ref pr) = state.profile_registry else {
+        return 0;
+    };
+    match pr.get(path).await {
+        Some(ctx) => ctx.registry_view.merged_catalog().await.len(),
+        None => 0,
+    }
+}
+
+/// Build a [`ProfileSummary`] from a [`crate::config::ProfileConfig`].
+async fn build_profile_summary(
+    state: &ManagementState,
+    cfg: &Config,
+    profile: &crate::config::ProfileConfig,
+) -> ProfileSummary {
+    let (js, toon) = resolve_profile_flags(profile, cfg);
+    let tool_count = profile_tool_count(state, &profile.path).await;
+    ProfileSummary {
+        name: profile.name.clone(),
+        path: profile.path.clone(),
+        endpoints: profile.endpoints.clone(),
+        js_execution: js,
+        toon_output: toon,
+        endpoint_count: profile.endpoints.len(),
+        tool_count,
+    }
+}
+
+/// Validate a request body for create / update. Returns a 400 response on
+/// failure; on success returns the [`crate::config::ProfileConfig`] that
+/// would land in `config.toml`.
+fn validate_profile_request(
+    req: &ProfileRequest,
+    cfg: &Config,
+    existing_path_lower: Option<&str>,
+) -> Result<crate::config::ProfileConfig, Box<axum::http::Response<axum::body::Body>>> {
+    let bad_request = |err: &str, detail: String| -> Box<axum::http::Response<axum::body::Body>> {
+        Box::new(error_response(StatusCode::BAD_REQUEST, err, Some(&detail)).into_response())
+    };
+    let conflict = |err: &str, detail: String| -> Box<axum::http::Response<axum::body::Body>> {
+        Box::new(error_response(StatusCode::CONFLICT, err, Some(&detail)).into_response())
+    };
+
+    if req.name.trim().is_empty() {
+        return Err(bad_request(
+            "invalid profile",
+            "Profile name must not be empty".to_string(),
+        ));
+    }
+    if let Err(msg) = crate::config::validate_profile_path(&req.path) {
+        return Err(bad_request("invalid profile path", msg));
+    }
+    let new_path_lower = req.path.to_ascii_lowercase();
+    // Uniqueness: scan current profiles, ignoring the profile we're updating
+    // in place (matched by its current path, case-insensitive).
+    if let Some(profiles) = cfg.profiles.as_ref() {
+        for p in profiles {
+            let p_lower = p.path.to_ascii_lowercase();
+            if Some(p_lower.as_str()) == existing_path_lower {
+                continue;
+            }
+            if p_lower == new_path_lower {
+                return Err(conflict(
+                    "duplicate profile path",
+                    format!(
+                        "Profile path '{}' is already in use (paths are case-insensitive).",
+                        req.path
+                    ),
+                ));
+            }
+            if p.name == req.name && existing_path_lower != Some(p_lower.as_str()) {
+                return Err(conflict(
+                    "duplicate profile name",
+                    format!("Profile name '{}' is already in use.", req.name),
+                ));
+            }
+        }
+    }
+    let endpoint_names: std::collections::HashSet<&str> =
+        cfg.endpoints.iter().map(|e| e.name.as_str()).collect();
+    for ep in &req.endpoints {
+        if !endpoint_names.contains(ep.as_str()) {
+            return Err(bad_request(
+                "unknown endpoint",
+                format!(
+                    "Profile '{}' references unknown endpoint '{}'",
+                    req.name, ep
+                ),
+            ));
+        }
+    }
+    Ok(crate::config::ProfileConfig {
+        name: req.name.clone(),
+        path: req.path.clone(),
+        endpoints: req.endpoints.clone(),
+        js_execution: req.js_execution,
+        toon_output: req.toon_output,
+    })
+}
+
+/// Persist the updated profile list back to `config.toml`, preserving the
+/// rest of the document. Mirrors the targeted-edit pattern used by
+/// [`delete_endpoint`] / [`oauth_setup_commit`].
+fn write_profiles_to_disk(
+    config_path: &std::path::Path,
+    profiles: &[crate::config::ProfileConfig],
+) -> Result<(), (StatusCode, &'static str, String)> {
+    let contents = std::fs::read_to_string(config_path).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to read config file",
+            e.to_string(),
+        )
+    })?;
+    let mut parsed: toml::Table = contents.parse().map_err(|e: toml::de::Error| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to parse config file",
+            e.to_string(),
+        )
+    })?;
+
+    if profiles.is_empty() {
+        parsed.remove("profiles");
+    } else {
+        let arr: Vec<toml::Value> = profiles
+            .iter()
+            .map(|p| {
+                toml::Value::try_from(p)
+                    .expect("ProfileConfig is Serialize and round-trips through toml::Value")
+            })
+            .collect();
+        parsed.insert("profiles".into(), toml::Value::Array(arr));
+    }
+
+    let new_contents = toml::to_string_pretty(&parsed).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to serialize config",
+            e.to_string(),
+        )
+    })?;
+    crate::config::write_config_file(config_path, &new_contents).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to write config file",
+            e.to_string(),
+        )
+    })?;
+    Ok(())
+}
+
+/// Helper that writes `new_profiles` to disk, swaps them into the in-memory
+/// [`ManagementState::config`], and rebuilds the live [`ProfileRegistry`] so
+/// `/mcp/{profile}` reflects the change immediately. Returns the resolved
+/// config path on success.
+async fn apply_profiles_change(
+    state: &ManagementState,
+    new_profiles: Vec<crate::config::ProfileConfig>,
+) -> Result<(), Box<axum::http::Response<axum::body::Body>>> {
+    let Some(ref config_path) = state.config_path else {
+        return Err(Box::new(
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "config_path not configured",
+                Some("The management API was not initialised with a config file path."),
+            )
+            .into_response(),
+        ));
+    };
+    let resolved = crate::config::expand_tilde(config_path);
+    if let Err((status, err, detail)) = write_profiles_to_disk(&resolved, &new_profiles) {
+        return Err(Box::new(
+            error_response(status, err, Some(&detail)).into_response(),
+        ));
+    }
+    // Swap the in-memory config baseline and rebuild the live registry.
+    // R4.B will additionally rebuild on file-watcher events; for the
+    // self-written change we do it inline so the response reflects the
+    // post-write state without waiting on the watcher debounce.
+    let relay_clone = {
+        let mut cfg = state.config.write().await;
+        cfg.profiles = if new_profiles.is_empty() {
+            None
+        } else {
+            Some(new_profiles.clone())
+        };
+        cfg.relay.clone()
+    };
+    if let Some(ref pr) = state.profile_registry {
+        pr.rebuild(&new_profiles, &relay_clone).await;
+    }
+    Ok(())
+}
+
+/// GET /api/profiles — list all profiles with resolved flags + live tool count.
+async fn list_profiles(State(state): State<ManagementState>) -> impl IntoResponse {
+    let cfg = state.config.read().await;
+    let profiles = cfg.profiles.clone().unwrap_or_default();
+    let mut out: Vec<ProfileSummary> = Vec::with_capacity(profiles.len());
+    for p in &profiles {
+        out.push(build_profile_summary(&state, &cfg, p).await);
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    Json(out).into_response()
+}
+
+/// POST /api/profiles — create a new profile.
+async fn create_profile(
+    State(state): State<ManagementState>,
+    Json(req): Json<ProfileRequest>,
+) -> impl IntoResponse {
+    let cfg_snapshot = state.config.read().await.clone();
+    let new_profile = match validate_profile_request(&req, &cfg_snapshot, None) {
+        Ok(p) => p,
+        Err(resp) => return *resp,
+    };
+    let mut profiles = cfg_snapshot.profiles.clone().unwrap_or_default();
+    profiles.push(new_profile.clone());
+    if let Err(resp) = apply_profiles_change(&state, profiles).await {
+        return *resp;
+    }
+    let cfg = state.config.read().await;
+    let summary = build_profile_summary(&state, &cfg, &new_profile).await;
+    (StatusCode::CREATED, Json(summary)).into_response()
+}
+
+/// GET /api/profiles/{path} — read one profile (with full scoped catalog).
+async fn get_profile(
+    State(state): State<ManagementState>,
+    Path(path): Path<String>,
+) -> impl IntoResponse {
+    let cfg = state.config.read().await;
+    let path_lower = path.to_ascii_lowercase();
+    let Some(profile) = cfg
+        .profiles
+        .as_ref()
+        .and_then(|ps| {
+            ps.iter()
+                .find(|p| p.path.to_ascii_lowercase() == path_lower)
+        })
+        .cloned()
+    else {
+        return error_response(
+            StatusCode::NOT_FOUND,
+            "profile not found",
+            Some(&format!("No profile at path '{}'", path)),
+        )
+        .into_response();
+    };
+    let summary = build_profile_summary(&state, &cfg, &profile).await;
+    // Build a profile-scoped CatalogEntry list. When no profile_registry is
+    // wired (legacy test fixtures), the catalog is empty.
+    let tools: Vec<CatalogEntry> = if let Some(ref pr) = state.profile_registry {
+        match pr.get(&profile.path).await {
+            Some(ctx) => {
+                let (tools, lookup) = ctx.registry_view.merged_catalog_with_lookup().await;
+                let entries = state.registry.entries().read().await;
+                tools
+                    .into_iter()
+                    .map(|t| {
+                        let (endpoint_name, available) = match lookup.get(&t.name) {
+                            Some((ep, _raw)) => {
+                                let avail = entries
+                                    .get(ep.as_str())
+                                    .map(|e| {
+                                        !e.disabled
+                                            && matches!(
+                                                e.adapter.health(),
+                                                crate::adapter::HealthStatus::Healthy
+                                            )
+                                    })
+                                    .unwrap_or(false);
+                                (ep.clone(), avail)
+                            }
+                            None => ("unknown".to_string(), false),
+                        };
+                        CatalogEntry {
+                            name: t.name,
+                            description: t.description,
+                            input_schema: t.input_schema,
+                            annotations: t.annotations,
+                            endpoint: endpoint_name,
+                            available,
+                        }
+                    })
+                    .collect()
+            }
+            None => Vec::new(),
+        }
+    } else {
+        Vec::new()
+    };
+    Json(ProfileDetail { summary, tools }).into_response()
+}
+
+/// PUT /api/profiles/{path} — update / rename a profile.
+async fn update_profile(
+    State(state): State<ManagementState>,
+    Path(path): Path<String>,
+    Json(req): Json<ProfileRequest>,
+) -> impl IntoResponse {
+    let cfg_snapshot = state.config.read().await.clone();
+    let path_lower = path.to_ascii_lowercase();
+    let exists = cfg_snapshot
+        .profiles
+        .as_ref()
+        .map(|ps| ps.iter().any(|p| p.path.to_ascii_lowercase() == path_lower))
+        .unwrap_or(false);
+    if !exists {
+        return error_response(
+            StatusCode::NOT_FOUND,
+            "profile not found",
+            Some(&format!("No profile at path '{}'", path)),
+        )
+        .into_response();
+    }
+    let updated = match validate_profile_request(&req, &cfg_snapshot, Some(&path_lower)) {
+        Ok(p) => p,
+        Err(resp) => return *resp,
+    };
+    let mut profiles = cfg_snapshot.profiles.clone().unwrap_or_default();
+    for p in profiles.iter_mut() {
+        if p.path.to_ascii_lowercase() == path_lower {
+            *p = updated.clone();
+            break;
+        }
+    }
+    if let Err(resp) = apply_profiles_change(&state, profiles).await {
+        return *resp;
+    }
+    let cfg = state.config.read().await;
+    let summary = build_profile_summary(&state, &cfg, &updated).await;
+    (StatusCode::OK, Json(summary)).into_response()
+}
+
+/// DELETE /api/profiles/{path} — remove a profile.
+async fn delete_profile(
+    State(state): State<ManagementState>,
+    Path(path): Path<String>,
+) -> impl IntoResponse {
+    let cfg_snapshot = state.config.read().await.clone();
+    let path_lower = path.to_ascii_lowercase();
+    let exists = cfg_snapshot
+        .profiles
+        .as_ref()
+        .map(|ps| ps.iter().any(|p| p.path.to_ascii_lowercase() == path_lower))
+        .unwrap_or(false);
+    if !exists {
+        return error_response(
+            StatusCode::NOT_FOUND,
+            "profile not found",
+            Some(&format!("No profile at path '{}'", path)),
+        )
+        .into_response();
+    }
+    let profiles: Vec<_> = cfg_snapshot
+        .profiles
+        .clone()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|p| p.path.to_ascii_lowercase() != path_lower)
+        .collect();
+    if let Err(resp) = apply_profiles_change(&state, profiles).await {
+        return *resp;
+    }
+    StatusCode::NO_CONTENT.into_response()
+}
+
+/// GET /api/endpoints/{name}/profiles — which profiles include this endpoint.
+async fn get_endpoint_profile_membership(
+    State(state): State<ManagementState>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    let cfg = state.config.read().await;
+    let endpoint_exists = cfg.endpoints.iter().any(|e| e.name == name);
+    if !endpoint_exists {
+        return endpoint_not_found(&name).into_response();
+    }
+    let mut paths: Vec<String> = cfg
+        .profiles
+        .as_ref()
+        .map(|ps| {
+            ps.iter()
+                .filter(|p| p.endpoints.iter().any(|ep| ep == &name))
+                .map(|p| p.path.clone())
+                .collect()
+        })
+        .unwrap_or_default();
+    paths.sort();
+    Json(serde_json::json!({ "profiles": paths })).into_response()
+}
+
+// ---------------------------------------------------------------------------
 // Router builder
 // ---------------------------------------------------------------------------
 
@@ -2348,6 +2808,17 @@ pub fn management_routes(state: ManagementState) -> Router {
         .route("/api/config", get(get_config))
         .route("/api/config/reload", post(reload_config))
         .route("/api/test-connection", post(test_connection))
+        // Profile CRUD (R4.A) — spec §8.1, §8.2.
+        .route("/api/profiles", get(list_profiles).post(create_profile))
+        .route(
+            "/api/profiles/{path}",
+            get(get_profile).put(update_profile).delete(delete_profile),
+        )
+        // Endpoint → profile membership (read-only, spec §8.3).
+        .route(
+            "/api/endpoints/{name}/profiles",
+            get(get_endpoint_profile_membership),
+        )
         // No CORS layer: this router is served exclusively over a Unix-domain
         // socket / Windows named pipe (see `management_listener`), which is not
         // reachable from a browser and has no cross-origin attack surface.
@@ -2716,6 +3187,7 @@ mod tests {
             oauth_adapter_inners: None,
             token_manager: None,
             setup_manager: None,
+            profile_registry: None,
         }
     }
 
@@ -2975,6 +3447,7 @@ mod tests {
             oauth_adapter_inners: None,
             token_manager: None,
             setup_manager: None,
+            profile_registry: None,
         };
         let app = management_routes(state);
 
@@ -3049,6 +3522,7 @@ mod tests {
             oauth_adapter_inners: None,
             token_manager: None,
             setup_manager: None,
+            profile_registry: None,
         };
         let registry_for_poll = state.registry.clone();
         let app = management_routes(state);
@@ -3182,6 +3656,7 @@ mod tests {
             oauth_adapter_inners: None,
             token_manager: None,
             setup_manager: None,
+            profile_registry: None,
         };
         let registry_for_poll = state.registry.clone();
         let app = management_routes(state);
@@ -3685,6 +4160,7 @@ command = "echo"
             oauth_adapter_inners: Some(oauth_inners),
             token_manager: Some(token_manager),
             setup_manager: None,
+            profile_registry: None,
         };
 
         (state, shared_inner)
@@ -3998,6 +4474,7 @@ command = "echo"
             oauth_adapter_inners: None,
             token_manager: None,
             setup_manager: Some(Arc::new(OAuthSetupManager::new())),
+            profile_registry: None,
         }
     }
 
@@ -4660,6 +5137,7 @@ command = "echo"
             oauth_adapter_inners: None,
             token_manager: Some(token_manager.clone()),
             setup_manager: None,
+            profile_registry: None,
         };
         (state, token_manager)
     }
@@ -4859,6 +5337,7 @@ command = "echo"
             oauth_adapter_inners: None,
             token_manager: None,
             setup_manager: None,
+            profile_registry: None,
         };
         (state, flow_mgr)
     }
@@ -5298,6 +5777,7 @@ command = "echo"
             oauth_adapter_inners: Some(oauth_inners.clone()),
             token_manager: Some(token_manager),
             setup_manager: None,
+            profile_registry: None,
         };
         let app = management_routes(state);
         let resp = app
@@ -5368,6 +5848,7 @@ client_id = "client123"
             oauth_adapter_inners: Some(oauth_inners.clone()),
             token_manager: Some(token_manager),
             setup_manager: None,
+            profile_registry: None,
         };
         let app = management_routes(state);
         let resp = app
@@ -5398,5 +5879,454 @@ client_id = "client123"
         crate::config::write_config_file(&path, "# placeholder").unwrap();
         let mode = std::fs::metadata(&path).unwrap().permissions().mode();
         assert_eq!(mode & 0o777, 0o600, "Expected 0600, got {:o}", mode & 0o777);
+    }
+
+    // ---------------------------------------------------------------------
+    // R4.A — Profile CRUD + endpoint membership (test matrix #21, #22)
+    // ---------------------------------------------------------------------
+
+    fn profiles_test_config(endpoint_names: &[&str]) -> Config {
+        Config {
+            relay: RelayConfig {
+                machine_name: "test".into(),
+                local_js_execution: None,
+                token_dir: None,
+                allow_insecure_oauth: None,
+                toon_output: None,
+                startup_init_timeout_secs: None,
+            },
+            endpoints: endpoint_names
+                .iter()
+                .map(|n| EndpointConfig {
+                    name: (*n).to_string(),
+                    description: None,
+                    tool_prefix: None,
+                    transport: Transport::Stdio,
+                    command: Some("echo".into()),
+                    args: None,
+                    url: None,
+                    env: None,
+                    headers: None,
+                    disabled: false,
+                    disabled_tools: Vec::new(),
+                    oauth_server_url: None,
+                    client_id: None,
+                    client_secret: None,
+                    scopes: None,
+                    token_endpoint: None,
+                    server_type_override: None,
+                })
+                .collect(),
+            profiles: None,
+        }
+    }
+
+    /// Build a `ManagementState` wired to a real on-disk `config.toml` and a
+    /// live `ProfileRegistry`, plus `endpoint_names` worth of registered
+    /// mock adapters. Returns the state and the path to the config file so
+    /// tests can assert TOML writeback.
+    async fn profiles_test_state(
+        endpoint_names: &[&str],
+        config_file: &std::path::Path,
+    ) -> ManagementState {
+        let registry = AdapterRegistry::new();
+        for name in endpoint_names {
+            registry
+                .register(
+                    (*name).to_string(),
+                    Box::new(MockAdapter::healthy_with_tools(vec![ToolInfo {
+                        name: format!("{}_tool", name),
+                        description: None,
+                        input_schema: serde_json::json!({}),
+                        annotations: None,
+                    }])),
+                    "stdio".to_string(),
+                    None,
+                    Some((*name).to_string()),
+                )
+                .await;
+        }
+        let registry_arc = Arc::new(registry);
+        let cfg = profiles_test_config(endpoint_names);
+        // Seed the on-disk file so writeback round-trips through a real
+        // TOML document and we can verify formatting.
+        let toml_str = toml::to_string_pretty(&cfg).unwrap();
+        std::fs::write(config_file, toml_str).unwrap();
+
+        let profile_registry = Arc::new(ProfileRegistry::new((*registry_arc).clone()));
+        profile_registry.rebuild(&[], &cfg.relay).await;
+
+        ManagementState {
+            registry: registry_arc,
+            config: Arc::new(RwLock::new(cfg)),
+            start_time: Instant::now(),
+            config_path: Some(config_file.to_path_buf()),
+            oauth_flow_manager: None,
+            relay_port: 9400,
+            oauth_adapter_inners: None,
+            token_manager: None,
+            setup_manager: None,
+            profile_registry: Some(profile_registry),
+        }
+    }
+
+    /// Matrix row #21 — Management API CRUD round trip.
+    ///
+    /// Create → list → get → update → delete, asserting status codes, JSON
+    /// shapes, TOML writeback, and that the live `ProfileRegistry`
+    /// reflects each mutation.
+    #[tokio::test]
+    async fn management_profiles_full_crud_round_trip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_file = tmp.path().join("config.toml");
+        let state = profiles_test_state(&["gmail", "linear", "todoist"], &config_file).await;
+        let profile_registry = state.profile_registry.clone().unwrap();
+        let app = management_routes(state);
+
+        // ---- CREATE ----
+        let create_body = serde_json::json!({
+            "name": "Work",
+            "path": "work",
+            "endpoints": ["gmail", "linear"],
+            "js_execution": true,
+            "toon_output": true,
+        });
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/api/profiles")
+                    .header("content-type", "application/json")
+                    .body(Body::from(create_body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let body = body_json(resp).await;
+        assert_eq!(body["name"], "Work");
+        assert_eq!(body["path"], "work");
+        assert_eq!(body["endpoint_count"], 2);
+        assert_eq!(body["tool_count"], 2); // gmail_tool + linear_tool
+        assert_eq!(body["js_execution"], true);
+        assert_eq!(body["toon_output"], true);
+        // Writeback: config.toml now contains the profile.
+        let on_disk = std::fs::read_to_string(&config_file).unwrap();
+        assert!(on_disk.contains("[[profiles]]"));
+        assert!(on_disk.contains("name = \"Work\""));
+        assert!(on_disk.contains("path = \"work\""));
+        // Live registry sees the new profile.
+        assert!(profile_registry.get("work").await.is_some());
+
+        // ---- LIST ----
+        let resp = app
+            .clone()
+            .oneshot(Request::get("/api/profiles").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let arr = body.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["path"], "work");
+
+        // ---- GET (case-insensitive path lookup) ----
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::get("/api/profiles/WORK")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["name"], "Work");
+        let tools = body["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 2, "profile catalog must contain 2 tools");
+        let tool_names: std::collections::HashSet<&str> = tools
+            .iter()
+            .map(|t| t["name"].as_str().unwrap_or(""))
+            .collect();
+        assert!(tool_names.contains("gmail__gmail_tool"));
+        assert!(tool_names.contains("linear__linear_tool"));
+
+        // ---- UPDATE (rename + change endpoints) ----
+        let update_body = serde_json::json!({
+            "name": "Daily",
+            "path": "daily",
+            "endpoints": ["gmail", "linear", "todoist"],
+            "js_execution": false,
+            "toon_output": false,
+        });
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::put("/api/profiles/work")
+                    .header("content-type", "application/json")
+                    .body(Body::from(update_body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["name"], "Daily");
+        assert_eq!(body["path"], "daily");
+        assert_eq!(body["endpoint_count"], 3);
+        assert_eq!(body["js_execution"], false);
+        assert!(profile_registry.get("work").await.is_none());
+        assert!(profile_registry.get("daily").await.is_some());
+
+        // ---- DELETE ----
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::delete("/api/profiles/daily")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+        assert!(profile_registry.get("daily").await.is_none());
+        let on_disk = std::fs::read_to_string(&config_file).unwrap();
+        assert!(
+            !on_disk.contains("[[profiles]]"),
+            "TOML must drop the [[profiles]] block when empty, got:\n{}",
+            on_disk
+        );
+
+        // ---- LIST is now empty ----
+        let resp = app
+            .clone()
+            .oneshot(Request::get("/api/profiles").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let body = body_json(resp).await;
+        assert!(body.as_array().unwrap().is_empty());
+    }
+
+    /// Matrix row #22 — `GET /api/endpoints/{name}/profiles` returns the
+    /// list of profile paths containing the endpoint.
+    #[tokio::test]
+    async fn management_endpoint_profiles_membership() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_file = tmp.path().join("config.toml");
+        let state = profiles_test_state(&["gmail", "linear", "todoist"], &config_file).await;
+        let app = management_routes(state);
+
+        // Seed two profiles via the API: gmail is in both, todoist in none.
+        for (name, path, endpoints) in [
+            ("Work", "work", vec!["gmail", "linear"]),
+            ("Personal", "personal", vec!["gmail"]),
+        ] {
+            let body = serde_json::json!({
+                "name": name,
+                "path": path,
+                "endpoints": endpoints,
+                "js_execution": false,
+                "toon_output": true,
+            });
+            let resp = app
+                .clone()
+                .oneshot(
+                    Request::post("/api/profiles")
+                        .header("content-type", "application/json")
+                        .body(Body::from(body.to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::CREATED);
+        }
+
+        // gmail → both profiles, sorted.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::get("/api/endpoints/gmail/profiles")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let arr = body["profiles"].as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0], "personal");
+        assert_eq!(arr[1], "work");
+
+        // linear → only "work".
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::get("/api/endpoints/linear/profiles")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = body_json(resp).await;
+        assert_eq!(body["profiles"].as_array().unwrap().len(), 1);
+        assert_eq!(body["profiles"][0], "work");
+
+        // todoist → no profiles.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::get("/api/endpoints/todoist/profiles")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = body_json(resp).await;
+        assert!(body["profiles"].as_array().unwrap().is_empty());
+
+        // Unknown endpoint → 404.
+        let resp = app
+            .oneshot(
+                Request::get("/api/endpoints/missing/profiles")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// Validation: `POST /api/profiles` rejects invalid paths (regex +
+    /// reserved-name list — spec §2.3) and unknown endpoint references with
+    /// 4xx responses, and never writes the bad payload to disk.
+    #[tokio::test]
+    async fn management_profiles_post_rejects_invalid_payloads() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_file = tmp.path().join("config.toml");
+        let state = profiles_test_state(&["gmail"], &config_file).await;
+        let app = management_routes(state);
+        let before = std::fs::read_to_string(&config_file).unwrap();
+
+        let cases: &[(&str, serde_json::Value, StatusCode)] = &[
+            (
+                "empty name",
+                serde_json::json!({ "name": "", "path": "work", "endpoints": [] }),
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                "reserved path",
+                serde_json::json!({ "name": "X", "path": "sse", "endpoints": [] }),
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                "invalid path characters",
+                serde_json::json!({ "name": "X", "path": "with space", "endpoints": [] }),
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                "unknown endpoint reference",
+                serde_json::json!({ "name": "X", "path": "x", "endpoints": ["nonexistent"] }),
+                StatusCode::BAD_REQUEST,
+            ),
+        ];
+        for (label, body, want_status) in cases {
+            let resp = app
+                .clone()
+                .oneshot(
+                    Request::post("/api/profiles")
+                        .header("content-type", "application/json")
+                        .body(Body::from(body.to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                resp.status(),
+                *want_status,
+                "case '{}' should reject with {}",
+                label,
+                want_status
+            );
+        }
+        // None of the rejected payloads should have touched the file.
+        let after = std::fs::read_to_string(&config_file).unwrap();
+        assert_eq!(
+            before, after,
+            "rejected POSTs must not write to config.toml"
+        );
+    }
+
+    /// `PUT /api/profiles/{path}` on a missing profile returns 404, and a
+    /// rename to a path that collides with another profile returns 409.
+    #[tokio::test]
+    async fn management_profiles_put_404_and_conflict() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_file = tmp.path().join("config.toml");
+        let state = profiles_test_state(&["gmail"], &config_file).await;
+        let app = management_routes(state);
+
+        // 404 on update of nonexistent profile.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::put("/api/profiles/ghost")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "name": "Ghost",
+                            "path": "ghost",
+                            "endpoints": [],
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        // Seed two profiles, then try to rename one onto the other's path.
+        for (name, path) in [("A", "alpha"), ("B", "bravo")] {
+            let resp = app
+                .clone()
+                .oneshot(
+                    Request::post("/api/profiles")
+                        .header("content-type", "application/json")
+                        .body(Body::from(
+                            serde_json::json!({
+                                "name": name,
+                                "path": path,
+                                "endpoints": [],
+                            })
+                            .to_string(),
+                        ))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::CREATED);
+        }
+        let resp = app
+            .oneshot(
+                Request::put("/api/profiles/bravo")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "name": "B",
+                            "path": "ALPHA",
+                            "endpoints": [],
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::CONFLICT,
+            "rename onto existing path must 409 (case-insensitive)"
+        );
     }
 }

--- a/src/profile_registry.rs
+++ b/src/profile_registry.rs
@@ -28,37 +28,27 @@ use serde_json::Value;
 use tokio::sync::{broadcast, RwLock};
 
 use crate::adapter::{AdapterError, ToolInfo};
-use crate::config::{ProfileConfig, RelayConfig};
+use crate::config::ProfileConfig;
 use crate::js_sandbox::MetaToolHandler;
 use crate::registry::{AdapterRegistry, MetaToolRegistry};
-
-/// Effective default for [`RelayConfig::local_js_execution`] when the field
-/// is omitted from `config.toml`. Mirrors the main.rs startup default.
-const DEFAULT_LOCAL_JS_EXECUTION: bool = false;
-
-/// Effective default for [`RelayConfig::toon_output`] when neither
-/// `--no-toon` nor the config field is set. Mirrors the main.rs startup
-/// default.
-const DEFAULT_TOON_OUTPUT: bool = true;
 
 /// Runtime state for a single resolved profile.
 ///
 /// Constructed by [`ProfileRegistry::rebuild`] and handed (as `Arc`) to the
 /// profile-scoped request handlers landing in R2.B. Per-profile JS-execution
-/// and TOON-output flags are pre-resolved here so handlers don't have to
-/// reach back into [`RelayConfig`].
+/// and TOON-output flags are copied verbatim from the profile config — the
+/// loader requires concrete booleans per spec §2.4, so handlers don't fall
+/// back to relay-wide defaults.
 pub struct ProfileContext {
     /// The original profile configuration this context was built from.
     pub config: ProfileConfig,
     /// Filtered view over the global [`AdapterRegistry`].
     pub registry_view: ProfileRegistryView,
-    /// Resolved per-profile JS-execution flag (inherited from
-    /// `RelayConfig::local_js_execution` when [`ProfileConfig::js_execution`]
-    /// is `None`).
+    /// Per-profile JS-execution flag (mirror of
+    /// [`ProfileConfig::js_execution`]).
     pub js_execution: bool,
-    /// Resolved per-profile TOON-output flag (inherited from
-    /// `RelayConfig::toon_output` when [`ProfileConfig::toon_output`] is
-    /// `None`).
+    /// Per-profile TOON-output flag (mirror of
+    /// [`ProfileConfig::toon_output`]).
     pub toon_output: bool,
     /// Per-profile [`MetaToolHandler`]. Populated by R3.A once
     /// `MetaToolHandler` is parameterised over a `MetaToolRegistry` trait
@@ -234,15 +224,10 @@ impl ProfileRegistry {
     ///
     /// The swap is atomic from the perspective of [`Self::get`] / [`Self::list`]
     /// callers: a single write-lock acquisition replaces the entire map.
-    /// Resolves per-profile `js_execution` and `toon_output` against
-    /// `relay_config`, falling back to the same defaults `main.rs` uses at
-    /// startup (`local_js_execution = false`, `toon_output = true`).
-    pub async fn rebuild(&self, profiles: &[ProfileConfig], relay_config: &RelayConfig) {
-        let global_js = relay_config
-            .local_js_execution
-            .unwrap_or(DEFAULT_LOCAL_JS_EXECUTION);
-        let global_toon = relay_config.toon_output.unwrap_or(DEFAULT_TOON_OUTPUT);
-
+    /// Per-profile `js_execution` and `toon_output` are copied straight from
+    /// the profile config — the loader (`validate_profiles`) requires those
+    /// fields to be present, so there is no fallback to relay-wide defaults.
+    pub async fn rebuild(&self, profiles: &[ProfileConfig]) {
         let mut new_map: HashMap<String, Arc<ProfileContext>> = HashMap::new();
         for profile in profiles {
             let allowed: HashSet<String> = profile.endpoints.iter().cloned().collect();
@@ -255,8 +240,8 @@ impl ProfileRegistry {
             let ctx = ProfileContext {
                 config: profile.clone(),
                 registry_view: view,
-                js_execution: profile.js_execution.unwrap_or(global_js),
-                toon_output: profile.toon_output.unwrap_or(global_toon),
+                js_execution: profile.js_execution,
+                toon_output: profile.toon_output,
                 meta_tool_handler: Some(Arc::new(handler)),
             };
             new_map.insert(profile.path.to_ascii_lowercase(), Arc::new(ctx));
@@ -328,17 +313,6 @@ mod tests {
         }
     }
 
-    fn relay_cfg() -> RelayConfig {
-        RelayConfig {
-            machine_name: "test".into(),
-            local_js_execution: None,
-            token_dir: None,
-            allow_insecure_oauth: None,
-            toon_output: None,
-            startup_init_timeout_secs: None,
-        }
-    }
-
     async fn registry_with_four_endpoints() -> AdapterRegistry {
         let registry = AdapterRegistry::new();
         for (name, tool_name) in [
@@ -368,16 +342,13 @@ mod tests {
     async fn scoped_catalog_includes_only_profile_endpoints() {
         let registry = registry_with_four_endpoints().await;
         let pr = ProfileRegistry::new(registry);
-        pr.rebuild(
-            &[ProfileConfig {
-                name: "Work".into(),
-                path: "work".into(),
-                endpoints: vec!["gmail".into(), "linear".into()],
-                js_execution: None,
-                toon_output: None,
-            }],
-            &relay_cfg(),
-        )
+        pr.rebuild(&[ProfileConfig {
+            name: "Work".into(),
+            path: "work".into(),
+            endpoints: vec!["gmail".into(), "linear".into()],
+            js_execution: false,
+            toon_output: true,
+        }])
         .await;
 
         let ctx = pr.get("work").await.expect("profile should exist");
@@ -395,16 +366,13 @@ mod tests {
     async fn route_tool_call_rejects_out_of_profile_tool() {
         let registry = registry_with_four_endpoints().await;
         let pr = ProfileRegistry::new(registry);
-        pr.rebuild(
-            &[ProfileConfig {
-                name: "Work".into(),
-                path: "work".into(),
-                endpoints: vec!["gmail".into(), "linear".into()],
-                js_execution: None,
-                toon_output: None,
-            }],
-            &relay_cfg(),
-        )
+        pr.rebuild(&[ProfileConfig {
+            name: "Work".into(),
+            path: "work".into(),
+            endpoints: vec!["gmail".into(), "linear".into()],
+            js_execution: false,
+            toon_output: true,
+        }])
         .await;
 
         let ctx = pr.get("work").await.unwrap();
@@ -430,16 +398,13 @@ mod tests {
     async fn route_tool_call_succeeds_for_in_profile_tool() {
         let registry = registry_with_four_endpoints().await;
         let pr = ProfileRegistry::new(registry);
-        pr.rebuild(
-            &[ProfileConfig {
-                name: "Work".into(),
-                path: "work".into(),
-                endpoints: vec!["gmail".into(), "linear".into()],
-                js_execution: None,
-                toon_output: None,
-            }],
-            &relay_cfg(),
-        )
+        pr.rebuild(&[ProfileConfig {
+            name: "Work".into(),
+            path: "work".into(),
+            endpoints: vec!["gmail".into(), "linear".into()],
+            js_execution: false,
+            toon_output: true,
+        }])
         .await;
 
         let ctx = pr.get("work").await.unwrap();
@@ -455,16 +420,13 @@ mod tests {
     #[tokio::test]
     async fn get_is_case_insensitive() {
         let pr = ProfileRegistry::new(AdapterRegistry::new());
-        pr.rebuild(
-            &[ProfileConfig {
-                name: "Work".into(),
-                path: "Work-Stuff".into(),
-                endpoints: vec![],
-                js_execution: None,
-                toon_output: None,
-            }],
-            &relay_cfg(),
-        )
+        pr.rebuild(&[ProfileConfig {
+            name: "Work".into(),
+            path: "Work-Stuff".into(),
+            endpoints: vec![],
+            js_execution: false,
+            toon_output: true,
+        }])
         .await;
 
         assert!(pr.get("work-stuff").await.is_some());
@@ -476,29 +438,23 @@ mod tests {
     #[tokio::test]
     async fn rebuild_swaps_atomically() {
         let pr = ProfileRegistry::new(AdapterRegistry::new());
-        pr.rebuild(
-            &[ProfileConfig {
-                name: "A".into(),
-                path: "a".into(),
-                endpoints: vec![],
-                js_execution: None,
-                toon_output: None,
-            }],
-            &relay_cfg(),
-        )
+        pr.rebuild(&[ProfileConfig {
+            name: "A".into(),
+            path: "a".into(),
+            endpoints: vec![],
+            js_execution: false,
+            toon_output: true,
+        }])
         .await;
         assert!(pr.get("a").await.is_some());
 
-        pr.rebuild(
-            &[ProfileConfig {
-                name: "B".into(),
-                path: "b".into(),
-                endpoints: vec![],
-                js_execution: None,
-                toon_output: None,
-            }],
-            &relay_cfg(),
-        )
+        pr.rebuild(&[ProfileConfig {
+            name: "B".into(),
+            path: "b".into(),
+            endpoints: vec![],
+            js_execution: false,
+            toon_output: true,
+        }])
         .await;
         assert!(pr.get("a").await.is_none(), "old profile must be evicted");
         assert!(pr.get("b").await.is_some());
@@ -506,44 +462,33 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolves_js_and_toon_inheritance() {
+    async fn rebuild_copies_js_and_toon_from_profile() {
         let pr = ProfileRegistry::new(AdapterRegistry::new());
-        let relay = RelayConfig {
-            machine_name: "test".into(),
-            local_js_execution: Some(true),
-            token_dir: None,
-            allow_insecure_oauth: None,
-            toon_output: Some(false),
-            startup_init_timeout_secs: None,
-        };
-        pr.rebuild(
-            &[
-                ProfileConfig {
-                    name: "Inherit".into(),
-                    path: "inherit".into(),
-                    endpoints: vec![],
-                    js_execution: None,
-                    toon_output: None,
-                },
-                ProfileConfig {
-                    name: "Override".into(),
-                    path: "override".into(),
-                    endpoints: vec![],
-                    js_execution: Some(false),
-                    toon_output: Some(true),
-                },
-            ],
-            &relay,
-        )
+        pr.rebuild(&[
+            ProfileConfig {
+                name: "On".into(),
+                path: "on".into(),
+                endpoints: vec![],
+                js_execution: true,
+                toon_output: false,
+            },
+            ProfileConfig {
+                name: "Off".into(),
+                path: "off".into(),
+                endpoints: vec![],
+                js_execution: false,
+                toon_output: true,
+            },
+        ])
         .await;
 
-        let inherit = pr.get("inherit").await.unwrap();
-        assert!(inherit.js_execution, "should inherit relay's true");
-        assert!(!inherit.toon_output, "should inherit relay's false");
+        let on = pr.get("on").await.unwrap();
+        assert!(on.js_execution);
+        assert!(!on.toon_output);
 
-        let override_ctx = pr.get("override").await.unwrap();
-        assert!(!override_ctx.js_execution);
-        assert!(override_ctx.toon_output);
+        let off = pr.get("off").await.unwrap();
+        assert!(!off.js_execution);
+        assert!(off.toon_output);
     }
 
     /// R3.A: every profile gets its own [`MetaToolHandler`] at rebuild
@@ -552,16 +497,13 @@ mod tests {
     #[tokio::test]
     async fn rebuild_populates_per_profile_meta_tool_handler() {
         let pr = ProfileRegistry::new(AdapterRegistry::new());
-        pr.rebuild(
-            &[ProfileConfig {
-                name: "P".into(),
-                path: "p".into(),
-                endpoints: vec![],
-                js_execution: None,
-                toon_output: None,
-            }],
-            &relay_cfg(),
-        )
+        pr.rebuild(&[ProfileConfig {
+            name: "P".into(),
+            path: "p".into(),
+            endpoints: vec![],
+            js_execution: false,
+            toon_output: true,
+        }])
         .await;
         assert!(pr.get("p").await.unwrap().meta_tool_handler.is_some());
     }
@@ -572,16 +514,13 @@ mod tests {
     async fn per_profile_handler_scopes_list_tools() {
         let registry = registry_with_four_endpoints().await;
         let pr = ProfileRegistry::new(registry);
-        pr.rebuild(
-            &[ProfileConfig {
-                name: "Work".into(),
-                path: "work".into(),
-                endpoints: vec!["gmail".into(), "linear".into()],
-                js_execution: None,
-                toon_output: None,
-            }],
-            &relay_cfg(),
-        )
+        pr.rebuild(&[ProfileConfig {
+            name: "Work".into(),
+            path: "work".into(),
+            endpoints: vec!["gmail".into(), "linear".into()],
+            js_execution: false,
+            toon_output: true,
+        }])
         .await;
 
         let ctx = pr.get("work").await.unwrap();
@@ -619,16 +558,13 @@ mod tests {
     async fn per_profile_handler_scopes_search_tools() {
         let registry = registry_with_four_endpoints().await;
         let pr = ProfileRegistry::new(registry);
-        pr.rebuild(
-            &[ProfileConfig {
-                name: "Work".into(),
-                path: "work".into(),
-                endpoints: vec!["gmail".into(), "linear".into()],
-                js_execution: None,
-                toon_output: None,
-            }],
-            &relay_cfg(),
-        )
+        pr.rebuild(&[ProfileConfig {
+            name: "Work".into(),
+            path: "work".into(),
+            endpoints: vec!["gmail".into(), "linear".into()],
+            js_execution: false,
+            toon_output: true,
+        }])
         .await;
 
         let ctx = pr.get("work").await.unwrap();
@@ -693,16 +629,13 @@ mod tests {
     async fn per_profile_handler_execute_tools_rejects_out_of_profile_call() {
         let registry = registry_with_four_endpoints().await;
         let pr = ProfileRegistry::with_sandbox_timeout(registry, Duration::from_secs(5));
-        pr.rebuild(
-            &[ProfileConfig {
-                name: "Work".into(),
-                path: "work".into(),
-                endpoints: vec!["gmail".into(), "linear".into()],
-                js_execution: None,
-                toon_output: None,
-            }],
-            &relay_cfg(),
-        )
+        pr.rebuild(&[ProfileConfig {
+            name: "Work".into(),
+            path: "work".into(),
+            endpoints: vec!["gmail".into(), "linear".into()],
+            js_execution: false,
+            toon_output: true,
+        }])
         .await;
 
         let ctx = pr.get("work").await.unwrap();

--- a/src/profile_registry.rs
+++ b/src/profile_registry.rs
@@ -1,0 +1,497 @@
+//! Per-profile runtime registry — Slice 1, R2.A.
+//!
+//! A *profile* is a named subset of configured endpoints (see
+//! [`crate::config::ProfileConfig`]). At runtime each profile is represented
+//! by a [`ProfileContext`] held inside the relay-wide [`ProfileRegistry`].
+//! Profile-scoped request handlers look the context up by URL path and use
+//! its [`ProfileRegistryView`] in place of the full [`AdapterRegistry`] so
+//! catalogue listings and tool calls only see the endpoints that belong to
+//! that profile.
+//!
+//! The per-profile [`MetaToolHandler`] (Engineering Spec §3.5) is deferred to
+//! task R3.A — that task will parameterise `MetaToolHandler` over a small
+//! `MetaToolRegistry` trait. Until then [`ProfileContext::meta_tool_handler`]
+//! is left `None`; profile-scoped HTTP handlers landing in R2.B/R3.A will
+//! fill it in.
+//!
+//! The accessors below are flagged `#[allow(dead_code)]` because their only
+//! callers (the profile-scoped HTTP/SSE handlers) land in R2.B / R3.A. The
+//! attribute will be removed in the task that wires the first consumer.
+#![allow(dead_code)]
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use serde_json::Value;
+use tokio::sync::RwLock;
+
+use crate::adapter::{AdapterError, ToolInfo};
+use crate::config::{ProfileConfig, RelayConfig};
+use crate::js_sandbox::MetaToolHandler;
+use crate::registry::AdapterRegistry;
+
+/// Effective default for [`RelayConfig::local_js_execution`] when the field
+/// is omitted from `config.toml`. Mirrors the main.rs startup default.
+const DEFAULT_LOCAL_JS_EXECUTION: bool = false;
+
+/// Effective default for [`RelayConfig::toon_output`] when neither
+/// `--no-toon` nor the config field is set. Mirrors the main.rs startup
+/// default.
+const DEFAULT_TOON_OUTPUT: bool = true;
+
+/// Runtime state for a single resolved profile.
+///
+/// Constructed by [`ProfileRegistry::rebuild`] and handed (as `Arc`) to the
+/// profile-scoped request handlers landing in R2.B. Per-profile JS-execution
+/// and TOON-output flags are pre-resolved here so handlers don't have to
+/// reach back into [`RelayConfig`].
+pub struct ProfileContext {
+    /// The original profile configuration this context was built from.
+    pub config: ProfileConfig,
+    /// Filtered view over the global [`AdapterRegistry`].
+    pub registry_view: ProfileRegistryView,
+    /// Resolved per-profile JS-execution flag (inherited from
+    /// `RelayConfig::local_js_execution` when [`ProfileConfig::js_execution`]
+    /// is `None`).
+    pub js_execution: bool,
+    /// Resolved per-profile TOON-output flag (inherited from
+    /// `RelayConfig::toon_output` when [`ProfileConfig::toon_output`] is
+    /// `None`).
+    pub toon_output: bool,
+    /// Per-profile [`MetaToolHandler`]. Populated by R3.A once
+    /// `MetaToolHandler` is parameterised over a `MetaToolRegistry` trait
+    /// (recon §D3, locked decision #4). `None` at the moment.
+    pub meta_tool_handler: Option<Arc<MetaToolHandler>>,
+}
+
+/// Filtered view over an [`AdapterRegistry`] that restricts catalogue
+/// listings and tool routing to a fixed set of endpoint names.
+///
+/// Cheap to clone — internally `Arc`s the allowed-endpoints set and reuses
+/// the registry's cached merged catalogue.
+#[derive(Clone)]
+pub struct ProfileRegistryView {
+    inner: AdapterRegistry,
+    allowed_endpoints: Arc<HashSet<String>>,
+}
+
+impl ProfileRegistryView {
+    /// Build a view restricted to `allowed_endpoints`.
+    pub fn new(inner: AdapterRegistry, allowed_endpoints: HashSet<String>) -> Self {
+        Self {
+            inner,
+            allowed_endpoints: Arc::new(allowed_endpoints),
+        }
+    }
+
+    /// Borrow the underlying [`AdapterRegistry`].
+    pub fn inner(&self) -> &AdapterRegistry {
+        &self.inner
+    }
+
+    /// The set of endpoint names this view exposes.
+    pub fn allowed_endpoints(&self) -> &HashSet<String> {
+        &self.allowed_endpoints
+    }
+
+    /// Merged catalogue filtered to tools whose owning endpoint is in
+    /// [`Self::allowed_endpoints`].
+    pub async fn merged_catalog(&self) -> Vec<ToolInfo> {
+        let (catalog, lookup) = self.inner.merged_catalog_with_lookup().await;
+        catalog
+            .into_iter()
+            .filter(|tool| {
+                lookup
+                    .get(&tool.name)
+                    .map(|(endpoint, _)| self.allowed_endpoints.contains(endpoint))
+                    .unwrap_or(false)
+            })
+            .collect()
+    }
+
+    /// Filtered variant of [`AdapterRegistry::merged_catalog_with_lookup`].
+    pub async fn merged_catalog_with_lookup(
+        &self,
+    ) -> (Vec<ToolInfo>, HashMap<String, (String, String)>) {
+        let (catalog, lookup) = self.inner.merged_catalog_with_lookup().await;
+        let filtered_lookup: HashMap<String, (String, String)> = lookup
+            .into_iter()
+            .filter(|(_, (endpoint, _))| self.allowed_endpoints.contains(endpoint))
+            .collect();
+        let filtered_catalog = catalog
+            .into_iter()
+            .filter(|tool| filtered_lookup.contains_key(&tool.name))
+            .collect();
+        (filtered_catalog, filtered_lookup)
+    }
+
+    /// Route a prefixed tool call, rejecting any tool whose owning endpoint
+    /// is not in [`Self::allowed_endpoints`].
+    pub async fn route_tool_call(
+        &self,
+        prefixed_name: &str,
+        arguments: Value,
+    ) -> Result<Value, AdapterError> {
+        let (_, lookup) = self.inner.merged_catalog_with_lookup().await;
+        let (endpoint, _) = lookup.get(prefixed_name).ok_or_else(|| {
+            AdapterError::ProtocolError(format!("no tool '{}' in profile", prefixed_name))
+        })?;
+        if !self.allowed_endpoints.contains(endpoint) {
+            return Err(AdapterError::ProtocolError(format!(
+                "tool '{}' is not available in this profile",
+                prefixed_name
+            )));
+        }
+        self.inner.route_tool_call(prefixed_name, arguments).await
+    }
+}
+
+/// Relay-wide profile registry. Thread-safe, hot-reload-aware.
+///
+/// Profiles are keyed by their lowercased [`ProfileConfig::path`] — path
+/// uniqueness is enforced case-insensitively at config-validation time (see
+/// [`crate::config::validate_profiles`]) so lowercased keys yield the same
+/// uniqueness invariant inside the registry.
+pub struct ProfileRegistry {
+    profiles: Arc<RwLock<HashMap<String, Arc<ProfileContext>>>>,
+    adapter_registry: AdapterRegistry,
+}
+
+impl ProfileRegistry {
+    /// Create an empty registry. Call [`Self::rebuild`] before serving any
+    /// requests.
+    pub fn new(adapter_registry: AdapterRegistry) -> Self {
+        Self {
+            profiles: Arc::new(RwLock::new(HashMap::new())),
+            adapter_registry,
+        }
+    }
+
+    /// Replace the current profile set with one built from `profiles`.
+    ///
+    /// The swap is atomic from the perspective of [`Self::get`] / [`Self::list`]
+    /// callers: a single write-lock acquisition replaces the entire map.
+    /// Resolves per-profile `js_execution` and `toon_output` against
+    /// `relay_config`, falling back to the same defaults `main.rs` uses at
+    /// startup (`local_js_execution = false`, `toon_output = true`).
+    pub async fn rebuild(&self, profiles: &[ProfileConfig], relay_config: &RelayConfig) {
+        let global_js = relay_config
+            .local_js_execution
+            .unwrap_or(DEFAULT_LOCAL_JS_EXECUTION);
+        let global_toon = relay_config.toon_output.unwrap_or(DEFAULT_TOON_OUTPUT);
+
+        let mut new_map: HashMap<String, Arc<ProfileContext>> = HashMap::new();
+        for profile in profiles {
+            let allowed: HashSet<String> = profile.endpoints.iter().cloned().collect();
+            let view = ProfileRegistryView::new(self.adapter_registry.clone(), allowed);
+            let ctx = ProfileContext {
+                config: profile.clone(),
+                registry_view: view,
+                js_execution: profile.js_execution.unwrap_or(global_js),
+                toon_output: profile.toon_output.unwrap_or(global_toon),
+                meta_tool_handler: None,
+            };
+            new_map.insert(profile.path.to_ascii_lowercase(), Arc::new(ctx));
+        }
+
+        *self.profiles.write().await = new_map;
+    }
+
+    /// Look up a profile by URL path (case-insensitive).
+    pub async fn get(&self, path: &str) -> Option<Arc<ProfileContext>> {
+        self.profiles
+            .read()
+            .await
+            .get(&path.to_ascii_lowercase())
+            .cloned()
+    }
+
+    /// Snapshot all registered profile contexts. Order is unspecified —
+    /// callers that present profiles to users should sort.
+    pub async fn list(&self) -> Vec<Arc<ProfileContext>> {
+        self.profiles.read().await.values().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapter::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
+    use async_trait::async_trait;
+    use serde_json::json;
+
+    /// Minimal in-test adapter — mirrors `registry.rs`'s private MockAdapter.
+    struct MockAdapter {
+        tools: Vec<ToolInfo>,
+    }
+
+    #[async_trait]
+    impl McpAdapter for MockAdapter {
+        async fn initialize(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+        async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
+            Ok(self.tools.clone())
+        }
+        async fn call_tool(
+            &self,
+            name: &str,
+            arguments: serde_json::Value,
+        ) -> Result<serde_json::Value, AdapterError> {
+            Ok(json!({ "called": name, "args": arguments }))
+        }
+        fn health(&self) -> HealthStatus {
+            HealthStatus::Healthy
+        }
+        fn server_type(&self) -> Option<String> {
+            None
+        }
+        async fn shutdown(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+    }
+
+    fn tool(name: &str) -> ToolInfo {
+        ToolInfo {
+            name: name.into(),
+            description: Some(format!("{name} tool")),
+            input_schema: json!({"type": "object"}),
+            annotations: None,
+        }
+    }
+
+    fn relay_cfg() -> RelayConfig {
+        RelayConfig {
+            machine_name: "test".into(),
+            local_js_execution: None,
+            token_dir: None,
+            allow_insecure_oauth: None,
+            toon_output: None,
+            startup_init_timeout_secs: None,
+        }
+    }
+
+    async fn registry_with_four_endpoints() -> AdapterRegistry {
+        let registry = AdapterRegistry::new();
+        for (name, tool_name) in [
+            ("gmail", "send_email"),
+            ("linear", "create_issue"),
+            ("todoist", "add_task"),
+            ("notes", "search_notes"),
+        ] {
+            registry
+                .register(
+                    name.into(),
+                    Box::new(MockAdapter {
+                        tools: vec![tool(tool_name)],
+                    }),
+                    "stdio".into(),
+                    None,
+                    Some(name.into()),
+                )
+                .await;
+        }
+        registry
+    }
+
+    /// Test-matrix row #7: profile with 2 of 4 endpoints → catalog has only
+    /// those 2 endpoints' tools.
+    #[tokio::test]
+    async fn scoped_catalog_includes_only_profile_endpoints() {
+        let registry = registry_with_four_endpoints().await;
+        let pr = ProfileRegistry::new(registry);
+        pr.rebuild(
+            &[ProfileConfig {
+                name: "Work".into(),
+                path: "work".into(),
+                endpoints: vec!["gmail".into(), "linear".into()],
+                js_execution: None,
+                toon_output: None,
+            }],
+            &relay_cfg(),
+        )
+        .await;
+
+        let ctx = pr.get("work").await.expect("profile should exist");
+        let catalog = ctx.registry_view.merged_catalog().await;
+        let names: HashSet<&str> = catalog.iter().map(|t| t.name.as_str()).collect();
+        assert_eq!(catalog.len(), 2, "expected 2 tools, got {:?}", names);
+        assert!(names.contains("gmail__send_email"));
+        assert!(names.contains("linear__create_issue"));
+        assert!(!names.contains("todoist__add_task"));
+        assert!(!names.contains("notes__search_notes"));
+    }
+
+    /// Test-matrix row #8: call to a tool outside the profile → error.
+    #[tokio::test]
+    async fn route_tool_call_rejects_out_of_profile_tool() {
+        let registry = registry_with_four_endpoints().await;
+        let pr = ProfileRegistry::new(registry);
+        pr.rebuild(
+            &[ProfileConfig {
+                name: "Work".into(),
+                path: "work".into(),
+                endpoints: vec!["gmail".into(), "linear".into()],
+                js_execution: None,
+                toon_output: None,
+            }],
+            &relay_cfg(),
+        )
+        .await;
+
+        let ctx = pr.get("work").await.unwrap();
+        let err = ctx
+            .registry_view
+            .route_tool_call("todoist__add_task", json!({}))
+            .await
+            .expect_err("call to out-of-profile tool must fail");
+        match err {
+            AdapterError::ProtocolError(msg) => {
+                assert!(
+                    msg.contains("todoist__add_task")
+                        && msg.contains("not available in this profile"),
+                    "unexpected error message: {msg}"
+                );
+            }
+            other => panic!("expected ProtocolError, got {other:?}"),
+        }
+    }
+
+    /// Test-matrix row #9: call to a tool inside the profile → success.
+    #[tokio::test]
+    async fn route_tool_call_succeeds_for_in_profile_tool() {
+        let registry = registry_with_four_endpoints().await;
+        let pr = ProfileRegistry::new(registry);
+        pr.rebuild(
+            &[ProfileConfig {
+                name: "Work".into(),
+                path: "work".into(),
+                endpoints: vec!["gmail".into(), "linear".into()],
+                js_execution: None,
+                toon_output: None,
+            }],
+            &relay_cfg(),
+        )
+        .await;
+
+        let ctx = pr.get("work").await.unwrap();
+        let result = ctx
+            .registry_view
+            .route_tool_call("gmail__send_email", json!({"to": "x@example.com"}))
+            .await
+            .expect("in-profile tool call should succeed");
+        assert_eq!(result["called"], "send_email");
+        assert_eq!(result["args"]["to"], "x@example.com");
+    }
+
+    #[tokio::test]
+    async fn get_is_case_insensitive() {
+        let pr = ProfileRegistry::new(AdapterRegistry::new());
+        pr.rebuild(
+            &[ProfileConfig {
+                name: "Work".into(),
+                path: "Work-Stuff".into(),
+                endpoints: vec![],
+                js_execution: None,
+                toon_output: None,
+            }],
+            &relay_cfg(),
+        )
+        .await;
+
+        assert!(pr.get("work-stuff").await.is_some());
+        assert!(pr.get("WORK-STUFF").await.is_some());
+        assert!(pr.get("Work-Stuff").await.is_some());
+        assert!(pr.get("other").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn rebuild_swaps_atomically() {
+        let pr = ProfileRegistry::new(AdapterRegistry::new());
+        pr.rebuild(
+            &[ProfileConfig {
+                name: "A".into(),
+                path: "a".into(),
+                endpoints: vec![],
+                js_execution: None,
+                toon_output: None,
+            }],
+            &relay_cfg(),
+        )
+        .await;
+        assert!(pr.get("a").await.is_some());
+
+        pr.rebuild(
+            &[ProfileConfig {
+                name: "B".into(),
+                path: "b".into(),
+                endpoints: vec![],
+                js_execution: None,
+                toon_output: None,
+            }],
+            &relay_cfg(),
+        )
+        .await;
+        assert!(pr.get("a").await.is_none(), "old profile must be evicted");
+        assert!(pr.get("b").await.is_some());
+        assert_eq!(pr.list().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn resolves_js_and_toon_inheritance() {
+        let pr = ProfileRegistry::new(AdapterRegistry::new());
+        let relay = RelayConfig {
+            machine_name: "test".into(),
+            local_js_execution: Some(true),
+            token_dir: None,
+            allow_insecure_oauth: None,
+            toon_output: Some(false),
+            startup_init_timeout_secs: None,
+        };
+        pr.rebuild(
+            &[
+                ProfileConfig {
+                    name: "Inherit".into(),
+                    path: "inherit".into(),
+                    endpoints: vec![],
+                    js_execution: None,
+                    toon_output: None,
+                },
+                ProfileConfig {
+                    name: "Override".into(),
+                    path: "override".into(),
+                    endpoints: vec![],
+                    js_execution: Some(false),
+                    toon_output: Some(true),
+                },
+            ],
+            &relay,
+        )
+        .await;
+
+        let inherit = pr.get("inherit").await.unwrap();
+        assert!(inherit.js_execution, "should inherit relay's true");
+        assert!(!inherit.toon_output, "should inherit relay's false");
+
+        let override_ctx = pr.get("override").await.unwrap();
+        assert!(!override_ctx.js_execution);
+        assert!(override_ctx.toon_output);
+    }
+
+    #[tokio::test]
+    async fn meta_tool_handler_is_none_until_r3a() {
+        let pr = ProfileRegistry::new(AdapterRegistry::new());
+        pr.rebuild(
+            &[ProfileConfig {
+                name: "P".into(),
+                path: "p".into(),
+                endpoints: vec![],
+                js_execution: None,
+                toon_output: None,
+            }],
+            &relay_cfg(),
+        )
+        .await;
+        assert!(pr.get("p").await.unwrap().meta_tool_handler.is_none());
+    }
+}

--- a/src/profile_registry.rs
+++ b/src/profile_registry.rs
@@ -21,14 +21,16 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::Duration;
 
+use async_trait::async_trait;
 use serde_json::Value;
-use tokio::sync::RwLock;
+use tokio::sync::{broadcast, RwLock};
 
 use crate::adapter::{AdapterError, ToolInfo};
 use crate::config::{ProfileConfig, RelayConfig};
 use crate::js_sandbox::MetaToolHandler;
-use crate::registry::AdapterRegistry;
+use crate::registry::{AdapterRegistry, MetaToolRegistry};
 
 /// Effective default for [`RelayConfig::local_js_execution`] when the field
 /// is omitted from `config.toml`. Mirrors the main.rs startup default.
@@ -146,6 +148,46 @@ impl ProfileRegistryView {
     }
 }
 
+#[async_trait]
+impl MetaToolRegistry for ProfileRegistryView {
+    async fn merged_catalog(&self) -> Vec<ToolInfo> {
+        ProfileRegistryView::merged_catalog(self).await
+    }
+
+    async fn merged_catalog_with_lookup(
+        &self,
+    ) -> (Vec<ToolInfo>, HashMap<String, (String, String)>) {
+        ProfileRegistryView::merged_catalog_with_lookup(self).await
+    }
+
+    async fn route_tool_call(
+        &self,
+        prefixed_name: &str,
+        arguments: Value,
+    ) -> Result<Value, AdapterError> {
+        ProfileRegistryView::route_tool_call(self, prefixed_name, arguments).await
+    }
+
+    fn catalog_generation(&self) -> u64 {
+        // Delegate to the underlying registry. A profile view is a strict
+        // subset of the global catalog, so any mutation that bumps the
+        // global generation also implicitly invalidates per-profile
+        // search-index caches keyed on this counter.
+        self.inner.catalog_generation()
+    }
+
+    fn subscribe_tools_changed(&self) -> broadcast::Receiver<String> {
+        // Delegate to the underlying registry — R3.D's SSE handler is the
+        // consumer that filters ticks against
+        // [`Self::allowed_endpoints`].
+        self.inner.subscribe_tools_changed()
+    }
+}
+
+/// Default per-profile JS sandbox timeout, in seconds. Mirrors the value
+/// passed to the global [`MetaToolHandler`] in `main.rs`.
+const DEFAULT_SANDBOX_TIMEOUT_SECS: u64 = 30;
+
 /// Relay-wide profile registry. Thread-safe, hot-reload-aware.
 ///
 /// Profiles are keyed by their lowercased [`ProfileConfig::path`] — path
@@ -155,15 +197,36 @@ impl ProfileRegistryView {
 pub struct ProfileRegistry {
     profiles: Arc<RwLock<HashMap<String, Arc<ProfileContext>>>>,
     adapter_registry: AdapterRegistry,
+    /// Per-profile JS sandbox timeout passed through to each profile's
+    /// [`MetaToolHandler`] at rebuild time. Held on the registry (not on
+    /// each [`ProfileContext`]) so it stays in lockstep with the global
+    /// handler's value and is reapplied on every hot reload.
+    sandbox_timeout: Duration,
 }
 
 impl ProfileRegistry {
-    /// Create an empty registry. Call [`Self::rebuild`] before serving any
-    /// requests.
+    /// Create an empty registry with the default sandbox timeout
+    /// ([`DEFAULT_SANDBOX_TIMEOUT_SECS`]). Call [`Self::rebuild`] before
+    /// serving any requests.
     pub fn new(adapter_registry: AdapterRegistry) -> Self {
+        Self::with_sandbox_timeout(
+            adapter_registry,
+            Duration::from_secs(DEFAULT_SANDBOX_TIMEOUT_SECS),
+        )
+    }
+
+    /// Create an empty registry with a custom sandbox timeout. Used by
+    /// tests that want a tighter budget; production callers should use
+    /// [`Self::new`] so the per-profile timeout matches the global
+    /// `MetaToolHandler`.
+    pub fn with_sandbox_timeout(
+        adapter_registry: AdapterRegistry,
+        sandbox_timeout: Duration,
+    ) -> Self {
         Self {
             profiles: Arc::new(RwLock::new(HashMap::new())),
             adapter_registry,
+            sandbox_timeout,
         }
     }
 
@@ -184,12 +247,17 @@ impl ProfileRegistry {
         for profile in profiles {
             let allowed: HashSet<String> = profile.endpoints.iter().cloned().collect();
             let view = ProfileRegistryView::new(self.adapter_registry.clone(), allowed);
+            // Per-profile `MetaToolHandler` parameterised over the filtered
+            // view (locked decision Relay #2). The handler's search-index
+            // cache is private to this context, so per-profile catalogs
+            // never bleed into a different profile's search results.
+            let handler = MetaToolHandler::new(Arc::new(view.clone()), self.sandbox_timeout);
             let ctx = ProfileContext {
                 config: profile.clone(),
                 registry_view: view,
                 js_execution: profile.js_execution.unwrap_or(global_js),
                 toon_output: profile.toon_output.unwrap_or(global_toon),
-                meta_tool_handler: None,
+                meta_tool_handler: Some(Arc::new(handler)),
             };
             new_map.insert(profile.path.to_ascii_lowercase(), Arc::new(ctx));
         }
@@ -478,8 +546,11 @@ mod tests {
         assert!(override_ctx.toon_output);
     }
 
+    /// R3.A: every profile gets its own [`MetaToolHandler`] at rebuild
+    /// time, wrapping the profile's [`ProfileRegistryView`]. The placeholder
+    /// `None` from R2.A is gone.
     #[tokio::test]
-    async fn meta_tool_handler_is_none_until_r3a() {
+    async fn rebuild_populates_per_profile_meta_tool_handler() {
         let pr = ProfileRegistry::new(AdapterRegistry::new());
         pr.rebuild(
             &[ProfileConfig {
@@ -492,6 +563,176 @@ mod tests {
             &relay_cfg(),
         )
         .await;
-        assert!(pr.get("p").await.unwrap().meta_tool_handler.is_none());
+        assert!(pr.get("p").await.unwrap().meta_tool_handler.is_some());
+    }
+
+    /// Per-profile `MetaToolHandler::list_tools` sees only the profile's
+    /// allowed-endpoint tools, not the global catalog.
+    #[tokio::test]
+    async fn per_profile_handler_scopes_list_tools() {
+        let registry = registry_with_four_endpoints().await;
+        let pr = ProfileRegistry::new(registry);
+        pr.rebuild(
+            &[ProfileConfig {
+                name: "Work".into(),
+                path: "work".into(),
+                endpoints: vec!["gmail".into(), "linear".into()],
+                js_execution: None,
+                toon_output: None,
+            }],
+            &relay_cfg(),
+        )
+        .await;
+
+        let ctx = pr.get("work").await.unwrap();
+        let handler = ctx
+            .meta_tool_handler
+            .as_ref()
+            .expect("R3.A populates the per-profile handler");
+        let result = handler
+            .list_tools(None, None)
+            .await
+            .expect("list_tools must succeed");
+        let tools = result["tools"].as_array().expect("tools array");
+        let names: HashSet<&str> = tools
+            .iter()
+            .map(|t| t["name"].as_str().unwrap_or(""))
+            .collect();
+        assert_eq!(
+            tools.len(),
+            2,
+            "expected 2 in-profile tools, got {:?}",
+            names
+        );
+        assert!(names.contains("gmail__send_email"));
+        assert!(names.contains("linear__create_issue"));
+        assert!(!names.contains("todoist__add_task"));
+        assert!(!names.contains("notes__search_notes"));
+    }
+
+    /// Test-matrix row #15: per-profile `MetaToolHandler::search_tools`
+    /// only returns tools whose owning endpoint is in the profile's allowed
+    /// set, even when the query would otherwise match a global,
+    /// out-of-profile tool (`notes__search_notes` here scores on `"search"`
+    /// but the profile view never surfaces it).
+    #[tokio::test]
+    async fn per_profile_handler_scopes_search_tools() {
+        let registry = registry_with_four_endpoints().await;
+        let pr = ProfileRegistry::new(registry);
+        pr.rebuild(
+            &[ProfileConfig {
+                name: "Work".into(),
+                path: "work".into(),
+                endpoints: vec!["gmail".into(), "linear".into()],
+                js_execution: None,
+                toon_output: None,
+            }],
+            &relay_cfg(),
+        )
+        .await;
+
+        let ctx = pr.get("work").await.unwrap();
+        let handler = ctx
+            .meta_tool_handler
+            .as_ref()
+            .expect("R3.A populates the per-profile handler");
+
+        // Empty query → first-page slice of the profile-filtered catalog,
+        // so the result is exactly the profile's two tools.
+        let page = handler
+            .search_tools("", None)
+            .await
+            .expect("search_tools (empty query) must succeed");
+        let page_arr = page.as_array().expect("search result is a JSON array");
+        let page_names: HashSet<&str> = page_arr
+            .iter()
+            .map(|t| t["name"].as_str().unwrap_or(""))
+            .collect();
+        assert_eq!(
+            page_arr.len(),
+            2,
+            "empty-query page should match profile catalog size, got {:?}",
+            page_names
+        );
+        assert!(page_names.contains("gmail__send_email"));
+        assert!(page_names.contains("linear__create_issue"));
+        assert!(!page_names.contains("todoist__add_task"));
+        assert!(!page_names.contains("notes__search_notes"));
+
+        // Token query → out-of-profile `notes__search_notes` would normally
+        // match "search" but must not appear because the per-profile handler
+        // never sees it.
+        let matches = handler
+            .search_tools("search", None)
+            .await
+            .expect("search_tools (token query) must succeed");
+        let matches_arr = matches.as_array().expect("search result is an array");
+        let match_names: HashSet<&str> = matches_arr
+            .iter()
+            .map(|t| t["name"].as_str().unwrap_or(""))
+            .collect();
+        assert!(
+            !match_names.contains("notes__search_notes"),
+            "out-of-profile tool must not appear in per-profile search, got {:?}",
+            match_names
+        );
+        assert!(
+            !match_names.contains("todoist__add_task"),
+            "out-of-profile tool must not appear in per-profile search, got {:?}",
+            match_names
+        );
+    }
+
+    /// Test-matrix row #12: an `execute_tools` script run by the per-profile
+    /// [`MetaToolHandler`] cannot reach a tool whose owning endpoint is
+    /// outside the profile. The sandbox sees only the profile-filtered
+    /// catalog, so `call("todoist__add_task")` from inside the script
+    /// surfaces the "unknown tool" error rather than reaching the global
+    /// registry.
+    #[tokio::test]
+    async fn per_profile_handler_execute_tools_rejects_out_of_profile_call() {
+        let registry = registry_with_four_endpoints().await;
+        let pr = ProfileRegistry::with_sandbox_timeout(registry, Duration::from_secs(5));
+        pr.rebuild(
+            &[ProfileConfig {
+                name: "Work".into(),
+                path: "work".into(),
+                endpoints: vec!["gmail".into(), "linear".into()],
+                js_execution: None,
+                toon_output: None,
+            }],
+            &relay_cfg(),
+        )
+        .await;
+
+        let ctx = pr.get("work").await.unwrap();
+        let handler = ctx
+            .meta_tool_handler
+            .as_ref()
+            .expect("R3.A populates the per-profile handler");
+
+        // Wrap the call so the script surfaces the underlying JS error
+        // string from `tools.call` rather than propagating it out as a
+        // sandbox-level error.
+        let script = r#"
+            try {
+                call("todoist__add_task", { content: "x" });
+                return { ok: true };
+            } catch (e) {
+                return { error: String(e && e.message ? e.message : e) };
+            }
+        "#;
+        let result = handler
+            .execute_tools(script)
+            .await
+            .expect("execute_tools should return the script's error value");
+        let err_msg = result
+            .get("error")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        assert!(
+            err_msg.contains("todoist__add_task"),
+            "expected error to mention the out-of-profile tool, got: {err_msg}"
+        );
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,5 +1,7 @@
 use crate::adapter::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
 use crate::prefix;
+use async_trait::async_trait;
+use serde_json::Value;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -388,6 +390,35 @@ impl AdapterRegistry {
         adapters.len()
     }
 
+    /// Profile-scoped variant of [`Self::all_server_types`] — only adapters
+    /// whose endpoint name is in `allowed_endpoints` contribute. Used by the
+    /// `_for_profile` advertising builders so per-profile `instructions` and
+    /// meta-tool descriptions list only the profile's server types.
+    pub async fn server_types_in(&self, allowed_endpoints: &HashSet<String>) -> BTreeSet<String> {
+        let adapters = self.adapters.read().await;
+        adapters
+            .iter()
+            .filter(|(name, _)| allowed_endpoints.contains(*name))
+            .filter_map(|(_, entry)| {
+                entry
+                    .adapter
+                    .server_type()
+                    .or_else(|| entry.adapter.configured_server_type())
+            })
+            .map(|s| s.to_lowercase())
+            .collect()
+    }
+
+    /// Profile-scoped variant of [`Self::all_endpoint_count`] — counts only
+    /// adapters whose endpoint name is in `allowed_endpoints`.
+    pub async fn endpoint_count_in(&self, allowed_endpoints: &HashSet<String>) -> usize {
+        let adapters = self.adapters.read().await;
+        adapters
+            .keys()
+            .filter(|name| allowed_endpoints.contains(*name))
+            .count()
+    }
+
     /// Access the underlying adapters map (for management API use).
     pub fn entries(&self) -> &Arc<RwLock<HashMap<String, RegisteredAdapter>>> {
         &self.adapters
@@ -565,6 +596,89 @@ impl AdapterRegistry {
             "Routing tool call"
         );
         entry.adapter.call_tool(tool, arguments).await
+    }
+}
+
+/// Abstraction over the catalog/routing surface used by [`MetaToolHandler`]
+/// and the JS sandbox, so they can operate on either the global
+/// [`AdapterRegistry`] or a per-profile filtered view
+/// (`profile_registry::ProfileRegistryView`).
+///
+/// Per locked decision Relay #2 the surface is intentionally narrow:
+/// `merged_catalog`, `merged_catalog_with_lookup`, `route_tool_call`, and
+/// `subscribe_tools_changed`. `catalog_generation` is also included because
+/// `MetaToolHandler::search_tools` uses it as a cache invalidation key — a
+/// per-profile view delegates to the underlying registry's counter so
+/// catalog mutations correctly invalidate per-profile caches too.
+#[async_trait]
+pub trait MetaToolRegistry: Send + Sync {
+    /// Build (or fetch the cached) merged tool catalog visible to this
+    /// scope. Names are prefixed per the adapter's `tool_prefix` (see
+    /// [`AdapterRegistry::merged_catalog`]); profile-scoped impls filter to
+    /// tools owned by in-profile endpoints.
+    async fn merged_catalog(&self) -> Vec<ToolInfo>;
+
+    /// Variant of [`Self::merged_catalog`] that also returns the
+    /// `prefixed_name → (endpoint, raw_name)` reverse lookup map, filtered
+    /// to the same scope as the catalog.
+    ///
+    /// `allow(dead_code)`: callers in the bin compilation unit reach
+    /// this method through `MetaToolHandler` which is built only by
+    /// `ProfileRegistry::rebuild` and `main.rs` — the bin's dead-code
+    /// pass doesn't see those call sites uniformly, so this and
+    /// [`Self::subscribe_tools_changed`] are annotated explicitly.
+    #[allow(dead_code)]
+    async fn merged_catalog_with_lookup(
+        &self,
+    ) -> (Vec<ToolInfo>, HashMap<String, (String, String)>);
+
+    /// Route a prefixed tool call. Profile-scoped impls reject tools whose
+    /// owning endpoint is not in the profile.
+    async fn route_tool_call(
+        &self,
+        prefixed_name: &str,
+        arguments: Value,
+    ) -> Result<Value, AdapterError>;
+
+    /// Current catalog generation. Monotonically increases on every
+    /// catalog-affecting mutation; profile-scoped impls delegate to the
+    /// underlying registry's counter.
+    fn catalog_generation(&self) -> u64;
+
+    /// Subscribe to the relay-wide tools-changed broadcast. Each tick
+    /// yields the endpoint name that emitted the change. Profile-scoped
+    /// impls delegate to the underlying registry — consumers (e.g. the
+    /// SSE handler in R3.D) filter on endpoint membership.
+    #[allow(dead_code)]
+    fn subscribe_tools_changed(&self) -> broadcast::Receiver<String>;
+}
+
+#[async_trait]
+impl MetaToolRegistry for AdapterRegistry {
+    async fn merged_catalog(&self) -> Vec<ToolInfo> {
+        AdapterRegistry::merged_catalog(self).await
+    }
+
+    async fn merged_catalog_with_lookup(
+        &self,
+    ) -> (Vec<ToolInfo>, HashMap<String, (String, String)>) {
+        AdapterRegistry::merged_catalog_with_lookup(self).await
+    }
+
+    async fn route_tool_call(
+        &self,
+        prefixed_name: &str,
+        arguments: Value,
+    ) -> Result<Value, AdapterError> {
+        AdapterRegistry::route_tool_call(self, prefixed_name, arguments).await
+    }
+
+    fn catalog_generation(&self) -> u64 {
+        AdapterRegistry::catalog_generation(self)
+    }
+
+    fn subscribe_tools_changed(&self) -> broadcast::Receiver<String> {
+        AdapterRegistry::subscribe_tools_changed(self)
     }
 }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -101,12 +101,13 @@ pub struct AdapterRegistry {
     catalog_generation: Arc<AtomicU64>,
     /// Relay-wide tools-changed broadcast. Fan-in for every per-endpoint
     /// `subscribe_tools_changed` tick observed by
-    /// [`AdapterRegistry::tools_changed_listener_loop`]. Downstream consumers
-    /// (e.g. the `/mcp/sse` handler) subscribe via
-    /// [`AdapterRegistry::subscribe_tools_changed`] to forward
-    /// `notifications/tools/list_changed` to connected MCP clients without
-    /// caring which upstream endpoint emitted the change.
-    tools_changed_tx: broadcast::Sender<()>,
+    /// [`AdapterRegistry::tools_changed_listener_loop`]. The payload is the
+    /// endpoint name that emitted the change, so downstream consumers can
+    /// filter by endpoint (e.g. per-profile SSE handlers that only forward
+    /// `notifications/tools/list_changed` when an endpoint inside their
+    /// profile changes). Consumers that don't care about origin (e.g. the
+    /// global `/mcp/sse` handler) forward unconditionally.
+    tools_changed_tx: broadcast::Sender<String>,
 }
 
 impl Default for AdapterRegistry {
@@ -128,21 +129,23 @@ impl AdapterRegistry {
     }
 
     /// Subscribe to the relay-wide tools-changed broadcast. Each `recv()`
-    /// represents at least one `notifications/tools/list_changed` tick from
-    /// some registered adapter since the previous receive. Mirrors the
-    /// per-adapter [`McpAdapter::subscribe_tools_changed`] policy: `Lagged`
-    /// is also surfaced as a tick by the fan-in loop, and `Closed` only
-    /// happens when the registry itself is dropped.
-    pub fn subscribe_tools_changed(&self) -> broadcast::Receiver<()> {
+    /// yields the endpoint name that emitted a
+    /// `notifications/tools/list_changed` tick since the previous receive.
+    /// Mirrors the per-adapter [`McpAdapter::subscribe_tools_changed`]
+    /// policy: `Lagged` is also surfaced as a tick (the endpoint name is
+    /// lost in that case — consumers should forward unconditionally), and
+    /// `Closed` only happens when the registry itself is dropped.
+    pub fn subscribe_tools_changed(&self) -> broadcast::Receiver<String> {
         self.tools_changed_tx.subscribe()
     }
 
-    /// Send a synthetic tools-changed tick on the relay-wide broadcast.
-    /// Test-only escape hatch so server-side handler tests can exercise the
-    /// fan-out path without standing up a real adapter and listener task.
+    /// Send a synthetic tools-changed tick on the relay-wide broadcast for
+    /// the given endpoint name. Test-only escape hatch so server-side
+    /// handler tests can exercise the fan-out path without standing up a
+    /// real adapter and listener task.
     #[cfg(test)]
-    pub(crate) fn tick_tools_changed_for_test(&self) {
-        let _ = self.tools_changed_tx.send(());
+    pub(crate) fn tick_tools_changed_for_test(&self, endpoint: &str) {
+        let _ = self.tools_changed_tx.send(endpoint.to_string());
     }
 
     /// Register an adapter under the given endpoint name.
@@ -213,9 +216,11 @@ impl AdapterRegistry {
     /// — as well as a `Lagged` error (treated as a missed-but-coalesced tick)
     /// — invalidates the per-endpoint tools cache followed by the merged
     /// catalog cache, then fans the tick into the relay-wide
-    /// `tools_changed_tx` so downstream consumers (e.g. the `/mcp/sse`
-    /// handler) can forward `notifications/tools/list_changed` to connected
-    /// MCP clients. A `Closed` receiver terminates the loop.
+    /// `tools_changed_tx` (carrying the endpoint name) so downstream
+    /// consumers (e.g. the `/mcp/sse` handler, or future per-profile SSE
+    /// handlers that filter by endpoint membership) can forward
+    /// `notifications/tools/list_changed` to connected MCP clients. A
+    /// `Closed` receiver terminates the loop.
     async fn tools_changed_listener_loop(
         registry: Self,
         endpoint: String,
@@ -226,7 +231,7 @@ impl AdapterRegistry {
                 Ok(()) => {
                     registry.invalidate_endpoint_tool_cache(&endpoint).await;
                     registry.invalidate_catalog_cache().await;
-                    let _ = registry.tools_changed_tx.send(());
+                    let _ = registry.tools_changed_tx.send(endpoint.clone());
                 }
                 Err(broadcast::error::RecvError::Lagged(skipped)) => {
                     debug!(
@@ -236,7 +241,7 @@ impl AdapterRegistry {
                     );
                     registry.invalidate_endpoint_tool_cache(&endpoint).await;
                     registry.invalidate_catalog_cache().await;
-                    let _ = registry.tools_changed_tx.send(());
+                    let _ = registry.tools_changed_tx.send(endpoint.clone());
                 }
                 Err(broadcast::error::RecvError::Closed) => {
                     debug!(endpoint = %endpoint, "tools-changed listener channel closed");
@@ -2001,7 +2006,8 @@ mod tests {
     /// A per-endpoint adapter tick must also fan into the relay-wide
     /// `subscribe_tools_changed` channel so server-side consumers (e.g. the
     /// `/mcp/sse` handler) can forward `notifications/tools/list_changed`
-    /// to MCP clients.
+    /// to MCP clients. The fanned-in payload carries the endpoint name so
+    /// per-profile SSE handlers can filter by endpoint membership.
     #[tokio::test]
     async fn test_tools_changed_tick_fans_in_to_relay_subscribers() {
         let registry = AdapterRegistry::new();
@@ -2018,13 +2024,16 @@ mod tests {
             .await;
 
         // Drive a per-endpoint tick; the listener loop should observe it and
-        // fan it into the relay-wide broadcast.
+        // fan it into the relay-wide broadcast with the endpoint name.
         tx.send(()).unwrap();
         let recv = tokio::time::timeout(std::time::Duration::from_secs(1), relay_rx.recv()).await;
-        assert!(
-            matches!(recv, Ok(Ok(()))),
-            "relay-wide tools-changed subscriber should receive the fanned-in tick (got {recv:?})"
-        );
+        match recv {
+            Ok(Ok(name)) => assert_eq!(name, "ep", "fanned-in payload should be the endpoint name"),
+            other => panic!(
+                "relay-wide tools-changed subscriber should receive the fanned-in tick \
+                 carrying the endpoint name (got {other:?})"
+            ),
+        }
     }
 
     #[tokio::test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -2836,42 +2836,32 @@ mod tests {
     }
 
     /// Populate `state.profile_registry` with a single profile whose path is
-    /// `path` and whose endpoint set is `endpoints`. JS execution and TOON
-    /// inherit from the relay defaults (off / on).
+    /// `path` and whose endpoint set is `endpoints`. JS execution defaults
+    /// to off and TOON output to on — matching the historical "inherit from
+    /// relay defaults" resolution callers relied on.
     async fn install_profile(state: &AppState, path: &str, endpoints: Vec<String>) {
-        install_profile_with_flags(state, path, endpoints, None, None, None, None).await;
+        install_profile_with_flags(state, path, endpoints, false, true).await;
     }
 
     /// Variant of [`install_profile`] that takes explicit `js_execution` /
-    /// `toon_output` overrides for both the relay defaults and the profile
-    /// itself. `None` on a profile field means "Inherit" — the resolved
-    /// `ProfileContext::js_execution` / `toon_output` then falls back to the
-    /// matching relay default (also passed in as `Option`).
+    /// `toon_output` values for the installed profile. Both fields are
+    /// required on the profile config; callers pick concrete booleans for
+    /// whichever path the test wants to exercise.
     async fn install_profile_with_flags(
         state: &AppState,
         path: &str,
         endpoints: Vec<String>,
-        relay_js: Option<bool>,
-        relay_toon: Option<bool>,
-        profile_js: Option<bool>,
-        profile_toon: Option<bool>,
+        js_execution: bool,
+        toon_output: bool,
     ) {
-        let relay = crate::config::RelayConfig {
-            machine_name: "test".into(),
-            local_js_execution: relay_js,
-            token_dir: None,
-            allow_insecure_oauth: None,
-            toon_output: relay_toon,
-            startup_init_timeout_secs: None,
-        };
         let profile = crate::config::ProfileConfig {
             name: path.to_string(),
             path: path.to_string(),
             endpoints,
-            js_execution: profile_js,
-            toon_output: profile_toon,
+            js_execution,
+            toon_output,
         };
-        state.profile_registry.rebuild(&[profile], &relay).await;
+        state.profile_registry.rebuild(&[profile]).await;
     }
 
     // Test-matrix row #24 — unknown profile path → 404 with JSON body.
@@ -3052,20 +3042,11 @@ mod tests {
                 Some("github".into()),
             )
             .await;
-        // R3.B: `ProfileContext::js_execution` is resolved at rebuild time
-        // from the relay config, not from the runtime atomic. Set the
-        // relay default to `Some(true)` so the profile inherits JS-on and
-        // advertises `execute_tools` in the catalog.
-        install_profile_with_flags(
-            &state,
-            "work",
-            vec!["gmail".into()],
-            Some(true),
-            None,
-            None,
-            None,
-        )
-        .await;
+        // R3.B: `ProfileContext::js_execution` is read directly from the
+        // profile config at rebuild time, not from the runtime atomic. Set
+        // it to `true` so this profile advertises `execute_tools` in the
+        // catalog.
+        install_profile_with_flags(&state, "work", vec!["gmail".into()], true, true).await;
         let profile_ctx = state.profile_registry.get("work").await.unwrap();
 
         let body = JsonRpcBody {
@@ -3108,8 +3089,7 @@ mod tests {
             !state.toon_enabled,
             "test relies on global toon default being off"
         );
-        install_profile_with_flags(&state, "work", vec![], None, Some(false), None, Some(true))
-            .await;
+        install_profile_with_flags(&state, "work", vec![], false, true).await;
         let resp = send_profile_request(
             state,
             "POST",
@@ -3143,11 +3123,10 @@ mod tests {
     #[tokio::test]
     async fn profile_toon_off_keeps_json_when_global_on() {
         let state = test_app_state();
-        install_profile_with_flags(&state, "work", vec![], None, Some(true), None, Some(false))
-            .await;
-        // Sanity: the global default the profile is overriding is actually on.
+        install_profile_with_flags(&state, "work", vec![], false, false).await;
+        // Sanity: the profile's TOON flag is off.
         let global_ctx = state.profile_registry.get("work").await.unwrap();
-        assert!(!global_ctx.toon_output, "profile override must be off");
+        assert!(!global_ctx.toon_output, "profile toon must be off");
         let resp = send_profile_request(
             state,
             "POST",
@@ -3183,8 +3162,7 @@ mod tests {
             !state.js_execution_mode.load(Ordering::Relaxed),
             "test relies on global JS default being off"
         );
-        install_profile_with_flags(&state, "work", vec![], Some(false), None, Some(true), None)
-            .await;
+        install_profile_with_flags(&state, "work", vec![], true, true).await;
         let resp = send_profile_request(
             state,
             "POST",
@@ -3212,8 +3190,7 @@ mod tests {
     #[tokio::test]
     async fn profile_js_off_hides_execute_tools_when_global_on() {
         let state = test_app_state();
-        install_profile_with_flags(&state, "work", vec![], Some(true), None, Some(false), None)
-            .await;
+        install_profile_with_flags(&state, "work", vec![], false, true).await;
         let resp = send_profile_request(
             state,
             "POST",

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,6 @@
 use crate::js_sandbox::MetaToolHandler;
 use crate::oauth::{OAuthFlowManager, OAuthSetupManager};
+use crate::profile_registry::ProfileRegistry;
 use crate::registry::AdapterRegistry;
 use crate::token_manager::TokenManager;
 use crate::OAuthAdapterInners;
@@ -32,6 +33,10 @@ pub struct AppState {
     pub registry: AdapterRegistry,
     pub js_execution_mode: Arc<AtomicBool>,
     pub meta_tool_handler: Arc<MetaToolHandler>,
+    /// Relay-wide profile registry. R2.B/R3.A wire profile-scoped routes
+    /// that resolve the active [`ProfileContext`] from the request path.
+    #[allow(dead_code)]
+    pub profile_registry: Arc<ProfileRegistry>,
     /// OAuth flow manager (shared with management routes).
     pub oauth_flow_manager: Option<Arc<OAuthFlowManager>>,
     /// Token manager for persisting OAuth tokens.
@@ -1148,10 +1153,12 @@ mod tests {
             Arc::new(registry.clone()),
             Duration::from_secs(5),
         ));
+        let profile_registry = Arc::new(ProfileRegistry::new(registry.clone()));
         AppState {
             registry,
             js_execution_mode: Arc::new(AtomicBool::new(false)),
             meta_tool_handler,
+            profile_registry,
             oauth_flow_manager: None,
             token_manager: None,
             oauth_adapter_inners: None,

--- a/src/server.rs
+++ b/src/server.rs
@@ -561,7 +561,12 @@ async fn mcp_sse(
         {
             return;
         }
-        while let Ok(()) | Err(RecvError::Lagged(_)) = tools_rx.recv().await {
+        // Global `/mcp/sse` forwards every tools-changed tick regardless of
+        // which endpoint emitted it. The payload (endpoint name) is unused
+        // here; per-profile SSE handlers use it to filter by endpoint
+        // membership. `Lagged` is also surfaced as a tick (endpoint name is
+        // lost in that case), so forward unconditionally on both arms.
+        while let Ok(_) | Err(RecvError::Lagged(_)) = tools_rx.recv().await {
             let frame = Event::default()
                 .data(r#"{"jsonrpc":"2.0","method":"notifications/tools/list_changed"}"#);
             if tx.send(Ok(frame)).await.is_err() {
@@ -2518,7 +2523,7 @@ mod tests {
         // races with the subscriber, so retry the tick until the frame lands.
         let driver = tokio::spawn(async move {
             for _ in 0..40 {
-                registry.tick_tools_changed_for_test();
+                registry.tick_tools_changed_for_test("test-endpoint");
                 tokio::time::sleep(Duration::from_millis(50)).await;
             }
         });

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,11 +1,11 @@
 use crate::js_sandbox::MetaToolHandler;
 use crate::oauth::{OAuthFlowManager, OAuthSetupManager};
-use crate::profile_registry::ProfileRegistry;
+use crate::profile_registry::{ProfileContext, ProfileRegistry};
 use crate::registry::AdapterRegistry;
 use crate::token_manager::TokenManager;
 use crate::OAuthAdapterInners;
 use axum::{
-    extract::{Query, State},
+    extract::{Path, Query, State},
     http::{HeaderMap, HeaderValue, Method, StatusCode},
     response::{
         sse::{Event, KeepAlive},
@@ -100,9 +100,15 @@ fn jsonrpc_error(id: Option<Value>, code: i64, message: &str) -> (StatusCode, Js
 }
 
 /// POST /mcp/initialize
+///
+/// `profile_ctx` is `Some` when the request arrived through a wildcard
+/// `/mcp/{profile}` route — `instructions` is then rendered against the
+/// profile's allowed endpoint set so only that profile's server types are
+/// advertised. `None` for the global `/mcp` path.
 async fn mcp_initialize(
     State(state): State<AppState>,
     Json(body): Json<JsonRpcBody>,
+    profile_ctx: Option<&ProfileContext>,
 ) -> Json<Value> {
     let mut result = json!({
         "protocolVersion": "2025-03-26",
@@ -114,7 +120,11 @@ async fn mcp_initialize(
             "version": env!("CARGO_PKG_VERSION")
         }
     });
-    if let Some(instructions) = crate::advertise::instructions(&state.registry).await {
+    let instructions = match profile_ctx {
+        Some(ctx) => crate::advertise::instructions_for_profile(&ctx.registry_view).await,
+        None => crate::advertise::instructions(&state.registry).await,
+    };
+    if let Some(instructions) = instructions {
         result["instructions"] = Value::String(instructions);
     }
     jsonrpc_response(body.id, result)
@@ -129,14 +139,29 @@ async fn mcp_initialize(
 ///
 /// The descriptions are built dynamically against the supplied [`AdapterRegistry`]
 /// so each `tools/list` response advertises the currently-Healthy server set
-/// (see `crate::advertise`).
+/// (see `crate::advertise`). When `profile_ctx` is `Some`, the `_for_profile`
+/// description builders are used so descriptions only mention server types
+/// inside the profile's allowed endpoint set.
 async fn meta_tool_definitions(
     js_mode: bool,
     registry: &AdapterRegistry,
     toon_enabled: bool,
+    profile_ctx: Option<&ProfileContext>,
 ) -> Vec<Value> {
-    let list_desc = crate::advertise::list_tools_description(registry).await;
-    let search_desc = crate::advertise::search_tools_description(registry, toon_enabled).await;
+    let (list_desc, search_desc) = match profile_ctx {
+        Some(ctx) => (
+            crate::advertise::list_tools_description_for_profile(&ctx.registry_view).await,
+            crate::advertise::search_tools_description_for_profile(
+                &ctx.registry_view,
+                toon_enabled,
+            )
+            .await,
+        ),
+        None => (
+            crate::advertise::list_tools_description(registry).await,
+            crate::advertise::search_tools_description(registry, toon_enabled).await,
+        ),
+    };
     let mut tools = vec![
         json!({
             "name": "list_tools",
@@ -165,7 +190,12 @@ async fn meta_tool_definitions(
     if !js_mode {
         return tools;
     }
-    let execute_desc = crate::advertise::execute_tools_description(registry).await;
+    let execute_desc = match profile_ctx {
+        Some(ctx) => {
+            crate::advertise::execute_tools_description_for_profile(&ctx.registry_view).await
+        }
+        None => crate::advertise::execute_tools_description(registry).await,
+    };
     tools.push(json!({
         "name": "execute_tools",
         "description": execute_desc,
@@ -181,12 +211,19 @@ async fn meta_tool_definitions(
 }
 
 /// POST /mcp/tools/list
+///
+/// `profile_ctx` threads the resolved [`ProfileContext`] from the wildcard
+/// `/mcp/{profile}` route so meta-tool descriptions advertise only the
+/// profile's server types. `None` for the global `/mcp` path. R3.A owns
+/// the catalog filtering itself (line 199 below).
 async fn mcp_tools_list(
     State(state): State<AppState>,
     Json(body): Json<JsonRpcBody>,
+    profile_ctx: Option<&ProfileContext>,
 ) -> Json<Value> {
     let js_mode = state.js_execution_mode.load(Ordering::Relaxed);
-    let meta_tools = meta_tool_definitions(js_mode, &state.registry, state.toon_enabled).await;
+    let meta_tools =
+        meta_tool_definitions(js_mode, &state.registry, state.toon_enabled, profile_ctx).await;
 
     let tools: Vec<Value> = if js_mode {
         // JS execution mode: only the 3 meta-tools (incl. execute_tools)
@@ -331,7 +368,19 @@ async fn mcp_tools_call(
 
 /// Handle a single JSON-RPC message object, returning `None` for notifications
 /// (which get 202 Accepted) or `Some(Value)` for requests that need a response.
-async fn handle_single_message(state: &AppState, msg: Value, headers_str: &str) -> Option<Value> {
+///
+/// `profile_ctx` is `Some` when the request arrived through a wildcard
+/// `/mcp/{profile}` route and identifies the resolved [`ProfileContext`]. It
+/// is `None` for the global `/mcp` endpoint. R3.C uses it to render
+/// profile-scoped `InitializeResult.instructions` and meta-tool
+/// descriptions; R3.A consumes it for per-profile catalog scoping and
+/// tools/call dispatch.
+async fn handle_single_message(
+    state: &AppState,
+    msg: Value,
+    headers_str: &str,
+    profile_ctx: Option<&ProfileContext>,
+) -> Option<Value> {
     let method = msg
         .get("method")
         .and_then(|v| v.as_str())
@@ -375,8 +424,8 @@ async fn handle_single_message(state: &AppState, msg: Value, headers_str: &str) 
         };
 
         let result: Result<Json<Value>, (StatusCode, Json<Value>)> = match method.as_str() {
-            "initialize" => Ok(mcp_initialize(State(state.clone()), Json(body)).await),
-            "tools/list" => Ok(mcp_tools_list(State(state.clone()), Json(body)).await),
+            "initialize" => Ok(mcp_initialize(State(state.clone()), Json(body), profile_ctx).await),
+            "tools/list" => Ok(mcp_tools_list(State(state.clone()), Json(body), profile_ctx).await),
             "tools/call" => mcp_tools_call(State(state.clone()), Json(body)).await,
             _ => Err(jsonrpc_error(
                 body.id,
@@ -461,11 +510,57 @@ async fn mcp_unified(
     headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> Response {
+    mcp_unified_impl(state, headers, body, None).await
+}
+
+/// POST `/mcp/{profile}` — profile-scoped variant of [`mcp_unified`].
+///
+/// Resolves the URL `{profile}` segment against
+/// [`AppState::profile_registry`] and 404s if unknown. On hit, delegates to
+/// [`mcp_unified_impl`] with the resolved [`ProfileContext`] so the global and
+/// profiled paths share a single dispatch implementation.
+///
+/// The catalog/tool-call scoping inside that shared implementation is wired
+/// in R3.A; for now the context is plumbed through but unused, and the
+/// dispatch behaviour matches the global `/mcp` endpoint.
+///
+/// The dispatch is wrapped in an `info_span!("mcp_request", profile = ...)`
+/// so every event emitted while handling the request — including the inner
+/// `request` span's `MCP request` / `MCP notification` lines and any
+/// adapter-side child spans — inherits the `profile` field. The field key
+/// `profile` is an immutable cross-stack contract with the desktop log
+/// parser (locked decision Cross-stack #1 / engineering-spec §7.1).
+async fn mcp_unified_profiled(
+    State(state): State<AppState>,
+    Path(profile_path): Path<String>,
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Response {
+    let Some(profile_ctx) = state.profile_registry.get(&profile_path).await else {
+        return profile_not_found_response(&profile_path);
+    };
+    let span = tracing::info_span!("mcp_request", profile = %profile_path);
+    mcp_unified_impl(state, headers, body, Some(profile_ctx))
+        .instrument(span)
+        .await
+}
+
+/// Shared body of [`mcp_unified`] and [`mcp_unified_profiled`]. `profile_ctx`
+/// is `None` for the global `/mcp` route and `Some(...)` for
+/// `/mcp/{profile}`; see [`handle_single_message`] for how it is threaded
+/// through to per-message dispatch.
+async fn mcp_unified_impl(
+    state: AppState,
+    headers: HeaderMap,
+    body: Value,
+    profile_ctx: Option<Arc<ProfileContext>>,
+) -> Response {
     let headers_str: String = headers
         .iter()
         .map(|(k, v)| format!("{}={}", k, v.to_str().unwrap_or("")))
         .collect::<Vec<_>>()
         .join(" ");
+    let profile_ctx_ref = profile_ctx.as_deref();
 
     match body {
         Value::Array(messages) => {
@@ -487,7 +582,9 @@ async fn mcp_unified(
 
             let mut responses: Vec<Value> = Vec::new();
             for msg in messages {
-                if let Some(resp) = handle_single_message(&state, msg, &headers_str).await {
+                if let Some(resp) =
+                    handle_single_message(&state, msg, &headers_str, profile_ctx_ref).await
+                {
                     responses.push(resp);
                 }
             }
@@ -507,18 +604,20 @@ async fn mcp_unified(
                     .into_response()
             }
         }
-        Value::Object(_) => match handle_single_message(&state, body, &headers_str).await {
-            Some(resp) => (
-                StatusCode::OK,
-                [(
-                    axum::http::header::CONTENT_TYPE,
-                    HeaderValue::from_static("application/json"),
-                )],
-                Json(resp),
-            )
-                .into_response(),
-            None => StatusCode::ACCEPTED.into_response(),
-        },
+        Value::Object(_) => {
+            match handle_single_message(&state, body, &headers_str, profile_ctx_ref).await {
+                Some(resp) => (
+                    StatusCode::OK,
+                    [(
+                        axum::http::header::CONTENT_TYPE,
+                        HeaderValue::from_static("application/json"),
+                    )],
+                    Json(resp),
+                )
+                    .into_response(),
+                None => StatusCode::ACCEPTED.into_response(),
+            }
+        }
         _ => (
             StatusCode::OK,
             [(
@@ -533,6 +632,30 @@ async fn mcp_unified(
         )
             .into_response(),
     }
+}
+
+/// JSON 404 body returned by profile-scoped routes when the URL `{profile}`
+/// segment does not resolve to a registered profile (test-matrix row #24).
+/// Shape mirrors the JSON-RPC error envelope used by [`mcp_unified`] for
+/// other invalid-request cases so generic JSON-RPC clients can surface a
+/// meaningful message.
+fn profile_not_found_response(profile_path: &str) -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        [(
+            axum::http::header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        )],
+        Json(json!({
+            "jsonrpc": "2.0",
+            "error": {
+                "code": -32004,
+                "message": format!("unknown profile '{}'", profile_path),
+            },
+            "id": null,
+        })),
+    )
+        .into_response()
 }
 
 /// GET /mcp/sse — basic SSE transport.
@@ -553,29 +676,97 @@ async fn mcp_unified(
 async fn mcp_sse(
     State(state): State<AppState>,
 ) -> Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>> {
+    build_mcp_sse_stream(&state, "/mcp", None)
+}
+
+/// GET `/mcp/{profile}/sse` — profile-scoped SSE transport.
+///
+/// Resolves the URL `{profile}` segment against
+/// [`AppState::profile_registry`] and 404s if unknown. On hit, returns the
+/// same SSE stream shape as [`mcp_sse`], pointing the initial `endpoint`
+/// event at `/mcp/{profile}` so SSE-only clients POST follow-up JSON-RPC
+/// requests back to the same profile.
+///
+/// Per locked decision Relay #6 the per-tick filter loop in
+/// [`build_mcp_sse_stream`] mirrors the existing `mcp_sse` pattern (single
+/// `recv().await` per iteration). The profile's allowed-endpoints set is
+/// passed in so `notifications/tools/list_changed` is only forwarded when
+/// the changed endpoint is in-profile (`Lagged` always forwards
+/// unconditionally because the endpoint name is lost).
+async fn mcp_sse_profiled(
+    State(state): State<AppState>,
+    Path(profile_path): Path<String>,
+) -> Response {
+    let Some(profile_ctx) = state.profile_registry.get(&profile_path).await else {
+        return profile_not_found_response(&profile_path);
+    };
+    let endpoint_uri = format!("/mcp/{}", profile_path);
+    let allowed = Arc::new(profile_ctx.registry_view.allowed_endpoints().clone());
+    build_mcp_sse_stream(&state, &endpoint_uri, Some(allowed)).into_response()
+}
+
+/// Build the SSE stream backing both [`mcp_sse`] and [`mcp_sse_profiled`].
+///
+/// `endpoint_data` is the value emitted on the initial `endpoint` event so
+/// SSE-only clients learn where to POST follow-up JSON-RPC requests
+/// (`/mcp` for the global route, `/mcp/{profile}` for the profiled one).
+///
+/// `allowed_endpoints` filters which `tools/list_changed` ticks are
+/// forwarded: `None` (global `/mcp/sse`) forwards every tick;
+/// `Some(set)` (profile-scoped) forwards only when the tick's endpoint name
+/// is in `set`. `Lagged` is always forwarded unconditionally because the
+/// originating endpoint name is lost on lag (the client will re-fetch
+/// `tools/list` on receipt and re-discover any in-profile changes).
+fn build_mcp_sse_stream(
+    state: &AppState,
+    endpoint_data: &str,
+    allowed_endpoints: Option<Arc<std::collections::HashSet<String>>>,
+) -> Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>> {
     use tokio::sync::broadcast::error::RecvError;
 
     let (tx, rx) = tokio::sync::mpsc::channel(16);
     let mut tools_rx = state.registry.subscribe_tools_changed();
+    let endpoint_data = endpoint_data.to_string();
 
     tokio::spawn(async move {
         if tx
-            .send(Ok(Event::default().event("endpoint").data("/mcp")))
+            .send(Ok(Event::default().event("endpoint").data(endpoint_data)))
             .await
             .is_err()
         {
             return;
         }
-        // Global `/mcp/sse` forwards every tools-changed tick regardless of
-        // which endpoint emitted it. The payload (endpoint name) is unused
-        // here; per-profile SSE handlers use it to filter by endpoint
-        // membership. `Lagged` is also surfaced as a tick (endpoint name is
-        // lost in that case), so forward unconditionally on both arms.
-        while let Ok(_) | Err(RecvError::Lagged(_)) = tools_rx.recv().await {
-            let frame = Event::default()
-                .data(r#"{"jsonrpc":"2.0","method":"notifications/tools/list_changed"}"#);
-            if tx.send(Ok(frame)).await.is_err() {
-                break;
+        // `Ok(name)` carries the endpoint that emitted the tick (registry
+        // fan-in at `registry.rs:234/244`); profile-scoped streams filter on
+        // membership while the global stream forwards every tick. `Lagged`
+        // loses the endpoint name, so we forward unconditionally on lag —
+        // any missed in-profile change is recovered when the client
+        // re-fetches `tools/list` after the notification. `Closed` only
+        // fires when the registry itself is dropped.
+        loop {
+            match tools_rx.recv().await {
+                Ok(name) => {
+                    let forward = match &allowed_endpoints {
+                        None => true,
+                        Some(set) => set.contains(&name),
+                    };
+                    if !forward {
+                        continue;
+                    }
+                    let frame = Event::default()
+                        .data(r#"{"jsonrpc":"2.0","method":"notifications/tools/list_changed"}"#);
+                    if tx.send(Ok(frame)).await.is_err() {
+                        break;
+                    }
+                }
+                Err(RecvError::Lagged(_)) => {
+                    let frame = Event::default()
+                        .data(r#"{"jsonrpc":"2.0","method":"notifications/tools/list_changed"}"#);
+                    if tx.send(Ok(frame)).await.is_err() {
+                        break;
+                    }
+                }
+                Err(RecvError::Closed) => break,
             }
         }
     });
@@ -845,7 +1036,7 @@ async fn mcp_initialize_logged(state: State<AppState>, body: Json<JsonRpcBody>) 
     async move {
         let start = Instant::now();
         let req_bytes = serde_json::to_string(&body.0).map(|s| s.len()).unwrap_or(0);
-        let resp = mcp_initialize(state, body).await;
+        let resp = mcp_initialize(state, body, None).await;
         let elapsed_ms = start.elapsed().as_millis() as u64;
         let resp_bytes = serde_json::to_string(&resp.0).map(|s| s.len()).unwrap_or(0);
         info!(
@@ -868,7 +1059,7 @@ async fn mcp_tools_list_logged(state: State<AppState>, body: Json<JsonRpcBody>) 
     async move {
         let start = Instant::now();
         let req_bytes = serde_json::to_string(&body.0).map(|s| s.len()).unwrap_or(0);
-        let resp = mcp_tools_list(state, body).await;
+        let resp = mcp_tools_list(state, body, None).await;
         let elapsed_ms = start.elapsed().as_millis() as u64;
         let resp_bytes = serde_json::to_string(&resp.0).map(|s| s.len()).unwrap_or(0);
         info!(
@@ -954,6 +1145,21 @@ async fn mcp_delete() -> Response {
     StatusCode::METHOD_NOT_ALLOWED.into_response()
 }
 
+/// Handler for `DELETE /mcp/{profile}` — profile-scoped variant of
+/// [`mcp_delete`]. Resolves the URL `{profile}` segment against
+/// [`AppState::profile_registry`] and returns 404 with a structured JSON
+/// body if unknown; on hit returns 405 to match the global `/mcp` route's
+/// opt-out from session termination.
+async fn mcp_delete_profiled(
+    State(state): State<AppState>,
+    Path(profile_path): Path<String>,
+) -> Response {
+    if state.profile_registry.get(&profile_path).await.is_none() {
+        return profile_not_found_response(&profile_path);
+    }
+    StatusCode::METHOD_NOT_ALLOWED.into_response()
+}
+
 /// Check whether an Origin header value is a localhost origin.
 /// Allows `http://localhost`, `http://127.0.0.1`, `http://[::1]` on any port.
 fn is_localhost_origin(origin: &str) -> bool {
@@ -1010,6 +1216,15 @@ pub fn build_router_with_origins(state: AppState, extra_origins: &[String]) -> R
         .route("/mcp/tools/list", post(mcp_tools_list_logged))
         .route("/mcp/tools/call", post(mcp_tools_call_logged))
         .route("/mcp/sse", get(mcp_sse))
+        // Profile-scoped variants. Per recon D7, axum 0.8 prefers the
+        // specific `/mcp/{initialize,tools,sse}` routes above over the
+        // `/mcp/{profile}` wildcard, and `RESERVED_PROFILE_PATHS` keeps
+        // profile names from colliding with the `/mcp/{profile}/sse` path.
+        .route(
+            "/mcp/{profile}",
+            post(mcp_unified_profiled).delete(mcp_delete_profiled),
+        )
+        .route("/mcp/{profile}/sse", get(mcp_sse_profiled))
         .route("/oauth/callback", get(oauth_callback))
         .layer(cors)
         .with_state(state)
@@ -1208,7 +1423,7 @@ mod tests {
             params: None,
             id: Some(json!(1)),
         };
-        let Json(resp) = mcp_initialize(State(state), Json(body)).await;
+        let Json(resp) = mcp_initialize(State(state), Json(body), None).await;
 
         assert_eq!(resp["jsonrpc"], "2.0");
         assert_eq!(resp["id"], 1);
@@ -1227,7 +1442,7 @@ mod tests {
     #[tokio::test]
     async fn meta_tool_definitions_contains_expected_tools() {
         let registry = AdapterRegistry::new();
-        let defs = meta_tool_definitions(true, &registry, false).await;
+        let defs = meta_tool_definitions(true, &registry, false, None).await;
         assert_eq!(defs.len(), 3);
 
         let names: Vec<&str> = defs.iter().map(|d| d["name"].as_str().unwrap()).collect();
@@ -1247,7 +1462,7 @@ mod tests {
     #[tokio::test]
     async fn meta_tool_definitions_hides_execute_tools_when_js_off() {
         let registry = AdapterRegistry::new();
-        let defs = meta_tool_definitions(false, &registry, false).await;
+        let defs = meta_tool_definitions(false, &registry, false, None).await;
         let names: Vec<&str> = defs.iter().map(|d| d["name"].as_str().unwrap()).collect();
         assert!(names.contains(&"list_tools"));
         assert!(names.contains(&"search_tools"));
@@ -1260,7 +1475,7 @@ mod tests {
     #[tokio::test]
     async fn test_list_tools_description_documents_return_format() {
         let registry = AdapterRegistry::new();
-        let defs = meta_tool_definitions(true, &registry, false).await;
+        let defs = meta_tool_definitions(true, &registry, false, None).await;
         let list_desc = defs.iter().find(|d| d["name"] == "list_tools").unwrap()["description"]
             .as_str()
             .unwrap();
@@ -1289,7 +1504,7 @@ mod tests {
     #[tokio::test]
     async fn test_search_tools_description_documents_behavior() {
         let registry = AdapterRegistry::new();
-        let defs = meta_tool_definitions(true, &registry, false).await;
+        let defs = meta_tool_definitions(true, &registry, false, None).await;
         let search_desc = defs.iter().find(|d| d["name"] == "search_tools").unwrap()["description"]
             .as_str()
             .unwrap();
@@ -1312,7 +1527,7 @@ mod tests {
     #[tokio::test]
     async fn test_execute_tools_description_has_examples() {
         let registry = AdapterRegistry::new();
-        let defs = meta_tool_definitions(true, &registry, false).await;
+        let defs = meta_tool_definitions(true, &registry, false, None).await;
         let exec_desc = defs.iter().find(|d| d["name"] == "execute_tools").unwrap()["description"]
             .as_str()
             .unwrap();
@@ -1391,7 +1606,7 @@ mod tests {
             params: None,
             id: Some(json!(1)),
         };
-        let Json(resp) = mcp_tools_list(State(state), Json(body)).await;
+        let Json(resp) = mcp_tools_list(State(state), Json(body), None).await;
         let tools = resp["result"]["tools"].as_array().unwrap();
 
         // With no adapters registered and JS mode off, only list_tools and
@@ -1414,7 +1629,7 @@ mod tests {
             params: None,
             id: Some(json!(1)),
         };
-        let Json(resp) = mcp_tools_list(State(state), Json(body)).await;
+        let Json(resp) = mcp_tools_list(State(state), Json(body), None).await;
         let tools = resp["result"]["tools"].as_array().unwrap();
         assert_eq!(tools.len(), 3);
     }
@@ -1557,7 +1772,7 @@ mod tests {
     #[tokio::test]
     async fn search_tools_advertising_includes_toon_hint_when_enabled() {
         let registry = AdapterRegistry::new();
-        let defs_on = meta_tool_definitions(true, &registry, true).await;
+        let defs_on = meta_tool_definitions(true, &registry, true, None).await;
         let search_desc = defs_on
             .iter()
             .find(|d| d["name"] == "search_tools")
@@ -1569,7 +1784,7 @@ mod tests {
             "expected TOON hint in: {search_desc}"
         );
 
-        let defs_off = meta_tool_definitions(true, &registry, false).await;
+        let defs_off = meta_tool_definitions(true, &registry, false, None).await;
         let search_desc_off = defs_off
             .iter()
             .find(|d| d["name"] == "search_tools")
@@ -2345,7 +2560,7 @@ mod tests {
             params: None,
             id: Some(json!(1)),
         };
-        let Json(resp) = mcp_tools_list(State(state), Json(body)).await;
+        let Json(resp) = mcp_tools_list(State(state), Json(body), None).await;
         let tools = resp["result"]["tools"].as_array().unwrap();
 
         let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
@@ -2370,7 +2585,7 @@ mod tests {
             params: None,
             id: Some(json!(1)),
         };
-        let Json(resp) = mcp_tools_list(State(state), Json(body)).await;
+        let Json(resp) = mcp_tools_list(State(state), Json(body), None).await;
         let tools = resp["result"]["tools"].as_array().unwrap();
         assert_eq!(tools.len(), 3);
 
@@ -2446,7 +2661,7 @@ mod tests {
             params: None,
             id: Some(json!(7)),
         };
-        let Json(resp) = mcp_initialize(State(state), Json(body)).await;
+        let Json(resp) = mcp_initialize(State(state), Json(body), None).await;
         assert_eq!(
             resp["result"]["capabilities"]["tools"]["listChanged"], true,
             "initialize must advertise tools.listChanged: true (got {resp})"
@@ -2547,5 +2762,616 @@ mod tests {
             text.contains("\"jsonrpc\":\"2.0\""),
             "frame should be a JSON-RPC notification (got: {text:?})"
         );
+    }
+
+    /// Helper: send `body` to a profile-scoped POST/DELETE/GET route via the
+    /// router and return the raw response. Mirrors [`post_mcp`] for the
+    /// `/mcp/{profile}` wildcard.
+    async fn send_profile_request(
+        state: AppState,
+        method: &str,
+        uri: &str,
+        body: Option<&Value>,
+    ) -> axum::response::Response {
+        use axum::body::Body;
+        use tower::ServiceExt;
+
+        let router = build_router(state);
+        let mut builder = axum::http::Request::builder().method(method).uri(uri);
+        let body_bytes = match body {
+            Some(v) => {
+                builder = builder.header("content-type", "application/json");
+                Body::from(serde_json::to_vec(v).unwrap())
+            }
+            None => Body::empty(),
+        };
+        let request = builder.body(body_bytes).unwrap();
+        router.oneshot(request).await.unwrap()
+    }
+
+    /// Populate `state.profile_registry` with a single profile whose path is
+    /// `path` and whose endpoint set is `endpoints`. JS execution and TOON
+    /// inherit from the relay defaults (off / on).
+    async fn install_profile(state: &AppState, path: &str, endpoints: Vec<String>) {
+        let relay = crate::config::RelayConfig {
+            machine_name: "test".into(),
+            local_js_execution: None,
+            token_dir: None,
+            allow_insecure_oauth: None,
+            toon_output: None,
+            startup_init_timeout_secs: None,
+        };
+        let profile = crate::config::ProfileConfig {
+            name: path.to_string(),
+            path: path.to_string(),
+            endpoints,
+            js_execution: None,
+            toon_output: None,
+        };
+        state.profile_registry.rebuild(&[profile], &relay).await;
+    }
+
+    // Test-matrix row #24 — unknown profile path → 404 with JSON body.
+    #[tokio::test]
+    async fn mcp_unified_profiled_unknown_profile_returns_404_json() {
+        let state = test_app_state();
+        let resp = send_profile_request(
+            state,
+            "POST",
+            "/mcp/nonexistent",
+            Some(&json!({"jsonrpc":"2.0","method":"initialize","id":1})),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        assert_eq!(
+            resp.headers()
+                .get(axum::http::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some("application/json")
+        );
+        let body = body_json(resp).await;
+        assert_eq!(body["jsonrpc"], "2.0");
+        assert!(body["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("nonexistent"));
+    }
+
+    // `DELETE /mcp/{unknown}` should also 404 with the same JSON shape, not
+    // 405 — the 405 contract is reserved for known profiles (mirroring the
+    // global `/mcp` opt-out from session termination).
+    #[tokio::test]
+    async fn mcp_delete_profiled_unknown_profile_returns_404_json() {
+        let state = test_app_state();
+        let resp = send_profile_request(state, "DELETE", "/mcp/nonexistent", None).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = body_json(resp).await;
+        assert!(body["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("nonexistent"));
+    }
+
+    // `GET /mcp/{unknown}/sse` should 404 with the same JSON shape.
+    #[tokio::test]
+    async fn mcp_sse_profiled_unknown_profile_returns_404_json() {
+        let state = test_app_state();
+        let resp = send_profile_request(state, "GET", "/mcp/nonexistent/sse", None).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = body_json(resp).await;
+        assert!(body["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("nonexistent"));
+    }
+
+    // Known profile path → POST delegates to the shared `mcp_unified_impl`
+    // and returns a normal JSON-RPC response (R3.A wires per-profile catalog
+    // scoping; this slice only verifies the route reaches the handler).
+    #[tokio::test]
+    async fn mcp_unified_profiled_known_profile_dispatches_initialize() {
+        let state = test_app_state();
+        install_profile(&state, "work", vec![]).await;
+        let resp = send_profile_request(
+            state,
+            "POST",
+            "/mcp/work",
+            Some(&json!({"jsonrpc":"2.0","method":"initialize","id":7})),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["id"], 7);
+        assert_eq!(body["result"]["serverInfo"]["name"], "Endara Relay");
+    }
+
+    // R3.C — profile-aware advertising wire-up.
+    //
+    // The matrix-row #15 contract is unit-tested in `crate::advertise` against
+    // the description builders directly. These integration tests verify that
+    // `mcp_initialize` and `mcp_tools_list` actually thread `profile_ctx`
+    // through and emit profile-scoped output, distinguishing the per-profile
+    // path from the global `/mcp` path. Endpoint count (not server_type) is
+    // used as the differentiator because the server.rs `MockAdapter` does
+    // not override `server_type()`.
+
+    // `mcp_initialize` with `Some(profile_ctx)` advertises a non-`None`
+    // `instructions` (lead-in only, since `MockAdapter` has no server_type)
+    // when the profile has overlapping endpoints. The global `/mcp` path
+    // sees the same registry so it also gets the lead-in — the differentiator
+    // is the profile-vs-global selection (per the `_for_profile` builder).
+    #[tokio::test]
+    async fn mcp_initialize_uses_profile_variant_when_ctx_present() {
+        let state = test_app_state();
+        // Register two endpoints in the relay-wide registry. Without
+        // server_type the lead-in renders without a `Connected server
+        // types:` line — which is exactly the shape we expect because
+        // `instructions_for_profile` should still emit the lead-in when
+        // the profile's allowed endpoints are registered.
+        state
+            .registry
+            .register(
+                "gmail".into(),
+                Box::new(MockAdapter::with_tools(&["send_email"])),
+                "stdio".into(),
+                None,
+                Some("gmail".into()),
+            )
+            .await;
+        state
+            .registry
+            .register(
+                "github".into(),
+                Box::new(MockAdapter::with_tools(&["list_issues"])),
+                "stdio".into(),
+                None,
+                Some("github".into()),
+            )
+            .await;
+        // Profile scoped to a non-overlapping endpoint → instructions must
+        // be `None` (the "no overlap" branch of `instructions_for_profile`).
+        install_profile(&state, "isolated", vec!["does-not-exist".into()]).await;
+        let profile_ctx = state.profile_registry.get("isolated").await.unwrap();
+
+        let body = JsonRpcBody {
+            jsonrpc: Some("2.0".into()),
+            method: Some("initialize".into()),
+            params: None,
+            id: Some(json!(1)),
+        };
+        let Json(resp) = mcp_initialize(State(state.clone()), Json(body), Some(&profile_ctx)).await;
+        assert!(
+            resp["result"].get("instructions").is_none(),
+            "profile with no in-scope endpoints must omit instructions, got: {resp}"
+        );
+
+        // Sanity check: the global path on the same state still includes
+        // instructions, proving the profile path took a different branch.
+        let body = JsonRpcBody {
+            jsonrpc: Some("2.0".into()),
+            method: Some("initialize".into()),
+            params: None,
+            id: Some(json!(2)),
+        };
+        let Json(global_resp) = mcp_initialize(State(state), Json(body), None).await;
+        assert!(
+            global_resp["result"]["instructions"].is_string(),
+            "global path must still advertise instructions, got: {global_resp}"
+        );
+    }
+
+    // `mcp_tools_list` with `Some(profile_ctx)` rebuilds the meta-tool
+    // descriptions against the profile view so the count suffix reflects
+    // only the profile's endpoints. Two endpoints registered globally, one
+    // in profile → list_tools description ends with "1 servers connected",
+    // not "2".
+    #[tokio::test]
+    async fn mcp_tools_list_meta_descriptions_are_profile_scoped() {
+        let state = test_app_state();
+        state.js_execution_mode.store(true, Ordering::Relaxed);
+        state
+            .registry
+            .register(
+                "gmail".into(),
+                Box::new(MockAdapter::with_tools(&["send_email"])),
+                "stdio".into(),
+                None,
+                Some("gmail".into()),
+            )
+            .await;
+        state
+            .registry
+            .register(
+                "github".into(),
+                Box::new(MockAdapter::with_tools(&["list_issues"])),
+                "stdio".into(),
+                None,
+                Some("github".into()),
+            )
+            .await;
+        install_profile(&state, "work", vec!["gmail".into()]).await;
+        let profile_ctx = state.profile_registry.get("work").await.unwrap();
+
+        let body = JsonRpcBody {
+            jsonrpc: Some("2.0".into()),
+            method: Some("tools/list".into()),
+            params: None,
+            id: Some(json!(1)),
+        };
+        let Json(resp) = mcp_tools_list(State(state), Json(body), Some(&profile_ctx)).await;
+        let tools = resp["result"]["tools"].as_array().unwrap();
+        let list_tools = tools
+            .iter()
+            .find(|t| t["name"] == "list_tools")
+            .expect("list_tools meta-tool present");
+        let desc = list_tools["description"].as_str().unwrap();
+        assert!(
+            desc.ends_with(" 1 servers connected via Endara Relay \u{2014} use search_tools to discover tools."),
+            "list_tools description must reflect profile's 1 endpoint, not the registry's 2: {desc}"
+        );
+        // `execute_tools` is advertised in JS mode → same profile-scoped suffix.
+        let execute_tools = tools
+            .iter()
+            .find(|t| t["name"] == "execute_tools")
+            .expect("execute_tools meta-tool present in JS mode");
+        let exec_desc = execute_tools["description"].as_str().unwrap();
+        assert!(
+            exec_desc.ends_with(" 1 servers connected via Endara Relay \u{2014} use search_tools to discover tools."),
+            "execute_tools description must reflect profile's 1 endpoint: {exec_desc}"
+        );
+    }
+
+    // Profile path lookup is case-insensitive (R2.A: registry lowercases keys).
+    #[tokio::test]
+    async fn mcp_unified_profiled_lookup_is_case_insensitive() {
+        let state = test_app_state();
+        install_profile(&state, "work", vec![]).await;
+        let resp = send_profile_request(
+            state,
+            "POST",
+            "/mcp/WORK",
+            Some(&json!({"jsonrpc":"2.0","method":"initialize","id":1})),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    // Known profile + DELETE → 405 (matches the global `/mcp` route).
+    #[tokio::test]
+    async fn mcp_delete_profiled_known_profile_returns_405() {
+        let state = test_app_state();
+        install_profile(&state, "work", vec![]).await;
+        let resp = send_profile_request(state, "DELETE", "/mcp/work", None).await;
+        assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    // Known profile + GET SSE → 200 + initial `endpoint` event points at the
+    // profile's URL so SSE-only clients POST follow-ups to `/mcp/{profile}`.
+    #[tokio::test]
+    async fn mcp_sse_profiled_known_profile_emits_endpoint_event() {
+        let state = test_app_state();
+        install_profile(&state, "work", vec![]).await;
+        let resp = send_profile_request(state, "GET", "/mcp/work/sse", None).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let text = read_sse_until(resp, Duration::from_secs(2), |s| {
+            s.contains("event: endpoint") && s.contains("data: /mcp/work")
+        })
+        .await;
+        assert!(
+            text.contains("event: endpoint") && text.contains("data: /mcp/work"),
+            "first SSE frame should be the endpoint event for /mcp/work (got: {text:?})"
+        );
+    }
+
+    // Sanity: legacy `/mcp/initialize`, `/mcp/tools/list`, `/mcp/sse` are
+    // still reachable after the wildcard `/mcp/{profile}` was added (recon
+    // D7 — axum 0.8 prefers specific routes over `{profile}` wildcards).
+    #[tokio::test]
+    async fn legacy_specific_mcp_routes_still_match_after_wildcard() {
+        use axum::body::Body;
+        use tower::ServiceExt;
+        let state = test_app_state();
+        let router = build_router(state);
+
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/mcp/initialize")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::to_vec(&json!({"jsonrpc":"2.0","method":"initialize","id":1})).unwrap(),
+            ))
+            .unwrap();
+        let resp = router.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["result"]["serverInfo"]["name"], "Endara Relay");
+
+        let req = axum::http::Request::builder()
+            .method("GET")
+            .uri("/mcp/sse")
+            .header("accept", "text/event-stream")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    /// Helper: open a profile-scoped SSE stream and return the response.
+    /// Mirrors the per-test boilerplate in [`mcp_sse_profiled_known_profile_emits_endpoint_event`].
+    async fn open_profile_sse(state: AppState, profile_path: &str) -> axum::response::Response {
+        use axum::body::Body;
+        use tower::ServiceExt;
+        let router = build_router(state);
+        let request = axum::http::Request::builder()
+            .method("GET")
+            .uri(format!("/mcp/{}/sse", profile_path))
+            .header("accept", "text/event-stream")
+            .body(Body::empty())
+            .unwrap();
+        router.oneshot(request).await.unwrap()
+    }
+
+    /// Drive `endpoint_name` tools-changed ticks on the registry until the
+    /// `deadline` elapses. Mirrors the retry-tick pattern used by the
+    /// existing `mcp_sse_forwards_tools_changed_notification` test: each
+    /// `subscribe_tools_changed()` call races with the in-handler subscriber
+    /// being installed, so a single send is unreliable.
+    async fn drive_ticks_until(
+        registry: AdapterRegistry,
+        endpoint_name: &str,
+        deadline: tokio::time::Instant,
+    ) {
+        let name = endpoint_name.to_string();
+        while tokio::time::Instant::now() < deadline {
+            registry.tick_tools_changed_for_test(&name);
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    // Test-matrix row #16 — in-profile endpoint change is forwarded on
+    // `/mcp/{profile}/sse`. The profile contains "gmail"; ticking "gmail"
+    // produces a `notifications/tools/list_changed` SSE frame.
+    #[tokio::test]
+    async fn mcp_sse_profiled_forwards_in_profile_tools_changed() {
+        let state = test_app_state();
+        install_profile(&state, "work", vec!["gmail".into(), "linear".into()]).await;
+        let registry = state.registry.clone();
+        let resp = open_profile_sse(state, "work").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        let driver = tokio::spawn(async move {
+            drive_ticks_until(registry, "gmail", deadline).await;
+        });
+        let text = read_sse_until(resp, Duration::from_secs(2), |s| {
+            s.contains("notifications/tools/list_changed")
+        })
+        .await;
+        driver.abort();
+        assert!(
+            text.contains("notifications/tools/list_changed"),
+            "expected in-profile tools/list_changed frame (got: {text:?})"
+        );
+    }
+
+    // Test-matrix row #17 — out-of-profile endpoint change is suppressed on
+    // `/mcp/{profile}/sse`. Ticking "todoist" (not in the profile) for the
+    // full window must not produce a `notifications/tools/list_changed`
+    // frame; only the initial `endpoint` event should be visible.
+    #[tokio::test]
+    async fn mcp_sse_profiled_suppresses_out_of_profile_tools_changed() {
+        let state = test_app_state();
+        install_profile(&state, "work", vec!["gmail".into(), "linear".into()]).await;
+        let registry = state.registry.clone();
+        let resp = open_profile_sse(state, "work").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let deadline = tokio::time::Instant::now() + Duration::from_millis(800);
+        let driver = tokio::spawn(async move {
+            drive_ticks_until(registry, "todoist", deadline).await;
+        });
+        let text = read_sse_until(resp, Duration::from_secs(1), |s| {
+            s.contains("notifications/tools/list_changed")
+        })
+        .await;
+        driver.abort();
+        assert!(
+            !text.contains("notifications/tools/list_changed"),
+            "out-of-profile tick must not be forwarded (got: {text:?})"
+        );
+        assert!(
+            text.contains("event: endpoint") && text.contains("data: /mcp/work"),
+            "initial endpoint frame should still be emitted (got: {text:?})"
+        );
+    }
+
+    // Mixed traffic: ticks alternate between in-profile and out-of-profile
+    // endpoints; only the in-profile tick must surface. Guards against an
+    // implementation that filters incorrectly (e.g. forwards everything or
+    // nothing).
+    #[tokio::test]
+    async fn mcp_sse_profiled_only_forwards_in_profile_when_mixed() {
+        let state = test_app_state();
+        install_profile(&state, "work", vec!["gmail".into()]).await;
+        let registry = state.registry.clone();
+        let resp = open_profile_sse(state, "work").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        let driver = tokio::spawn(async move {
+            while tokio::time::Instant::now() < deadline {
+                registry.tick_tools_changed_for_test("todoist");
+                registry.tick_tools_changed_for_test("gmail");
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        });
+        let text = read_sse_until(resp, Duration::from_secs(2), |s| {
+            s.contains("notifications/tools/list_changed")
+        })
+        .await;
+        driver.abort();
+        assert!(
+            text.contains("notifications/tools/list_changed"),
+            "expected at least one in-profile frame from mixed traffic (got: {text:?})"
+        );
+    }
+
+    // Sanity: the global `/mcp/sse` stream is unchanged by R3.D — it still
+    // forwards every tick regardless of the originating endpoint (the
+    // `None`-filter branch of `build_mcp_sse_stream`).
+    #[tokio::test]
+    async fn mcp_sse_global_forwards_every_endpoint_after_r3d() {
+        let state = test_app_state();
+        // No profile installed; the global handler ignores the profile
+        // registry entirely.
+        let registry = state.registry.clone();
+        let resp = open_profile_sse_via_global(state).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        let driver = tokio::spawn(async move {
+            drive_ticks_until(registry, "anything", deadline).await;
+        });
+        let text = read_sse_until(resp, Duration::from_secs(2), |s| {
+            s.contains("notifications/tools/list_changed")
+        })
+        .await;
+        driver.abort();
+        assert!(
+            text.contains("notifications/tools/list_changed"),
+            "global /mcp/sse must forward every tick regardless of endpoint (got: {text:?})"
+        );
+    }
+
+    /// Helper: open the global `/mcp/sse` stream. Kept separate from
+    /// [`open_profile_sse`] so the global regression test reads explicitly.
+    async fn open_profile_sse_via_global(state: AppState) -> axum::response::Response {
+        use axum::body::Body;
+        use tower::ServiceExt;
+        let router = build_router(state);
+        let request = axum::http::Request::builder()
+            .method("GET")
+            .uri("/mcp/sse")
+            .header("accept", "text/event-stream")
+            .body(Body::empty())
+            .unwrap();
+        router.oneshot(request).await.unwrap()
+    }
+
+    // R3.E — `profile` field in tracing spans. Nested under `tracing::profile`
+    // so `cargo test tracing::profile` (the verification command on the task
+    // note) selects exactly these cases. The inner module names intentionally
+    // shadow the `tracing` extern crate within this scope; tests reference it
+    // via the absolute path `::tracing::` to disambiguate.
+    mod tracing {
+        mod profile {
+            use super::super::*;
+            use ::tracing_subscriber::fmt::MakeWriter;
+            use std::io;
+            use std::sync::{Arc, Mutex};
+
+            /// In-memory `MakeWriter` so the test can read back every byte the
+            /// `fmt` subscriber emitted. Mirrors the buffered-writer pattern
+            /// already used in `watcher.rs::adapter_init_warns_...`.
+            #[derive(Clone, Default)]
+            struct BufWriter(Arc<Mutex<Vec<u8>>>);
+            impl io::Write for BufWriter {
+                fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                    self.0.lock().unwrap().extend_from_slice(buf);
+                    Ok(buf.len())
+                }
+                fn flush(&mut self) -> io::Result<()> {
+                    Ok(())
+                }
+            }
+            impl<'a> MakeWriter<'a> for BufWriter {
+                type Writer = BufWriter;
+                fn make_writer(&'a self) -> Self::Writer {
+                    self.clone()
+                }
+            }
+
+            /// Drain the buffer into a UTF-8 string.
+            fn captured(buf: &BufWriter) -> String {
+                String::from_utf8(buf.0.lock().unwrap().clone()).unwrap()
+            }
+
+            // Matrix #22 — profile-scoped POST emits at least one log line
+            // bearing `profile=<path>`. The `MCP request` line lives inside
+            // `handle_single_message`'s `request` span, which is itself a
+            // child of `mcp_request{profile=...}` thanks to the `.instrument`
+            // wrap on `mcp_unified_profiled`. With span-field propagation the
+            // child event's formatted output carries the parent's `profile`
+            // field.
+            #[tokio::test(flavor = "current_thread")]
+            async fn field_present_on_profiled_request() {
+                let buf = BufWriter::default();
+                let subscriber = ::tracing_subscriber::fmt()
+                    .with_writer(buf.clone())
+                    .with_max_level(::tracing::Level::INFO)
+                    .with_ansi(false)
+                    .finish();
+                let _guard = ::tracing::subscriber::set_default(subscriber);
+
+                let state = test_app_state();
+                install_profile(&state, "work", vec!["gmail".into()]).await;
+                let resp = send_profile_request(
+                    state,
+                    "POST",
+                    "/mcp/work",
+                    Some(&json!({"jsonrpc":"2.0","method":"initialize","id":1})),
+                )
+                .await;
+                assert_eq!(resp.status(), StatusCode::OK);
+                // Drain the body so the handler future fully completes before
+                // we read the captured logs.
+                let _ = body_json(resp).await;
+
+                let text = captured(&buf);
+                assert!(
+                    text.contains("profile=work"),
+                    "expected `profile=work` in tracing output for /mcp/work; got: {text:?}"
+                );
+                assert!(
+                    text.contains("MCP request"),
+                    "expected the inner `MCP request` log line to appear; got: {text:?}"
+                );
+            }
+
+            // Counterpart to the matrix #22 row: the global `/mcp` route MUST
+            // NOT add a `profile` field. Locked decision Cross-stack #1 makes
+            // the field key `profile=` an immutable contract, so any
+            // accidental insertion (e.g. a stray default span) would break
+            // the desktop log filter's per-profile dropdown.
+            #[tokio::test(flavor = "current_thread")]
+            async fn field_absent_on_global_request() {
+                let buf = BufWriter::default();
+                let subscriber = ::tracing_subscriber::fmt()
+                    .with_writer(buf.clone())
+                    .with_max_level(::tracing::Level::INFO)
+                    .with_ansi(false)
+                    .finish();
+                let _guard = ::tracing::subscriber::set_default(subscriber);
+
+                let state = test_app_state();
+                let resp = post_mcp(
+                    state,
+                    &json!({"jsonrpc":"2.0","method":"initialize","id":1}),
+                )
+                .await;
+                assert_eq!(resp.status(), StatusCode::OK);
+                let _ = body_json(resp).await;
+
+                let text = captured(&buf);
+                assert!(
+                    text.contains("MCP request"),
+                    "expected the global `MCP request` log line to appear; got: {text:?}"
+                );
+                assert!(
+                    !text.contains("profile="),
+                    "global /mcp must not introduce a `profile` field; got: {text:?}"
+                );
+            }
+        }
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -216,14 +216,25 @@ async fn meta_tool_definitions(
 /// `/mcp/{profile}` route so meta-tool descriptions advertise only the
 /// profile's server types. `None` for the global `/mcp` path. R3.A owns
 /// the catalog filtering itself (line 199 below).
+///
+/// Per-profile `js_execution` and `toon_output` (R3.B) override the global
+/// [`AppState::js_execution_mode`] and [`AppState::toon_enabled`] toggles
+/// whenever `profile_ctx` is `Some`. `ProfileContext` already pre-resolves
+/// the `Inherit | On | Off` semantics (`None` falls back to the global flag
+/// at rebuild time), so the gate sites just read the resolved `bool`.
 async fn mcp_tools_list(
     State(state): State<AppState>,
     Json(body): Json<JsonRpcBody>,
     profile_ctx: Option<&ProfileContext>,
 ) -> Json<Value> {
-    let js_mode = state.js_execution_mode.load(Ordering::Relaxed);
+    let js_mode = profile_ctx
+        .map(|c| c.js_execution)
+        .unwrap_or_else(|| state.js_execution_mode.load(Ordering::Relaxed));
+    let toon_enabled = profile_ctx
+        .map(|c| c.toon_output)
+        .unwrap_or(state.toon_enabled);
     let meta_tools =
-        meta_tool_definitions(js_mode, &state.registry, state.toon_enabled, profile_ctx).await;
+        meta_tool_definitions(js_mode, &state.registry, toon_enabled, profile_ctx).await;
 
     let tools: Vec<Value> = if js_mode {
         // JS execution mode: only the 3 meta-tools (incl. execute_tools)
@@ -262,9 +273,18 @@ async fn mcp_tools_list(
 }
 
 /// POST /mcp/tools/call
+///
+/// `profile_ctx` is `Some` for the wildcard `/mcp/{profile}` route and
+/// `None` for the global `/mcp` (and legacy `/mcp/tools/call`) path. When
+/// present, per-profile `js_execution` and `toon_output` (R3.B) override
+/// the global [`AppState::js_execution_mode`] / [`AppState::toon_enabled`]
+/// toggles, and the per-profile [`MetaToolHandler`] handles the meta-tool
+/// dispatch so list/search/execute see only the profile's allowed
+/// endpoints.
 async fn mcp_tools_call(
     State(state): State<AppState>,
     Json(body): Json<JsonRpcBody>,
+    profile_ctx: Option<&ProfileContext>,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
     let params = body.params.unwrap_or(json!({}));
     let tool_name = params
@@ -273,7 +293,19 @@ async fn mcp_tools_call(
         .ok_or_else(|| jsonrpc_error(body.id.clone(), -32602, "missing 'name' in params"))?;
     let arguments = params.get("arguments").cloned().unwrap_or(json!({}));
 
-    let js_mode = state.js_execution_mode.load(Ordering::Relaxed);
+    let js_mode = profile_ctx
+        .map(|c| c.js_execution)
+        .unwrap_or_else(|| state.js_execution_mode.load(Ordering::Relaxed));
+    let toon_enabled = profile_ctx
+        .map(|c| c.toon_output)
+        .unwrap_or(state.toon_enabled);
+    // `ProfileContext::meta_tool_handler` is populated by `ProfileRegistry::rebuild`
+    // (R3.A) over the profile's [`ProfileRegistryView`] — using it here keeps
+    // list/search/execute scoped to the profile's allowed endpoints. The global
+    // handler is the fallback for `/mcp` and the legacy `/mcp/tools/call`.
+    let handler: &MetaToolHandler = profile_ctx
+        .and_then(|c| c.meta_tool_handler.as_deref())
+        .unwrap_or(&state.meta_tool_handler);
 
     // Check if this is a meta-tool call
     match tool_name {
@@ -286,11 +318,11 @@ async fn mcp_tools_call(
                 .get("offset")
                 .and_then(|v| v.as_u64())
                 .map(|v| v as usize);
-            match state.meta_tool_handler.list_tools(limit, offset).await {
+            match handler.list_tools(limit, offset).await {
                 Ok(result) => {
                     return Ok(jsonrpc_response(
                         body.id,
-                        wrap_meta_tool_result(result, state.toon_enabled),
+                        wrap_meta_tool_result(result, toon_enabled),
                     ))
                 }
                 Err(e) => return Err(jsonrpc_error(body.id, -32603, &e.to_string())),
@@ -305,11 +337,11 @@ async fn mcp_tools_call(
                 .get("limit")
                 .and_then(|v| v.as_u64())
                 .map(|v| v as usize);
-            match state.meta_tool_handler.search_tools(query, limit).await {
+            match handler.search_tools(query, limit).await {
                 Ok(result) => {
                     return Ok(jsonrpc_response(
                         body.id,
-                        wrap_meta_tool_result(result, state.toon_enabled),
+                        wrap_meta_tool_result(result, toon_enabled),
                     ))
                 }
                 Err(e) => return Err(jsonrpc_error(body.id, -32603, &e.to_string())),
@@ -331,11 +363,11 @@ async fn mcp_tools_call(
                 .get("script")
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
-            match state.meta_tool_handler.execute_tools(script).await {
+            match handler.execute_tools(script).await {
                 Ok(result) => {
                     return Ok(jsonrpc_response(
                         body.id,
-                        wrap_meta_tool_result(result, state.toon_enabled),
+                        wrap_meta_tool_result(result, toon_enabled),
                     ))
                 }
                 Err(e) => return Err(jsonrpc_error(body.id, -32603, &e.to_string())),
@@ -353,9 +385,17 @@ async fn mcp_tools_call(
         ));
     }
 
-    match state.registry.route_tool_call(tool_name, arguments).await {
+    let route_result = match profile_ctx {
+        Some(ctx) => {
+            ctx.registry_view
+                .route_tool_call(tool_name, arguments)
+                .await
+        }
+        None => state.registry.route_tool_call(tool_name, arguments).await,
+    };
+    match route_result {
         Ok(result) => {
-            let result = if state.toon_enabled {
+            let result = if toon_enabled {
                 crate::toon_convert::toonify_call_result(result)
             } else {
                 result
@@ -426,7 +466,7 @@ async fn handle_single_message(
         let result: Result<Json<Value>, (StatusCode, Json<Value>)> = match method.as_str() {
             "initialize" => Ok(mcp_initialize(State(state.clone()), Json(body), profile_ctx).await),
             "tools/list" => Ok(mcp_tools_list(State(state.clone()), Json(body), profile_ctx).await),
-            "tools/call" => mcp_tools_call(State(state.clone()), Json(body)).await,
+            "tools/call" => mcp_tools_call(State(state.clone()), Json(body), profile_ctx).await,
             _ => Err(jsonrpc_error(
                 body.id,
                 -32601,
@@ -1085,7 +1125,7 @@ async fn mcp_tools_call_logged(
     async move {
         let start = Instant::now();
         let req_bytes = serde_json::to_string(&body.0).map(|s| s.len()).unwrap_or(0);
-        let result = mcp_tools_call(state, body).await;
+        let result = mcp_tools_call(state, body, None).await;
         let elapsed_ms = start.elapsed().as_millis() as u64;
         match &result {
             Ok(Json(resp)) => {
@@ -1645,7 +1685,7 @@ mod tests {
             params: Some(json!({"name": "list_tools", "arguments": {}})),
             id: Some(json!(1)),
         };
-        let result = mcp_tools_call(State(state.clone()), Json(body)).await;
+        let result = mcp_tools_call(State(state.clone()), Json(body), None).await;
         let Json(resp) = result.unwrap();
         let content = resp["result"]["content"]
             .as_array()
@@ -1663,7 +1703,7 @@ mod tests {
             params: Some(json!({"name": "search_tools", "arguments": {"query": "test"}})),
             id: Some(json!(2)),
         };
-        let result = mcp_tools_call(State(state.clone()), Json(body)).await;
+        let result = mcp_tools_call(State(state.clone()), Json(body), None).await;
         let Json(resp) = result.unwrap();
         let content = resp["result"]["content"]
             .as_array()
@@ -1679,7 +1719,7 @@ mod tests {
             params: Some(json!({"name": "execute_tools", "arguments": {"script": ""}})),
             id: Some(json!(3)),
         };
-        let result = mcp_tools_call(State(state), Json(body)).await;
+        let result = mcp_tools_call(State(state), Json(body), None).await;
         // execute_tools with empty script may error — either way, check the shape
         match result {
             Ok(Json(resp)) => {
@@ -1705,7 +1745,9 @@ mod tests {
             params: Some(json!({"name": "list_tools", "arguments": {}})),
             id: Some(json!(1)),
         };
-        let Json(resp) = mcp_tools_call(State(state), Json(body)).await.unwrap();
+        let Json(resp) = mcp_tools_call(State(state), Json(body), None)
+            .await
+            .unwrap();
         let text = resp["result"]["content"][0]["text"].as_str().unwrap();
         // TOON output for the `{ tools, total, limit, offset }` envelope is
         // never valid JSON — it starts with field declarations, not `{`.
@@ -1737,7 +1779,9 @@ mod tests {
             })),
             id: Some(json!(2)),
         };
-        let Json(resp) = mcp_tools_call(State(state), Json(body)).await.unwrap();
+        let Json(resp) = mcp_tools_call(State(state), Json(body), None)
+            .await
+            .unwrap();
         let text = resp["result"]["content"][0]["text"].as_str().unwrap();
         assert!(
             serde_json::from_str::<Value>(text).is_err(),
@@ -1761,7 +1805,9 @@ mod tests {
             params: Some(json!({"name": "list_tools", "arguments": {}})),
             id: Some(json!(1)),
         };
-        let Json(resp) = mcp_tools_call(State(state), Json(body)).await.unwrap();
+        let Json(resp) = mcp_tools_call(State(state), Json(body), None)
+            .await
+            .unwrap();
         let text = resp["result"]["content"][0]["text"].as_str().unwrap();
         let parsed: Value = serde_json::from_str(text).expect("JSON when toon disabled");
         assert!(parsed["tools"].is_array());
@@ -2793,20 +2839,37 @@ mod tests {
     /// `path` and whose endpoint set is `endpoints`. JS execution and TOON
     /// inherit from the relay defaults (off / on).
     async fn install_profile(state: &AppState, path: &str, endpoints: Vec<String>) {
+        install_profile_with_flags(state, path, endpoints, None, None, None, None).await;
+    }
+
+    /// Variant of [`install_profile`] that takes explicit `js_execution` /
+    /// `toon_output` overrides for both the relay defaults and the profile
+    /// itself. `None` on a profile field means "Inherit" — the resolved
+    /// `ProfileContext::js_execution` / `toon_output` then falls back to the
+    /// matching relay default (also passed in as `Option`).
+    async fn install_profile_with_flags(
+        state: &AppState,
+        path: &str,
+        endpoints: Vec<String>,
+        relay_js: Option<bool>,
+        relay_toon: Option<bool>,
+        profile_js: Option<bool>,
+        profile_toon: Option<bool>,
+    ) {
         let relay = crate::config::RelayConfig {
             machine_name: "test".into(),
-            local_js_execution: None,
+            local_js_execution: relay_js,
             token_dir: None,
             allow_insecure_oauth: None,
-            toon_output: None,
+            toon_output: relay_toon,
             startup_init_timeout_secs: None,
         };
         let profile = crate::config::ProfileConfig {
             name: path.to_string(),
             path: path.to_string(),
             endpoints,
-            js_execution: None,
-            toon_output: None,
+            js_execution: profile_js,
+            toon_output: profile_toon,
         };
         state.profile_registry.rebuild(&[profile], &relay).await;
     }
@@ -2989,7 +3052,20 @@ mod tests {
                 Some("github".into()),
             )
             .await;
-        install_profile(&state, "work", vec!["gmail".into()]).await;
+        // R3.B: `ProfileContext::js_execution` is resolved at rebuild time
+        // from the relay config, not from the runtime atomic. Set the
+        // relay default to `Some(true)` so the profile inherits JS-on and
+        // advertises `execute_tools` in the catalog.
+        install_profile_with_flags(
+            &state,
+            "work",
+            vec!["gmail".into()],
+            Some(true),
+            None,
+            None,
+            None,
+        )
+        .await;
         let profile_ctx = state.profile_registry.get("work").await.unwrap();
 
         let body = JsonRpcBody {
@@ -3019,6 +3095,146 @@ mod tests {
             exec_desc.ends_with(" 1 servers connected via Endara Relay \u{2014} use search_tools to discover tools."),
             "execute_tools description must reflect profile's 1 endpoint: {exec_desc}"
         );
+    }
+
+    // Test-matrix row #12 — per-profile `toon_output = true` produces a
+    // TOON-encoded `list_tools` response even when the relay default
+    // (`relay.toon_output`) is off. Exercises the profile override path in
+    // `mcp_tools_call`.
+    #[tokio::test]
+    async fn profile_toon_on_encodes_toon_when_global_off() {
+        let state = test_app_state();
+        assert!(
+            !state.toon_enabled,
+            "test relies on global toon default being off"
+        );
+        install_profile_with_flags(&state, "work", vec![], None, Some(false), None, Some(true))
+            .await;
+        let resp = send_profile_request(
+            state,
+            "POST",
+            "/mcp/work",
+            Some(&json!({
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "list_tools", "arguments": {}},
+                "id": 1
+            })),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let text = body["result"]["content"][0]["text"].as_str().unwrap();
+        // TOON output for the `{ tools, total, limit, offset }` envelope is
+        // never valid JSON — it starts with field declarations, not `{`.
+        assert!(
+            serde_json::from_str::<Value>(text).is_err(),
+            "profile toon=on must yield TOON text, got JSON-parseable: {text}"
+        );
+        assert!(
+            text.contains("total:"),
+            "expected TOON field syntax in: {text}"
+        );
+    }
+
+    // Test-matrix row #13 — per-profile `toon_output = false` keeps the
+    // `list_tools` response as raw JSON even when the relay default
+    // (`relay.toon_output`) is on. Mirror of #12 for the override-off path.
+    #[tokio::test]
+    async fn profile_toon_off_keeps_json_when_global_on() {
+        let state = test_app_state();
+        install_profile_with_flags(&state, "work", vec![], None, Some(true), None, Some(false))
+            .await;
+        // Sanity: the global default the profile is overriding is actually on.
+        let global_ctx = state.profile_registry.get("work").await.unwrap();
+        assert!(!global_ctx.toon_output, "profile override must be off");
+        let resp = send_profile_request(
+            state,
+            "POST",
+            "/mcp/work",
+            Some(&json!({
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "list_tools", "arguments": {}},
+                "id": 1
+            })),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let text = body["result"]["content"][0]["text"].as_str().unwrap();
+        let parsed: Value =
+            serde_json::from_str(text).expect("profile toon=off must yield JSON text");
+        assert!(
+            parsed["tools"].is_array(),
+            "expected `tools` array in JSON: {text}"
+        );
+    }
+
+    // R3.B — per-profile `js_execution = true` enables `execute_tools` and
+    // gates direct tool calls even when the relay default
+    // (`relay.local_js_execution`) is off. The `tools/call` for an unknown
+    // direct tool must surface the JS-mode rejection error, not the
+    // generic "unknown tool" path.
+    #[tokio::test]
+    async fn profile_js_on_rejects_direct_tool_calls_when_global_off() {
+        let state = test_app_state();
+        assert!(
+            !state.js_execution_mode.load(Ordering::Relaxed),
+            "test relies on global JS default being off"
+        );
+        install_profile_with_flags(&state, "work", vec![], Some(false), None, Some(true), None)
+            .await;
+        let resp = send_profile_request(
+            state,
+            "POST",
+            "/mcp/work",
+            Some(&json!({
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "anything", "arguments": {}},
+                "id": 1
+            })),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let msg = body["error"]["message"].as_str().unwrap_or("");
+        assert!(
+            msg.contains("JS execution mode"),
+            "expected JS-mode rejection, got: {body}"
+        );
+    }
+
+    // R3.B — per-profile `js_execution = false` hides `execute_tools` from
+    // the catalog even when the relay default (`relay.local_js_execution`)
+    // is on. Symmetric to the override-on test above.
+    #[tokio::test]
+    async fn profile_js_off_hides_execute_tools_when_global_on() {
+        let state = test_app_state();
+        install_profile_with_flags(&state, "work", vec![], Some(true), None, Some(false), None)
+            .await;
+        let resp = send_profile_request(
+            state,
+            "POST",
+            "/mcp/work",
+            Some(&json!({
+                "jsonrpc": "2.0",
+                "method": "tools/list",
+                "id": 1
+            })),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let tools = body["result"]["tools"].as_array().unwrap();
+        assert!(
+            tools.iter().all(|t| t["name"] != "execute_tools"),
+            "execute_tools must be hidden when profile js=off, got: {tools:?}"
+        );
+        // The non-JS meta-tools are still advertised.
+        assert!(tools.iter().any(|t| t["name"] == "list_tools"));
+        assert!(tools.iter().any(|t| t["name"] == "search_tools"));
     }
 
     // Profile path lookup is case-insensitive (R2.A: registry lowercases keys).

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -201,10 +201,7 @@ async fn reload_and_apply(
     // write-lock swap so requests in flight see either the old or the new
     // map atomically.
     profile_registry
-        .rebuild(
-            new_config.profiles.as_deref().unwrap_or(&[]),
-            &new_config.relay,
-        )
+        .rebuild(new_config.profiles.as_deref().unwrap_or(&[]))
         .await;
 
     // Update baseline.
@@ -1767,7 +1764,7 @@ mod tests {
                 // Mirror main.rs: rebuild once at startup against the initial
                 // config so the watcher's first reload sees a populated map.
                 profile_registry
-                    .rebuild(initial.profiles.as_deref().unwrap_or(&[]), &initial.relay)
+                    .rebuild(initial.profiles.as_deref().unwrap_or(&[]))
                     .await;
 
                 let current_config = Arc::new(Mutex::new(initial));
@@ -1808,6 +1805,8 @@ command = "/bin/true"
 name = "Work"
 path = "work"
 endpoints = ["ep1"]
+js_execution = false
+toon_output = true
 "#;
 
             /// Matrix #18: adding a `[[profiles]]` block to `config.toml`
@@ -1914,6 +1913,8 @@ command = "/bin/true"
 name = "Broken"
 path = "broken"
 endpoints = ["does-not-exist"]
+js_execution = false
+toon_output = true
 "#;
                 std::fs::write(&path, invalid).unwrap();
 

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -3,14 +3,15 @@ use crate::adapter::oauth::{OAuthAdapter, OAuthAdapterConfig};
 use crate::adapter::sse::{SseAdapter, SseConfig};
 use crate::adapter::stdio::{StdioAdapter, StdioConfig};
 use crate::adapter::{FailedAdapter, McpAdapter, StartingAdapter};
-use crate::config::{self, ConfigDiff, EndpointConfig, Transport};
+use crate::config::{self, Config, ConfigDiff, EndpointConfig, Transport};
 use crate::oauth::OAuthFlowManager;
+use crate::profile_registry::ProfileRegistry;
 use crate::registry::AdapterRegistry;
 use crate::token_manager::TokenManager;
 use crate::OAuthAdapterInners;
 use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -29,11 +30,13 @@ impl ConfigWatcher {
     /// registry (adding/removing/restarting adapters as needed).
     ///
     /// Returns a `JoinHandle` for the background task.
+    #[allow(clippy::too_many_arguments)]
     pub fn start(
         config_path: PathBuf,
         registry: Arc<AdapterRegistry>,
         machine_name: String,
         js_execution_mode: Arc<AtomicBool>,
+        profile_registry: Arc<ProfileRegistry>,
         token_manager: Arc<TokenManager>,
         _oauth_flow_manager: Arc<OAuthFlowManager>,
         oauth_adapter_inners: OAuthAdapterInners,
@@ -44,6 +47,7 @@ impl ConfigWatcher {
                 registry,
                 machine_name,
                 js_execution_mode,
+                profile_registry,
                 token_manager,
                 oauth_adapter_inners,
             )
@@ -60,6 +64,7 @@ async fn watch_loop(
     registry: Arc<AdapterRegistry>,
     _machine_name: String,
     js_execution_mode: Arc<AtomicBool>,
+    profile_registry: Arc<ProfileRegistry>,
     token_manager: Arc<TokenManager>,
     oauth_adapter_inners: OAuthAdapterInners,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -112,49 +117,98 @@ async fn watch_loop(
 
         info!(path = %config_path.display(), "Config file change detected, reloading");
 
-        // Parse new config gracefully
-        let (new_config, warnings) = match config::load_config_graceful(&config_path) {
-            Ok(result) => result,
-            Err(e) => {
-                warn!(error = %e, "Failed to parse updated config, keeping current config");
-                continue;
-            }
-        };
-
-        for w in &warnings {
-            warn!("{}", w);
-        }
-
-        let warned_names = config::warned_endpoint_names(&warnings);
-
-        // Diff and apply
-        let old_config = current_config.lock().await;
-        let diff = config::diff_configs(&old_config, &new_config);
-        drop(old_config);
-
-        apply_diff_graceful(
-            &diff,
+        let _ = reload_and_apply(
+            &config_path,
+            &current_config,
             &registry,
-            &warnings,
-            &warned_names,
+            &js_execution_mode,
+            &profile_registry,
             &token_manager,
             &oauth_adapter_inners,
-            new_config.relay.allow_insecure_oauth.unwrap_or(false),
+        )
+        .await;
+    }
+
+    Ok(())
+}
+
+/// Reload `config_path` from disk and reconcile it into the running relay.
+///
+/// Performs **keep-last-good** semantics: if the file fails to parse OR fails
+/// fail-fast profile validation (`[[profiles]]` block — see
+/// [`config::validate_profiles`]), the previous registry state is preserved
+/// untouched and an `Err` is returned with the parse/validation error logged.
+/// Per-endpoint validation failures are surfaced as warnings (FailedAdapter
+/// registrations) rather than aborting the reload, matching the pre-existing
+/// hot-reload behaviour.
+///
+/// Returns `Ok(())` when the reload was applied (including warning-only
+/// reloads); returns `Err(ConfigError)` when nothing was applied because the
+/// new config could not be parsed or its profile block was invalid.
+async fn reload_and_apply(
+    config_path: &Path,
+    current_config: &Arc<Mutex<Config>>,
+    registry: &Arc<AdapterRegistry>,
+    js_execution_mode: &Arc<AtomicBool>,
+    profile_registry: &Arc<ProfileRegistry>,
+    token_manager: &Arc<TokenManager>,
+    oauth_adapter_inners: &OAuthAdapterInners,
+) -> Result<(), config::ConfigError> {
+    // Parse new config gracefully. Fatal errors (parse failure or
+    // fail-fast profile-validation failure) bail out without touching the
+    // running registry — that is the keep-last-good guarantee.
+    let (new_config, warnings) = match config::load_config_graceful(config_path) {
+        Ok(result) => result,
+        Err(e) => {
+            warn!(error = %e, "Failed to parse updated config, keeping current config");
+            return Err(e);
+        }
+    };
+
+    for w in &warnings {
+        warn!("{}", w);
+    }
+
+    let warned_names = config::warned_endpoint_names(&warnings);
+
+    // Diff and apply endpoint changes.
+    let old_config = current_config.lock().await;
+    let diff = config::diff_configs(&old_config, &new_config);
+    drop(old_config);
+
+    apply_diff_graceful(
+        &diff,
+        registry,
+        &warnings,
+        &warned_names,
+        token_manager,
+        oauth_adapter_inners,
+        new_config.relay.allow_insecure_oauth.unwrap_or(false),
+    )
+    .await;
+
+    // Update JS execution mode flag if it changed.
+    let new_js_mode = new_config.relay.local_js_execution.unwrap_or(false);
+    let old_js_mode = js_execution_mode.load(Ordering::Relaxed);
+    if new_js_mode != old_js_mode {
+        js_execution_mode.store(new_js_mode, Ordering::Relaxed);
+        info!(js_execution_mode = new_js_mode, "JS execution mode updated");
+    }
+
+    // Rebuild the profile registry from the reloaded config. Per recon §D4
+    // the watcher is the source of truth for profile state, mirroring how
+    // `js_execution_mode` is propagated above. `rebuild` performs a single
+    // write-lock swap so requests in flight see either the old or the new
+    // map atomically.
+    profile_registry
+        .rebuild(
+            new_config.profiles.as_deref().unwrap_or(&[]),
+            &new_config.relay,
         )
         .await;
 
-        // Update JS execution mode flag if it changed
-        let new_js_mode = new_config.relay.local_js_execution.unwrap_or(false);
-        let old_js_mode = js_execution_mode.load(Ordering::Relaxed);
-        if new_js_mode != old_js_mode {
-            js_execution_mode.store(new_js_mode, Ordering::Relaxed);
-            info!(js_execution_mode = new_js_mode, "JS execution mode updated");
-        }
-
-        // Update baseline
-        *current_config.lock().await = new_config;
-    }
-
+    // Update baseline.
+    *current_config.lock().await = new_config;
     Ok(())
 }
 
@@ -1671,5 +1725,236 @@ mod tests {
         let ep = oauth_endpoint_with("ep", None, None);
         let resolved = resolve_oauth_token_endpoint(&ep, false).await;
         assert_eq!(resolved, "/token");
+    }
+
+    // ---- R4.B: hot reload of ProfileRegistry ----------------------------
+    //
+    // The matrix rows under §11 (#18 add, #19 remove, #20 invalid keep-last-
+    // good) are exercised by `reload_and_apply`: it is the extracted body of
+    // the watcher loop, so driving it directly with on-disk config files
+    // mirrors the watcher tick without the filesystem-event timing flakiness.
+    mod hot_reload {
+        mod profile {
+            use super::super::*;
+            use crate::config::Config;
+            use crate::profile_registry::ProfileRegistry;
+            use std::path::PathBuf;
+            use std::sync::atomic::AtomicBool;
+            use std::sync::Arc;
+            use tokio::sync::Mutex;
+
+            /// Build the initial in-memory state the watcher would have after
+            /// loading `config.toml` for the first time at startup.
+            async fn setup_initial(
+                initial_toml: &str,
+            ) -> (
+                tempfile::TempDir,
+                PathBuf,
+                Arc<Mutex<Config>>,
+                Arc<AdapterRegistry>,
+                Arc<ProfileRegistry>,
+                Arc<AtomicBool>,
+                Arc<TokenManager>,
+                OAuthAdapterInners,
+            ) {
+                let tmp = tempfile::tempdir().unwrap();
+                let path = tmp.path().join("config.toml");
+                std::fs::write(&path, initial_toml).unwrap();
+                let (initial, _warnings) = config::load_config_graceful(&path).unwrap();
+
+                let registry = Arc::new(AdapterRegistry::new());
+                let profile_registry = Arc::new(ProfileRegistry::new((*registry).clone()));
+                // Mirror main.rs: rebuild once at startup against the initial
+                // config so the watcher's first reload sees a populated map.
+                profile_registry
+                    .rebuild(initial.profiles.as_deref().unwrap_or(&[]), &initial.relay)
+                    .await;
+
+                let current_config = Arc::new(Mutex::new(initial));
+                let js_mode = Arc::new(AtomicBool::new(false));
+                let (token_manager, inners) = test_oauth_infra();
+                (
+                    tmp,
+                    path,
+                    current_config,
+                    registry,
+                    profile_registry,
+                    js_mode,
+                    token_manager,
+                    inners,
+                )
+            }
+
+            const CONFIG_NO_PROFILES: &str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "ep1"
+transport = "stdio"
+command = "/bin/true"
+"#;
+
+            const CONFIG_ONE_PROFILE: &str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "ep1"
+transport = "stdio"
+command = "/bin/true"
+
+[[profiles]]
+name = "Work"
+path = "work"
+endpoints = ["ep1"]
+"#;
+
+            /// Matrix #18: adding a `[[profiles]]` block to `config.toml`
+            /// makes the new profile discoverable on the next watcher tick.
+            #[tokio::test]
+            async fn add_profile_appears_in_registry_after_reload() {
+                let (_tmp, path, current_config, registry, profile_registry, js_mode, tm, inners) =
+                    setup_initial(CONFIG_NO_PROFILES).await;
+
+                assert!(profile_registry.get("work").await.is_none());
+
+                std::fs::write(&path, CONFIG_ONE_PROFILE).unwrap();
+                reload_and_apply(
+                    &path,
+                    &current_config,
+                    &registry,
+                    &js_mode,
+                    &profile_registry,
+                    &tm,
+                    &inners,
+                )
+                .await
+                .expect("reload should succeed");
+
+                let ctx = profile_registry
+                    .get("work")
+                    .await
+                    .expect("profile 'work' should be served after reload");
+                assert_eq!(ctx.config.name, "Work");
+                assert_eq!(ctx.config.endpoints, vec!["ep1".to_string()]);
+                assert_eq!(
+                    current_config
+                        .lock()
+                        .await
+                        .profiles
+                        .as_deref()
+                        .unwrap()
+                        .len(),
+                    1
+                );
+            }
+
+            /// Matrix #19: removing a `[[profiles]]` block from
+            /// `config.toml` makes the prior profile vanish from the
+            /// registry on the next watcher tick (its `/mcp/{path}` route
+            /// then 404s via `ProfileRegistry::get` returning `None`).
+            #[tokio::test]
+            async fn remove_profile_disappears_from_registry_after_reload() {
+                let (_tmp, path, current_config, registry, profile_registry, js_mode, tm, inners) =
+                    setup_initial(CONFIG_ONE_PROFILE).await;
+
+                assert!(profile_registry.get("work").await.is_some());
+
+                std::fs::write(&path, CONFIG_NO_PROFILES).unwrap();
+                reload_and_apply(
+                    &path,
+                    &current_config,
+                    &registry,
+                    &js_mode,
+                    &profile_registry,
+                    &tm,
+                    &inners,
+                )
+                .await
+                .expect("reload should succeed");
+
+                assert!(
+                    profile_registry.get("work").await.is_none(),
+                    "removed profile must no longer be served"
+                );
+                assert!(profile_registry.list().await.is_empty());
+            }
+
+            /// Matrix #20: an updated `config.toml` whose `[[profiles]]`
+            /// block fails fail-fast validation (here: references an
+            /// undeclared endpoint) is rejected. `reload_and_apply` returns
+            /// `Err` and the previously-served profile registry is kept
+            /// intact — keep-last-good semantics per spec §11.
+            #[tokio::test]
+            async fn invalid_profile_reload_keeps_last_good_registry() {
+                let (_tmp, path, current_config, registry, profile_registry, js_mode, tm, inners) =
+                    setup_initial(CONFIG_ONE_PROFILE).await;
+
+                let good_before = profile_registry
+                    .get("work")
+                    .await
+                    .expect("baseline profile must be served");
+                assert_eq!(good_before.config.endpoints, vec!["ep1".to_string()]);
+
+                // New config references an endpoint that does not exist —
+                // `validate_profiles` returns a ValidationError, so
+                // `load_config_graceful` (and therefore `reload_and_apply`)
+                // bails out without touching the registry.
+                let invalid = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "ep1"
+transport = "stdio"
+command = "/bin/true"
+
+[[profiles]]
+name = "Broken"
+path = "broken"
+endpoints = ["does-not-exist"]
+"#;
+                std::fs::write(&path, invalid).unwrap();
+
+                let err = reload_and_apply(
+                    &path,
+                    &current_config,
+                    &registry,
+                    &js_mode,
+                    &profile_registry,
+                    &tm,
+                    &inners,
+                )
+                .await
+                .expect_err("invalid profile config must be rejected");
+                assert!(
+                    matches!(err, config::ConfigError::ValidationError(_)),
+                    "expected ValidationError, got {err:?}"
+                );
+
+                // The previously-served profile is still reachable, the
+                // broken one was never installed, and the baseline config
+                // snapshot was not advanced.
+                let good_after = profile_registry
+                    .get("work")
+                    .await
+                    .expect("last-good profile must remain after failed reload");
+                assert_eq!(good_after.config.endpoints, vec!["ep1".to_string()]);
+                assert!(
+                    profile_registry.get("broken").await.is_none(),
+                    "broken profile must never be installed"
+                );
+                let baseline = current_config.lock().await;
+                let baseline_names: Vec<String> = baseline
+                    .profiles
+                    .as_deref()
+                    .unwrap_or(&[])
+                    .iter()
+                    .map(|p| p.name.clone())
+                    .collect();
+                assert_eq!(baseline_names, vec!["Work".to_string()]);
+            }
+        }
     }
 }

--- a/tests/health_endpoint_integration.rs
+++ b/tests/health_endpoint_integration.rs
@@ -5,6 +5,7 @@
 //! `uptime_secs` fields, and that the `Content-Type` is JSON.
 
 use endara_relay::js_sandbox::MetaToolHandler;
+use endara_relay::profile_registry::ProfileRegistry;
 use endara_relay::registry::AdapterRegistry;
 use endara_relay::server::{build_router, start_server, AppState};
 use std::net::SocketAddr;
@@ -19,6 +20,7 @@ async fn setup_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
         registry: registry.clone(),
         js_execution_mode: Arc::new(AtomicBool::new(false)),
         meta_tool_handler: Arc::new(MetaToolHandler::new(registry_arc, Duration::from_secs(30))),
+        profile_registry: Arc::new(ProfileRegistry::new(registry.clone())),
         oauth_flow_manager: None,
         token_manager: None,
         oauth_adapter_inners: None,

--- a/tests/hot_reload_integration.rs
+++ b/tests/hot_reload_integration.rs
@@ -82,6 +82,7 @@ async fn test_config_diff_add_endpoint() {
             token_endpoint: None,
             server_type_override: None,
         }],
+        profiles: None,
     };
 
     let new_config = config::Config {
@@ -133,6 +134,7 @@ async fn test_config_diff_add_endpoint() {
                 server_type_override: None,
             },
         ],
+        profiles: None,
     };
 
     let diff = config::diff_configs(&old_config, &new_config);
@@ -262,6 +264,7 @@ async fn test_config_diff_remove_endpoint() {
                 server_type_override: None,
             },
         ],
+        profiles: None,
     };
 
     let new_config = config::Config {
@@ -292,6 +295,7 @@ async fn test_config_diff_remove_endpoint() {
             token_endpoint: None,
             server_type_override: None,
         }],
+        profiles: None,
     };
 
     let diff = config::diff_configs(&old_config, &new_config);

--- a/tests/js_execution_integration.rs
+++ b/tests/js_execution_integration.rs
@@ -7,6 +7,7 @@
 use endara_relay::adapter::stdio::{StdioAdapter, StdioConfig};
 use endara_relay::adapter::McpAdapter;
 use endara_relay::js_sandbox::MetaToolHandler;
+use endara_relay::profile_registry::ProfileRegistry;
 use endara_relay::registry::AdapterRegistry;
 use endara_relay::server::{build_router, start_server, AppState};
 use serde_json::json;
@@ -50,6 +51,7 @@ async fn setup_js_server(js_mode: bool) -> (SocketAddr, tokio::task::JoinHandle<
         registry: registry.clone(),
         js_execution_mode: Arc::new(AtomicBool::new(js_mode)),
         meta_tool_handler: Arc::new(MetaToolHandler::new(registry_arc, Duration::from_secs(30))),
+        profile_registry: Arc::new(ProfileRegistry::new(registry.clone())),
         oauth_flow_manager: None,
         token_manager: None,
         oauth_adapter_inners: None,

--- a/tests/management_api_integration.rs
+++ b/tests/management_api_integration.rs
@@ -136,6 +136,7 @@ async fn start_management_server(
         oauth_adapter_inners: None,
         token_manager: None,
         setup_manager: None,
+        profile_registry: None,
     };
 
     let app = management_routes(state);
@@ -324,6 +325,7 @@ async fn start_management_server_with_config(
         oauth_adapter_inners: None,
         token_manager: None,
         setup_manager: None,
+        profile_registry: None,
     };
 
     let app = management_routes(state);

--- a/tests/management_api_integration.rs
+++ b/tests/management_api_integration.rs
@@ -106,6 +106,7 @@ fn test_config() -> Config {
             token_endpoint: None,
             server_type_override: None,
         }],
+        profiles: None,
     }
 }
 

--- a/tests/mcp_server_integration.rs
+++ b/tests/mcp_server_integration.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use endara_relay::adapter::stdio::{StdioAdapter, StdioConfig};
 use endara_relay::adapter::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
 use endara_relay::js_sandbox::MetaToolHandler;
+use endara_relay::profile_registry::ProfileRegistry;
 use endara_relay::registry::AdapterRegistry;
 use endara_relay::server::{build_router, start_server, AppState};
 use serde_json::{json, Value};
@@ -46,6 +47,7 @@ async fn setup_server() -> (SocketAddr, AdapterRegistry, tokio::task::JoinHandle
         registry: registry.clone(),
         js_execution_mode: Arc::new(AtomicBool::new(false)),
         meta_tool_handler: Arc::new(MetaToolHandler::new(registry_arc, Duration::from_secs(30))),
+        profile_registry: Arc::new(ProfileRegistry::new(registry.clone())),
         oauth_flow_manager: None,
         token_manager: None,
         oauth_adapter_inners: None,
@@ -228,10 +230,12 @@ async fn setup_native_toon_server(toon_enabled: bool) -> (SocketAddr, tokio::tas
         .await;
 
     let registry_arc = Arc::new(registry.clone());
+    let profile_registry = Arc::new(ProfileRegistry::new(registry.clone()));
     let state = AppState {
         registry,
         js_execution_mode: Arc::new(AtomicBool::new(false)),
         meta_tool_handler: Arc::new(MetaToolHandler::new(registry_arc, Duration::from_secs(30))),
+        profile_registry,
         oauth_flow_manager: None,
         token_manager: None,
         oauth_adapter_inners: None,

--- a/tests/multi_endpoint_integration.rs
+++ b/tests/multi_endpoint_integration.rs
@@ -7,6 +7,7 @@
 use endara_relay::adapter::stdio::{StdioAdapter, StdioConfig};
 use endara_relay::adapter::McpAdapter;
 use endara_relay::js_sandbox::MetaToolHandler;
+use endara_relay::profile_registry::ProfileRegistry;
 use endara_relay::registry::AdapterRegistry;
 use endara_relay::server::{build_router, start_server, AppState};
 use serde_json::json;
@@ -83,6 +84,7 @@ async fn setup_multi_endpoint_server() -> (SocketAddr, AdapterRegistry, tokio::t
         registry: registry.clone(),
         js_execution_mode: Arc::new(AtomicBool::new(false)),
         meta_tool_handler: Arc::new(MetaToolHandler::new(registry_arc, Duration::from_secs(30))),
+        profile_registry: Arc::new(ProfileRegistry::new(registry.clone())),
         oauth_flow_manager: None,
         token_manager: None,
         oauth_adapter_inners: None,
@@ -232,6 +234,7 @@ async fn test_multi_endpoint_overlapping_tool_names() {
         registry: registry.clone(),
         js_execution_mode: Arc::new(AtomicBool::new(false)),
         meta_tool_handler: Arc::new(MetaToolHandler::new(registry_arc, Duration::from_secs(30))),
+        profile_registry: Arc::new(ProfileRegistry::new(registry.clone())),
         oauth_flow_manager: None,
         token_manager: None,
         oauth_adapter_inners: None,

--- a/tests/oauth_setup_integration.rs
+++ b/tests/oauth_setup_integration.rs
@@ -47,6 +47,7 @@ fn empty_config() -> Config {
             token_endpoint: None,
             server_type_override: None,
         }],
+        profiles: None,
     }
 }
 

--- a/tests/oauth_setup_integration.rs
+++ b/tests/oauth_setup_integration.rs
@@ -63,6 +63,7 @@ async fn start_setup_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
         oauth_adapter_inners: None,
         token_manager: None,
         setup_manager: Some(Arc::new(OAuthSetupManager::new())),
+        profile_registry: None,
     };
 
     let app = management_routes(state);


### PR DESCRIPTION
## Summary

Implements **endpoint profiles** (Issue #77) — namespace MCP servers by project so users can serve subsets of configured endpoints at `/mcp/{profile}` with independent JS-execution and TOON-output toggles, manage profiles via the management API, and hot-reload changes from `config.toml`.

Engineering Spec: §1–§8 covers config schema, registry, request routing, meta-tools, advertising, SSE filtering, management API, and hot-reload integration.

## Changes (8 commits)

1. `refactor(registry): tools_changed broadcast carries endpoint name` — `broadcast::Sender<String>` so profile-scoped SSE can filter by endpoint membership (Spec §6).
2. `feat(config): add ProfileConfig + path validation + startup validation` — `[[profiles]]` TOML key, `validate_profile_path` (regex), startup-time checks for duplicate paths/names and unknown endpoint references (Spec §1, §2).
3. `feat: add ProfileRegistry, ProfileRegistryView, and AppState wiring` — `ProfileRegistry` keyed by path; `ProfileRegistryView` exposes per-profile scoped catalog + routing (Spec §3).
4. `feat(profiles): per-profile MetaToolRegistry trait + profile-aware advertising` — generalises `MetaToolHandler` over `MetaToolRegistry` trait; `AdapterRegistry` and `ProfileRegistryView` both implement it; per-profile `list_tools` / `search_tools` / `execute_tools` descriptions reflect only the profile's endpoints (Spec §4, §5).
5. `feat(profiles): per-profile js_execution + toon_output gating in /mcp/{profile}` — `mcp_request_profiled` and `mcp_sse_profiled` honour the per-profile booleans independent of the global toggles (Spec §3, §6).
6. `feat(management): profile CRUD + endpoint membership API (R4.A)` — `GET/POST/PUT/DELETE /management/profiles` + endpoint-profile membership endpoint; rewrites `config.toml` via the existing rewrite path (Spec §7).
7. `feat(profiles): hot reload + keep-last-good for ProfileRegistry (R4.B)` — `ConfigWatcher` calls `profile_registry.rebuild(...)` before swapping the active config; invalid `[[profiles]]` blocks keep the last good registry (Spec §8).
8. `refactor(profiles): make js_execution/toon_output strictly boolean` — drop optional `Auto`/`Inherit` modes; per-profile flags are plain `bool` per the locked Spec decision.

## Test plan

Full verification report is on the `R5.A` task note. Summary:

| Gate | Result |
|---|---|
| `cargo fmt --check` | ✅ clean |
| `cargo clippy --all-targets -- -D warnings` | ✅ clean |
| `cargo test --lib` | ✅ 723 passed / 0 failed |
| `cargo test` (full suite) | ✅ all binaries green (oauth integration tests are flaky under parallelism — unrelated, passes with `--test-threads=1`) |

### Spec §11 test-matrix coverage (#1–#22, all ✅)

- Config validation: `profile_path_accepts_valid`, `profile_path_rejects_invalid_chars`, `profile_path_rejects_reserved`, `profile_toml_parses`, `profile_missing_endpoint_ref_errors`, `profile_duplicate_paths_error`, `profile_duplicate_names_error`
- Registry: `scoped_catalog_includes_only_profile_endpoints`, `route_tool_call_rejects_out_of_profile_tool`, `route_tool_call_succeeds_for_in_profile_tool`, `per_profile_handler_execute_tools_rejects_out_of_profile_call`
- Per-profile JS / TOON: `profile_js_on_rejects_direct_tool_calls_when_global_off`, `profile_js_off_hides_execute_tools_when_global_on`, `profile_toon_on_encodes_toon_when_global_off`, `profile_toon_off_keeps_json_when_global_on`
- Advertising: `instructions_for_profile_filters_server_types_and_count`, `list_tools_description_for_profile_counts_only_profile_endpoints`, `search_tools_description_for_profile_filters_types_and_respects_toon`, `execute_tools_description_for_profile_counts_only_profile_endpoints`
- SSE filtering: `mcp_sse_profiled_forwards_in_profile_tools_changed`, `mcp_sse_profiled_suppresses_out_of_profile_tools_changed`, `mcp_sse_profiled_only_forwards_in_profile_when_mixed`
- Hot reload: `add_profile_appears_in_registry_after_reload`, `remove_profile_disappears_from_registry_after_reload`, `invalid_profile_reload_keeps_last_good_registry`
- Management API: `management_profiles_full_crud_round_trip`, `management_profiles_post_rejects_invalid_payloads`, `management_profiles_put_404_and_conflict`, `management_endpoint_profiles_membership`

### Regression checks

- `/mcp` (the everything endpoint) behavior is byte-identical to pre-change for unprofiled requests (`tests/streamable_http_integration.rs`, 6 tests pass).
- `tools_changed` broadcast payload change is scoped to `registry.rs`; per-adapter senders unchanged.
- All existing `MetaToolHandler` tests pass under the new trait-parameterised form.

## Non-goals (per Spec §12)

- Disabling `/mcp` (the everything endpoint)
- Per-profile health/lifecycle tracking
- Profile-specific OAuth flows
- Profile ordering or priority
- Last-used timestamp on profiles
- Migrating endpoint creation from `config.toml` to the management API (separate issue)

## Follow-up

Desktop UI work (Profiles tab, per-profile JS/TOON toggles, log filter) ships in a separate `endara-ai/endara-desktop` PR and is coordinated to land in the same `vX.Y.Z-rc.N` cycle.

Closes #77 (once both relay and desktop PRs merge and ship in matching rc tags).
