### PR TITLE
fix(adapter): send notifications/initialized after MCP handshake on stdio and sse

### DIFF
--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -440,6 +440,61 @@ impl SseAdapter {
         }
     }
 
+    /// Send a JSON-RPC notification via POST to the endpoint. Notifications
+    /// have no `id` and do not produce a response — we only inspect the HTTP
+    /// status. Used for `notifications/initialized` after the handshake.
+    async fn send_notification(
+        &self,
+        method: &str,
+        params: Option<Value>,
+    ) -> Result<(), AdapterError> {
+        let endpoint = {
+            let guard = self.post_endpoint.read().await;
+            guard.clone().ok_or(AdapterError::NotInitialized)?
+        };
+
+        let mut request = json!({
+            "jsonrpc": "2.0",
+            "method": method,
+        });
+        if let Some(p) = params {
+            request["params"] = p;
+        }
+
+        debug!(method = method, endpoint = %endpoint, "sending SSE JSON-RPC notification");
+
+        let resp = self
+            .client
+            .post(&endpoint)
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| {
+                if e.is_timeout() {
+                    AdapterError::Timeout(self.config.timeout_secs)
+                } else if e.is_connect() {
+                    AdapterError::ConnectionFailed(format!("{}: {}", endpoint, e))
+                } else {
+                    AdapterError::HttpError {
+                        status: 0,
+                        body: e.to_string(),
+                    }
+                }
+            })?;
+
+        let status = resp.status();
+        if status.is_success() {
+            debug!(method = method, status = %status, "notification accepted");
+            Ok(())
+        } else {
+            let body = resp.text().await.unwrap_or_default();
+            Err(AdapterError::HttpError {
+                status: status.as_u16(),
+                body,
+            })
+        }
+    }
+
     /// Send a JSON-RPC request via POST to the endpoint and wait for the response via SSE.
     async fn send_request(
         &self,
@@ -580,6 +635,17 @@ impl SseAdapter {
         }
         *self.server_type.write().await = effective;
         *self.upstream_server_name.write().await = Some(upstream_stripped);
+
+        // Per the MCP spec the client MUST send a notifications/initialized
+        // notification after a successful initialize exchange. Failure is
+        // non-fatal — log and continue, matching the STDIO/HTTP adapters.
+        if let Err(e) = self
+            .send_notification("notifications/initialized", None)
+            .await
+        {
+            warn!(url = %self.config.url, error = %e, "failed to send notifications/initialized");
+        }
+
         *self.health.write().await = HealthStatus::Healthy;
         self.crash_tracker.lock().await.reset();
         // Emit a tick after every successful (re)connect + handshake so any
@@ -913,6 +979,8 @@ mod tests {
             /// When true, /message does NOT broadcast `tools/call` responses
             /// (used to test pending-request error propagation).
             silent_on_tools_call: AtomicBool,
+            /// Bodies of every POST /message received, in arrival order.
+            posts: std::sync::Mutex<Vec<Value>>,
         }
 
         /// Handle for a running test server; aborts on drop.
@@ -993,8 +1061,16 @@ mod tests {
         async fn handle_message(
             State(app): State<AppState>,
             Json(body): Json<Value>,
-        ) -> Json<Value> {
+        ) -> axum::response::Response {
+            app.fake.posts.lock().unwrap().push(body.clone());
+
             let method = body["method"].as_str().unwrap_or("").to_string();
+
+            // Notifications have no `id` and produce no response body.
+            if body.get("id").is_none() {
+                return (StatusCode::ACCEPTED, "").into_response();
+            }
+
             let id = body["id"].as_u64().unwrap_or(0);
             let response = match method.as_str() {
                 "initialize" => json!({
@@ -1021,7 +1097,7 @@ mod tests {
             if is_tools_call && app.fake.close_on_tools_call.load(Ordering::SeqCst) {
                 let _ = app.close_tx.send(());
             }
-            Json(response)
+            Json(response).into_response()
         }
 
         async fn start_test_server() -> FakeServer {
@@ -1081,6 +1157,58 @@ mod tests {
                 }
                 tokio::time::sleep(Duration::from_millis(20)).await;
             }
+        }
+
+        #[tokio::test]
+        async fn test_sse_sends_initialized_notification_after_handshake() {
+            let server = start_test_server().await;
+            let mut adapter = build_adapter(&server.url, 5).await;
+
+            adapter.initialize().await.unwrap();
+
+            let posts = server.state.posts.lock().unwrap().clone();
+            assert!(
+                posts.len() >= 2,
+                "expected at least 2 POSTs (initialize + notifications/initialized), got {}: {:?}",
+                posts.len(),
+                posts
+            );
+
+            let init_idx = posts
+                .iter()
+                .position(|b| b.get("method").and_then(|m| m.as_str()) == Some("initialize"))
+                .expect("initialize POST should be recorded");
+            let notif_idx = posts
+                .iter()
+                .position(|b| {
+                    b.get("method").and_then(|m| m.as_str()) == Some("notifications/initialized")
+                })
+                .expect("notifications/initialized POST should be recorded");
+            assert!(
+                notif_idx > init_idx,
+                "notifications/initialized must come after initialize; init_idx={}, notif_idx={}",
+                init_idx,
+                notif_idx
+            );
+
+            let notif = &posts[notif_idx];
+            assert!(
+                notif.get("id").is_none(),
+                "notifications/initialized must not carry an id field, got {:?}",
+                notif
+            );
+            // No other request methods should have been POSTed between
+            // initialize and notifications/initialized.
+            for (i, b) in posts.iter().enumerate() {
+                if i > init_idx && i < notif_idx {
+                    panic!(
+                        "unexpected POST between initialize and notifications/initialized: {:?}",
+                        b
+                    );
+                }
+            }
+
+            adapter.shutdown().await.unwrap();
         }
 
         #[tokio::test]

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -402,11 +402,46 @@ impl StdioAdapter {
             .ok_or_else(|| AdapterError::ProtocolError("response has no result".into()))
     }
 
+    /// Send a JSON-RPC notification (no id, no response expected).
+    ///
+    /// Writes a single newline-terminated frame to the child's stdin. Unlike
+    /// [`Self::send_request`], this does not allocate a request id, does not
+    /// register a pending entry, and does not wait for a response.
+    async fn send_notification(
+        &self,
+        method: &str,
+        params: Option<Value>,
+    ) -> Result<(), AdapterError> {
+        let notification = jsonrpc::new_notification(method, params);
+        let mut line = serde_json::to_string(&notification)?;
+        line.push('\n');
+
+        let mut writer_guard = self.stdin_writer.lock().await;
+        let writer = writer_guard.as_mut().ok_or(AdapterError::NotInitialized)?;
+        if let Err(e) = writer.write_all(line.as_bytes()).await {
+            return Err(AdapterError::ProcessCrashed(format!(
+                "stdin write failed: {}",
+                e
+            )));
+        }
+        if let Err(e) = writer.flush().await {
+            return Err(AdapterError::ProcessCrashed(format!(
+                "stdin flush failed: {}",
+                e
+            )));
+        }
+        Ok(())
+    }
+
     /// Perform the MCP initialize handshake.
     ///
     /// This method enforces that the server MUST provide a valid `serverInfo.name`
     /// in the initialize response. If the name is missing, empty, or reduces to
     /// empty after sanitization, the handshake fails with a ProtocolError.
+    ///
+    /// On success, a `notifications/initialized` notification is sent to the
+    /// server (per the MCP spec) before returning. A failure to send that
+    /// notification is logged at `warn!` level but does not fail the handshake.
     async fn mcp_initialize(&self) -> Result<(), AdapterError> {
         let params = json!({
             "protocolVersion": "2024-11-05",
@@ -461,6 +496,16 @@ impl StdioAdapter {
         }
         *self.server_type.write().await = effective;
         *self.upstream_server_name.write().await = Some(upstream_stripped);
+
+        // Per the MCP spec the client MUST send a notifications/initialized
+        // notification after a successful initialize exchange. Strict servers
+        // refuse all subsequent requests until they observe it.
+        if let Err(e) = self
+            .send_notification("notifications/initialized", None)
+            .await
+        {
+            warn!(error = %e, "failed to send notifications/initialized");
+        }
 
         info!("MCP initialize handshake complete");
         Ok(())
@@ -1140,5 +1185,109 @@ for line in sys.stdin:
         }
 
         adapter.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_stdio_sends_initialized_notification_after_handshake() {
+        // Python script that records every received stdin line to a file
+        // (path passed via the RECORD_PATH env var) and responds to the
+        // initialize and tools/list requests with minimal valid results.
+        let script = r#"
+import sys, json, os
+record_path = os.environ["RECORD_PATH"]
+with open(record_path, "w") as rec:
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        rec.write(line + "\n")
+        rec.flush()
+        try:
+            req = json.loads(line)
+        except Exception:
+            continue
+        method = req.get("method")
+        req_id = req.get("id")
+        if req_id is None:
+            # Notifications get no response.
+            continue
+        if method == "initialize":
+            resp = {
+                "jsonrpc": "2.0",
+                "result": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "serverInfo": {"name": "test", "version": "0.1"},
+                },
+                "id": req_id,
+            }
+        elif method == "tools/list":
+            resp = {"jsonrpc": "2.0", "result": {"tools": []}, "id": req_id}
+        else:
+            resp = {"jsonrpc": "2.0", "result": {}, "id": req_id}
+        sys.stdout.write(json.dumps(resp) + "\n")
+        sys.stdout.flush()
+"#;
+        let record_path = std::env::temp_dir().join(format!(
+            "endara-stdio-init-{}-{}.log",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let mut env = HashMap::new();
+        env.insert(
+            "RECORD_PATH".to_string(),
+            record_path.to_string_lossy().into_owned(),
+        );
+        let mut adapter = StdioAdapter::new(StdioConfig {
+            command: "python3".to_string(),
+            args: vec!["-u".to_string(), "-c".to_string(), script.to_string()],
+            env,
+            ..Default::default()
+        });
+
+        (&mut adapter as &mut dyn McpAdapter)
+            .initialize()
+            .await
+            .unwrap();
+        let _ = adapter.list_tools().await.unwrap();
+
+        // Give the Python script a moment to flush before we read the file.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        adapter.shutdown().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let recorded = std::fs::read_to_string(&record_path)
+            .expect("record file should exist after handshake + list_tools");
+        let _ = std::fs::remove_file(&record_path);
+        let frames: Vec<Value> = recorded
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str(l).expect("each recorded line is valid JSON"))
+            .collect();
+
+        assert!(
+            frames.len() >= 3,
+            "expected at least 3 frames, got {}: {:?}",
+            frames.len(),
+            frames
+        );
+        assert_eq!(frames[0]["method"].as_str(), Some("initialize"));
+        assert!(
+            frames[0].get("id").and_then(|v| v.as_u64()).is_some(),
+            "initialize frame must carry a numeric id"
+        );
+        assert_eq!(
+            frames[1]["method"].as_str(),
+            Some("notifications/initialized")
+        );
+        assert!(
+            frames[1].get("id").is_none(),
+            "notifications/initialized frame must not have an id field, got: {:?}",
+            frames[1]
+        );
+        assert_eq!(frames[2]["method"].as_str(), Some("tools/list"));
     }
 }

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -11,6 +11,15 @@ pub struct JsonRpcRequest {
     pub id: u64,
 }
 
+/// JSON-RPC 2.0 notification (request without an `id`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonRpcNotification {
+    pub jsonrpc: String,
+    pub method: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub params: Option<Value>,
+}
+
 /// JSON-RPC 2.0 response.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JsonRpcResponse {
@@ -38,6 +47,15 @@ pub fn new_request(method: &str, params: Option<Value>, id: u64) -> JsonRpcReque
         method: method.to_string(),
         params,
         id,
+    }
+}
+
+/// Create a new JSON-RPC 2.0 notification (no `id` field).
+pub fn new_notification(method: &str, params: Option<Value>) -> JsonRpcNotification {
+    JsonRpcNotification {
+        jsonrpc: "2.0".to_string(),
+        method: method.to_string(),
+        params,
     }
 }
 


### PR DESCRIPTION
## Summary

Fix the MCP `initialize` handshake in the relay's STDIO and SSE adapters so that strict upstream MCP servers (notably the Python-based `elevenlabs-mcp`) accept post-initialize requests instead of rejecting them with `Received request before initialization was complete` (`mcp.shared.session:363`).

Per the MCP spec (revisions 2024-11-05 / 2025-03-26), after the `initialize` request/response the client MUST send a `notifications/initialized` notification before any other request. The HTTP adapter already does this (`http.rs:621-628`); STDIO and SSE skipped it. Lenient servers accepted the protocol violation; strict ones (Python MCP SDK with default `InitializationOptions`) did not.

## User-visible symptom (before this fix)

```
endara_relay::adapter::stdio: MCP server stderr stderr_line= WARNING Failed to validate request: Received
endara_relay::adapter::stdio: MCP server stderr stderr_line= request before initialization was
endara_relay::adapter::stdio: MCP server stderr stderr_line= complete
```

And `tools/list` against the strict server returns no tools.

## Changes

- **`adapter/stdio.rs`** — new `send_notification` helper writes a newline-terminated JSON-RPC notification (no `id`, no pending entry) via the existing stdin mutex. Called from `mcp_initialize` after the `serverInfo` validation. Failure is logged at `warn!` and does not fail the handshake (matches the HTTP adapter's permissive policy).
- **`adapter/sse.rs`** — new `send_notification` helper POSTs the JSON-RPC notification to the SSE post endpoint using the same endpoint resolution as `send_request`. Called from `initialize()` after `server_type` / `upstream_server_name` are recorded. Failure is logged at `warn!` and does not fail the handshake.
- **`jsonrpc.rs`** — small additive `JsonRpcNotification` type + `new_notification` helper to keep the construction in one place.

## Tests

- `adapter::stdio::tests::test_stdio_sends_initialized_notification_after_handshake` — drives a Python harness that records every stdin frame and asserts the order `initialize` → `notifications/initialized` (no `id`) → `tools/list`.
- `adapter::sse::tests::reconnect::test_sse_sends_initialized_notification_after_handshake` — extends the fake SSE server to record POST bodies (returns 202 for notifications); asserts the body and ordering.

## Verification

```
cd packages/relay && cargo fmt --check
cd packages/relay && cargo clippy --all-targets -- -D warnings
cd packages/relay && cargo test
```

All clean. Full suite: ~728 tests, 0 failures.

## Non-goals

- Refactoring JSON-RPC framing into a shared library (small targeted helpers per adapter is fine).
- Re-handshaking on stdio respawn (`try_respawn` already calls `mcp_initialize`, so it gets the fix for free).
- Changing the relay's own `protocolVersion` value or the capabilities sent in `initialize`.
- HTTP adapter (already correct).

## Rollback

Both changes are additive (one extra stdin write / HTTP POST per handshake). Reverting this PR restores prior behavior; no schema or persistent-state changes.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author