### PR TITLE
chore: bump version to 0.1.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "endara-relay"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endara-relay"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 description = "Local MCP tool aggregator — aggregate multiple MCP servers behind a single endpoint"
 license = "Apache-2.0"


### PR DESCRIPTION
Bumps the committed base version to 0.1.9 after the v0.1.8 stable release. rc suffixes are added by the release workflow from the git tag, not the committed version. See AGENTS.md "Release versioning".