### PR TITLE
feat: tool-call event bus for desktop overlay

### DIFF
--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -2,7 +2,9 @@ use super::server_name::{sanitize_server_name, ServerNameError};
 use super::server_type_resolution::{effective_server_type, strip_mcp_server_suffix};
 use super::stdio::{iso8601_now, RingBuffer};
 use super::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
-use crate::events::{annotations_from_value, ToolCallEvent, ToolCallEventBus};
+use crate::events::{
+    annotations_from_value, current_request_context, ToolCallEvent, ToolCallEventBus,
+};
 use crate::jsonrpc::{self, JsonRpcResponse};
 use async_trait::async_trait;
 use reqwest::Client;
@@ -695,6 +697,13 @@ impl McpAdapter for HttpAdapter {
     }
 
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
+        // Capture caller span context BEFORE `.instrument(self.span)` re-enters
+        // the adapter's own `endpoint` span — endpoint is constructed at
+        // adapter init time with no parent linkage to per-request spans, so
+        // reading the context from inside the instrumented body would lose
+        // the `request{id}` / `mcp_request{profile}` scope.
+        // See `events::SpanFieldCaptureLayer`.
+        let span_ctx = current_request_context();
         async {
             let request_id = uuid::Uuid::new_v4().to_string();
             if let Some(bus) = self.event_bus.get() {
@@ -706,12 +715,13 @@ impl McpAdapter for HttpAdapter {
                     .and_then(|v| v.as_ref().and_then(annotations_from_value));
                 bus.send(ToolCallEvent::Started {
                     request_id: request_id.clone(),
+                    jsonrpc_id: span_ctx.jsonrpc_id.clone(),
                     ts: iso8601_now(),
                     endpoint: self.config.endpoint_name.clone(),
                     transport: "http".into(),
                     server_type: self.server_type.read().await.clone(),
                     server_name: self.upstream_server_name.read().await.clone(),
-                    profile: None,
+                    profile: span_ctx.profile.clone(),
                     tool: name.to_string(),
                     annotations,
                 });
@@ -758,12 +768,14 @@ impl McpAdapter for HttpAdapter {
                 match &result {
                     Ok(_) => bus.send(ToolCallEvent::Completed {
                         request_id,
+                        jsonrpc_id: span_ctx.jsonrpc_id.clone(),
                         ts,
                         duration_ms: duration_ms_u64,
                         status: "ok".into(),
                     }),
                     Err(e) => bus.send(ToolCallEvent::Failed {
                         request_id,
+                        jsonrpc_id: span_ctx.jsonrpc_id.clone(),
                         ts,
                         duration_ms: duration_ms_u64,
                         status: "error".into(),

--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -1,14 +1,15 @@
 use super::server_name::{sanitize_server_name, ServerNameError};
 use super::server_type_resolution::{effective_server_type, strip_mcp_server_suffix};
-use super::stdio::RingBuffer;
+use super::stdio::{iso8601_now, RingBuffer};
 use super::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
+use crate::events::{annotations_from_value, ToolCallEvent, ToolCallEventBus};
 use crate::jsonrpc::{self, JsonRpcResponse};
 use async_trait::async_trait;
 use reqwest::Client;
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use tokio::sync::{broadcast, Mutex, Notify, RwLock};
 use tokio::task::JoinHandle;
@@ -91,6 +92,13 @@ pub struct HttpAdapter {
     /// listener loop exits cleanly between SSE reads and reconnect backoffs
     /// instead of waiting out the current sleep / network read.
     shutdown_notify: Arc<Notify>,
+    /// Shared typed event bus for the desktop overlay's SSE stream. See the
+    /// matching field on [`super::stdio::StdioAdapter`].
+    event_bus: Arc<OnceLock<ToolCallEventBus>>,
+    /// Per-tool annotation cache populated from `list_tools()` responses so
+    /// `call_tool` can attach hint metadata to the overlay's `started`
+    /// event without a second round-trip.
+    tool_annotations_cache: Arc<RwLock<HashMap<String, Option<Value>>>>,
 }
 
 impl HttpAdapter {
@@ -149,6 +157,8 @@ impl HttpAdapter {
             tools_changed_tx,
             listener_handle: Arc::new(Mutex::new(None)),
             shutdown_notify: Arc::new(Notify::new()),
+            event_bus: Arc::new(OnceLock::new()),
+            tool_annotations_cache: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -192,7 +202,17 @@ impl HttpAdapter {
             tools_changed_tx,
             listener_handle: Arc::new(Mutex::new(None)),
             shutdown_notify: Arc::new(Notify::new()),
+            event_bus: Arc::new(OnceLock::new()),
+            tool_annotations_cache: Arc::new(RwLock::new(HashMap::new())),
         }
+    }
+
+    /// Install the given event-bus handle (Arc-cloned) on this adapter,
+    /// replacing the slot reserved by the constructor. Used by
+    /// [`crate::adapter::oauth::OAuthAdapter`] to share a single
+    /// `OnceLock` cell across every inner adapter it rebuilds.
+    pub(crate) fn set_event_bus_handle(&mut self, handle: Arc<OnceLock<ToolCallEventBus>>) {
+        self.event_bus = handle;
     }
 
     fn next_id(&self) -> u64 {
@@ -661,6 +681,13 @@ impl McpAdapter for HttpAdapter {
                 .get("tools")
                 .ok_or_else(|| AdapterError::ProtocolError("missing 'tools' field".into()))?;
             let tools: Vec<ToolInfo> = serde_json::from_value(tools_value.clone())?;
+            // Refresh the per-tool annotations cache for overlay events.
+            let mut cache = self.tool_annotations_cache.write().await;
+            cache.clear();
+            for tool in &tools {
+                cache.insert(tool.name.clone(), tool.annotations.clone());
+            }
+            drop(cache);
             Ok(tools)
         }
         .instrument(self.span.clone())
@@ -669,6 +696,26 @@ impl McpAdapter for HttpAdapter {
 
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
         async {
+            let request_id = uuid::Uuid::new_v4().to_string();
+            if let Some(bus) = self.event_bus.get() {
+                let annotations = self
+                    .tool_annotations_cache
+                    .read()
+                    .await
+                    .get(name)
+                    .and_then(|v| v.as_ref().and_then(annotations_from_value));
+                bus.send(ToolCallEvent::Started {
+                    request_id: request_id.clone(),
+                    ts: iso8601_now(),
+                    endpoint: self.config.endpoint_name.clone(),
+                    transport: "http".into(),
+                    server_type: self.server_type.read().await.clone(),
+                    server_name: self.upstream_server_name.read().await.clone(),
+                    profile: None,
+                    tool: name.to_string(),
+                    annotations,
+                });
+            }
             let params = json!({
                 "name": name,
                 "arguments": arguments,
@@ -705,10 +752,33 @@ impl McpAdapter for HttpAdapter {
                     "Tool call failed"
                 ),
             }
+            if let Some(bus) = self.event_bus.get() {
+                let duration_ms_u64 = duration_ms as u64;
+                let ts = iso8601_now();
+                match &result {
+                    Ok(_) => bus.send(ToolCallEvent::Completed {
+                        request_id,
+                        ts,
+                        duration_ms: duration_ms_u64,
+                        status: "ok".into(),
+                    }),
+                    Err(e) => bus.send(ToolCallEvent::Failed {
+                        request_id,
+                        ts,
+                        duration_ms: duration_ms_u64,
+                        status: "error".into(),
+                        error_message: e.to_string(),
+                    }),
+                }
+            }
             result
         }
         .instrument(self.span.clone())
         .await
+    }
+
+    fn set_event_bus(&self, bus: ToolCallEventBus) {
+        let _ = self.event_bus.set(bus);
     }
 
     fn health(&self) -> HealthStatus {

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -41,6 +41,24 @@ pub struct ToolInfo {
     pub annotations: Option<Value>,
 }
 
+/// Max character count retained from `HttpError.body` when formatting an
+/// `AdapterError` for display. Upstream MCP servers occasionally return
+/// multi-KB HTML error pages or stack traces; including those verbatim
+/// in `Failed` events would leak noise into the management UI / logs.
+pub const HTTP_ERROR_BODY_MAX_CHARS: usize = 200;
+
+/// Return at most `max_chars` characters from `s`, appending `"…"` if the
+/// input was longer. Counts by `char` (not byte) so the result is always a
+/// valid UTF-8 boundary even for multi-byte input.
+pub fn truncate_for_display(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        s.to_string()
+    } else {
+        let head: String = s.chars().take(max_chars).collect();
+        format!("{head}…")
+    }
+}
+
 /// Errors that can occur in adapter operations.
 #[derive(Debug, thiserror::Error)]
 pub enum AdapterError {
@@ -69,7 +87,10 @@ pub enum AdapterError {
     #[error("connection failed: {0}")]
     ConnectionFailed(String),
 
-    #[error("HTTP error {status}: {body}")]
+    #[error(
+        "HTTP error {status}: {}",
+        truncate_for_display(body, HTTP_ERROR_BODY_MAX_CHARS)
+    )]
     HttpError { status: u16, body: String },
 
     #[error("Authentication required for endpoint '{endpoint}': {message}")]
@@ -301,5 +322,57 @@ mod tests {
     fn failed_adapter_without_override_returns_none() {
         let adapter = FailedAdapter::new("validation failed".to_string());
         assert_eq!(adapter.configured_server_type(), None);
+    }
+
+    #[test]
+    fn truncate_for_display_passes_short_input_unchanged() {
+        assert_eq!(truncate_for_display("short body", 200), "short body");
+        let exact: String = "a".repeat(200);
+        assert_eq!(truncate_for_display(&exact, 200), exact);
+    }
+
+    #[test]
+    fn truncate_for_display_truncates_long_input_with_ellipsis() {
+        let body: String = "a".repeat(500);
+        let out = truncate_for_display(&body, 200);
+        assert!(
+            out.ends_with('…'),
+            "expected trailing ellipsis, got {out:?}"
+        );
+        let n_chars = out.chars().count();
+        assert_eq!(n_chars, 201, "expected 200 chars + ellipsis, got {n_chars}");
+    }
+
+    #[test]
+    fn truncate_for_display_respects_char_boundaries_for_multibyte() {
+        // A 300-char string of multi-byte chars must truncate on a char
+        // boundary (no UTF-8 panic) and stay within max_chars + 1.
+        let body: String = "✓".repeat(300);
+        let out = truncate_for_display(&body, 200);
+        assert!(out.ends_with('…'));
+        assert_eq!(out.chars().count(), 201);
+    }
+
+    #[test]
+    fn http_error_display_truncates_oversized_body() {
+        let body: String = "x".repeat(1024);
+        let err = AdapterError::HttpError {
+            status: 500,
+            body: body.clone(),
+        };
+        let rendered = err.to_string();
+        assert!(rendered.starts_with("HTTP error 500: "));
+        assert!(rendered.ends_with('…'));
+        // "HTTP error 500: " (16 chars) + 200 chars + "…" (1 char) = 217.
+        assert_eq!(rendered.chars().count(), 16 + HTTP_ERROR_BODY_MAX_CHARS + 1);
+    }
+
+    #[test]
+    fn http_error_display_preserves_short_body_verbatim() {
+        let err = AdapterError::HttpError {
+            status: 404,
+            body: "not found".to_string(),
+        };
+        assert_eq!(err.to_string(), "HTTP error 404: not found");
     }
 }

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -161,6 +161,17 @@ pub trait McpAdapter: Send + Sync {
     fn subscribe_tools_changed(&self) -> Option<tokio::sync::broadcast::Receiver<()>> {
         None
     }
+
+    /// Wire a shared [`crate::events::ToolCallEventBus`] into the adapter so
+    /// `call_tool` can publish typed `started` / `completed` / `failed`
+    /// events for the desktop overlay's SSE stream.
+    ///
+    /// Default impl is a no-op so placeholder adapters
+    /// ([`FailedAdapter`], [`StartingAdapter`]) and any future read-only
+    /// adapters don't need to participate. Concrete transports (STDIO, SSE,
+    /// HTTP, OAuth) override this and stash the bus for use during
+    /// `call_tool`.
+    fn set_event_bus(&self, _bus: crate::events::ToolCallEventBus) {}
 }
 
 /// A placeholder adapter registered when the real adapter fails to initialize.

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 use reqwest::Client;
 use serde_json::Value;
 use std::collections::VecDeque;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio::task::{AbortHandle, JoinHandle};
@@ -156,6 +156,11 @@ pub struct OAuthAdapterInner {
     /// `endpoint`/`transport="oauth"` (and `server_type` once the inner MCP
     /// handshake completes).
     pub span: tracing::Span,
+    /// Shared `OnceLock` cell for the desktop overlay's event bus. Owned at
+    /// the OAuth layer so that every inner HTTP adapter rebuilt during a
+    /// token swap shares the same slot — the outer `set_event_bus` call
+    /// thus reaches both the current inner adapter and any future one.
+    event_bus: Arc<OnceLock<crate::events::ToolCallEventBus>>,
 }
 
 impl OAuthAdapterInner {
@@ -581,6 +586,11 @@ impl OAuthAdapterInner {
             self.config.server_type_override.clone(),
             self.config.endpoint_name.clone(),
         );
+        // Share the OAuth adapter's event-bus OnceLock with the new inner so
+        // overlay events fire from the inner's `call_tool` once the bus is
+        // wired, even across token swaps. The outer `set_event_bus` writes
+        // through this same cell.
+        adapter.set_event_bus_handle(self.event_bus.clone());
         match adapter.initialize().await {
             Ok(()) => {
                 // Mirror the stdio/sse/http adapters: once the inner MCP
@@ -860,6 +870,7 @@ impl OAuthAdapter {
                 outer_tools_changed_tx,
                 inner_forwarder_handle: Mutex::new(None),
                 span,
+                event_bus: Arc::new(OnceLock::new()),
             }),
         }
     }
@@ -1120,6 +1131,14 @@ impl McpAdapter for OAuthAdapter {
             Some(adapter) => adapter.activity_log().await,
             None => vec![],
         }
+    }
+
+    fn set_event_bus(&self, bus: crate::events::ToolCallEventBus) {
+        // Writes through the shared `OnceLock` cell. Every inner HTTP
+        // adapter built (now or after a token swap) shares this cell via
+        // [`HttpAdapter::set_event_bus_handle`], so the bus reaches both
+        // the current inner adapter and any future one.
+        let _ = self.inner.event_bus.set(bus);
     }
 }
 

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -999,38 +999,55 @@ impl McpAdapter for OAuthAdapter {
     }
 
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
-        async {
-            let guard = self.inner.inner_adapter.read().await;
-            let adapter = match guard.as_ref() {
-                Some(a) => a,
-                None => {
-                    return Err(AdapterError::ConnectionFailed(
-                        "not authenticated — complete OAuth login first".to_string(),
-                    ));
-                }
-            };
+        // NB: do NOT wrap the inner adapter's `call_tool` invocations in
+        // `.instrument(self.inner.span)`. The inner `HttpAdapter::call_tool`
+        // captures the caller's per-request span context (`request{id}`,
+        // `mcp_request{profile}`) BEFORE entering its own span so it can
+        // attach `jsonrpc_id`/`profile` to the published `ToolCallEvent`s.
+        // OAuth's `inner.span` is the persistent endpoint span built at init
+        // time with no parent linkage to per-request spans, so wrapping the
+        // inner call here would zero out those fields on every OAuth-routed
+        // tool call. The OAuth endpoint span is still applied around the
+        // refresh / state-transition branches below where it actually adds
+        // useful context.
+        let guard = self.inner.inner_adapter.read().await;
+        let adapter = match guard.as_ref() {
+            Some(a) => a,
+            None => {
+                return Err(AdapterError::ConnectionFailed(
+                    "not authenticated — complete OAuth login first".to_string(),
+                ));
+            }
+        };
 
-            match adapter.call_tool(name, arguments.clone()).await {
-                Ok(result) => Ok(result),
-                Err(AdapterError::HttpError { status: 401, .. }) => {
-                    // Drop the read lock before refreshing
-                    drop(guard);
+        match adapter.call_tool(name, arguments.clone()).await {
+            Ok(result) => Ok(result),
+            Err(AdapterError::HttpError { status: 401, .. }) => {
+                // Drop the read lock before refreshing
+                drop(guard);
 
+                let refresh_result = async {
                     info!("Got 401, attempting token refresh");
+                    self.inner.do_token_refresh().await
+                }
+                .instrument(self.inner.span.clone())
+                .await;
 
-                    match self.inner.do_token_refresh().await {
-                        Ok(new_tokens) => {
-                            self.inner.apply_tokens(new_tokens).await;
-                            // Retry with new token
-                            let guard = self.inner.inner_adapter.read().await;
-                            let adapter = guard.as_ref().ok_or_else(|| {
-                                AdapterError::ConnectionFailed(
-                                    "Adapter lost during refresh".to_string(),
-                                )
-                            })?;
-                            adapter.call_tool(name, arguments).await
-                        }
-                        Err(e) => {
+                match refresh_result {
+                    Ok(new_tokens) => {
+                        self.inner.apply_tokens(new_tokens).await;
+                        // Retry with new token — again in caller's span so
+                        // the inner adapter sees the per-request scope.
+                        let guard = self.inner.inner_adapter.read().await;
+                        let adapter = guard.as_ref().ok_or_else(|| {
+                            AdapterError::ConnectionFailed(
+                                "Adapter lost during refresh".to_string(),
+                            )
+                        })?;
+                        adapter.call_tool(name, arguments).await
+                    }
+                    Err(e) => {
+                        async {
                             warn!(
                                 error = %e,
                                 "Token refresh after 401 failed"
@@ -1041,18 +1058,18 @@ impl McpAdapter for OAuthAdapter {
                                     "401 on call_tool, refresh failed",
                                 )
                                 .await;
-                            Err(AdapterError::AuthenticationRequired {
-                                endpoint: self.inner.config.endpoint_name.clone(),
-                                message: "Token expired and refresh failed. Re-authenticate in Endara Desktop.".to_string(),
-                            })
                         }
+                        .instrument(self.inner.span.clone())
+                        .await;
+                        Err(AdapterError::AuthenticationRequired {
+                            endpoint: self.inner.config.endpoint_name.clone(),
+                            message: "Token expired and refresh failed. Re-authenticate in Endara Desktop.".to_string(),
+                        })
                     }
                 }
-                Err(other) => Err(other),
             }
+            Err(other) => Err(other),
         }
-        .instrument(self.inner.span.clone())
-        .await
     }
 
     fn server_type(&self) -> Option<String> {
@@ -2728,5 +2745,99 @@ mod tests {
         assert_eq!(state, OAuthState::AuthRequired);
 
         server.abort();
+    }
+
+    /// Regression: a `call_tool` routed through `OAuthAdapter` (which wraps an
+    /// inner `HttpAdapter`) must publish a [`ToolCallEvent::Started`] whose
+    /// `jsonrpc_id` and `profile` fields are populated from the caller's
+    /// per-request span scope (`mcp_request{profile}` > `request{id}`).
+    ///
+    /// Before the fix, `OAuthAdapter::call_tool` wrapped the inner-adapter
+    /// invocation in `.instrument(self.inner.span)` — the OAuth endpoint span
+    /// has no parent linkage to the per-request spans, so the inner
+    /// `HttpAdapter::call_tool`'s `current_request_context()` walk found
+    /// neither field and emitted `jsonrpc_id: None` / `profile: None` for
+    /// every OAuth-authenticated endpoint.
+    ///
+    /// `#[test]` (not `#[tokio::test]`) because we install the capture layer
+    /// via `with_default(...)` and drive an inner current-thread runtime so
+    /// the dispatcher stays attached across `tokio::spawn`'d tasks.
+    #[test]
+    fn call_tool_publishes_jsonrpc_id_and_profile_from_request_span() {
+        use crate::events::{SpanFieldCaptureLayer, ToolCallEvent, ToolCallEventBus};
+        use tracing::Instrument;
+        use tracing_subscriber::prelude::*;
+
+        let subscriber = tracing_subscriber::registry().with(SpanFieldCaptureLayer);
+        tracing::subscriber::with_default(subscriber, || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                let (url, server) = spawn_minimal_mcp_server().await;
+                let mut config = make_config();
+                config.url = url;
+                let adapter = make_adapter(config);
+
+                // Wire the event bus before applying tokens so the rebuilt
+                // inner HttpAdapter sees the shared OnceLock immediately.
+                let bus = ToolCallEventBus::with_default_capacity();
+                adapter.set_event_bus(bus.clone());
+                let mut rx = bus.subscribe();
+
+                adapter
+                    .inner
+                    .apply_tokens(TokenSet {
+                        access_token: "test-access".to_string(),
+                        refresh_token: None,
+                        expires_at: None,
+                        token_type: "Bearer".to_string(),
+                        scope: None,
+                        issued_at: None,
+                    })
+                    .await;
+
+                let id_str = "42".to_string();
+                let profile_str = "test".to_string();
+                let mcp_span = tracing::info_span!(
+                    "mcp_request",
+                    profile = %profile_str,
+                );
+                let req_span =
+                    tracing::info_span!(parent: &mcp_span, "request", method = "tools/call", id = %id_str);
+
+                let result =
+                    async { adapter.call_tool("ping", serde_json::json!({})).await }
+                        .instrument(req_span)
+                        .await;
+                assert!(result.is_ok(), "expected Ok from minimal MCP server, got {result:?}");
+
+                let started = rx.try_recv().expect("started event must be buffered");
+                match started {
+                    ToolCallEvent::Started {
+                        jsonrpc_id,
+                        profile,
+                        transport,
+                        ..
+                    } => {
+                        assert_eq!(jsonrpc_id.as_deref(), Some("42"));
+                        assert_eq!(profile.as_deref(), Some("test"));
+                        // Inner is HttpAdapter, so transport should be "http".
+                        assert_eq!(transport, "http");
+                    }
+                    other => panic!("expected Started event, got {other:?}"),
+                }
+                let completed = rx.try_recv().expect("completed event must be buffered");
+                match completed {
+                    ToolCallEvent::Completed { jsonrpc_id, .. } => {
+                        assert_eq!(jsonrpc_id.as_deref(), Some("42"));
+                    }
+                    other => panic!("expected Completed event, got {other:?}"),
+                }
+
+                server.abort();
+            });
+        });
     }
 }

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -2,7 +2,9 @@ use super::server_name::{sanitize_server_name, ServerNameError};
 use super::server_type_resolution::{effective_server_type, strip_mcp_server_suffix};
 use super::stdio::{iso8601_now, RingBuffer};
 use super::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
-use crate::events::{annotations_from_value, ToolCallEvent, ToolCallEventBus};
+use crate::events::{
+    annotations_from_value, current_request_context, ToolCallEvent, ToolCallEventBus,
+};
 use crate::jsonrpc::{self, JsonRpcResponse};
 use async_trait::async_trait;
 use reqwest::Client;
@@ -767,6 +769,13 @@ impl McpAdapter for SseAdapter {
     }
 
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
+        // Capture caller span context BEFORE `.instrument(self.span)` re-enters
+        // the adapter's own `endpoint` span — endpoint is constructed at
+        // adapter init time with no parent linkage to per-request spans, so
+        // reading the context from inside the instrumented body would lose
+        // the `request{id}` / `mcp_request{profile}` scope.
+        // See `events::SpanFieldCaptureLayer`.
+        let span_ctx = current_request_context();
         async {
             let request_id = uuid::Uuid::new_v4().to_string();
             if let Some(bus) = self.event_bus.get() {
@@ -778,12 +787,13 @@ impl McpAdapter for SseAdapter {
                     .and_then(|v| v.as_ref().and_then(annotations_from_value));
                 bus.send(ToolCallEvent::Started {
                     request_id: request_id.clone(),
+                    jsonrpc_id: span_ctx.jsonrpc_id.clone(),
                     ts: iso8601_now(),
                     endpoint: self.config.endpoint_name.clone(),
                     transport: "sse".into(),
                     server_type: self.server_type.read().await.clone(),
                     server_name: self.upstream_server_name.read().await.clone(),
-                    profile: None,
+                    profile: span_ctx.profile.clone(),
                     tool: name.to_string(),
                     annotations,
                 });
@@ -830,12 +840,14 @@ impl McpAdapter for SseAdapter {
                 match &result {
                     Ok(_) => bus.send(ToolCallEvent::Completed {
                         request_id,
+                        jsonrpc_id: span_ctx.jsonrpc_id.clone(),
                         ts,
                         duration_ms: duration_ms_u64,
                         status: "ok".into(),
                     }),
                     Err(e) => bus.send(ToolCallEvent::Failed {
                         request_id,
+                        jsonrpc_id: span_ctx.jsonrpc_id.clone(),
                         ts,
                         duration_ms: duration_ms_u64,
                         status: "error".into(),

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -1,14 +1,15 @@
 use super::server_name::{sanitize_server_name, ServerNameError};
 use super::server_type_resolution::{effective_server_type, strip_mcp_server_suffix};
-use super::stdio::RingBuffer;
+use super::stdio::{iso8601_now, RingBuffer};
 use super::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
+use crate::events::{annotations_from_value, ToolCallEvent, ToolCallEventBus};
 use crate::jsonrpc::{self, JsonRpcResponse};
 use async_trait::async_trait;
 use reqwest::Client;
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use tokio::sync::{broadcast, Mutex, Notify, RwLock};
 use tokio::time::Instant;
@@ -153,6 +154,13 @@ pub struct SseAdapter {
     /// body with this span so events carry `endpoint`/`transport` (and
     /// `server_type` once the MCP handshake completes).
     span: tracing::Span,
+    /// Shared typed event bus for the desktop overlay's SSE stream. See
+    /// the matching field on [`super::stdio::StdioAdapter`].
+    event_bus: Arc<OnceLock<ToolCallEventBus>>,
+    /// Per-tool annotation cache populated from `list_tools()` responses so
+    /// `call_tool` can attach hint metadata to the overlay's `started`
+    /// event without a second round-trip.
+    tool_annotations_cache: Arc<RwLock<HashMap<String, Option<Value>>>>,
 }
 
 impl SseAdapter {
@@ -209,6 +217,8 @@ impl SseAdapter {
             shutdown_notify: Arc::new(Notify::new()),
             tools_changed_tx,
             span,
+            event_bus: Arc::new(OnceLock::new()),
+            tool_annotations_cache: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -743,6 +753,13 @@ impl McpAdapter for SseAdapter {
                 .get("tools")
                 .ok_or_else(|| AdapterError::ProtocolError("missing 'tools' field".into()))?;
             let tools: Vec<ToolInfo> = serde_json::from_value(tools_value.clone())?;
+            // Refresh the per-tool annotations cache for overlay events.
+            let mut cache = self.tool_annotations_cache.write().await;
+            cache.clear();
+            for tool in &tools {
+                cache.insert(tool.name.clone(), tool.annotations.clone());
+            }
+            drop(cache);
             Ok(tools)
         }
         .instrument(self.span.clone())
@@ -751,6 +768,26 @@ impl McpAdapter for SseAdapter {
 
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
         async {
+            let request_id = uuid::Uuid::new_v4().to_string();
+            if let Some(bus) = self.event_bus.get() {
+                let annotations = self
+                    .tool_annotations_cache
+                    .read()
+                    .await
+                    .get(name)
+                    .and_then(|v| v.as_ref().and_then(annotations_from_value));
+                bus.send(ToolCallEvent::Started {
+                    request_id: request_id.clone(),
+                    ts: iso8601_now(),
+                    endpoint: self.config.endpoint_name.clone(),
+                    transport: "sse".into(),
+                    server_type: self.server_type.read().await.clone(),
+                    server_name: self.upstream_server_name.read().await.clone(),
+                    profile: None,
+                    tool: name.to_string(),
+                    annotations,
+                });
+            }
             let params = json!({
                 "name": name,
                 "arguments": arguments,
@@ -787,10 +824,33 @@ impl McpAdapter for SseAdapter {
                     "Tool call failed"
                 ),
             }
+            if let Some(bus) = self.event_bus.get() {
+                let duration_ms_u64 = duration_ms as u64;
+                let ts = iso8601_now();
+                match &result {
+                    Ok(_) => bus.send(ToolCallEvent::Completed {
+                        request_id,
+                        ts,
+                        duration_ms: duration_ms_u64,
+                        status: "ok".into(),
+                    }),
+                    Err(e) => bus.send(ToolCallEvent::Failed {
+                        request_id,
+                        ts,
+                        duration_ms: duration_ms_u64,
+                        status: "error".into(),
+                        error_message: e.to_string(),
+                    }),
+                }
+            }
             result
         }
         .instrument(self.span.clone())
         .await
+    }
+
+    fn set_event_bus(&self, bus: ToolCallEventBus) {
+        let _ = self.event_bus.set(bus);
     }
 
     fn health(&self) -> HealthStatus {

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -1,6 +1,7 @@
 use super::server_name::{sanitize_server_name, ServerNameError};
 use super::server_type_resolution::{effective_server_type, strip_mcp_server_suffix};
 use super::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
+use crate::events::{annotations_from_value, ToolCallEvent, ToolCallEventBus};
 use crate::jsonrpc::{self, JsonRpcResponse};
 use crate::shell_env;
 use async_trait::async_trait;
@@ -8,7 +9,7 @@ use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::process::Stdio;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::{broadcast, Mutex, RwLock};
@@ -134,6 +135,16 @@ impl CrashTracker {
     }
 }
 
+/// Format the current UTC time as an RFC-3339 / ISO-8601 string with
+/// millisecond precision (e.g. `2026-05-27T04:36:29.710Z`). Shared by all
+/// three adapters' `call_tool` event timestamps so the overlay sees a
+/// consistent format regardless of transport.
+pub(crate) fn iso8601_now() -> String {
+    chrono::Utc::now()
+        .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+        .to_string()
+}
+
 /// Calculate backoff duration from crash count (exposed for testing).
 #[allow(dead_code)] // Used in tests
 pub fn calculate_backoff(consecutive_crashes: u32) -> Duration {
@@ -174,6 +185,19 @@ pub struct StdioAdapter {
     /// body with this span so events carry `endpoint`/`transport` (and
     /// `server_type` once the MCP handshake completes).
     span: tracing::Span,
+    /// Shared typed event bus for the desktop overlay's SSE stream. Set
+    /// once by [`Self::set_event_bus`] from `main.rs`/`watcher.rs` after
+    /// construction; `None` keeps `call_tool` silent (no events published)
+    /// which is what the legacy unit tests and ad-hoc constructions want.
+    /// Wrapped in `Arc<OnceLock<_>>` for symmetry with the other adapters
+    /// (SSE / HTTP derive `Clone`) and to keep the setter `&self`.
+    event_bus: Arc<OnceLock<ToolCallEventBus>>,
+    /// Per-tool annotation cache populated from `list_tools()` responses so
+    /// `call_tool` can attach hint metadata to the `started` event without
+    /// re-querying the upstream server. Stored as the raw `annotations`
+    /// JSON value so the [`annotations_from_value`] helper performs the
+    /// MCP-spec key mapping at event-emission time.
+    tool_annotations_cache: Arc<RwLock<HashMap<String, Option<Value>>>>,
     // Background task handles
     _stderr_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
     _stdout_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
@@ -202,6 +226,8 @@ impl StdioAdapter {
             upstream_server_name: Arc::new(RwLock::new(None)),
             tools_changed_tx,
             span,
+            event_bus: Arc::new(OnceLock::new()),
+            tool_annotations_cache: Arc::new(RwLock::new(HashMap::new())),
             _stderr_handle: Arc::new(Mutex::new(None)),
             _stdout_handle: Arc::new(Mutex::new(None)),
         }
@@ -533,6 +559,18 @@ impl McpAdapter for StdioAdapter {
                 .get("tools")
                 .ok_or_else(|| AdapterError::ProtocolError("missing 'tools' field".into()))?;
             let tools: Vec<ToolInfo> = serde_json::from_value(tools_value.clone())?;
+            // Refresh the per-tool annotations cache used by `call_tool` to
+            // join hint metadata onto the overlay's `started` event. Mirrors
+            // the registry's tool cache lifecycle: rewritten on every
+            // successful list, never trimmed (the worst-case footprint is
+            // one entry per advertised tool, which is bounded by the
+            // upstream server's catalogue).
+            let mut cache = self.tool_annotations_cache.write().await;
+            cache.clear();
+            for tool in &tools {
+                cache.insert(tool.name.clone(), tool.annotations.clone());
+            }
+            drop(cache);
             Ok(tools)
         }
         .instrument(self.span.clone())
@@ -541,6 +579,28 @@ impl McpAdapter for StdioAdapter {
 
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
         async {
+            let request_id = uuid::Uuid::new_v4().to_string();
+            // Publish `started` before the network/process round-trip so the
+            // overlay can spawn an in-flight card immediately.
+            if let Some(bus) = self.event_bus.get() {
+                let annotations = self
+                    .tool_annotations_cache
+                    .read()
+                    .await
+                    .get(name)
+                    .and_then(|v| v.as_ref().and_then(annotations_from_value));
+                bus.send(ToolCallEvent::Started {
+                    request_id: request_id.clone(),
+                    ts: iso8601_now(),
+                    endpoint: self.config.endpoint_name.clone(),
+                    transport: "stdio".into(),
+                    server_type: self.server_type.read().await.clone(),
+                    server_name: self.upstream_server_name.read().await.clone(),
+                    profile: None,
+                    tool: name.to_string(),
+                    annotations,
+                });
+            }
             let params = json!({
                 "name": name,
                 "arguments": arguments,
@@ -563,10 +623,33 @@ impl McpAdapter for StdioAdapter {
                     "Tool call failed"
                 ),
             }
+            if let Some(bus) = self.event_bus.get() {
+                let duration_ms_u64 = duration_ms as u64;
+                let ts = iso8601_now();
+                match &result {
+                    Ok(_) => bus.send(ToolCallEvent::Completed {
+                        request_id,
+                        ts,
+                        duration_ms: duration_ms_u64,
+                        status: "ok".into(),
+                    }),
+                    Err(e) => bus.send(ToolCallEvent::Failed {
+                        request_id,
+                        ts,
+                        duration_ms: duration_ms_u64,
+                        status: "error".into(),
+                        error_message: e.to_string(),
+                    }),
+                }
+            }
             result
         }
         .instrument(self.span.clone())
         .await
+    }
+
+    fn set_event_bus(&self, bus: ToolCallEventBus) {
+        let _ = self.event_bus.set(bus);
     }
 
     fn health(&self) -> HealthStatus {

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -1,7 +1,9 @@
 use super::server_name::{sanitize_server_name, ServerNameError};
 use super::server_type_resolution::{effective_server_type, strip_mcp_server_suffix};
 use super::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
-use crate::events::{annotations_from_value, ToolCallEvent, ToolCallEventBus};
+use crate::events::{
+    annotations_from_value, current_request_context, ToolCallEvent, ToolCallEventBus,
+};
 use crate::jsonrpc::{self, JsonRpcResponse};
 use crate::shell_env;
 use async_trait::async_trait;
@@ -578,6 +580,14 @@ impl McpAdapter for StdioAdapter {
     }
 
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
+        // Pull JSON-RPC id and profile from the surrounding tracing spans
+        // (`request{id=...}` / `mcp_request{profile=...}`) BEFORE re-entering
+        // the adapter's own `endpoint` span — the endpoint span was created
+        // at adapter construction time and is not parented to the per-request
+        // span, so a `current_request_context()` call from inside the
+        // `.instrument(self.span)` body would lose the caller's span scope.
+        // See `events::SpanFieldCaptureLayer`.
+        let span_ctx = current_request_context();
         async {
             let request_id = uuid::Uuid::new_v4().to_string();
             // Publish `started` before the network/process round-trip so the
@@ -591,12 +601,13 @@ impl McpAdapter for StdioAdapter {
                     .and_then(|v| v.as_ref().and_then(annotations_from_value));
                 bus.send(ToolCallEvent::Started {
                     request_id: request_id.clone(),
+                    jsonrpc_id: span_ctx.jsonrpc_id.clone(),
                     ts: iso8601_now(),
                     endpoint: self.config.endpoint_name.clone(),
                     transport: "stdio".into(),
                     server_type: self.server_type.read().await.clone(),
                     server_name: self.upstream_server_name.read().await.clone(),
-                    profile: None,
+                    profile: span_ctx.profile.clone(),
                     tool: name.to_string(),
                     annotations,
                 });
@@ -629,12 +640,14 @@ impl McpAdapter for StdioAdapter {
                 match &result {
                     Ok(_) => bus.send(ToolCallEvent::Completed {
                         request_id,
+                        jsonrpc_id: span_ctx.jsonrpc_id.clone(),
                         ts,
                         duration_ms: duration_ms_u64,
                         status: "ok".into(),
                     }),
                     Err(e) => bus.send(ToolCallEvent::Failed {
                         request_id,
+                        jsonrpc_id: span_ctx.jsonrpc_id.clone(),
                         ts,
                         duration_ms: duration_ms_u64,
                         status: "error".into(),
@@ -1372,5 +1385,65 @@ with open(record_path, "w") as rec:
             frames[1]
         );
         assert_eq!(frames[2]["method"].as_str(), Some("tools/list"));
+    }
+
+    /// End-to-end sanity check that `jsonrpc_id` flows from the surrounding
+    /// `request` tracing span into the published [`ToolCallEvent::Started`]
+    /// and [`ToolCallEvent::Failed`] events. Uses a non-spawned `StdioAdapter`
+    /// so `send_request` returns `AdapterError::NotInitialized` immediately —
+    /// the `Started` event still publishes before the network attempt, and
+    /// the `Failed` event publishes on the resulting `Err`.
+    ///
+    /// `#[test]` (not `#[tokio::test]`) because we install the capture layer
+    /// via `with_default(...)` and drive an inner current-thread runtime.
+    #[test]
+    fn call_tool_publishes_jsonrpc_id_from_request_span() {
+        use crate::events::{SpanFieldCaptureLayer, ToolCallEvent, ToolCallEventBus};
+        use tracing::Instrument;
+        use tracing_subscriber::prelude::*;
+
+        let subscriber = tracing_subscriber::registry().with(SpanFieldCaptureLayer);
+        tracing::subscriber::with_default(subscriber, || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                let bus = ToolCallEventBus::with_default_capacity();
+                let adapter = StdioAdapter::new(StdioConfig {
+                    command: "nonexistent-binary-for-span-test".to_string(),
+                    args: vec![],
+                    env: HashMap::new(),
+                    ..Default::default()
+                });
+                adapter.set_event_bus(bus.clone());
+                let mut rx = bus.subscribe();
+
+                let id_str = "99".to_string();
+                let span = tracing::info_span!("request", method = "tools/call", id = %id_str);
+                let result = async { adapter.call_tool("nope", serde_json::json!({})).await }
+                    .instrument(span)
+                    .await;
+                assert!(
+                    result.is_err(),
+                    "expected NotInitialized error, got {result:?}"
+                );
+
+                let started = rx.try_recv().expect("started event must be buffered");
+                match started {
+                    ToolCallEvent::Started { jsonrpc_id, .. } => {
+                        assert_eq!(jsonrpc_id.as_deref(), Some("99"));
+                    }
+                    other => panic!("expected Started event, got {other:?}"),
+                }
+                let failed = rx.try_recv().expect("failed event must be buffered");
+                match failed {
+                    ToolCallEvent::Failed { jsonrpc_id, .. } => {
+                        assert_eq!(jsonrpc_id.as_deref(), Some("99"));
+                    }
+                    other => panic!("expected Failed event, got {other:?}"),
+                }
+            });
+        });
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -15,6 +15,12 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::sync::broadcast;
+use tracing::field::{Field, Visit};
+use tracing::span::Attributes;
+use tracing::{Id, Subscriber};
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::Layer;
 
 /// Default capacity for the broadcast channel. Lagged receivers (slow overlay
 /// clients) drop the oldest events; 256 buffers ~1s of bursty traffic at a
@@ -80,6 +86,13 @@ pub enum ToolCallEvent {
     /// Emitted at `call_tool` entry, before any network/process I/O.
     Started {
         request_id: String,
+        /// JSON-RPC envelope id (as serialised by `serde_json::Value::to_string`)
+        /// extracted from the surrounding `request` tracing span. Used by the
+        /// desktop overlay to click-to-jump from an overlay card to the
+        /// matching `request{id="..."}` log row. `None` when no `request` span
+        /// is on the stack (e.g. internal callers).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        jsonrpc_id: Option<String>,
         ts: String,
         endpoint: String,
         transport: String,
@@ -96,6 +109,8 @@ pub enum ToolCallEvent {
     /// Emitted on `Ok(_)` return from the underlying `tools/call` request.
     Completed {
         request_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        jsonrpc_id: Option<String>,
         ts: String,
         duration_ms: u64,
         /// Always `"ok"` for completed events; carried so the overlay can use
@@ -106,6 +121,8 @@ pub enum ToolCallEvent {
     /// overlay can render the failure reason without re-querying logs.
     Failed {
         request_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        jsonrpc_id: Option<String>,
         ts: String,
         duration_ms: u64,
         /// Always `"error"` for failed events.
@@ -163,6 +180,137 @@ impl Default for ToolCallEventBus {
     }
 }
 
+/// Subset of the `request{...}` and `mcp_request{...}` span fields captured
+/// into span extensions by [`SpanFieldCaptureLayer`] and surfaced to adapter
+/// code via [`current_request_context`]. Adapters use this to populate
+/// `jsonrpc_id` (from the inner `request` span) and `profile` (from the outer
+/// `mcp_request` span) on every emitted [`ToolCallEvent`] without taking a
+/// breaking change to the [`crate::adapter::McpAdapter::call_tool`] signature.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct RequestSpanContext {
+    /// JSON-RPC envelope id as serialised by `Value::to_string` (numbers
+    /// render unquoted, strings render with quotes). `None` when no
+    /// `request` span is on the stack or when the id was the literal
+    /// `"null"` sentinel (notifications, which don't reach `call_tool`).
+    pub jsonrpc_id: Option<String>,
+    /// Profile path segment from `/mcp/{profile}`. `None` for the global
+    /// `/mcp` endpoint.
+    pub profile: Option<String>,
+}
+
+/// Fields captured per span by [`SpanFieldCaptureLayer`]. Stored in the
+/// span's extensions so [`current_request_context`] can read them back when
+/// an adapter publishes a [`ToolCallEvent`]. Carrying both fields in one
+/// extension keeps the per-span allocation count to one.
+#[derive(Debug, Default, Clone)]
+struct CapturedSpanFields {
+    jsonrpc_id: Option<String>,
+    profile: Option<String>,
+}
+
+/// Visits a span's recorded fields once at span creation time, capturing the
+/// JSON-RPC id from the `request` span and the profile path from the
+/// `mcp_request` span. Other fields are ignored.
+struct CapturingVisitor<'a> {
+    captured: &'a mut CapturedSpanFields,
+    is_request: bool,
+    is_mcp_request: bool,
+}
+
+impl<'a> Visit for CapturingVisitor<'a> {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.record(field.name(), value.to_string());
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        // `info_span!("...", x = %expr)` may route through `record_debug`
+        // when the value is not a primitive `String`/`&str`; the formatted
+        // output matches what the tracing fmt layer prints.
+        self.record(field.name(), format!("{:?}", value));
+    }
+}
+
+impl<'a> CapturingVisitor<'a> {
+    fn record(&mut self, name: &str, value: String) {
+        if self.is_request && name == "id" {
+            // The `request` span uses `id = %id_str` where `id_str` is
+            // `"null"` for notifications. `call_tool` is never reached for
+            // notifications, but we still skip the sentinel so a stray
+            // emitter cannot leak a fake id into an event.
+            if value != "null" {
+                self.captured.jsonrpc_id = Some(value);
+            }
+        } else if self.is_mcp_request && name == "profile" {
+            self.captured.profile = Some(value);
+        }
+    }
+}
+
+/// Tracing [`Layer`] that captures the JSON-RPC id and profile fields from
+/// the relay's `request` and `mcp_request` spans into span extensions so
+/// [`current_request_context`] can surface them to adapter code without a
+/// trait-level signature change. Install once at process start in
+/// `main.rs` via `tracing_subscriber::registry().with(SpanFieldCaptureLayer)`.
+pub struct SpanFieldCaptureLayer;
+
+impl<S> Layer<S> for SpanFieldCaptureLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let name = attrs.metadata().name();
+        let is_request = name == "request";
+        let is_mcp_request = name == "mcp_request";
+        if !(is_request || is_mcp_request) {
+            return;
+        }
+        let mut captured = CapturedSpanFields::default();
+        let mut visitor = CapturingVisitor {
+            captured: &mut captured,
+            is_request,
+            is_mcp_request,
+        };
+        attrs.record(&mut visitor);
+        if let Some(span) = ctx.span(id) {
+            span.extensions_mut().insert(captured);
+        }
+    }
+}
+
+/// Walk the current tracing span scope and pull the JSON-RPC id (from the
+/// nearest `request` span) and profile (from the nearest `mcp_request`
+/// span) previously captured by [`SpanFieldCaptureLayer`]. Returns a
+/// fully-`None` [`RequestSpanContext`] when no subscriber is installed (e.g.
+/// in unit tests that do not configure tracing) or when the capture layer is
+/// not in the layer stack — adapters degrade to omitting both fields.
+pub fn current_request_context() -> RequestSpanContext {
+    let mut ctx = RequestSpanContext::default();
+    tracing::Span::current().with_subscriber(|(id, sub)| {
+        let Some(reg) = sub.downcast_ref::<tracing_subscriber::Registry>() else {
+            return;
+        };
+        let Some(span) = reg.span(id) else {
+            return;
+        };
+        for s in span.scope() {
+            let ext = s.extensions();
+            if let Some(captured) = ext.get::<CapturedSpanFields>() {
+                if ctx.jsonrpc_id.is_none() {
+                    if let Some(v) = &captured.jsonrpc_id {
+                        ctx.jsonrpc_id = Some(v.clone());
+                    }
+                }
+                if ctx.profile.is_none() {
+                    if let Some(v) = &captured.profile {
+                        ctx.profile = Some(v.clone());
+                    }
+                }
+            }
+        }
+    });
+    ctx
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -174,6 +322,7 @@ mod tests {
     fn started_event_serializes_with_kind_tag() {
         let ev = ToolCallEvent::Started {
             request_id: "rid-1".into(),
+            jsonrpc_id: Some("42".into()),
             ts: "2026-05-27T04:36:29.710Z".into(),
             endpoint: "github".into(),
             transport: "stdio".into(),
@@ -192,18 +341,42 @@ mod tests {
         assert_eq!(v["kind"], "started");
         assert_eq!(v["tool"], "list_issues");
         assert_eq!(v["annotations"]["read_only"], true);
+        assert_eq!(v["jsonrpc_id"], "42");
+    }
+
+    #[test]
+    fn started_event_omits_jsonrpc_id_when_none() {
+        let ev = ToolCallEvent::Started {
+            request_id: "rid-1".into(),
+            jsonrpc_id: None,
+            ts: "t".into(),
+            endpoint: "github".into(),
+            transport: "stdio".into(),
+            server_type: None,
+            server_name: None,
+            profile: None,
+            tool: "list_issues".into(),
+            annotations: None,
+        };
+        let v = serde_json::to_value(&ev).unwrap();
+        assert!(
+            v.get("jsonrpc_id").is_none(),
+            "jsonrpc_id should be omitted when None, got {v}"
+        );
     }
 
     #[test]
     fn completed_and_failed_serialize_with_status() {
         let completed = ToolCallEvent::Completed {
             request_id: "rid-1".into(),
+            jsonrpc_id: Some("\"abc\"".into()),
             ts: "t".into(),
             duration_ms: 12,
             status: "ok".into(),
         };
         let failed = ToolCallEvent::Failed {
             request_id: "rid-2".into(),
+            jsonrpc_id: None,
             ts: "t".into(),
             duration_ms: 9,
             status: "error".into(),
@@ -213,9 +386,14 @@ mod tests {
         let f = serde_json::to_value(&failed).unwrap();
         assert_eq!(c["kind"], "completed");
         assert_eq!(c["status"], "ok");
+        assert_eq!(c["jsonrpc_id"], "\"abc\"");
         assert_eq!(f["kind"], "failed");
         assert_eq!(f["status"], "error");
         assert_eq!(f["error_message"], "boom");
+        assert!(
+            f.get("jsonrpc_id").is_none(),
+            "failed jsonrpc_id None should be omitted, got {f}"
+        );
     }
 
     #[test]
@@ -248,6 +426,7 @@ mod tests {
         let mut b = bus.subscribe();
         bus.send(ToolCallEvent::Completed {
             request_id: "r".into(),
+            jsonrpc_id: None,
             ts: "t".into(),
             duration_ms: 1,
             status: "ok".into(),
@@ -268,6 +447,7 @@ mod tests {
         for i in 0..10 {
             bus.send(ToolCallEvent::Completed {
                 request_id: format!("r-{i}"),
+                jsonrpc_id: None,
                 ts: "t".into(),
                 duration_ms: i,
                 status: "ok".into(),
@@ -292,9 +472,75 @@ mod tests {
         assert_eq!(bus.receiver_count(), 0);
         bus.send(ToolCallEvent::Completed {
             request_id: "r".into(),
+            jsonrpc_id: None,
             ts: "t".into(),
             duration_ms: 1,
             status: "ok".into(),
+        });
+    }
+
+    /// With [`SpanFieldCaptureLayer`] installed, an adapter running inside an
+    /// `mcp_request{profile=...}` > `request{id=...}` scope can pull both
+    /// values via [`current_request_context`] — this is the foundation for
+    /// per-event `jsonrpc_id` plumbing without a `call_tool` trait change.
+    #[test]
+    fn current_request_context_walks_request_and_mcp_request_spans() {
+        use tracing::Instrument;
+        use tracing_subscriber::prelude::*;
+
+        let subscriber = tracing_subscriber::registry().with(SpanFieldCaptureLayer);
+        tracing::subscriber::with_default(subscriber, || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                let id_str = "7".to_string();
+                let profile = "work".to_string();
+                let outer = tracing::info_span!("mcp_request", profile = %profile);
+                let captured = async {
+                    let inner = tracing::info_span!("request", method = "tools/call", id = %id_str);
+                    async { current_request_context() }.instrument(inner).await
+                }
+                .instrument(outer)
+                .await;
+                assert_eq!(captured.jsonrpc_id.as_deref(), Some("7"));
+                assert_eq!(captured.profile.as_deref(), Some("work"));
+            });
+        });
+    }
+
+    /// No `request` span on the stack → both fields stay `None`. Adapters
+    /// running outside an HTTP-routed request (e.g. background init) must
+    /// degrade silently.
+    #[test]
+    fn current_request_context_without_spans_returns_none() {
+        use tracing_subscriber::prelude::*;
+        let subscriber = tracing_subscriber::registry().with(SpanFieldCaptureLayer);
+        tracing::subscriber::with_default(subscriber, || {
+            let ctx = current_request_context();
+            assert_eq!(ctx, RequestSpanContext::default());
+        });
+    }
+
+    /// Sanity-check the "null" id sentinel: notifications would record
+    /// `id = "null"`; the visitor must not propagate that as a real id.
+    #[test]
+    fn null_jsonrpc_id_is_ignored_by_capture_visitor() {
+        use tracing::Instrument;
+        use tracing_subscriber::prelude::*;
+        let subscriber = tracing_subscriber::registry().with(SpanFieldCaptureLayer);
+        tracing::subscriber::with_default(subscriber, || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                let id_str = "null".to_string();
+                let span = tracing::info_span!("request", method = "x", id = %id_str);
+                let ctx = async { current_request_context() }.instrument(span).await;
+                assert_eq!(ctx.jsonrpc_id, None);
+            });
         });
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -151,6 +151,7 @@ impl ToolCallEventBus {
     }
 
     /// Current subscriber count (used by tests).
+    #[cfg(test)]
     pub fn receiver_count(&self) -> usize {
         self.tx.receiver_count()
     }

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,0 +1,299 @@
+//! Typed tool-call event bus and JSON schema for the desktop overlay.
+//!
+//! Adapters emit a [`ToolCallEvent::Started`] at `call_tool` entry and a
+//! matching [`ToolCallEvent::Completed`] or [`ToolCallEvent::Failed`] at
+//! completion. Events are fanned out through a Tokio `broadcast` channel via
+//! [`ToolCallEventBus`]; the management-API SSE handler at
+//! `GET /api/events/tool-calls` subscribes once per client and forwards every
+//! event. Slow / disconnected subscribers are dropped per Tokio `broadcast`
+//! semantics so the relay never blocks tool-call execution on a stalled
+//! overlay listener.
+//!
+//! The on-wire JSON schema matches the desktop overlay store; see the
+//! workspace spec under "Event schema (SSE over mgmt socket)".
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::sync::broadcast;
+
+/// Default capacity for the broadcast channel. Lagged receivers (slow overlay
+/// clients) drop the oldest events; 256 buffers ~1s of bursty traffic at a
+/// generous 256 events/s without back-pressuring producers.
+pub const DEFAULT_BUS_CAPACITY: usize = 256;
+
+/// MCP tool annotations carried on every `started` event so the overlay can
+/// render hint pills (destructive / open-world / read-only / idempotent)
+/// without re-querying `tools/list`. Each field is `Option<bool>` because the
+/// upstream server may report any subset of hints (or none at all).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolAnnotations {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub destructive: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub open_world: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub read_only: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub idempotent: Option<bool>,
+}
+
+impl ToolAnnotations {
+    /// Returns `true` when no hint fields were populated. Used by the
+    /// serializer skip-guard so empty annotation objects are omitted entirely.
+    pub fn is_empty(&self) -> bool {
+        self.destructive.is_none()
+            && self.open_world.is_none()
+            && self.read_only.is_none()
+            && self.idempotent.is_none()
+    }
+}
+
+/// Parse the `annotations` field returned by `tools/list` (per MCP spec) into
+/// the overlay's hint subset. The MCP wire fields are camelCased with a
+/// `Hint` suffix (`destructiveHint`, `openWorldHint`, `readOnlyHint`,
+/// `idempotentHint`) — see the MCP "Tool Annotations" docs. Anything that
+/// isn't an object, or an object with no recognised hints, returns `None` so
+/// the `started` event omits the `annotations` field entirely.
+pub fn annotations_from_value(value: &Value) -> Option<ToolAnnotations> {
+    let obj = value.as_object()?;
+    let pick = |k: &str| obj.get(k).and_then(|v| v.as_bool());
+    let ann = ToolAnnotations {
+        destructive: pick("destructiveHint"),
+        open_world: pick("openWorldHint"),
+        read_only: pick("readOnlyHint"),
+        idempotent: pick("idempotentHint"),
+    };
+    if ann.is_empty() {
+        None
+    } else {
+        Some(ann)
+    }
+}
+
+/// Typed tool-call lifecycle event published by adapters and consumed by the
+/// SSE handler. Serialised as an internally-tagged JSON object with a `kind`
+/// discriminator (`started` / `completed` / `failed`) so the desktop overlay
+/// can branch on a single field.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ToolCallEvent {
+    /// Emitted at `call_tool` entry, before any network/process I/O.
+    Started {
+        request_id: String,
+        ts: String,
+        endpoint: String,
+        transport: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        server_type: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        server_name: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        profile: Option<String>,
+        tool: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        annotations: Option<ToolAnnotations>,
+    },
+    /// Emitted on `Ok(_)` return from the underlying `tools/call` request.
+    Completed {
+        request_id: String,
+        ts: String,
+        duration_ms: u64,
+        /// Always `"ok"` for completed events; carried so the overlay can use
+        /// a single status field across `completed` and `failed`.
+        status: String,
+    },
+    /// Emitted on `Err(_)` return; carries the formatted error message so the
+    /// overlay can render the failure reason without re-querying logs.
+    Failed {
+        request_id: String,
+        ts: String,
+        duration_ms: u64,
+        /// Always `"error"` for failed events.
+        status: String,
+        error_message: String,
+    },
+}
+
+/// Broadcast fan-out wrapper around `tokio::sync::broadcast::Sender`.
+///
+/// Cloning the bus is cheap (clones the inner sender). Producers call
+/// [`ToolCallEventBus::send`]; subscribers call [`ToolCallEventBus::subscribe`]
+/// to receive a fresh `Receiver`. Sends never block: on a full ring the
+/// channel drops the oldest message and the corresponding subscriber sees
+/// `RecvError::Lagged` on its next `recv`.
+#[derive(Debug, Clone)]
+pub struct ToolCallEventBus {
+    tx: broadcast::Sender<ToolCallEvent>,
+}
+
+impl ToolCallEventBus {
+    /// Create a bus backed by a broadcast channel of `capacity` events.
+    pub fn new(capacity: usize) -> Self {
+        let (tx, _) = broadcast::channel(capacity);
+        Self { tx }
+    }
+
+    /// Create a bus with [`DEFAULT_BUS_CAPACITY`].
+    pub fn with_default_capacity() -> Self {
+        Self::new(DEFAULT_BUS_CAPACITY)
+    }
+
+    /// Publish an event. Returns silently when no subscribers are attached
+    /// (the normal idle case) — slow subscribers are surfaced via the
+    /// per-receiver `Lagged` error, not here.
+    pub fn send(&self, event: ToolCallEvent) {
+        let _ = self.tx.send(event);
+    }
+
+    /// Subscribe a fresh receiver. Each SSE client gets its own.
+    pub fn subscribe(&self) -> broadcast::Receiver<ToolCallEvent> {
+        self.tx.subscribe()
+    }
+
+    /// Current subscriber count (used by tests).
+    pub fn receiver_count(&self) -> usize {
+        self.tx.receiver_count()
+    }
+}
+
+impl Default for ToolCallEventBus {
+    fn default() -> Self {
+        Self::with_default_capacity()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::time::Duration;
+    use tokio::sync::broadcast::error::RecvError;
+
+    #[test]
+    fn started_event_serializes_with_kind_tag() {
+        let ev = ToolCallEvent::Started {
+            request_id: "rid-1".into(),
+            ts: "2026-05-27T04:36:29.710Z".into(),
+            endpoint: "github".into(),
+            transport: "stdio".into(),
+            server_type: Some("github".into()),
+            server_name: Some("github".into()),
+            profile: Some("default".into()),
+            tool: "list_issues".into(),
+            annotations: Some(ToolAnnotations {
+                destructive: Some(false),
+                open_world: Some(true),
+                read_only: Some(true),
+                idempotent: Some(true),
+            }),
+        };
+        let v = serde_json::to_value(&ev).unwrap();
+        assert_eq!(v["kind"], "started");
+        assert_eq!(v["tool"], "list_issues");
+        assert_eq!(v["annotations"]["read_only"], true);
+    }
+
+    #[test]
+    fn completed_and_failed_serialize_with_status() {
+        let completed = ToolCallEvent::Completed {
+            request_id: "rid-1".into(),
+            ts: "t".into(),
+            duration_ms: 12,
+            status: "ok".into(),
+        };
+        let failed = ToolCallEvent::Failed {
+            request_id: "rid-2".into(),
+            ts: "t".into(),
+            duration_ms: 9,
+            status: "error".into(),
+            error_message: "boom".into(),
+        };
+        let c = serde_json::to_value(&completed).unwrap();
+        let f = serde_json::to_value(&failed).unwrap();
+        assert_eq!(c["kind"], "completed");
+        assert_eq!(c["status"], "ok");
+        assert_eq!(f["kind"], "failed");
+        assert_eq!(f["status"], "error");
+        assert_eq!(f["error_message"], "boom");
+    }
+
+    #[test]
+    fn annotations_from_value_maps_mcp_hint_keys() {
+        let v = json!({
+            "destructiveHint": true,
+            "openWorldHint": false,
+            "readOnlyHint": false,
+            "idempotentHint": true,
+            "title": "ignored"
+        });
+        let ann = annotations_from_value(&v).expect("annotations parsed");
+        assert_eq!(ann.destructive, Some(true));
+        assert_eq!(ann.open_world, Some(false));
+        assert_eq!(ann.read_only, Some(false));
+        assert_eq!(ann.idempotent, Some(true));
+    }
+
+    #[test]
+    fn annotations_from_value_returns_none_when_no_hints() {
+        assert!(annotations_from_value(&json!({"title": "foo"})).is_none());
+        assert!(annotations_from_value(&json!("not-an-object")).is_none());
+        assert!(annotations_from_value(&json!({})).is_none());
+    }
+
+    #[tokio::test]
+    async fn bus_fans_out_to_every_subscriber() {
+        let bus = ToolCallEventBus::with_default_capacity();
+        let mut a = bus.subscribe();
+        let mut b = bus.subscribe();
+        bus.send(ToolCallEvent::Completed {
+            request_id: "r".into(),
+            ts: "t".into(),
+            duration_ms: 1,
+            status: "ok".into(),
+        });
+        let ra = a.recv().await.unwrap();
+        let rb = b.recv().await.unwrap();
+        assert_eq!(ra, rb);
+    }
+
+    #[tokio::test]
+    async fn bus_drops_oldest_on_lagged_subscriber_without_blocking_producer() {
+        // Capacity 2 keeps the test cheap; producer sends 10 events while
+        // the slow subscriber is parked. Tokio broadcast drops the oldest
+        // events and surfaces a single `Lagged` error to the slow receiver
+        // on its next recv() — the producer never blocks.
+        let bus = ToolCallEventBus::new(2);
+        let mut slow = bus.subscribe();
+        for i in 0..10 {
+            bus.send(ToolCallEvent::Completed {
+                request_id: format!("r-{i}"),
+                ts: "t".into(),
+                duration_ms: i,
+                status: "ok".into(),
+            });
+        }
+        let err = tokio::time::timeout(Duration::from_millis(100), slow.recv())
+            .await
+            .expect("recv should not hang")
+            .expect_err("first recv after lag returns Lagged");
+        assert!(matches!(err, RecvError::Lagged(_)));
+        let next = slow.recv().await.unwrap();
+        if let ToolCallEvent::Completed { request_id, .. } = next {
+            assert!(request_id.starts_with("r-"));
+        } else {
+            panic!("expected Completed event");
+        }
+    }
+
+    #[tokio::test]
+    async fn bus_send_with_no_subscribers_is_silent() {
+        let bus = ToolCallEventBus::with_default_capacity();
+        assert_eq!(bus.receiver_count(), 0);
+        bus.send(ToolCallEvent::Completed {
+            request_id: "r".into(),
+            ts: "t".into(),
+            duration_ms: 1,
+            status: "ok".into(),
+        });
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod adapter;
 pub mod advertise;
 pub mod config;
+pub mod events;
 pub mod js_sandbox;
 pub mod jsonrpc;
 pub mod management;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod config;
+mod events;
 mod js_sandbox;
 mod management;
 mod management_listener;
@@ -19,6 +20,7 @@ mod toon_convert;
 use adapter::oauth::{OAuthAdapter, OAuthAdapterConfig, OAuthAdapterInner};
 use adapter::{FailedAdapter, McpAdapter, StartingAdapter};
 use clap::{Parser, Subcommand, ValueEnum};
+use events::ToolCallEventBus;
 use js_sandbox::MetaToolHandler;
 use oauth::{OAuthFlowManager, OAuthSetupManager};
 use profile_registry::ProfileRegistry;
@@ -304,6 +306,13 @@ async fn main() {
             // Create adapter registry
             let registry = AdapterRegistry::new();
 
+            // Typed tool-call event bus consumed by the desktop overlay's
+            // SSE stream (`GET /api/events/tool-calls`). One bus per relay
+            // process; cloned cheaply into each adapter's setter and into
+            // ManagementState. See [`events`] module docs for ring-buffer
+            // semantics.
+            let event_bus = ToolCallEventBus::with_default_capacity();
+
             // Track duplicate endpoint names: first occurrence wins
             let mut registered_names = std::collections::HashSet::new();
 
@@ -416,6 +425,11 @@ async fn main() {
                     };
 
                     let adapter = OAuthAdapter::new(oauth_config, token_manager.clone());
+                    // Wire the overlay event bus before initialize() so the
+                    // inner HTTP adapter built during the first apply_tokens
+                    // round (which can race the management socket binding)
+                    // already publishes call_tool events.
+                    adapter.set_event_bus(event_bus.clone());
                     let shared_inner = adapter.shared_inner();
                     oauth_adapter_inners
                         .write()
@@ -487,9 +501,11 @@ async fn main() {
                 let tm = token_manager.clone();
                 let oai = oauth_adapter_inners.clone();
                 let settled = settled_inits.clone();
+                let bus = event_bus.clone();
                 let handle = tokio::spawn(async move {
                     let adapter =
-                        watcher::create_adapter(&ep, &tm, &oai, allow_insecure_oauth).await;
+                        watcher::create_adapter(&ep, &tm, &oai, allow_insecure_oauth, Some(&bus))
+                            .await;
                     let mut entries = reg.entries().write().await;
                     if let Some(entry) = entries.get_mut(ep.name.as_str()) {
                         entry.adapter = adapter;
@@ -621,6 +637,7 @@ async fn main() {
                 token_manager: Some(token_manager.clone()),
                 setup_manager: Some(setup_manager.clone()),
                 profile_registry: Some(profile_registry.clone()),
+                event_bus: Some(event_bus.clone()),
             };
             // Build the MCP (TCP) and management (UDS / Named Pipe) routers
             // separately. The management API carries credential-bearing routes
@@ -756,6 +773,7 @@ async fn main() {
                         oauth_flow_manager.clone(),
                         oauth_adapter_inners.clone(),
                         shared_config.clone(),
+                        Some(event_bus.clone()),
                     );
 
                     handle.await.ok();

--- a/src/main.rs
+++ b/src/main.rs
@@ -309,15 +309,19 @@ async fn main() {
             let oauth_flow_manager = Arc::new(OAuthFlowManager::new());
             let oauth_adapter_inners: OAuthAdapterInners = Arc::new(RwLock::new(HashMap::new()));
 
-            // Create adapter registry
-            let registry = AdapterRegistry::new();
-
             // Typed tool-call event bus consumed by the desktop overlay's
             // SSE stream (`GET /api/events/tool-calls`). One bus per relay
             // process; cloned cheaply into each adapter's setter and into
             // ManagementState. See [`events`] module docs for ring-buffer
             // semantics.
             let event_bus = ToolCallEventBus::with_default_capacity();
+
+            // Create adapter registry. Wire the same bus into the
+            // registry so its early-rejection branches in
+            // `route_tool_call` (unknown prefix, missing/disabled/unhealthy
+            // endpoint, disabled tool) emit `Started` + `Failed` pairs
+            // alongside the per-adapter emissions.
+            let registry = AdapterRegistry::new().with_event_bus(event_bus.clone());
 
             // Track duplicate endpoint names: first occurrence wins
             let mut registered_names = std::collections::HashSet::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,7 +155,13 @@ fn init_tracing(
             .boxed(),
     };
 
+    // SpanFieldCaptureLayer captures the JSON-RPC id (from `request` spans)
+    // and profile (from `mcp_request` spans) into per-span extensions so
+    // adapters can populate `jsonrpc_id` / `profile` on every
+    // `ToolCallEvent` without a breaking `McpAdapter::call_tool` signature
+    // change. Cheap: only allocates for the two named spans.
     tracing_subscriber::registry()
+        .with(events::SpanFieldCaptureLayer)
         .with(stdout_layer)
         .with(file_layer)
         .init();

--- a/src/management.rs
+++ b/src/management.rs
@@ -21,6 +21,7 @@ use crate::adapter::sse::{SseAdapter, SseConfig};
 use crate::adapter::stdio::{StdioAdapter, StdioConfig};
 use crate::adapter::{FailedAdapter, HealthStatus, McpAdapter, StartingAdapter};
 use crate::config::Config;
+use crate::events::ToolCallEventBus;
 use crate::oauth::{OAuthFlowManager, OAuthSetupManager, PkceChallenge};
 use crate::profile_registry::ProfileRegistry;
 use crate::registry::AdapterRegistry;
@@ -56,6 +57,12 @@ pub struct ManagementState {
     /// R4.B). `None` is permitted for legacy test fixtures that don't
     /// exercise the profile routes.
     pub profile_registry: Option<Arc<ProfileRegistry>>,
+    /// Shared typed tool-call event bus consumed by the desktop overlay's
+    /// SSE stream at `GET /api/events/tool-calls`. Adapters publish
+    /// `started` / `completed` / `failed` events via the same bus. `None`
+    /// is permitted for unit-test fixtures that do not exercise the
+    /// overlay route; in that case the SSE handler returns 503.
+    pub event_bus: Option<ToolCallEventBus>,
 }
 
 // ---------------------------------------------------------------------------
@@ -345,6 +352,7 @@ async fn restart_endpoint(
     let config = state.config.clone();
     let token_manager = state.token_manager.clone();
     let oauth_adapter_inners = state.oauth_adapter_inners.clone();
+    let event_bus = state.event_bus.clone();
     let task_name = name.clone();
 
     tokio::spawn(async move {
@@ -380,7 +388,8 @@ async fn restart_endpoint(
                 )))
             });
             let oai = oauth_adapter_inners.unwrap_or_else(|| Arc::new(RwLock::new(HashMap::new())));
-            crate::watcher::create_adapter(&ep, &tm, &oai, allow_insecure_oauth).await
+            crate::watcher::create_adapter(&ep, &tm, &oai, allow_insecure_oauth, event_bus.as_ref())
+                .await
         } else {
             // Endpoint not in config: re-initialize the previous adapter in
             // place. On failure, surface the error via FailedAdapter so the
@@ -589,6 +598,7 @@ async fn reload_config(State(state): State<ManagementState>) -> Json<ActionRespo
         &token_manager,
         &oauth_adapter_inners,
         new_config.relay.allow_insecure_oauth.unwrap_or(false),
+        state.event_bus.as_ref(),
     )
     .await;
 
@@ -3268,6 +3278,7 @@ async fn apply_endpoint_change(
         &token_manager,
         &oauth_adapter_inners,
         new_cfg.relay.allow_insecure_oauth.unwrap_or(false),
+        state.event_bus.as_ref(),
     )
     .await;
 
@@ -3316,6 +3327,71 @@ async fn update_endpoint(
         return *resp;
     }
     (StatusCode::OK, Json(endpoint_summary_from(&new_ep))).into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Tool-call event SSE stream
+// ---------------------------------------------------------------------------
+
+/// `GET /api/events/tool-calls` — Server-Sent-Events stream of every
+/// [`ToolCallEvent`] published on the relay's typed event bus. Each adapter
+/// emits a `started` event at `call_tool` entry and a matching
+/// `completed` / `failed` event at the end of the round-trip; the desktop
+/// overlay subscribes once per session and renders cards from those events.
+///
+/// Subscribers are independent broadcast receivers, so a slow / disconnected
+/// client only impacts itself: on `Lagged` the handler emits a single
+/// `event: lagged` SSE comment and continues from the freshest available
+/// frame. Tokio broadcast's drop-oldest semantics guarantee producers
+/// (`call_tool` invocations) never block on overlay clients.
+///
+/// A 15 s SSE keep-alive prevents idle reverse proxies (or, more relevantly,
+/// the desktop's Unix-socket HTTP client) from collapsing the connection.
+async fn tool_call_events_sse(State(state): State<ManagementState>) -> axum::response::Response {
+    use axum::response::sse::{Event, KeepAlive, Sse};
+    use std::convert::Infallible;
+    use std::time::Duration;
+    use tokio::sync::broadcast::error::RecvError;
+    use tokio_stream::wrappers::ReceiverStream;
+
+    let Some(bus) = state.event_bus.clone() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "event bus not configured").into_response();
+    };
+
+    let (tx, rx) = tokio::sync::mpsc::channel::<Result<Event, Infallible>>(64);
+    let mut event_rx = bus.subscribe();
+
+    tokio::spawn(async move {
+        loop {
+            match event_rx.recv().await {
+                Ok(ev) => {
+                    let frame = match serde_json::to_string(&ev) {
+                        Ok(s) => Event::default().data(s),
+                        Err(e) => {
+                            warn!(error = %e, "Failed to serialize ToolCallEvent for SSE stream");
+                            continue;
+                        }
+                    };
+                    if tx.send(Ok(frame)).await.is_err() {
+                        break;
+                    }
+                }
+                Err(RecvError::Lagged(skipped)) => {
+                    let frame = Event::default()
+                        .event("lagged")
+                        .data(format!("{{\"skipped\":{}}}", skipped));
+                    if tx.send(Ok(frame)).await.is_err() {
+                        break;
+                    }
+                }
+                Err(RecvError::Closed) => break,
+            }
+        }
+    });
+
+    Sse::new(ReceiverStream::new(rx))
+        .keep_alive(KeepAlive::new().interval(Duration::from_secs(15)))
+        .into_response()
 }
 
 // ---------------------------------------------------------------------------
@@ -3382,6 +3458,8 @@ pub fn management_routes(state: ManagementState) -> Router {
             "/api/endpoints/{name}/profiles",
             get(get_endpoint_profile_membership),
         )
+        // Desktop overlay's typed tool-call event SSE stream.
+        .route("/api/events/tool-calls", get(tool_call_events_sse))
         // No CORS layer: this router is served exclusively over a Unix-domain
         // socket / Windows named pipe (see `management_listener`), which is not
         // reachable from a browser and has no cross-origin attack surface.
@@ -3766,6 +3844,7 @@ mod tests {
             token_manager: None,
             setup_manager: None,
             profile_registry: None,
+            event_bus: None,
         }
     }
 
@@ -4026,6 +4105,7 @@ mod tests {
             token_manager: None,
             setup_manager: None,
             profile_registry: None,
+            event_bus: None,
         };
         let app = management_routes(state);
 
@@ -4101,6 +4181,7 @@ mod tests {
             token_manager: None,
             setup_manager: None,
             profile_registry: None,
+            event_bus: None,
         };
         let registry_for_poll = state.registry.clone();
         let app = management_routes(state);
@@ -4235,6 +4316,7 @@ mod tests {
             token_manager: None,
             setup_manager: None,
             profile_registry: None,
+            event_bus: None,
         };
         let registry_for_poll = state.registry.clone();
         let app = management_routes(state);
@@ -4342,6 +4424,7 @@ mod tests {
             token_manager: None,
             setup_manager: None,
             profile_registry: None,
+            event_bus: None,
         };
 
         // Subscribe BEFORE issuing the restart so we don't race the
@@ -4945,6 +5028,7 @@ command = "echo"
             token_manager: Some(token_manager),
             setup_manager: None,
             profile_registry: None,
+            event_bus: None,
         };
 
         (state, shared_inner)
@@ -5259,6 +5343,7 @@ command = "echo"
             token_manager: None,
             setup_manager: Some(Arc::new(OAuthSetupManager::new())),
             profile_registry: None,
+            event_bus: None,
         }
     }
 
@@ -5922,6 +6007,7 @@ command = "echo"
             token_manager: Some(token_manager.clone()),
             setup_manager: None,
             profile_registry: None,
+            event_bus: None,
         };
         (state, token_manager)
     }
@@ -6122,6 +6208,7 @@ command = "echo"
             token_manager: None,
             setup_manager: None,
             profile_registry: None,
+            event_bus: None,
         };
         (state, flow_mgr)
     }
@@ -6562,6 +6649,7 @@ command = "echo"
             token_manager: Some(token_manager),
             setup_manager: None,
             profile_registry: None,
+            event_bus: None,
         };
         let app = management_routes(state);
         let resp = app
@@ -6633,6 +6721,7 @@ client_id = "client123"
             token_manager: Some(token_manager),
             setup_manager: None,
             profile_registry: None,
+            event_bus: None,
         };
         let app = management_routes(state);
         let resp = app
@@ -6751,6 +6840,7 @@ client_id = "client123"
             token_manager: None,
             setup_manager: None,
             profile_registry: Some(profile_registry),
+            event_bus: None,
         }
     }
 
@@ -7266,6 +7356,7 @@ client_id = "client123"
             token_manager: None,
             setup_manager: None,
             profile_registry: None,
+            event_bus: None,
         }
     }
 
@@ -7569,6 +7660,103 @@ client_id = "client123"
         assert_eq!(
             before, after,
             "rejected rename must not write to config.toml"
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // GET /api/events/tool-calls — desktop overlay SSE stream
+    // -------------------------------------------------------------------
+
+    /// 503 when the bus isn't wired (legacy test fixtures / first-run race
+    /// between the management socket binding and bus construction).
+    #[tokio::test]
+    async fn tool_call_events_sse_returns_503_without_bus() {
+        let mut state = test_state(vec![]).await;
+        state.event_bus = None;
+        let router = management_routes(state);
+        let req = Request::builder()
+            .uri("/api/events/tool-calls")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    /// Bus-wired stream returns 200 with the SSE content-type and an active
+    /// keep-alive (so the desktop's Unix-socket HTTP client doesn't drop the
+    /// idle connection). We don't assert on the keep-alive comment frame
+    /// timing here — the keep-alive interval is 15 s — but we do verify
+    /// that a published event reaches the body within a short timeout, and
+    /// that subsequent reads keep returning bytes (i.e. the stream is not
+    /// closed by axum's keep-alive layer).
+    #[tokio::test]
+    async fn tool_call_events_sse_streams_published_events() {
+        use http_body_util::BodyExt;
+        let bus = ToolCallEventBus::with_default_capacity();
+        let mut state = test_state(vec![]).await;
+        state.event_bus = Some(bus.clone());
+        let router = management_routes(state);
+        let req = Request::builder()
+            .uri("/api/events/tool-calls")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let ct = resp
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        assert!(
+            ct.starts_with("text/event-stream"),
+            "expected SSE content-type, got {:?}",
+            ct
+        );
+
+        // Wait for the spawned task to attach its receiver, then publish.
+        let mut body = resp.into_body();
+        for _ in 0..50 {
+            if bus.receiver_count() > 0 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(bus.receiver_count() > 0, "SSE handler should subscribe");
+        bus.send(crate::events::ToolCallEvent::Completed {
+            request_id: "rid-1".into(),
+            ts: "2026-05-27T00:00:00.000Z".into(),
+            duration_ms: 5,
+            status: "ok".into(),
+        });
+
+        // Read a few chunks until we observe the JSON payload.
+        let mut buf = Vec::new();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while std::time::Instant::now() < deadline {
+            let frame = tokio::time::timeout(std::time::Duration::from_millis(200), body.frame())
+                .await
+                .ok()
+                .and_then(|f| f);
+            if let Some(Ok(frame)) = frame {
+                if let Some(data) = frame.data_ref() {
+                    buf.extend_from_slice(data);
+                    if String::from_utf8_lossy(&buf).contains("\"kind\":\"completed\"") {
+                        break;
+                    }
+                }
+            }
+        }
+        let text = String::from_utf8_lossy(&buf);
+        assert!(
+            text.contains("\"kind\":\"completed\""),
+            "expected 'completed' frame in SSE body, got: {}",
+            text
+        );
+        assert!(
+            text.contains("\"request_id\":\"rid-1\""),
+            "expected request_id in SSE body, got: {}",
+            text
         );
     }
 }

--- a/src/management.rs
+++ b/src/management.rs
@@ -7725,6 +7725,7 @@ client_id = "client123"
         assert!(bus.receiver_count() > 0, "SSE handler should subscribe");
         bus.send(crate::events::ToolCallEvent::Completed {
             request_id: "rid-1".into(),
+            jsonrpc_id: Some("42".into()),
             ts: "2026-05-27T00:00:00.000Z".into(),
             duration_ms: 5,
             status: "ok".into(),
@@ -7756,6 +7757,11 @@ client_id = "client123"
         assert!(
             text.contains("\"request_id\":\"rid-1\""),
             "expected request_id in SSE body, got: {}",
+            text
+        );
+        assert!(
+            text.contains("\"jsonrpc_id\":\"42\""),
+            "expected jsonrpc_id in SSE body, got: {}",
             text
         );
     }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,4 +1,6 @@
+use crate::adapter::stdio::iso8601_now;
 use crate::adapter::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
+use crate::events::{current_request_context, ToolCallEvent, ToolCallEventBus};
 use crate::prefix;
 use async_trait::async_trait;
 use serde_json::Value;
@@ -110,6 +112,16 @@ pub struct AdapterRegistry {
     /// profile changes). Consumers that don't care about origin (e.g. the
     /// global `/mcp/sse` handler) forward unconditionally.
     tools_changed_tx: broadcast::Sender<String>,
+    /// Optional shared [`ToolCallEventBus`] used by [`Self::route_tool_call`]
+    /// to publish `started` + `failed` pairs for early-rejection branches
+    /// that short-circuit before reaching an adapter's `call_tool` (unknown
+    /// prefix, missing adapter, disabled endpoint, unhealthy endpoint,
+    /// disabled tool). `None` by default so the many test-only call sites
+    /// that construct a bare registry without a bus keep compiling; wired in
+    /// by `main.rs` via [`Self::with_event_bus`] so the overlay still gets
+    /// the same `Started` → `Failed` transition adapters produce for calls
+    /// that do reach the network.
+    event_bus: Option<ToolCallEventBus>,
 }
 
 impl Default for AdapterRegistry {
@@ -127,7 +139,21 @@ impl AdapterRegistry {
             catalog_cache: Arc::new(RwLock::new(None)),
             catalog_generation: Arc::new(AtomicU64::new(0)),
             tools_changed_tx,
+            event_bus: None,
         }
+    }
+
+    /// Attach a shared [`ToolCallEventBus`] so [`Self::route_tool_call`]
+    /// publishes a `Started` + `Failed` pair for every early-rejection
+    /// branch (unknown prefix, missing/disabled/unhealthy endpoint,
+    /// disabled tool). The same bus instance must be wired into adapters
+    /// via [`McpAdapter::set_event_bus`] so the overlay sees a single
+    /// fan-out for both pre-adapter and adapter-side failures. Builder
+    /// style so the existing many-call-sites `AdapterRegistry::new()`
+    /// continues to compile unchanged.
+    pub fn with_event_bus(mut self, bus: ToolCallEventBus) -> Self {
+        self.event_bus = Some(bus);
+        self
     }
 
     /// Subscribe to the relay-wide tools-changed broadcast. Each `recv()`
@@ -560,7 +586,13 @@ impl AdapterRegistry {
     /// Route a prefixed tool call to the correct adapter.
     ///
     /// Rebuilds the reverse-lookup map from the current catalog to find the
-    /// target endpoint and raw tool name for the given prefixed name.
+    /// target endpoint and raw tool name for the given prefixed name. Every
+    /// early-rejection branch (unknown prefix, missing adapter, disabled
+    /// endpoint, unhealthy endpoint, disabled tool) emits a
+    /// [`ToolCallEvent::Started`] + [`ToolCallEvent::Failed`] pair on the
+    /// shared [`ToolCallEventBus`] (when wired via [`Self::with_event_bus`])
+    /// so the desktop overlay shows the same brief in-flight → failed card
+    /// it would render for an adapter-side failure.
     pub async fn route_tool_call(
         &self,
         prefixed_name: &str,
@@ -568,37 +600,81 @@ impl AdapterRegistry {
     ) -> Result<serde_json::Value, AdapterError> {
         let (_, lookup) = self.merged_catalog_with_lookup().await;
 
-        let (endpoint, tool) = lookup.get(prefixed_name).ok_or_else(|| {
-            AdapterError::ProtocolError(format!(
-                "no tool found for prefixed name '{}'",
-                prefixed_name
-            ))
-        })?;
+        let (endpoint, tool) = match lookup.get(prefixed_name) {
+            Some(v) => v,
+            None => {
+                // Branch 1: unknown prefixed name. We have no endpoint or
+                // adapter to consult, so server_type/server_name are omitted
+                // and transport falls back to the "unknown" sentinel.
+                return Err(self.publish_early_rejection(
+                    prefixed_name.to_string(),
+                    "unknown".to_string(),
+                    "unknown".to_string(),
+                    None,
+                    None,
+                    format!("no tool found for prefixed name '{}'", prefixed_name),
+                ));
+            }
+        };
 
         let adapters = self.adapters.read().await;
-        let entry = adapters.get(endpoint).ok_or_else(|| {
-            AdapterError::ProtocolError(format!("no adapter found for endpoint '{}'", endpoint))
-        })?;
+        let entry = match adapters.get(endpoint) {
+            Some(e) => e,
+            None => {
+                // Branch 2: lookup pointed at an endpoint the registry no
+                // longer has an adapter for (e.g. catalog cached across a
+                // remove). transport/server_type/server_name unknown.
+                return Err(self.publish_early_rejection(
+                    tool.clone(),
+                    endpoint.clone(),
+                    "unknown".to_string(),
+                    None,
+                    None,
+                    format!("no adapter found for endpoint '{}'", endpoint),
+                ));
+            }
+        };
 
         if entry.disabled {
-            return Err(AdapterError::ProtocolError(format!(
-                "endpoint '{}' is disabled",
-                endpoint
-            )));
+            // Branch 3: endpoint is administratively disabled.
+            return Err(self.publish_early_rejection(
+                tool.clone(),
+                endpoint.clone(),
+                entry.transport.clone(),
+                entry.adapter.server_type(),
+                entry.adapter.upstream_server_name(),
+                format!("endpoint '{}' is disabled", endpoint),
+            ));
         }
 
         if !matches!(entry.adapter.health(), HealthStatus::Healthy) {
-            return Err(AdapterError::ProtocolError(format!(
-                "tool '{}' is currently unavailable: endpoint '{}' is not healthy",
-                tool, endpoint
-            )));
+            // Branch 4: endpoint is registered + enabled but not Healthy.
+            return Err(self.publish_early_rejection(
+                tool.clone(),
+                endpoint.clone(),
+                entry.transport.clone(),
+                entry.adapter.server_type(),
+                entry.adapter.upstream_server_name(),
+                format!(
+                    "tool '{}' is currently unavailable: endpoint '{}' is not healthy",
+                    tool, endpoint
+                ),
+            ));
         }
 
         if entry.disabled_tools.contains(tool) {
-            return Err(AdapterError::ProtocolError(format!(
-                "tool '{}' is disabled on endpoint '{}'",
-                tool, endpoint
-            )));
+            // Branch 5: tool is disabled on this endpoint. Normally
+            // `merged_catalog_with_lookup` filters disabled tools so this
+            // branch is only reachable when the lookup was cached before
+            // the tool was added to `disabled_tools`.
+            return Err(self.publish_early_rejection(
+                tool.clone(),
+                endpoint.clone(),
+                entry.transport.clone(),
+                entry.adapter.server_type(),
+                entry.adapter.upstream_server_name(),
+                format!("tool '{}' is disabled on endpoint '{}'", tool, endpoint),
+            ));
         }
 
         info!(
@@ -608,6 +684,59 @@ impl AdapterRegistry {
             "Routing tool call"
         );
         entry.adapter.call_tool(tool, arguments).await
+    }
+
+    /// Publish a `Started` + `Failed` pair on the shared
+    /// [`ToolCallEventBus`] (when wired) for an early-rejection branch of
+    /// [`Self::route_tool_call`], then return the matching
+    /// [`AdapterError::ProtocolError`]. Kept in lockstep with the
+    /// per-adapter `call_tool` emission pattern in
+    /// `adapter/stdio.rs::call_tool` so the overlay sees a uniform
+    /// `Started` → `Failed` transition regardless of whether the call was
+    /// rejected pre-adapter or returned an error from the upstream MCP
+    /// server. The error text returned here MUST match the pre-event
+    /// strings (`no tool found for prefixed name`,
+    /// `no adapter found for endpoint`, `endpoint '{}' is disabled`,
+    /// `tool '{}' is currently unavailable: endpoint '{}' is not healthy`,
+    /// `tool '{}' is disabled on endpoint '{}'`) — external log scrapers
+    /// may depend on the exact wording.
+    fn publish_early_rejection(
+        &self,
+        tool: String,
+        endpoint: String,
+        transport: String,
+        server_type: Option<String>,
+        server_name: Option<String>,
+        error_message: String,
+    ) -> AdapterError {
+        if let Some(bus) = &self.event_bus {
+            let span_ctx = current_request_context();
+            let request_id = uuid::Uuid::new_v4().to_string();
+            // Emit `Started` first so the overlay can spawn an in-flight
+            // card before it sees `Failed`, matching the
+            // adapter-side ordering.
+            bus.send(ToolCallEvent::Started {
+                request_id: request_id.clone(),
+                jsonrpc_id: span_ctx.jsonrpc_id.clone(),
+                ts: iso8601_now(),
+                endpoint,
+                transport,
+                server_type,
+                server_name,
+                profile: span_ctx.profile.clone(),
+                tool,
+                annotations: None,
+            });
+            bus.send(ToolCallEvent::Failed {
+                request_id,
+                jsonrpc_id: span_ctx.jsonrpc_id,
+                ts: iso8601_now(),
+                duration_ms: 0,
+                status: "error".to_string(),
+                error_message: error_message.clone(),
+            });
+        }
+        AdapterError::ProtocolError(error_message)
     }
 }
 
@@ -2571,6 +2700,256 @@ mod tests {
             1,
             "expected exactly one underlying list_tools call; the second \
              caller must observe the populated cache after the populate lock"
+        );
+    }
+
+    // --- Early-rejection event emission (route_tool_call) ---
+    //
+    // Each of the 5 early-rejection branches in `route_tool_call` must
+    // publish a `Started` + `Failed` pair on the wired
+    // `ToolCallEventBus` before returning the underlying
+    // `AdapterError::ProtocolError`. The error string must match the
+    // pre-event wording exactly (log scrapers depend on it).
+
+    /// Drain the next two events from `rx` and assert they form a matched
+    /// `Started` + `Failed` pair carrying the expected tool name and error
+    /// message. Returns the request_id so the caller can assert nothing
+    /// else followed.
+    async fn assert_started_then_failed(
+        rx: &mut tokio::sync::broadcast::Receiver<ToolCallEvent>,
+        expected_tool: &str,
+        expected_endpoint: Option<&str>,
+        expected_error: &str,
+    ) -> String {
+        let started = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("started event arrived")
+            .expect("started recv ok");
+        let (sid, sendpoint) = match started {
+            ToolCallEvent::Started {
+                request_id,
+                tool,
+                endpoint,
+                ..
+            } => {
+                assert_eq!(tool, expected_tool, "Started.tool");
+                if let Some(exp) = expected_endpoint {
+                    assert_eq!(endpoint, exp, "Started.endpoint");
+                }
+                (request_id, endpoint)
+            }
+            other => panic!("expected Started, got {:?}", other),
+        };
+        let _ = sendpoint;
+        let failed = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("failed event arrived")
+            .expect("failed recv ok");
+        match failed {
+            ToolCallEvent::Failed {
+                request_id,
+                status,
+                error_message,
+                ..
+            } => {
+                assert_eq!(request_id, sid, "Failed.request_id matches Started");
+                assert_eq!(status, "error");
+                assert_eq!(error_message, expected_error);
+            }
+            other => panic!("expected Failed, got {:?}", other),
+        }
+        sid
+    }
+
+    #[tokio::test]
+    async fn route_unknown_prefix_emits_started_and_failed() {
+        let bus = ToolCallEventBus::with_default_capacity();
+        let mut rx = bus.subscribe();
+        let registry = AdapterRegistry::new().with_event_bus(bus);
+
+        let err = registry
+            .route_tool_call("ghost_tool", json!({}))
+            .await
+            .expect_err("unknown prefix should reject");
+        let expected = "no tool found for prefixed name 'ghost_tool'";
+        match &err {
+            AdapterError::ProtocolError(msg) => assert_eq!(msg, expected),
+            other => panic!("expected ProtocolError, got {:?}", other),
+        }
+        assert_started_then_failed(&mut rx, "ghost_tool", Some("unknown"), expected).await;
+    }
+
+    #[tokio::test]
+    async fn route_missing_adapter_emits_started_and_failed() {
+        // Build a lookup pointing at endpoint `ep` then remove the
+        // adapter without invalidating the cached lookup so route hits
+        // the "no adapter found" branch.
+        let bus = ToolCallEventBus::with_default_capacity();
+        let mut rx = bus.subscribe();
+        let registry = AdapterRegistry::new().with_event_bus(bus);
+        registry
+            .register(
+                "ep".into(),
+                Box::new(MockAdapter::healthy(vec![make_tool("read")])),
+                "stdio".into(),
+                None,
+                Some("ep".into()),
+            )
+            .await;
+        // Warm the cached lookup so the subsequent removal keeps the
+        // (prefixed_name -> ("ep", "read")) mapping in `catalog_cache`.
+        let _ = registry.merged_catalog_with_lookup().await;
+        // Bypass `remove()` (which invalidates the catalog) by yanking
+        // the adapter directly out of the inner map.
+        registry.adapters.write().await.remove("ep");
+
+        let err = registry
+            .route_tool_call("read", json!({}))
+            .await
+            .expect_err("missing adapter should reject");
+        let expected = "no adapter found for endpoint 'ep'";
+        match &err {
+            AdapterError::ProtocolError(msg) => assert_eq!(msg, expected),
+            other => panic!("expected ProtocolError, got {:?}", other),
+        }
+        assert_started_then_failed(&mut rx, "read", Some("ep"), expected).await;
+    }
+
+    #[tokio::test]
+    async fn route_disabled_endpoint_emits_started_and_failed() {
+        let bus = ToolCallEventBus::with_default_capacity();
+        let mut rx = bus.subscribe();
+        let registry = AdapterRegistry::new().with_event_bus(bus);
+        registry
+            .register(
+                "ep".into(),
+                Box::new(MockAdapter::healthy(vec![make_tool("read")])),
+                "stdio".into(),
+                None,
+                Some("ep".into()),
+            )
+            .await;
+        // Warm the lookup, then disable the endpoint without
+        // invalidating so the branch is reachable.
+        let _ = registry.merged_catalog_with_lookup().await;
+        registry
+            .adapters
+            .write()
+            .await
+            .get_mut("ep")
+            .unwrap()
+            .disabled = true;
+
+        let err = registry
+            .route_tool_call("read", json!({}))
+            .await
+            .expect_err("disabled endpoint should reject");
+        let expected = "endpoint 'ep' is disabled";
+        match &err {
+            AdapterError::ProtocolError(msg) => assert_eq!(msg, expected),
+            other => panic!("expected ProtocolError, got {:?}", other),
+        }
+        assert_started_then_failed(&mut rx, "read", Some("ep"), expected).await;
+    }
+
+    #[tokio::test]
+    async fn route_unhealthy_endpoint_emits_started_and_failed() {
+        let bus = ToolCallEventBus::with_default_capacity();
+        let mut rx = bus.subscribe();
+        let registry = AdapterRegistry::new().with_event_bus(bus);
+        // Register an unhealthy adapter that still publishes a tool so
+        // the lookup contains it (the catalog includes unhealthy tools
+        // marked `[⚠️ UNAVAILABLE]`).
+        registry
+            .register(
+                "ep".into(),
+                Box::new(MockAdapter::unhealthy_with_tools(vec![make_tool("read")])),
+                "stdio".into(),
+                None,
+                Some("ep".into()),
+            )
+            .await;
+
+        let err = registry
+            .route_tool_call("read", json!({}))
+            .await
+            .expect_err("unhealthy endpoint should reject");
+        let expected = "tool 'read' is currently unavailable: endpoint 'ep' is not healthy";
+        match &err {
+            AdapterError::ProtocolError(msg) => assert_eq!(msg, expected),
+            other => panic!("expected ProtocolError, got {:?}", other),
+        }
+        assert_started_then_failed(&mut rx, "read", Some("ep"), expected).await;
+    }
+
+    #[tokio::test]
+    async fn route_disabled_tool_emits_started_and_failed() {
+        let bus = ToolCallEventBus::with_default_capacity();
+        let mut rx = bus.subscribe();
+        let registry = AdapterRegistry::new().with_event_bus(bus);
+        registry
+            .register(
+                "ep".into(),
+                Box::new(MockAdapter::healthy(vec![make_tool("read")])),
+                "stdio".into(),
+                None,
+                Some("ep".into()),
+            )
+            .await;
+        // Warm the lookup so the disabled-tool branch becomes reachable
+        // (merged_catalog_with_lookup filters disabled tools, so a
+        // post-disable lookup rebuild would route the call through the
+        // unknown-prefix branch instead).
+        let _ = registry.merged_catalog_with_lookup().await;
+        registry
+            .adapters
+            .write()
+            .await
+            .get_mut("ep")
+            .unwrap()
+            .disabled_tools
+            .insert("read".into());
+
+        let err = registry
+            .route_tool_call("read", json!({}))
+            .await
+            .expect_err("disabled tool should reject");
+        let expected = "tool 'read' is disabled on endpoint 'ep'";
+        match &err {
+            AdapterError::ProtocolError(msg) => assert_eq!(msg, expected),
+            other => panic!("expected ProtocolError, got {:?}", other),
+        }
+        assert_started_then_failed(&mut rx, "read", Some("ep"), expected).await;
+    }
+
+    #[tokio::test]
+    async fn route_success_does_not_emit_registry_events() {
+        // Sanity check: when the call reaches the adapter (and the mock
+        // adapter does not publish events), the registry must not emit
+        // a stray `Started`/`Failed` pair.
+        let bus = ToolCallEventBus::with_default_capacity();
+        let mut rx = bus.subscribe();
+        let registry = AdapterRegistry::new().with_event_bus(bus);
+        registry
+            .register(
+                "ep".into(),
+                Box::new(MockAdapter::healthy(vec![make_tool("read")])),
+                "stdio".into(),
+                None,
+                Some("ep".into()),
+            )
+            .await;
+
+        let result = registry.route_tool_call("read", json!({})).await.unwrap();
+        assert_eq!(result["called"], "read");
+        let try_recv = rx.try_recv();
+        assert!(
+            matches!(
+                try_recv,
+                Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+            ),
+            "registry must not publish events on the happy path; got {:?}",
+            try_recv
         );
     }
 }

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -4,6 +4,7 @@ use crate::adapter::sse::{SseAdapter, SseConfig};
 use crate::adapter::stdio::{StdioAdapter, StdioConfig};
 use crate::adapter::{FailedAdapter, McpAdapter, StartingAdapter};
 use crate::config::{self, Config, ConfigDiff, EndpointConfig, Transport};
+use crate::events::ToolCallEventBus;
 use crate::oauth::OAuthFlowManager;
 use crate::profile_registry::ProfileRegistry;
 use crate::registry::AdapterRegistry;
@@ -41,6 +42,7 @@ impl ConfigWatcher {
         _oauth_flow_manager: Arc<OAuthFlowManager>,
         oauth_adapter_inners: OAuthAdapterInners,
         shared_config: Arc<RwLock<Config>>,
+        event_bus: Option<ToolCallEventBus>,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
             if let Err(e) = watch_loop(
@@ -52,6 +54,7 @@ impl ConfigWatcher {
                 token_manager,
                 oauth_adapter_inners,
                 shared_config,
+                event_bus,
             )
             .await
             {
@@ -71,6 +74,7 @@ async fn watch_loop(
     token_manager: Arc<TokenManager>,
     oauth_adapter_inners: OAuthAdapterInners,
     shared_config: Arc<RwLock<Config>>,
+    event_bus: Option<ToolCallEventBus>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let (tx, mut rx) = tokio::sync::mpsc::channel(16);
 
@@ -125,6 +129,7 @@ async fn watch_loop(
             &profile_registry,
             &token_manager,
             &oauth_adapter_inners,
+            event_bus.as_ref(),
         )
         .await;
     }
@@ -145,6 +150,7 @@ async fn watch_loop(
 /// Returns `Ok(())` when the reload was applied (including warning-only
 /// reloads); returns `Err(ConfigError)` when nothing was applied because the
 /// new config could not be parsed or its profile block was invalid.
+#[allow(clippy::too_many_arguments)]
 async fn reload_and_apply(
     config_path: &Path,
     shared_config: &Arc<RwLock<Config>>,
@@ -153,6 +159,7 @@ async fn reload_and_apply(
     profile_registry: &Arc<ProfileRegistry>,
     token_manager: &Arc<TokenManager>,
     oauth_adapter_inners: &OAuthAdapterInners,
+    event_bus: Option<&ToolCallEventBus>,
 ) -> Result<(), config::ConfigError> {
     // Parse new config gracefully. Fatal errors (parse failure or
     // fail-fast profile-validation failure) bail out without touching the
@@ -187,6 +194,7 @@ async fn reload_and_apply(
         token_manager,
         oauth_adapter_inners,
         new_config.relay.allow_insecure_oauth.unwrap_or(false),
+        event_bus,
     )
     .await;
 
@@ -217,12 +225,14 @@ async fn reload_and_apply(
 ///
 /// This is public so it can also be called from a manual reload endpoint.
 #[allow(dead_code)]
+#[allow(clippy::too_many_arguments)]
 pub async fn apply_diff(
     diff: &ConfigDiff,
     registry: &AdapterRegistry,
     token_manager: &Arc<TokenManager>,
     oauth_adapter_inners: &OAuthAdapterInners,
     allow_insecure_oauth: bool,
+    event_bus: Option<&ToolCallEventBus>,
 ) {
     // Remove endpoints
     for name in &diff.removed {
@@ -278,8 +288,10 @@ pub async fn apply_diff(
         let name_clone = name.clone();
         let tm = token_manager.clone();
         let oai = oauth_adapter_inners.clone();
+        let bus = event_bus.cloned();
         tokio::spawn(async move {
-            let adapter = create_adapter(&ep_clone, &tm, &oai, allow_insecure_oauth).await;
+            let adapter =
+                create_adapter(&ep_clone, &tm, &oai, allow_insecure_oauth, bus.as_ref()).await;
             let mut entries = reg.entries().write().await;
             if let Some(entry) = entries.get_mut(name_clone.as_str()) {
                 entry.adapter = adapter;
@@ -321,8 +333,10 @@ pub async fn apply_diff(
         let ep_clone = ep.clone();
         let tm = token_manager.clone();
         let oai = oauth_adapter_inners.clone();
+        let bus = event_bus.cloned();
         tokio::spawn(async move {
-            let adapter = create_adapter(&ep_clone, &tm, &oai, allow_insecure_oauth).await;
+            let adapter =
+                create_adapter(&ep_clone, &tm, &oai, allow_insecure_oauth, bus.as_ref()).await;
             let mut entries = reg.entries().write().await;
             if let Some(entry) = entries.get_mut(ep_clone.name.as_str()) {
                 entry.adapter = adapter;
@@ -347,6 +361,7 @@ pub async fn apply_diff(
 ///
 /// Endpoints whose names appear in `warned_names` are registered as `FailedAdapter`
 /// with the warning message instead of attempting initialization.
+#[allow(clippy::too_many_arguments)]
 pub async fn apply_diff_graceful(
     diff: &ConfigDiff,
     registry: &AdapterRegistry,
@@ -355,6 +370,7 @@ pub async fn apply_diff_graceful(
     token_manager: &Arc<TokenManager>,
     oauth_adapter_inners: &OAuthAdapterInners,
     allow_insecure_oauth: bool,
+    event_bus: Option<&ToolCallEventBus>,
 ) {
     // Build warning message map
     let warning_messages: std::collections::HashMap<String, String> = {
@@ -449,8 +465,10 @@ pub async fn apply_diff_graceful(
         let name_clone = name.clone();
         let tm = token_manager.clone();
         let oai = oauth_adapter_inners.clone();
+        let bus = event_bus.cloned();
         tokio::spawn(async move {
-            let adapter = create_adapter(&ep_clone, &tm, &oai, allow_insecure_oauth).await;
+            let adapter =
+                create_adapter(&ep_clone, &tm, &oai, allow_insecure_oauth, bus.as_ref()).await;
             let mut entries = reg.entries().write().await;
             if let Some(entry) = entries.get_mut(name_clone.as_str()) {
                 entry.adapter = adapter;
@@ -519,8 +537,10 @@ pub async fn apply_diff_graceful(
         let ep_clone = ep.clone();
         let tm = token_manager.clone();
         let oai = oauth_adapter_inners.clone();
+        let bus = event_bus.cloned();
         tokio::spawn(async move {
-            let adapter = create_adapter(&ep_clone, &tm, &oai, allow_insecure_oauth).await;
+            let adapter =
+                create_adapter(&ep_clone, &tm, &oai, allow_insecure_oauth, bus.as_ref()).await;
             let mut entries = reg.entries().write().await;
             if let Some(entry) = entries.get_mut(ep_clone.name.as_str()) {
                 entry.adapter = adapter;
@@ -658,6 +678,7 @@ pub(crate) async fn create_adapter(
     token_manager: &Arc<TokenManager>,
     oauth_adapter_inners: &OAuthAdapterInners,
     allow_insecure_oauth: bool,
+    event_bus: Option<&ToolCallEventBus>,
 ) -> Box<dyn McpAdapter> {
     match ep.transport {
         Transport::Stdio => {
@@ -669,6 +690,9 @@ pub(crate) async fn create_adapter(
                 endpoint_name: ep.name.clone(),
             };
             let mut adapter = StdioAdapter::new(stdio_config);
+            if let Some(bus) = event_bus {
+                adapter.set_event_bus(bus.clone());
+            }
             match adapter.initialize().await {
                 Ok(()) => Box::new(adapter),
                 Err(e) => {
@@ -687,6 +711,9 @@ pub(crate) async fn create_adapter(
             sse_config.server_type_override = ep.server_type_override.clone();
             sse_config.endpoint_name = ep.name.clone();
             let mut adapter = SseAdapter::new(sse_config);
+            if let Some(bus) = event_bus {
+                adapter.set_event_bus(bus.clone());
+            }
             match adapter.initialize().await {
                 Ok(()) => Box::new(adapter),
                 Err(e) => {
@@ -705,6 +732,9 @@ pub(crate) async fn create_adapter(
             http_config.server_type_override = ep.server_type_override.clone();
             http_config.endpoint_name = ep.name.clone();
             let mut adapter = HttpAdapter::new(http_config);
+            if let Some(bus) = event_bus {
+                adapter.set_event_bus(bus.clone());
+            }
             match adapter.initialize().await {
                 Ok(()) => Box::new(adapter),
                 Err(e) => {
@@ -734,6 +764,9 @@ pub(crate) async fn create_adapter(
             };
 
             let mut adapter = OAuthAdapter::new(oauth_config, token_manager.clone());
+            if let Some(bus) = event_bus {
+                adapter.set_event_bus(bus.clone());
+            }
             let shared_inner = adapter.shared_inner();
             oauth_adapter_inners
                 .write()
@@ -905,7 +938,7 @@ mod tests {
             )
             .await;
 
-        apply_diff(&empty_diff(), &registry, &tm, &inners, false).await;
+        apply_diff(&empty_diff(), &registry, &tm, &inners, false, None).await;
 
         // Existing adapter should still be there, not shut down
         assert!(!shutdown.load(std::sync::atomic::Ordering::SeqCst));
@@ -932,7 +965,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &inners, false).await;
+        apply_diff(&diff, &registry, &tm, &inners, false, None).await;
 
         assert!(shutdown.load(std::sync::atomic::Ordering::SeqCst));
         assert!(registry.merged_catalog().await.is_empty());
@@ -948,7 +981,7 @@ mod tests {
         };
 
         // Should not panic
-        apply_diff(&diff, &registry, &tm, &inners, false).await;
+        apply_diff(&diff, &registry, &tm, &inners, false, None).await;
     }
 
     #[tokio::test]
@@ -992,7 +1025,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &inners, false).await;
+        apply_diff(&diff, &registry, &tm, &inners, false, None).await;
 
         // Old adapter should have been shut down
         assert!(shutdown.load(std::sync::atomic::Ordering::SeqCst));
@@ -1027,7 +1060,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &inners, false).await;
+        apply_diff(&diff, &registry, &tm, &inners, false, None).await;
 
         // Wait for background initialization to complete
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -1079,7 +1112,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &inners, false).await;
+        apply_diff(&diff, &registry, &tm, &inners, false, None).await;
 
         // "keep" should still be alive
         assert!(!shutdown_keep.load(std::sync::atomic::Ordering::SeqCst));
@@ -1120,7 +1153,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &inners, false).await;
+        apply_diff(&diff, &registry, &tm, &inners, false, None).await;
 
         // Wait for background initialization to complete
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -1189,7 +1222,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &inners, true).await;
+        apply_diff(&diff, &registry, &tm, &inners, true, None).await;
 
         // Wait for background initialization to register the OAuth adapter inner.
         let stop = std::time::Instant::now() + std::time::Duration::from_secs(2);
@@ -1236,6 +1269,7 @@ mod tests {
             &tm,
             &inners,
             false,
+            None,
         )
         .await;
 
@@ -1282,7 +1316,10 @@ mod tests {
         let warned: std::collections::HashSet<String> =
             warnings.iter().map(|w| w.endpoint_name.clone()).collect();
 
-        apply_diff_graceful(&diff, &registry, &warnings, &warned, &tm, &inners, false).await;
+        apply_diff_graceful(
+            &diff, &registry, &warnings, &warned, &tm, &inners, false, None,
+        )
+        .await;
 
         // No background spawn for warned endpoints — entry is final immediately.
         let entries = registry.entries().read().await;
@@ -1332,7 +1369,10 @@ mod tests {
         }];
         let warned: std::collections::HashSet<String> = ["ep".to_string()].into_iter().collect();
 
-        apply_diff_graceful(&diff, &registry, &warnings, &warned, &tm, &inners, false).await;
+        apply_diff_graceful(
+            &diff, &registry, &warnings, &warned, &tm, &inners, false, None,
+        )
+        .await;
 
         // Old adapter shut down synchronously.
         assert!(shutdown.load(std::sync::atomic::Ordering::SeqCst));
@@ -1382,7 +1422,10 @@ mod tests {
         let warnings: Vec<config::EndpointValidationWarning> = vec![];
         let warned: std::collections::HashSet<String> = std::collections::HashSet::new();
 
-        apply_diff_graceful(&diff, &registry, &warnings, &warned, &tm, &inners, true).await;
+        apply_diff_graceful(
+            &diff, &registry, &warnings, &warned, &tm, &inners, true, None,
+        )
+        .await;
 
         // Wait for background initialization to register the OAuth adapter inner.
         let stop = std::time::Instant::now() + std::time::Duration::from_secs(2);
@@ -1831,6 +1874,7 @@ toon_output = true
                     &profile_registry,
                     &tm,
                     &inners,
+                    None,
                 )
                 .await
                 .expect("reload should succeed");
@@ -1873,6 +1917,7 @@ toon_output = true
                     &profile_registry,
                     &tm,
                     &inners,
+                    None,
                 )
                 .await
                 .expect("reload should succeed");
@@ -1930,6 +1975,7 @@ toon_output = true
                     &profile_registry,
                     &tm,
                     &inners,
+                    None,
                 )
                 .await
                 .expect_err("invalid profile config must be rejected");
@@ -2123,6 +2169,7 @@ command = "/bin/true"
                     &profile_registry,
                     &tm,
                     &inners,
+                    None,
                 )
                 .await
                 .expect("reload should succeed");
@@ -2223,6 +2270,7 @@ command = "/bin/true"
                     token_manager: Some(token_manager.clone()),
                     setup_manager: None,
                     profile_registry: Some(profile_registry.clone()),
+                    event_bus: None,
                 };
                 let app = management_routes(state);
 
@@ -2257,6 +2305,7 @@ command = "/bin/true"
                     &profile_registry,
                     &token_manager,
                     &inners,
+                    None,
                 )
                 .await
                 .expect("reload of valid config must succeed");

--- a/tests/hot_reload_integration.rs
+++ b/tests/hot_reload_integration.rs
@@ -154,6 +154,7 @@ async fn test_config_diff_add_endpoint() {
         &token_manager,
         &oauth_adapter_inners,
         false,
+        None,
     )
     .await;
 
@@ -313,6 +314,7 @@ async fn test_config_diff_remove_endpoint() {
         &token_manager2,
         &oauth_adapter_inners2,
         false,
+        None,
     )
     .await;
 

--- a/tests/management_api_integration.rs
+++ b/tests/management_api_integration.rs
@@ -137,6 +137,7 @@ async fn start_management_server(
         token_manager: None,
         setup_manager: None,
         profile_registry: None,
+        event_bus: None,
     };
 
     let app = management_routes(state);
@@ -326,6 +327,7 @@ async fn start_management_server_with_config(
         token_manager: None,
         setup_manager: None,
         profile_registry: None,
+        event_bus: None,
     };
 
     let app = management_routes(state);

--- a/tests/oauth_setup_integration.rs
+++ b/tests/oauth_setup_integration.rs
@@ -64,6 +64,7 @@ async fn start_setup_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
         token_manager: None,
         setup_manager: Some(Arc::new(OAuthSetupManager::new())),
         profile_registry: None,
+        event_bus: None,
     };
 
     let app = management_routes(state);


### PR DESCRIPTION
## Summary

Adds a typed tool-call event bus (`ToolCallEvent::Started | Completed | Failed`) on a Tokio `broadcast` channel, exposed over HTTP as an SSE stream at `GET /api/events/tool-calls`. The desktop overlay window (sibling PR https://github.com/endara-ai/endara-desktop/pull/103) subscribes to this stream to render live in-flight / success / error cards for every tool call routed through the relay.

## What's in this PR

### Event bus core (`src/events.rs`)
- `ToolCallEvent` enum with `Started`, `Completed { duration_ms }`, and `Failed { duration_ms, error }` variants.
- Each event carries `request_id`, `endpoint_name`, `server_type`, `tool_name`, `jsonrpc_id`, and `profile` so the overlay can group and label cards correctly.
- `ToolCallEventBus` wraps a `broadcast::Sender` and exposes a non-blocking `emit()` that drops cleanly when there are no subscribers.
- `receiver_count()` is gated behind `cfg(test)` to keep `clippy -D warnings` clean in release builds.

### Adapter integration (`src/adapter/{http,sse,stdio,oauth}.rs`)
- Every adapter that issues a `call_tool` now emits `Started` before the underlying transport call and `Completed`/`Failed` after, using a single shared bus passed in at construction time.
- OAuth adapter preserves the per-request span scope through the inner `call_tool` so traces in `tracing-subscriber` stay correctly nested under the originating request.
- `HttpError`'s `Display` impl now truncates response bodies to avoid leaking large blobs (or full HTML error pages) into log lines and into the `Failed` event's `error` field.

### Registry early-rejection events (`src/registry.rs`)
- `AdapterRegistry::route_tool_call` now emits a `Started` + `Failed` pair for each of the 5 early-rejection branches — unknown prefix, missing adapter, disabled endpoint, unhealthy endpoint, disabled tool — before returning the same `AdapterError::ProtocolError` as before.
- This makes attempted-but-rejected calls visible in the overlay (e.g., a flash of a red card when a user invokes a tool against an unhealthy endpoint).
- 6 new unit tests: one per branch plus a happy-path no-emit regression guard.

### Management API (`src/management.rs`)
- New `GET /api/events/tool-calls` SSE endpoint that subscribes a fresh `broadcast::Receiver` and forwards every event as a `data:` line.
- Heartbeat comment frames every 15s so HTTP proxies don't kill idle streams.
- Disconnect cleanup happens automatically when the receiver is dropped.

### Wiring
- `main.rs` constructs a single `ToolCallEventBus`, hands it to the registry, and shares the same bus with the management API router.
- `watcher.rs` propagates the bus through hot-reload so live config updates don't disconnect SSE clients or drop in-flight emissions.

## Gates

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 752 lib + integration suites pass (6 new tests in registry, broadcast bus coverage in `events.rs`, SSE endpoint integration test in `management_api_integration.rs`)

## Manual verification

Used the overlay window in `endara-ai/endara-desktop` to drive 100-call parallel bursts against the gmail + linear adapters. Verified:
- In-flight / success / error cards transition smoothly through the lifecycle.
- Early-rejection branches (e.g., an unhealthy endpoint mid-burst) flash a red card instead of failing silently.
- The broadcast bus tolerates subscriber disconnect/reconnect without losing in-flight emissions for other subscribers.

## Sibling PR

Desktop consumer: https://github.com/endara-ai/endara-desktop/pull/103