### PR TITLE
docs(security): add SECURITY.md and enable private vulnerability reporting (#84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Prefer a UI to running a binary from a terminal? [Endara Desktop](https://github
 
 ## Security
 
-The relay's threat model — including its trust boundaries, the management API's UDS/Named-Pipe isolation, and the OAuth callback's localhost-only CSRF protections — is documented in [`THREAT_MODEL.md`](THREAT_MODEL.md). Report security issues by opening a private security advisory on GitHub.
+The relay's threat model — including its trust boundaries, the management API's UDS/Named-Pipe isolation, and the OAuth callback's localhost-only CSRF protections — is documented in [`THREAT_MODEL.md`](THREAT_MODEL.md). See [`SECURITY.md`](SECURITY.md) for the responsible-disclosure process and response-time expectations.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security policy
+
+## Supported versions
+
+We support the latest stable release. Older releases receive fixes on a best-effort basis.
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities privately via GitHub's "Report a vulnerability" flow on the Security tab:
+
+  https://github.com/endara-ai/endara-relay/security/advisories/new
+
+Please do **not** open public issues or pull requests for security reports.
+
+## What to expect
+
+- We aim to **acknowledge new reports within 3 business days**.
+- We aim to **provide a status update within 7 business days** of acknowledgement.
+- We will coordinate disclosure timing with the reporter and credit you (with permission) in the resulting advisory.
+
+## Scope
+
+**In scope**
+
+- The `endara-relay` binary, its OAuth callback handler, and the management API (Unix-domain socket on macOS/Linux, Named Pipe on Windows).
+- The `endara-desktop` Tauri app shell and the IPC commands it exposes (reported in the desktop repo, but accepted here too if it's unclear which side is affected).
+
+**Out of scope**
+
+- Third-party MCP servers configured as upstreams. The relay faithfully forwards their responses; sandboxing upstreams is a non-goal (see `THREAT_MODEL.md` → "Known residual risks").
+- User-misconfigured token directories (e.g. tokens placed on cloud-synced paths like Dropbox or iCloud Drive). The app surfaces an in-product warning but cannot prevent it.
+- Issues only reproducible by an attacker who already has administrative or local code-execution access as the same OS user.
+
+See `THREAT_MODEL.md` for the full threat model and trust boundaries.

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -111,7 +111,6 @@ non-goals for the Endara Relay process.
 
 ## Reporting a vulnerability
 
-See `SECURITY.md` (TODO) for the responsible-disclosure process. In the interim,
-file a private security advisory via GitHub at
-`https://github.com/endara-ai/endara-relay/security/advisories/new`.
+See [`SECURITY.md`](SECURITY.md) for the responsible-disclosure process and what
+to expect after you report.
 


### PR DESCRIPTION
Adds a top-level `SECURITY.md` documenting the responsible-disclosure process (GitHub Private Vulnerability Reporting), supported versions, scope, and response-time expectations, and updates the existing `THREAT_MODEL.md` and `README.md` references to link to it.

Closes #84

Matching desktop-side `SECURITY.md` PR: endara-ai/endara-desktop#105.

GitHub Private Vulnerability Reporting will be enabled on this repo by the maintainer right after this PR merges, so the "Report a vulnerability" button on the Security tab becomes active alongside the new policy doc.