### PR TITLE
feat(notifications): emit tools/list_changed on relay-side mutations

### DIFF
--- a/src/management.rs
+++ b/src/management.rs
@@ -310,6 +310,17 @@ fn categorize_error(reason: &str) -> String {
 /// in a background task that swaps the freshly-built adapter back into the
 /// registry on completion. Failures leave the registry entry as a
 /// `FailedAdapter` so the standard health channel surfaces the error.
+///
+/// Emits `tools_changed_tx` ticks on both the foreground placeholder swap
+/// (catalog briefly loses the endpoint's tools while `StartingAdapter` is in
+/// place) and the background re-init swap completion (catalog regains the
+/// rebuilt adapter's tools). Both ticks mirror what subscribers reading the
+/// catalog would actually observe at each phase; emitting only the second
+/// would hide the transient "tools gone" state. This is independent of any
+/// tick the rebuilt adapter's upstream may later emit via
+/// `rewire_tools_changed_listener` — that path handles real upstream
+/// `tools/list_changed` events, while these two ticks reflect the relay-side
+/// swap itself.
 async fn restart_endpoint(
     State(state): State<ManagementState>,
     Path(name): Path<String>,
@@ -324,6 +335,10 @@ async fn restart_endpoint(
         std::mem::replace(&mut entry.adapter, Box::new(StartingAdapter))
     };
     state.registry.invalidate_catalog_cache().await;
+    // Foreground tick: the catalog has just lost the endpoint's tools. Send
+    // after `invalidate_catalog_cache` so subscribers re-reading the catalog
+    // on receipt see the placeholder state.
+    state.registry.tick_tools_changed(&name);
 
     // Arc-clone everything the background task needs so it owns its captures.
     let registry = state.registry.clone();
@@ -401,6 +416,12 @@ async fn restart_endpoint(
         registry.rewire_tools_changed_listener(&task_name).await;
         registry.invalidate_endpoint_tool_cache(&task_name).await;
         registry.invalidate_catalog_cache().await;
+        // Background tick: the catalog has just regained the endpoint's
+        // tools via the rebuilt adapter. Sent after cache invalidation so
+        // subscribers re-reading the catalog see the post-swap state. This
+        // is distinct from any future tick emitted by the rewired listener
+        // when the upstream server itself sends `tools/list_changed`.
+        registry.tick_tools_changed(&task_name);
 
         tracing::info!(endpoint = %task_name, "Restart: background task complete");
     });
@@ -2901,7 +2922,7 @@ async fn disable_endpoint(
     State(state): State<ManagementState>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
-    {
+    let flipped = {
         let mut entries = state.registry.entries().write().await;
         let Some(entry) = entries.get_mut(&name) else {
             return endpoint_not_found(&name).into_response();
@@ -2914,10 +2935,15 @@ async fn disable_endpoint(
             )
             .into_response();
         }
+        let was_enabled = !entry.disabled;
         entry.disabled = true;
-    }
+        was_enabled
+    };
     state.registry.invalidate_catalog_cache().await;
     persist_disabled_state(&state).await;
+    if flipped {
+        state.registry.tick_tools_changed(&name);
+    }
     Json(ActionResponse {
         ok: true,
         message: format!("Endpoint '{}' disabled", name),
@@ -2930,16 +2956,20 @@ async fn enable_endpoint(
     State(state): State<ManagementState>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
-    let result = {
+    let (flipped, result) = {
         let mut entries = state.registry.entries().write().await;
         let Some(entry) = entries.get_mut(&name) else {
             return endpoint_not_found(&name).into_response();
         };
+        let was_disabled = entry.disabled;
         entry.disabled = false;
-        entry.adapter.initialize().await
+        (was_disabled, entry.adapter.initialize().await)
     };
     state.registry.invalidate_catalog_cache().await;
     persist_disabled_state(&state).await;
+    if flipped {
+        state.registry.tick_tools_changed(&name);
+    }
     match result {
         Ok(()) => Json(ActionResponse {
             ok: true,
@@ -2960,15 +2990,18 @@ async fn disable_tool(
     State(state): State<ManagementState>,
     Path((name, tool_name)): Path<(String, String)>,
 ) -> impl IntoResponse {
-    {
+    let flipped = {
         let mut entries = state.registry.entries().write().await;
         let Some(entry) = entries.get_mut(&name) else {
             return endpoint_not_found(&name).into_response();
         };
-        entry.disabled_tools.insert(tool_name.clone());
-    }
+        entry.disabled_tools.insert(tool_name.clone())
+    };
     state.registry.invalidate_catalog_cache().await;
     persist_disabled_state(&state).await;
+    if flipped {
+        state.registry.tick_tools_changed(&name);
+    }
     Json(ActionResponse {
         ok: true,
         message: format!("Tool '{}' disabled on '{}'", tool_name, name),
@@ -2981,15 +3014,18 @@ async fn enable_tool(
     State(state): State<ManagementState>,
     Path((name, tool_name)): Path<(String, String)>,
 ) -> impl IntoResponse {
-    {
+    let flipped = {
         let mut entries = state.registry.entries().write().await;
         let Some(entry) = entries.get_mut(&name) else {
             return endpoint_not_found(&name).into_response();
         };
-        entry.disabled_tools.remove(&tool_name);
-    }
+        entry.disabled_tools.remove(&tool_name)
+    };
     state.registry.invalidate_catalog_cache().await;
     persist_disabled_state(&state).await;
+    if flipped {
+        state.registry.tick_tools_changed(&name);
+    }
     Json(ActionResponse {
         ok: true,
         message: format!("Tool '{}' enabled on '{}'", tool_name, name),
@@ -3724,6 +3760,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn restart_endpoint_emits_foreground_and_background_ticks() {
+        use std::time::Duration;
+
+        // Use a SlowShutdownAdapter so the foreground placeholder swap is
+        // observable as a distinct event from the background re-init swap.
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "echo".to_string(),
+                Box::new(SlowShutdownAdapter::new(Duration::from_millis(150))),
+                "stdio".to_string(),
+                None,
+                Some("echo".to_string()),
+            )
+            .await;
+        let state = ManagementState {
+            registry: Arc::new(registry),
+            config: Arc::new(RwLock::new(test_config())),
+            start_time: Instant::now(),
+            config_path: None,
+            oauth_flow_manager: None,
+            relay_port: 9400,
+            oauth_adapter_inners: None,
+            token_manager: None,
+            setup_manager: None,
+            profile_registry: None,
+        };
+
+        // Subscribe BEFORE issuing the restart so we don't race the
+        // foreground tick. The relay-wide channel carries the endpoint name
+        // as its payload.
+        let mut rx = state.registry.subscribe_tools_changed();
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/echo/restart")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // First tick: foreground swap to StartingAdapter. It should arrive
+        // essentially immediately (well within the shutdown delay).
+        let first = tokio::time::timeout(Duration::from_millis(500), rx.recv())
+            .await
+            .expect("foreground tick did not arrive within 500ms")
+            .expect("foreground tick channel closed");
+        assert_eq!(first, "echo", "foreground tick should carry endpoint name");
+
+        // Second tick: background re-init swap completion. Allow extra time
+        // because the slow shutdown must finish before the new adapter is
+        // swapped in.
+        let second = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("background tick did not arrive within 5s")
+            .expect("background tick channel closed");
+        assert_eq!(second, "echo", "background tick should carry endpoint name");
+    }
+
+    #[tokio::test]
     async fn management_delete_endpoint_success() {
         // Write a temp config file with two endpoints
         let dir = std::env::temp_dir().join(format!("relay-test-delete-{}", std::process::id()));
@@ -4039,6 +4138,149 @@ command = "echo"
         let arr = body.as_array().unwrap();
         let read_tool = arr.iter().find(|t| t["name"] == "read").unwrap();
         assert_eq!(read_tool["disabled"], false);
+    }
+
+    // ---- tools_changed_tx tick coverage (one tick per real flip; zero on no-op)
+    //
+    // These tests subscribe to the relay-wide `tools_changed_tx` broadcast
+    // BEFORE issuing the management call and assert exactly one tick lands on
+    // a real state flip and zero ticks on a repeat (no-op) call. The payload
+    // is the endpoint name. Settling delays use a short sleep because
+    // `tools_changed_tx.send` is synchronous from the broadcast's standpoint
+    // but the management handler performs cache invalidation and disk
+    // persistence between the state mutation and the tick.
+
+    async fn post_ok(app: axum::Router, path: &str) {
+        let resp = app
+            .oneshot(Request::post(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK, "POST {} expected 200", path);
+    }
+
+    fn try_recv_tick(rx: &mut tokio::sync::broadcast::Receiver<String>) -> Option<String> {
+        match rx.try_recv() {
+            Ok(s) => Some(s),
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty) => None,
+            Err(e) => panic!("unexpected broadcast recv error: {e:?}"),
+        }
+    }
+
+    async fn assert_one_tick(rx: &mut tokio::sync::broadcast::Receiver<String>, endpoint: &str) {
+        let tick = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("expected one tools_changed_tx tick within 1s")
+            .expect("broadcast recv must succeed");
+        assert_eq!(tick, endpoint, "tick payload must be the endpoint name");
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(
+            try_recv_tick(rx).is_none(),
+            "exactly one tick expected; got a second"
+        );
+    }
+
+    async fn assert_no_tick(rx: &mut tokio::sync::broadcast::Receiver<String>) {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert!(
+            try_recv_tick(rx).is_none(),
+            "no-op mutation must not emit a tools_changed_tx tick"
+        );
+    }
+
+    #[tokio::test]
+    async fn disable_endpoint_ticks_once_on_flip_and_not_on_noop() {
+        let tools = vec![ToolInfo {
+            name: "t1".into(),
+            description: None,
+            input_schema: serde_json::json!({}),
+            annotations: None,
+        }];
+        let state = test_state(vec![("echo", MockAdapter::healthy_with_tools(tools))]).await;
+        // Hold the registry Arc so the broadcast sender outlives the router.
+        let registry = state.registry.clone();
+        let mut rx = registry.subscribe_tools_changed();
+        let app = management_routes(state);
+
+        // First disable — real flip, expect exactly one tick.
+        post_ok(app.clone(), "/api/endpoints/echo/disable").await;
+        assert_one_tick(&mut rx, "echo").await;
+
+        // Second disable — already disabled, expect zero ticks.
+        post_ok(app, "/api/endpoints/echo/disable").await;
+        assert_no_tick(&mut rx).await;
+    }
+
+    #[tokio::test]
+    async fn enable_endpoint_ticks_once_on_flip_and_not_on_noop() {
+        let tools = vec![ToolInfo {
+            name: "t1".into(),
+            description: None,
+            input_schema: serde_json::json!({}),
+            annotations: None,
+        }];
+        let state = test_state(vec![("echo", MockAdapter::healthy_with_tools(tools))]).await;
+        let app = management_routes(state.clone());
+
+        // Pre-condition: disable so the next enable is a real flip. Subscribe
+        // AFTER this so the disable tick doesn't pollute the receiver.
+        post_ok(app.clone(), "/api/endpoints/echo/disable").await;
+        let mut rx = state.registry.subscribe_tools_changed();
+
+        // Enable — real flip, expect exactly one tick.
+        post_ok(app.clone(), "/api/endpoints/echo/enable").await;
+        assert_one_tick(&mut rx, "echo").await;
+
+        // Enable again — already enabled, expect zero ticks.
+        post_ok(app, "/api/endpoints/echo/enable").await;
+        assert_no_tick(&mut rx).await;
+    }
+
+    #[tokio::test]
+    async fn disable_tool_ticks_once_on_flip_and_not_on_noop() {
+        let tools = vec![ToolInfo {
+            name: "read".into(),
+            description: Some("Read".into()),
+            input_schema: serde_json::json!({"type": "object"}),
+            annotations: None,
+        }];
+        let state = test_state(vec![("fs", MockAdapter::healthy_with_tools(tools))]).await;
+        // Hold the registry Arc so the broadcast sender outlives the router.
+        let registry = state.registry.clone();
+        let mut rx = registry.subscribe_tools_changed();
+        let app = management_routes(state);
+
+        // First disable — newly inserted, expect exactly one tick.
+        post_ok(app.clone(), "/api/endpoints/fs/tools/read/disable").await;
+        assert_one_tick(&mut rx, "fs").await;
+
+        // Second disable — already in disabled_tools, expect zero ticks.
+        post_ok(app, "/api/endpoints/fs/tools/read/disable").await;
+        assert_no_tick(&mut rx).await;
+    }
+
+    #[tokio::test]
+    async fn enable_tool_ticks_once_on_flip_and_not_on_noop() {
+        let tools = vec![ToolInfo {
+            name: "read".into(),
+            description: Some("Read".into()),
+            input_schema: serde_json::json!({"type": "object"}),
+            annotations: None,
+        }];
+        let state = test_state(vec![("fs", MockAdapter::healthy_with_tools(tools))]).await;
+        let app = management_routes(state.clone());
+
+        // Pre-condition: disable so the next enable is a real flip. Subscribe
+        // AFTER this so the disable tick doesn't pollute the receiver.
+        post_ok(app.clone(), "/api/endpoints/fs/tools/read/disable").await;
+        let mut rx = state.registry.subscribe_tools_changed();
+
+        // Enable — actually removed, expect exactly one tick.
+        post_ok(app.clone(), "/api/endpoints/fs/tools/read/enable").await;
+        assert_one_tick(&mut rx, "fs").await;
+
+        // Enable again — not in disabled_tools, expect zero ticks.
+        post_ok(app, "/api/endpoints/fs/tools/read/enable").await;
+        assert_no_tick(&mut rx).await;
     }
 
     #[tokio::test]

--- a/src/profile_registry.rs
+++ b/src/profile_registry.rs
@@ -192,6 +192,20 @@ pub struct ProfileRegistry {
     /// each [`ProfileContext`]) so it stays in lockstep with the global
     /// handler's value and is reapplied on every hot reload.
     sandbox_timeout: Duration,
+    /// Profile-membership broadcast — fan-out for
+    /// `notifications/tools/list_changed` on `/mcp/{profile}/sse` streams
+    /// when the *profile itself* changes (endpoint added/removed from the
+    /// profile, profile created/deleted, or `js_execution` toggled, which
+    /// flips whether `execute_tools` is advertised). Payload is the
+    /// lowercased profile path; per-profile SSE handlers filter on it.
+    ///
+    /// This sits alongside [`AdapterRegistry`]'s per-endpoint
+    /// `tools_changed_tx` broadcast rather than replacing it: per-endpoint
+    /// ticks are still the right signal for profile streams when an
+    /// endpoint *inside* the profile mutates, and keeping the two channels
+    /// separate avoids reshaping every existing consumer of the relay-wide
+    /// channel.
+    profiles_changed_tx: broadcast::Sender<String>,
 }
 
 impl ProfileRegistry {
@@ -213,11 +227,33 @@ impl ProfileRegistry {
         adapter_registry: AdapterRegistry,
         sandbox_timeout: Duration,
     ) -> Self {
+        let (profiles_changed_tx, _) = broadcast::channel(16);
         Self {
             profiles: Arc::new(RwLock::new(HashMap::new())),
             adapter_registry,
             sandbox_timeout,
+            profiles_changed_tx,
         }
+    }
+
+    /// Subscribe to the profile-membership broadcast. Each `recv()` yields
+    /// the lowercased profile path whose allowed-endpoints set or advertised
+    /// tool surface (e.g. `js_execution` toggle) changed since the previous
+    /// receive. `Lagged` is surfaced as a tick like the per-endpoint
+    /// `subscribe_tools_changed` — consumers should forward unconditionally
+    /// on lag.
+    pub fn subscribe_profiles_changed(&self) -> broadcast::Receiver<String> {
+        self.profiles_changed_tx.subscribe()
+    }
+
+    /// Send a synthetic profile-changed tick for the given profile path.
+    /// Test-only escape hatch mirroring
+    /// [`AdapterRegistry::tick_tools_changed_for_test`].
+    #[cfg(test)]
+    pub(crate) fn tick_profile_changed_for_test(&self, profile_path: &str) {
+        let _ = self
+            .profiles_changed_tx
+            .send(profile_path.to_ascii_lowercase());
     }
 
     /// Replace the current profile set with one built from `profiles`.
@@ -227,6 +263,17 @@ impl ProfileRegistry {
     /// Per-profile `js_execution` and `toon_output` are copied straight from
     /// the profile config — the loader (`validate_profiles`) requires those
     /// fields to be present, so there is no fallback to relay-wide defaults.
+    ///
+    /// After the swap, emits one
+    /// [`subscribe_profiles_changed`](Self::subscribe_profiles_changed) tick
+    /// per profile path whose membership or advertised-tool surface changed
+    /// — added profiles, removed profiles, profiles whose allowed-endpoint
+    /// set differs, and profiles whose `js_execution` toggle flipped (which
+    /// adds/removes `execute_tools` from the advertised catalog). A pure
+    /// `toon_output` flip is NOT signalled because it only affects response
+    /// serialization, not the advertised tool list. No-op rebuilds (same
+    /// configs in same order) emit nothing — satisfying spec acceptance #5
+    /// for profile-scoped streams.
     pub async fn rebuild(&self, profiles: &[ProfileConfig]) {
         let mut new_map: HashMap<String, Arc<ProfileContext>> = HashMap::new();
         for profile in profiles {
@@ -247,7 +294,40 @@ impl ProfileRegistry {
             new_map.insert(profile.path.to_ascii_lowercase(), Arc::new(ctx));
         }
 
-        *self.profiles.write().await = new_map;
+        // Diff old vs new under the write lock so the membership ticks we
+        // emit accurately describe the post-swap state. Collect the set of
+        // changed paths first, then drop the lock before broadcasting so a
+        // slow subscriber can't stall the swap.
+        let changed: Vec<String> = {
+            let mut guard = self.profiles.write().await;
+            let mut changed = Vec::new();
+            // Added or mutated profiles.
+            for (path, new_ctx) in new_map.iter() {
+                let dirty = match guard.get(path) {
+                    None => true,
+                    Some(old_ctx) => {
+                        old_ctx.registry_view.allowed_endpoints()
+                            != new_ctx.registry_view.allowed_endpoints()
+                            || old_ctx.js_execution != new_ctx.js_execution
+                    }
+                };
+                if dirty {
+                    changed.push(path.clone());
+                }
+            }
+            // Removed profiles.
+            for path in guard.keys() {
+                if !new_map.contains_key(path) {
+                    changed.push(path.clone());
+                }
+            }
+            *guard = new_map;
+            changed
+        };
+
+        for path in changed {
+            let _ = self.profiles_changed_tx.send(path);
+        }
     }
 
     /// Look up a profile by URL path (case-insensitive).

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -141,13 +141,22 @@ impl AdapterRegistry {
         self.tools_changed_tx.subscribe()
     }
 
+    /// Emit a synthetic tools-changed tick for `endpoint` on the relay-wide
+    /// broadcast. Used by management mutations (e.g. enable/disable an
+    /// endpoint or per-endpoint tool) that change the advertised catalog
+    /// without a real `notifications/tools/list_changed` event from the
+    /// underlying adapter. Sending on a closed broadcast is ignored.
+    pub(crate) fn tick_tools_changed(&self, endpoint: &str) {
+        let _ = self.tools_changed_tx.send(endpoint.to_string());
+    }
+
     /// Send a synthetic tools-changed tick on the relay-wide broadcast for
     /// the given endpoint name. Test-only escape hatch so server-side
     /// handler tests can exercise the fan-out path without standing up a
     /// real adapter and listener task.
     #[cfg(test)]
     pub(crate) fn tick_tools_changed_for_test(&self, endpoint: &str) {
-        let _ = self.tools_changed_tx.send(endpoint.to_string());
+        self.tick_tools_changed(endpoint);
     }
 
     /// Register an adapter under the given endpoint name.
@@ -161,6 +170,7 @@ impl AdapterRegistry {
     ) {
         debug!(endpoint = %name, ?tool_prefix, "Registering adapter");
         let listener_handle = self.spawn_tools_changed_listener(&name, adapter.as_ref());
+        let endpoint_for_tick = name.clone();
         let previous = self.adapters.write().await.insert(
             name,
             RegisteredAdapter {
@@ -182,6 +192,7 @@ impl AdapterRegistry {
             }
         }
         self.invalidate_catalog_cache().await;
+        let _ = self.tools_changed_tx.send(endpoint_for_tick);
     }
 
     /// Remove an adapter by endpoint name.
@@ -192,6 +203,7 @@ impl AdapterRegistry {
                 handle.abort();
             }
             self.invalidate_catalog_cache().await;
+            let _ = self.tools_changed_tx.send(name.to_string());
         }
         result
     }
@@ -2137,6 +2149,10 @@ mod tests {
             )
             .await;
 
+        // Drain the tick emitted by `register` itself so the next recv
+        // observes only the fanned-in per-endpoint tick.
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(1), relay_rx.recv()).await;
+
         // Drive a per-endpoint tick; the listener loop should observe it and
         // fan it into the relay-wide broadcast with the endpoint name.
         tx.send(()).unwrap();
@@ -2148,6 +2164,125 @@ mod tests {
                  carrying the endpoint name (got {other:?})"
             ),
         }
+    }
+
+    /// `register` must emit exactly one relay-wide tools-changed tick
+    /// carrying the endpoint name, after caches are invalidated.
+    #[tokio::test]
+    async fn test_register_emits_single_tools_changed_tick() {
+        let registry = AdapterRegistry::new();
+        let mut rx = registry.subscribe_tools_changed();
+        registry
+            .register(
+                "ep".into(),
+                Box::new(MockAdapter::healthy(vec![make_tool("a")])),
+                "stdio".into(),
+                None,
+                Some("ep".into()),
+            )
+            .await;
+
+        let first = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("register tick must fire within 1s")
+            .expect("broadcast must still be open");
+        assert_eq!(first, "ep");
+
+        // Exactly one tick — a second recv must time out.
+        let second = tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv()).await;
+        assert!(
+            second.is_err(),
+            "register must emit exactly one tick (got extra: {second:?})"
+        );
+    }
+
+    /// `remove` on an existing endpoint must emit exactly one tick
+    /// carrying the endpoint name.
+    #[tokio::test]
+    async fn test_remove_emits_single_tools_changed_tick() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "ep".into(),
+                Box::new(MockAdapter::healthy(vec![make_tool("a")])),
+                "stdio".into(),
+                None,
+                Some("ep".into()),
+            )
+            .await;
+
+        // Subscribe AFTER register so we only observe the remove tick.
+        let mut rx = registry.subscribe_tools_changed();
+        let removed = registry.remove("ep").await;
+        assert!(removed.is_some(), "endpoint should have been removed");
+
+        let first = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("remove tick must fire within 1s")
+            .expect("broadcast must still be open");
+        assert_eq!(first, "ep");
+
+        let second = tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv()).await;
+        assert!(
+            second.is_err(),
+            "remove must emit exactly one tick (got extra: {second:?})"
+        );
+    }
+
+    /// `remove` of a non-existent endpoint must NOT emit a tick.
+    #[tokio::test]
+    async fn test_remove_noop_emits_no_tools_changed_tick() {
+        let registry = AdapterRegistry::new();
+        let mut rx = registry.subscribe_tools_changed();
+        let removed = registry.remove("does-not-exist").await;
+        assert!(removed.is_none(), "no-op remove must return None");
+
+        let any = tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv()).await;
+        assert!(
+            any.is_err(),
+            "no-op remove must not emit any tick (got: {any:?})"
+        );
+    }
+
+    /// Re-registering an endpoint (overwriting an existing entry) must
+    /// emit exactly one tick per register call — not two.
+    #[tokio::test]
+    async fn test_reregister_emits_single_tools_changed_tick() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "ep".into(),
+                Box::new(MockAdapter::healthy(vec![make_tool("v1")])),
+                "stdio".into(),
+                None,
+                Some("ep".into()),
+            )
+            .await;
+
+        // Subscribe AFTER the first register so we only observe the
+        // overwrite tick.
+        let mut rx = registry.subscribe_tools_changed();
+        registry
+            .register(
+                "ep".into(),
+                Box::new(MockAdapter::healthy(vec![make_tool("v2")])),
+                "stdio".into(),
+                None,
+                Some("ep".into()),
+            )
+            .await;
+
+        let first = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("overwrite register tick must fire within 1s")
+            .expect("broadcast must still be open");
+        assert_eq!(first, "ep");
+
+        let second = tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv()).await;
+        assert!(
+            second.is_err(),
+            "overwrite register must emit exactly one tick (got extra: {second:?})"
+        );
     }
 
     #[tokio::test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -727,22 +727,42 @@ async fn mcp_sse(
 /// event at `/mcp/{profile}` so SSE-only clients POST follow-up JSON-RPC
 /// requests back to the same profile.
 ///
-/// Per locked decision Relay #6 the per-tick filter loop in
-/// [`build_mcp_sse_stream`] mirrors the existing `mcp_sse` pattern (single
-/// `recv().await` per iteration). The profile's allowed-endpoints set is
-/// passed in so `notifications/tools/list_changed` is only forwarded when
-/// the changed endpoint is in-profile (`Lagged` always forwards
-/// unconditionally because the endpoint name is lost).
+/// The profile filter passed into [`build_mcp_sse_stream`] re-reads the
+/// allowed-endpoints set from [`AppState::profile_registry`] on every
+/// per-endpoint tick so mid-stream profile-membership changes (via
+/// `update_profile` or the config watcher) take effect without
+/// reconnecting. Profile-level mutations (membership change, `js_execution`
+/// toggle, profile add/remove) arrive on the parallel
+/// [`ProfileRegistry::subscribe_profiles_changed`] channel.
 async fn mcp_sse_profiled(
     State(state): State<AppState>,
     Path(profile_path): Path<String>,
 ) -> Response {
-    let Some(profile_ctx) = state.profile_registry.get(&profile_path).await else {
+    if state.profile_registry.get(&profile_path).await.is_none() {
         return profile_not_found_response(&profile_path);
-    };
+    }
     let endpoint_uri = format!("/mcp/{}", profile_path);
-    let allowed = Arc::new(profile_ctx.registry_view.allowed_endpoints().clone());
-    build_mcp_sse_stream(&state, &endpoint_uri, Some(allowed)).into_response()
+    let filter = ProfileSseFilter {
+        path: profile_path.to_ascii_lowercase(),
+        registry: state.profile_registry.clone(),
+    };
+    build_mcp_sse_stream(&state, &endpoint_uri, Some(filter)).into_response()
+}
+
+/// Profile-scoped filter handed to [`build_mcp_sse_stream`].
+///
+/// The static `HashSet<String>` allowed-endpoints snapshot used pre-R3.D is
+/// replaced by a `(path, registry)` pair so the stream can resolve the
+/// *current* allowed set each tick. That way an `update_profile` that adds
+/// an endpoint surfaces on already-open SSE streams without forcing the
+/// client to reconnect (spec acceptance #2).
+struct ProfileSseFilter {
+    /// Lowercased profile path — keys the [`ProfileRegistry`] lookup and
+    /// matches against
+    /// [`ProfileRegistry::subscribe_profiles_changed`] payloads.
+    path: String,
+    /// Shared handle to the live profile registry.
+    registry: Arc<ProfileRegistry>,
 }
 
 /// Build the SSE stream backing both [`mcp_sse`] and [`mcp_sse_profiled`].
@@ -751,24 +771,51 @@ async fn mcp_sse_profiled(
 /// SSE-only clients learn where to POST follow-up JSON-RPC requests
 /// (`/mcp` for the global route, `/mcp/{profile}` for the profiled one).
 ///
-/// `allowed_endpoints` filters which `tools/list_changed` ticks are
-/// forwarded: `None` (global `/mcp/sse`) forwards every tick;
-/// `Some(set)` (profile-scoped) forwards only when the tick's endpoint name
-/// is in `set`. `Lagged` is always forwarded unconditionally because the
-/// originating endpoint name is lost on lag (the client will re-fetch
-/// `tools/list` on receipt and re-discover any in-profile changes).
+/// `profile_filter` controls which `tools/list_changed` ticks are
+/// forwarded:
+/// - `None` (global `/mcp/sse`) forwards every per-endpoint tick from
+///   [`AdapterRegistry::subscribe_tools_changed`] and ignores the profile
+///   channel entirely — behaviour unchanged from pre-R3.D.
+/// - `Some(filter)` (profile-scoped) forwards per-endpoint ticks only when
+///   the changed endpoint is in the profile's *current* allowed set
+///   (re-resolved against `filter.registry` each tick, so mid-stream
+///   membership changes take effect), AND forwards profile-channel ticks
+///   when the payload path matches `filter.path` (membership change, JS
+///   toggle, profile add/remove).
+///
+/// Both channels treat `Lagged` as an unconditional forward — the client
+/// re-fetches `tools/list` on receipt and re-discovers any missed change.
 fn build_mcp_sse_stream(
     state: &AppState,
     endpoint_data: &str,
-    allowed_endpoints: Option<Arc<std::collections::HashSet<String>>>,
+    profile_filter: Option<ProfileSseFilter>,
 ) -> Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>> {
     use tokio::sync::broadcast::error::RecvError;
 
     let (tx, rx) = tokio::sync::mpsc::channel(16);
     let mut tools_rx = state.registry.subscribe_tools_changed();
+    // Subscribe to the profile channel even for the global stream so the
+    // two `select!` branches are uniform; the `None` filter just drops the
+    // payloads on the floor. Keeping the subscription means a slow profile
+    // rebuild can't back-pressure the global stream into `Lagged`.
+    let mut profiles_rx = state.profile_registry.subscribe_profiles_changed();
+    // Keep-alive Arc clones moved into the spawn so the broadcast `Sender`s
+    // outlive the request scope. Without these, test harnesses that consume
+    // `AppState` into a one-shot router (e.g. `tower::ServiceExt::oneshot`)
+    // drop the underlying registries as soon as the response is built,
+    // closing both broadcast channels and tripping the `Closed` arms below
+    // before any tick can be evaluated. Production paths keep `AppState`
+    // alive for the lifetime of the server, so this is purely defensive for
+    // short-lived state scopes.
+    let registry_keepalive = state.registry.clone();
+    let profile_registry_keepalive = state.profile_registry.clone();
     let endpoint_data = endpoint_data.to_string();
 
     tokio::spawn(async move {
+        // Bind the keep-alives so the borrow checker keeps them in scope
+        // until the spawn exits.
+        let _registry_keepalive = registry_keepalive;
+        let _profile_registry_keepalive = profile_registry_keepalive;
         if tx
             .send(Ok(Event::default().event("endpoint").data(endpoint_data)))
             .await
@@ -776,37 +823,87 @@ fn build_mcp_sse_stream(
         {
             return;
         }
-        // `Ok(name)` carries the endpoint that emitted the tick (registry
-        // fan-in at `registry.rs:234/244`); profile-scoped streams filter on
-        // membership while the global stream forwards every tick. `Lagged`
-        // loses the endpoint name, so we forward unconditionally on lag —
-        // any missed in-profile change is recovered when the client
-        // re-fetches `tools/list` after the notification. `Closed` only
-        // fires when the registry itself is dropped.
+        // Re-usable JSON-RPC notification frame body. Defined once so both
+        // branches of the `select!` and the `Lagged` arms emit byte-for-byte
+        // identical SSE frames.
+        const FRAME_BODY: &str = r#"{"jsonrpc":"2.0","method":"notifications/tools/list_changed"}"#;
         loop {
-            match tools_rx.recv().await {
-                Ok(name) => {
-                    let forward = match &allowed_endpoints {
-                        None => true,
-                        Some(set) => set.contains(&name),
-                    };
-                    if !forward {
-                        continue;
-                    }
-                    let frame = Event::default()
-                        .data(r#"{"jsonrpc":"2.0","method":"notifications/tools/list_changed"}"#);
-                    if tx.send(Ok(frame)).await.is_err() {
-                        break;
+            tokio::select! {
+                ep_tick = tools_rx.recv() => {
+                    match ep_tick {
+                        Ok(name) => {
+                            // Resolve the live allowed-endpoints set per-tick
+                            // so membership changes published since stream
+                            // open take effect without reconnection.
+                            let forward = match &profile_filter {
+                                None => true,
+                                Some(f) => match f.registry.get(&f.path).await {
+                                    Some(ctx) => {
+                                        ctx.registry_view.allowed_endpoints().contains(&name)
+                                    }
+                                    // Profile deleted mid-stream: suppress
+                                    // per-endpoint ticks. The matching
+                                    // profile-channel tick (emitted by
+                                    // `rebuild`) will still flow through the
+                                    // other branch and deliver one final
+                                    // frame to the client.
+                                    None => false,
+                                },
+                            };
+                            if !forward {
+                                continue;
+                            }
+                            if tx.send(Ok(Event::default().data(FRAME_BODY))).await.is_err() {
+                                break;
+                            }
+                        }
+                        Err(RecvError::Lagged(_)) => {
+                            if tx.send(Ok(Event::default().data(FRAME_BODY))).await.is_err() {
+                                break;
+                            }
+                        }
+                        Err(RecvError::Closed) => break,
                     }
                 }
-                Err(RecvError::Lagged(_)) => {
-                    let frame = Event::default()
-                        .data(r#"{"jsonrpc":"2.0","method":"notifications/tools/list_changed"}"#);
-                    if tx.send(Ok(frame)).await.is_err() {
-                        break;
+                prof_tick = profiles_rx.recv() => {
+                    match prof_tick {
+                        Ok(path) => {
+                            // Profile-channel ticks only matter for
+                            // profile-scoped streams; the global stream
+                            // ignores them entirely (its tool surface is
+                            // governed by per-endpoint ticks).
+                            let forward = match &profile_filter {
+                                None => false,
+                                Some(f) => path == f.path,
+                            };
+                            if !forward {
+                                continue;
+                            }
+                            if tx.send(Ok(Event::default().data(FRAME_BODY))).await.is_err() {
+                                break;
+                            }
+                        }
+                        Err(RecvError::Lagged(_)) => {
+                            // Same policy as the per-endpoint channel: on
+                            // lag the originating path is lost, so forward
+                            // unconditionally for profile-scoped streams and
+                            // suppress for the global stream (which doesn't
+                            // care about profile ticks at all).
+                            if profile_filter.is_some()
+                                && tx.send(Ok(Event::default().data(FRAME_BODY))).await.is_err()
+                            {
+                                break;
+                            }
+                        }
+                        Err(RecvError::Closed) => {
+                            // The profile registry only drops when the
+                            // process exits; treat the same as the
+                            // per-endpoint `Closed` and bail out so we don't
+                            // spin on a dead channel.
+                            break;
+                        }
                     }
                 }
-                Err(RecvError::Closed) => break,
             }
         }
     });
@@ -2810,6 +2907,152 @@ mod tests {
         );
     }
 
+    /// End-to-end SSE smoke test covering the path the user originally cared
+    /// about: an MCP client subscribed to `/mcp/sse` is notified when a new
+    /// endpoint is registered, and a subsequent `tools/list` reflects both
+    /// the new tool and the `advertise.rs`-generated `Connected server
+    /// types: …` line on `search_tools`.
+    #[tokio::test]
+    async fn mcp_sse_e2e_new_endpoint_notifies_and_updates_descriptions() {
+        use axum::body::Body;
+        use tower::ServiceExt;
+
+        // Local mock that surfaces a `server_type()` so the advertised
+        // description in `search_tools` picks up a `Connected server types:`
+        // suffix. Kept inline to avoid touching the shared `MockAdapter`
+        // used by other tests.
+        struct TypedMockAdapter {
+            tools: Vec<ToolInfo>,
+            server_type_val: String,
+        }
+        #[async_trait]
+        impl McpAdapter for TypedMockAdapter {
+            async fn initialize(&mut self) -> Result<(), AdapterError> {
+                Ok(())
+            }
+            async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
+                Ok(self.tools.clone())
+            }
+            async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
+                Ok(json!({ "called": name, "args": arguments }))
+            }
+            fn health(&self) -> HealthStatus {
+                HealthStatus::Healthy
+            }
+            fn server_type(&self) -> Option<String> {
+                Some(self.server_type_val.clone())
+            }
+            async fn shutdown(&mut self) -> Result<(), AdapterError> {
+                Ok(())
+            }
+        }
+
+        let state = test_app_state();
+        let registry = state.registry.clone();
+        let router = build_router(state.clone());
+
+        // Step 1: open `/mcp/sse`. `build_mcp_sse_stream` subscribes to
+        // `tools_changed_tx` synchronously before returning, so any tick
+        // emitted after this point is guaranteed to be received.
+        let sse_request = axum::http::Request::builder()
+            .method("GET")
+            .uri("/mcp/sse")
+            .header("accept", "text/event-stream")
+            .body(Body::empty())
+            .unwrap();
+        let sse_resp = router.clone().oneshot(sse_request).await.unwrap();
+        assert_eq!(sse_resp.status(), StatusCode::OK);
+
+        // Step 2: register a new endpoint advertising a tool + a new
+        // server type. `register` emits a per-endpoint tick on
+        // `tools_changed_tx` (registry.rs:195).
+        let driver = tokio::spawn(async move {
+            // A small initial yield lets the spawned SSE writer task make
+            // forward progress past the `endpoint` event before the tick
+            // arrives. Without this the test still passes (the broadcast
+            // queues), but yielding makes the timing match what a real
+            // MCP client sees.
+            tokio::task::yield_now().await;
+            registry
+                .register(
+                    "smoke-ep".into(),
+                    Box::new(TypedMockAdapter {
+                        tools: vec![ToolInfo {
+                            name: "smoke_tool".into(),
+                            description: Some("smoke tool".into()),
+                            input_schema: json!({"type": "object"}),
+                            annotations: None,
+                        }],
+                        server_type_val: "smoke-server".into(),
+                    }),
+                    "stdio".into(),
+                    None,
+                    Some("smoke-ep".into()),
+                )
+                .await;
+        });
+
+        // Step 3: assert a `notifications/tools/list_changed` frame
+        // arrives within 1s. `read_sse_until` accumulates all bytes so
+        // the assertion below can also verify the initial endpoint
+        // event was delivered on the same stream.
+        let text = read_sse_until(sse_resp, Duration::from_secs(1), |s| {
+            s.contains("notifications/tools/list_changed")
+        })
+        .await;
+        driver.await.expect("registration driver task panicked");
+
+        assert!(
+            text.contains("event: endpoint") && text.contains("data: /mcp"),
+            "SSE stream should have delivered the initial endpoint event before the tools-changed frame (got: {text:?})"
+        );
+        assert!(
+            text.contains("notifications/tools/list_changed"),
+            "FRAME_MISSING: SSE stream did not deliver a notifications/tools/list_changed frame within 1s of registering a new endpoint (got: {text:?})"
+        );
+        assert!(
+            text.contains("\"jsonrpc\":\"2.0\""),
+            "FRAME_MISSING: tools/list_changed frame should be a JSON-RPC notification (got: {text:?})"
+        );
+
+        // Step 4: issue `tools/list` and verify the new endpoint's tool
+        // is present, and that `search_tools`'s description now includes
+        // the new server type via `Connected server types: …`.
+        let resp = post_mcp(
+            state.clone(),
+            &json!({"jsonrpc":"2.0","method":"tools/list","id":1}),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let tools = body["result"]["tools"]
+            .as_array()
+            .expect("tools/list result must have a tools array");
+
+        let tool_names: Vec<&str> = tools
+            .iter()
+            .map(|t| t["name"].as_str().unwrap_or(""))
+            .collect();
+        assert!(
+            tool_names.contains(&"smoke_tool"),
+            "CATALOG_ENTRY_MISSING: tools/list should include the newly registered endpoint's tool 'smoke_tool' (got names: {tool_names:?})"
+        );
+
+        let search_tools = tools
+            .iter()
+            .find(|t| t["name"] == "search_tools")
+            .expect("CATALOG_ENTRY_MISSING: tools/list must include the search_tools meta-tool");
+        let search_desc = search_tools["description"].as_str().unwrap_or("");
+        assert!(
+            search_desc.contains("Connected server types:"),
+            "DESCRIPTION_NOT_UPDATED: search_tools description should contain a 'Connected server types:' line now that an endpoint with a server_type is registered (got: {search_desc:?})"
+        );
+        assert!(
+            search_desc.contains("smoke-server"),
+            "DESCRIPTION_NOT_UPDATED: search_tools description should mention the new server type 'smoke-server' (got: {search_desc:?})"
+        );
+    }
+
     /// Helper: send `body` to a profile-scoped POST/DELETE/GET route via the
     /// router and return the raw response. Mirrors [`post_mcp`] for the
     /// `/mcp/{profile}` wildcard.
@@ -3449,6 +3692,289 @@ mod tests {
             .body(Body::empty())
             .unwrap();
         router.oneshot(request).await.unwrap()
+    }
+
+    // -- Profile-channel propagation matrix ----------------------------------
+    //
+    // The rows below back acceptance #2 of the spec: profile-scoped
+    // `/mcp/{profile}/sse` must receive a frame on profile-membership /
+    // toggle changes affecting it, and must re-read the live allowed-set
+    // when forwarding per-endpoint ticks so mid-stream membership changes
+    // take effect without reconnection. Each test mirrors the retry-tick
+    // pattern of the existing R3.D matrix (the in-handler subscriber races
+    // with the broadcast send, so single sends are unreliable).
+
+    /// Drive profile-changed ticks on `state.profile_registry` until
+    /// `deadline`. Mirrors [`drive_ticks_until`] but exercises the parallel
+    /// profile-channel installed alongside `AdapterRegistry`'s per-endpoint
+    /// channel.
+    async fn drive_profile_ticks_until(
+        state: AppState,
+        profile_path: &str,
+        deadline: tokio::time::Instant,
+    ) {
+        let path = profile_path.to_string();
+        while tokio::time::Instant::now() < deadline {
+            state.profile_registry.tick_profile_changed_for_test(&path);
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    // Matrix row A — profile-channel tick whose payload matches the
+    // stream's profile path is forwarded as a tools/list_changed frame.
+    // Backs spec acceptance #2: membership change emits a frame.
+    #[tokio::test]
+    async fn mcp_sse_profiled_forwards_profile_channel_tick() {
+        let state = test_app_state();
+        install_profile(&state, "work", vec!["gmail".into()]).await;
+        let resp = open_profile_sse(state.clone(), "work").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        let driver_state = state.clone();
+        let driver = tokio::spawn(async move {
+            drive_profile_ticks_until(driver_state, "work", deadline).await;
+        });
+        let text = read_sse_until(resp, Duration::from_secs(2), |s| {
+            s.contains("notifications/tools/list_changed")
+        })
+        .await;
+        driver.abort();
+        assert!(
+            text.contains("notifications/tools/list_changed"),
+            "expected profile-channel tick to be forwarded (got: {text:?})"
+        );
+    }
+
+    // Matrix row B — profile-channel tick for a *different* profile path
+    // is suppressed on this stream. Guards against the filter being too
+    // permissive (e.g. forwarding every profile tick).
+    #[tokio::test]
+    async fn mcp_sse_profiled_suppresses_other_profile_channel_tick() {
+        let state = test_app_state();
+        // Install both profiles so `mcp_sse_profiled` opens cleanly on `work`
+        // and the "personal" path is a legitimate payload value.
+        let profiles = vec![
+            crate::config::ProfileConfig {
+                name: "work".into(),
+                path: "work".into(),
+                endpoints: vec!["gmail".into()],
+                js_execution: false,
+                toon_output: true,
+            },
+            crate::config::ProfileConfig {
+                name: "personal".into(),
+                path: "personal".into(),
+                endpoints: vec!["todoist".into()],
+                js_execution: false,
+                toon_output: true,
+            },
+        ];
+        state.profile_registry.rebuild(&profiles).await;
+
+        let resp = open_profile_sse(state.clone(), "work").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let deadline = tokio::time::Instant::now() + Duration::from_millis(800);
+        let driver_state = state.clone();
+        let driver = tokio::spawn(async move {
+            drive_profile_ticks_until(driver_state, "personal", deadline).await;
+        });
+        let text = read_sse_until(resp, Duration::from_secs(1), |s| {
+            s.contains("notifications/tools/list_changed")
+        })
+        .await;
+        driver.abort();
+        assert!(
+            !text.contains("notifications/tools/list_changed"),
+            "other-profile tick must not be forwarded (got: {text:?})"
+        );
+        assert!(
+            text.contains("event: endpoint") && text.contains("data: /mcp/work"),
+            "initial endpoint frame should still be emitted (got: {text:?})"
+        );
+    }
+
+    // Matrix row C — a `rebuild` that adds an endpoint to the profile must
+    // emit one profile-channel tick (consumed by the open stream) and the
+    // *next* per-endpoint tick for the newly-added endpoint must be
+    // forwarded because the stream re-reads the allowed set live. Pre-R3.D
+    // the stream captured a static snapshot, so this test would have
+    // suppressed the post-rebuild "gmail" tick.
+    #[tokio::test]
+    async fn mcp_sse_profiled_picks_up_new_membership_live() {
+        let state = test_app_state();
+        // Start with an empty profile; "gmail" is initially out-of-profile.
+        install_profile(&state, "work", vec![]).await;
+        let resp = open_profile_sse(state.clone(), "work").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Rebuild to include "gmail". This emits a profile-channel tick.
+        install_profile(&state, "work", vec!["gmail".into()]).await;
+
+        // After the rebuild, per-endpoint ticks for "gmail" should now be
+        // forwarded. Drive ticks until the frame lands.
+        let registry = state.registry.clone();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        let driver = tokio::spawn(async move {
+            drive_ticks_until(registry, "gmail", deadline).await;
+        });
+        let text = read_sse_until(resp, Duration::from_secs(2), |s| {
+            s.contains("notifications/tools/list_changed")
+        })
+        .await;
+        driver.abort();
+        assert!(
+            text.contains("notifications/tools/list_changed"),
+            "expected post-rebuild in-profile tick to be forwarded (got: {text:?})"
+        );
+    }
+
+    // Matrix row D — converse of row C: a `rebuild` that *removes* an
+    // endpoint from the profile must cause subsequent per-endpoint ticks
+    // for that endpoint to be suppressed. The lone frame the stream is
+    // allowed to surface is the one fired by the rebuild itself (profile
+    // channel); after that, ticks against the removed endpoint must not
+    // appear.
+    #[tokio::test]
+    async fn mcp_sse_profiled_drops_removed_membership_live() {
+        let state = test_app_state();
+        install_profile(&state, "work", vec!["gmail".into()]).await;
+        let resp = open_profile_sse(state.clone(), "work").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Drain the initial `endpoint` event and the rebuild's profile
+        // tick, then prove the next "gmail" per-endpoint tick is dropped.
+        install_profile(&state, "work", vec![]).await;
+        // Give the spawned forwarder a beat to consume the profile-channel
+        // tick before we start driving per-endpoint ticks.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        // Now drive "gmail" per-endpoint ticks for a bounded window. The
+        // stream should swallow them all because "gmail" is no longer in
+        // the live allowed set.
+        let registry = state.registry.clone();
+        let deadline = tokio::time::Instant::now() + Duration::from_millis(800);
+        let driver = tokio::spawn(async move {
+            drive_ticks_until(registry, "gmail", deadline).await;
+        });
+        // Read for slightly longer than the deadline to confirm no extra
+        // frames arrive after the rebuild's bookkeeping tick.
+        let text = read_sse_until(resp, Duration::from_secs(1), |s| {
+            // Two frames would indicate the per-endpoint forwarding still
+            // sees "gmail" as in-profile.
+            s.matches("notifications/tools/list_changed").count() >= 2
+        })
+        .await;
+        driver.abort();
+        let frame_count = text.matches("notifications/tools/list_changed").count();
+        assert!(
+            frame_count <= 1,
+            "post-removal per-endpoint ticks for 'gmail' must be suppressed; \
+             got {frame_count} frames: {text:?}"
+        );
+    }
+
+    // Matrix row E — the global `/mcp/sse` stream ignores profile-channel
+    // ticks entirely. Without this, profile-membership churn (which is
+    // unrelated to the global tool surface) would spam every connected
+    // global client with redundant notifications.
+    #[tokio::test]
+    async fn mcp_sse_global_ignores_profile_channel_ticks() {
+        let state = test_app_state();
+        install_profile(&state, "work", vec!["gmail".into()]).await;
+        let resp = open_profile_sse_via_global(state.clone()).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let deadline = tokio::time::Instant::now() + Duration::from_millis(800);
+        let driver_state = state.clone();
+        let driver = tokio::spawn(async move {
+            drive_profile_ticks_until(driver_state, "work", deadline).await;
+        });
+        let text = read_sse_until(resp, Duration::from_secs(1), |s| {
+            s.contains("notifications/tools/list_changed")
+        })
+        .await;
+        driver.abort();
+        assert!(
+            !text.contains("notifications/tools/list_changed"),
+            "global /mcp/sse must ignore profile-channel ticks (got: {text:?})"
+        );
+    }
+
+    // Matrix row F — a no-op `rebuild` (same configs) MUST NOT emit a
+    // profile-channel tick. Backs spec acceptance #5 for profile streams.
+    #[tokio::test]
+    async fn rebuild_with_identical_config_emits_no_profile_tick() {
+        let state = test_app_state();
+        install_profile(&state, "work", vec!["gmail".into()]).await;
+        // Subscribe AFTER the initial rebuild so we only observe ticks from
+        // the second (no-op) rebuild.
+        let mut rx = state.profile_registry.subscribe_profiles_changed();
+        install_profile(&state, "work", vec!["gmail".into()]).await;
+        // Give the broadcast a beat to deliver, then assert nothing landed.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        match rx.try_recv() {
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty) => {}
+            other => panic!("no-op rebuild must not emit a profile tick (got: {other:?})"),
+        }
+    }
+
+    // Matrix row G — toggling `js_execution` on an otherwise-identical
+    // profile flips `execute_tools` in/out of the advertised catalog, so
+    // the rebuild must emit a profile-channel tick. Backs spec acceptance
+    // #2 ("profile sandbox/toggle changes that affect advertised tools").
+    #[tokio::test]
+    async fn rebuild_js_execution_toggle_emits_profile_tick() {
+        let state = test_app_state();
+        install_profile_with_flags(&state, "work", vec!["gmail".into()], false, true).await;
+        let mut rx = state.profile_registry.subscribe_profiles_changed();
+        install_profile_with_flags(&state, "work", vec!["gmail".into()], true, true).await;
+        let tick = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("profile-channel tick must arrive within 1s")
+            .expect("profile-channel recv must not error");
+        assert_eq!(
+            tick, "work",
+            "js_execution toggle on 'work' must tick the 'work' path"
+        );
+    }
+
+    // Matrix row H — toggling only `toon_output` does NOT change the
+    // advertised tool list (it only affects response serialization), so no
+    // profile-channel tick is emitted. Backs spec acceptance #5 (no frame
+    // on toggles that don't affect the advertised catalog).
+    #[tokio::test]
+    async fn rebuild_toon_only_toggle_emits_no_profile_tick() {
+        let state = test_app_state();
+        install_profile_with_flags(&state, "work", vec!["gmail".into()], false, true).await;
+        let mut rx = state.profile_registry.subscribe_profiles_changed();
+        install_profile_with_flags(&state, "work", vec!["gmail".into()], false, false).await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        match rx.try_recv() {
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty) => {}
+            other => {
+                panic!("toon_output-only toggle must not emit a profile tick (got: {other:?})")
+            }
+        }
+    }
+
+    // Matrix row I — removing a profile via `rebuild(&[])` must emit a
+    // final profile-channel tick for the now-deleted path so any open
+    // `/mcp/{path}/sse` stream gets one last `notifications/tools/list_changed`
+    // frame before its per-endpoint forwarding goes silent (because
+    // `ProfileRegistry::get` will return `None` from then on).
+    #[tokio::test]
+    async fn rebuild_emits_tick_for_removed_profile() {
+        let state = test_app_state();
+        install_profile(&state, "work", vec!["gmail".into()]).await;
+        let mut rx = state.profile_registry.subscribe_profiles_changed();
+        state.profile_registry.rebuild(&[]).await;
+        let tick = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("removal must tick within 1s")
+            .expect("profile-channel recv must not error");
+        assert_eq!(tick, "work", "removed profile path must be broadcast");
     }
 
     // R3.E — `profile` field in tracing spans. Nested under `tracing::profile`

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1957,5 +1957,195 @@ toon_output = true
                 assert_eq!(baseline_names, vec!["Work".to_string()]);
             }
         }
+
+        // ---- R3.D: tools_changed broadcast coverage from reload_and_apply ----
+        //
+        // Acceptance #4 in the R3.D spec: a single `reload_and_apply` that
+        // adds one endpoint, removes another, and leaves a third unchanged
+        // must emit exactly one `tools_changed` tick for the added endpoint,
+        // exactly one for the removed endpoint, and zero for the unchanged
+        // one. All add/remove paths in `apply_diff_graceful` flow through
+        // `AdapterRegistry::register` / `remove`, which already tick once
+        // per call (registry.rs:195 and :206); this test pins that wiring
+        // end-to-end so future watcher refactors can't silently break it.
+        mod tools_changed {
+            use super::super::*;
+            use crate::config::Config;
+            use crate::profile_registry::ProfileRegistry;
+            use std::collections::HashMap;
+            use std::path::PathBuf;
+            use std::sync::atomic::AtomicBool;
+            use std::sync::Arc;
+            use tokio::sync::Mutex;
+
+            /// Initial config: `keep` (unchanged across reload) + `remove_me`
+            /// (removed on reload).
+            const CONFIG_BEFORE: &str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "keep"
+transport = "stdio"
+command = "/bin/true"
+
+[[endpoints]]
+name = "remove_me"
+transport = "stdio"
+command = "/bin/true"
+"#;
+
+            /// New config: `keep` (unchanged) + `add_me` (newly added).
+            const CONFIG_AFTER: &str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "keep"
+transport = "stdio"
+command = "/bin/true"
+
+[[endpoints]]
+name = "add_me"
+transport = "stdio"
+command = "/bin/true"
+"#;
+
+            /// Build the in-memory state matching what main.rs would have
+            /// after loading `CONFIG_BEFORE` at startup, with `keep` and
+            /// `remove_me` pre-registered in the adapter registry so the
+            /// reload's `removed` branch actually has something to remove
+            /// (and therefore actually ticks).
+            async fn setup_with_endpoints() -> (
+                tempfile::TempDir,
+                PathBuf,
+                Arc<Mutex<Config>>,
+                Arc<AdapterRegistry>,
+                Arc<ProfileRegistry>,
+                Arc<AtomicBool>,
+                Arc<TokenManager>,
+                OAuthAdapterInners,
+            ) {
+                let tmp = tempfile::tempdir().unwrap();
+                let path = tmp.path().join("config.toml");
+                std::fs::write(&path, CONFIG_BEFORE).unwrap();
+                let (initial, _warnings) = config::load_config_graceful(&path).unwrap();
+
+                let registry = Arc::new(AdapterRegistry::new());
+                // Pre-register the two initial endpoints as MockAdapters so
+                // the reload's `remove("remove_me")` call actually finds and
+                // removes an entry (and therefore ticks). `keep` is also
+                // registered so its presence in the unchanged branch
+                // exercises the "no-op for unchanged" path realistically.
+                let dummy = Arc::new(std::sync::atomic::AtomicBool::new(false));
+                for name in ["keep", "remove_me"] {
+                    registry
+                        .register(
+                            name.into(),
+                            Box::new(MockAdapter::healthy(vec![make_tool("t")], dummy.clone())),
+                            "stdio".into(),
+                            None,
+                            Some(name.into()),
+                        )
+                        .await;
+                }
+
+                let profile_registry = Arc::new(ProfileRegistry::new((*registry).clone()));
+                profile_registry
+                    .rebuild(initial.profiles.as_deref().unwrap_or(&[]))
+                    .await;
+
+                let current_config = Arc::new(Mutex::new(initial));
+                let js_mode = Arc::new(AtomicBool::new(false));
+                let (token_manager, inners) = test_oauth_infra();
+                (
+                    tmp,
+                    path,
+                    current_config,
+                    registry,
+                    profile_registry,
+                    js_mode,
+                    token_manager,
+                    inners,
+                )
+            }
+
+            /// Drain every tick the subscriber sees within `budget`, returning
+            /// a per-endpoint count map. Uses a per-recv timeout (instead of
+            /// `try_recv`) so the test stays robust against background-task
+            /// scheduling jitter — the budget is generous enough to absorb
+            /// any synchronously-emitted tick from `reload_and_apply` while
+            /// still being short on test wall-clock.
+            async fn drain_ticks(
+                rx: &mut tokio::sync::broadcast::Receiver<String>,
+                budget: std::time::Duration,
+            ) -> HashMap<String, usize> {
+                let deadline = std::time::Instant::now() + budget;
+                let mut counts: HashMap<String, usize> = HashMap::new();
+                loop {
+                    let now = std::time::Instant::now();
+                    if now >= deadline {
+                        break;
+                    }
+                    let remaining = deadline - now;
+                    match tokio::time::timeout(remaining, rx.recv()).await {
+                        Ok(Ok(name)) => *counts.entry(name).or_insert(0) += 1,
+                        Ok(Err(_)) => break, // Lagged or Closed — stop draining.
+                        Err(_) => break,     // Timeout — no more ticks.
+                    }
+                }
+                counts
+            }
+
+            /// Spec R3.D acceptance #4: a reload that adds one endpoint,
+            /// removes another, and leaves a third unchanged must produce
+            /// exactly one `tools_changed` tick for the added endpoint, one
+            /// for the removed endpoint, and zero for the unchanged one.
+            #[tokio::test]
+            async fn reload_and_apply_ticks_added_and_removed_not_unchanged() {
+                let (_tmp, path, current_config, registry, profile_registry, js_mode, tm, inners) =
+                    setup_with_endpoints().await;
+
+                // Subscribe AFTER the initial pre-registration so we only
+                // observe the ticks driven by `reload_and_apply` itself.
+                let mut rx = registry.subscribe_tools_changed();
+
+                std::fs::write(&path, CONFIG_AFTER).unwrap();
+                reload_and_apply(
+                    &path,
+                    &current_config,
+                    &registry,
+                    &js_mode,
+                    &profile_registry,
+                    &tm,
+                    &inners,
+                )
+                .await
+                .expect("reload should succeed");
+
+                let counts = drain_ticks(&mut rx, std::time::Duration::from_millis(150)).await;
+
+                assert_eq!(
+                    counts.get("add_me").copied().unwrap_or(0),
+                    1,
+                    "added endpoint must emit exactly one tick (counts={counts:?})"
+                );
+                assert_eq!(
+                    counts.get("remove_me").copied().unwrap_or(0),
+                    1,
+                    "removed endpoint must emit exactly one tick (counts={counts:?})"
+                );
+                assert_eq!(
+                    counts.get("keep").copied().unwrap_or(0),
+                    0,
+                    "unchanged endpoint must emit zero ticks (counts={counts:?})"
+                );
+                assert_eq!(
+                    counts.values().sum::<usize>(),
+                    2,
+                    "reload should emit exactly 2 ticks total (counts={counts:?})"
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Relay was advertising `tools.listChanged: true` in `initialize` but only forwarded `notifications/tools/list_changed` when an upstream MCP server emitted one — every **relay-side** mutation (add/remove/enable/disable endpoint, enable/disable tool, restart endpoint, config hot-reload, profile-membership change) silently invalidated caches and left connected clients with a stale catalog. This PR makes the relay honor its own `listChanged` capability.

## What ships

- **Per-endpoint mutations** now tick `tools_changed_tx: broadcast::Sender<String>` after the state change is durable:
  - `AdapterRegistry::register` / `remove` (no-op `remove` correctly silent)
  - Management handlers: `disable_endpoint` / `enable_endpoint` / `disable_tool` / `enable_tool` (gated on prior state; no tick on no-op flips)
  - `restart_endpoint` — deliberate **dual-tick** on foreground placeholder swap AND background re-init swap (documented inline)
  - Watcher `reload_and_apply` — routes through `register`/`remove`, no production change required; test added
- **Profile-membership changes** flow on a new `profiles_changed_tx` channel from `ProfileRegistry`. `build_mcp_sse_stream` now uses a `ProfileSseFilter` that re-reads live allowed endpoints from the registry per tick, and subscribes to the profile channel for membership/sandbox toggles. Toon-only and no-op rebuilds emit nothing.
- **Keep-alive Arc** added in the SSE spawn so the broadcast `Sender`s outlive short request scopes (e.g. `tower::oneshot` in tests).

## Tests (added)

New SSE-stream tests covering the 9-row profile-matrix in the spec, 4 management flip/no-op pairs, register/remove plus no-op, restart foreground+background ordering, watcher add/remove/unchanged, and a full e2e smoke test `mcp_sse_e2e_new_endpoint_notifies_and_updates_descriptions` that asserts both the frame and the updated `Connected server types:` line in `search_tools`'s description.

## Known limitation (follow-up)

Watcher `apply_diff{,_graceful}` "changed"-branch goes `remove → register`, producing 2 SSE frames per changed endpoint per reload. Spec criterion #4 for config reloads uses **SHOULD** (not MUST), and frames are idempotent for MCP clients (each just triggers a `tools/list` re-fetch). Fix is ~30–60 min (silent `register_silent`/`remove_silent` variants + single explicit tick at end of the changed branch) and is tracked separately.

## Commit layout

Split into 4 conventional commits; each builds and tests pass on its own:

1. `feat(notifications): tick tools_changed on register/remove` — registry-layer plumbing + 4 unit tests
2. `feat(notifications): tick tools_changed on enable/disable handlers and restart_endpoint` — management handlers + 5 tests
3. `feat(notifications): add profile-channel propagation for tools/list_changed` — `profile_registry.rs` channel + `server.rs` SSE rewrite + 12 SSE/e2e tests
4. `test(watcher): add reload_and_apply tools_changed coverage` — watcher integration test only

## Verification

- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test` — 1617 passed / 0 failed / 5 ignored (consistent across two consecutive runs)
