### PR TITLE
feat(identity): capture inbound MCP client identity for audit logs + events

### DIFF
--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -882,6 +882,7 @@ impl McpAdapter for HttpAdapter {
                     profile: span_ctx.profile.clone(),
                     tool: name.to_string(),
                     annotations,
+                    client: span_ctx.client.clone(),
                 });
             }
             let params = json!({
@@ -905,11 +906,23 @@ impl McpAdapter for HttpAdapter {
                 ),
             };
             self.activity_log.write().await.push(log_line);
+            let client_name = span_ctx
+                .client
+                .as_ref()
+                .and_then(|c| c.display_name())
+                .unwrap_or_default();
+            let client_version = span_ctx
+                .client
+                .as_ref()
+                .and_then(|c| c.version.clone())
+                .unwrap_or_default();
             match &result {
                 Ok(_) => tracing::info!(
                     tool = %name,
                     status = "ok",
                     duration_ms = duration_ms,
+                    client_name = ?client_name,
+                    client_version = ?client_version,
                     "Tool call completed"
                 ),
                 Err(e) => tracing::warn!(
@@ -917,6 +930,8 @@ impl McpAdapter for HttpAdapter {
                     status = "error",
                     duration_ms = duration_ms,
                     error = %e,
+                    client_name = ?client_name,
+                    client_version = ?client_version,
                     "Tool call failed"
                 ),
             }

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -796,6 +796,7 @@ impl McpAdapter for SseAdapter {
                     profile: span_ctx.profile.clone(),
                     tool: name.to_string(),
                     annotations,
+                    client: span_ctx.client.clone(),
                 });
             }
             let params = json!({
@@ -819,11 +820,23 @@ impl McpAdapter for SseAdapter {
                 ),
             };
             self.activity_log.write().await.push(log_line);
+            let client_name = span_ctx
+                .client
+                .as_ref()
+                .and_then(|c| c.display_name())
+                .unwrap_or_default();
+            let client_version = span_ctx
+                .client
+                .as_ref()
+                .and_then(|c| c.version.clone())
+                .unwrap_or_default();
             match &result {
                 Ok(_) => tracing::info!(
                     tool = %name,
                     status = "ok",
                     duration_ms = duration_ms,
+                    client_name = ?client_name,
+                    client_version = ?client_version,
                     "Tool call completed"
                 ),
                 Err(e) => tracing::warn!(
@@ -831,6 +844,8 @@ impl McpAdapter for SseAdapter {
                     status = "error",
                     duration_ms = duration_ms,
                     error = %e,
+                    client_name = ?client_name,
+                    client_version = ?client_version,
                     "Tool call failed"
                 ),
             }

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -610,6 +610,7 @@ impl McpAdapter for StdioAdapter {
                     profile: span_ctx.profile.clone(),
                     tool: name.to_string(),
                     annotations,
+                    client: span_ctx.client.clone(),
                 });
             }
             let params = json!({
@@ -619,11 +620,23 @@ impl McpAdapter for StdioAdapter {
             let start = Instant::now();
             let result = self.send_request("tools/call", Some(params)).await;
             let duration_ms = start.elapsed().as_millis();
+            let client_name = span_ctx
+                .client
+                .as_ref()
+                .and_then(|c| c.display_name())
+                .unwrap_or_default();
+            let client_version = span_ctx
+                .client
+                .as_ref()
+                .and_then(|c| c.version.clone())
+                .unwrap_or_default();
             match &result {
                 Ok(_) => tracing::info!(
                     tool = %name,
                     status = "ok",
                     duration_ms = duration_ms,
+                    client_name = ?client_name,
+                    client_version = ?client_version,
                     "Tool call completed"
                 ),
                 Err(e) => tracing::warn!(
@@ -631,6 +644,8 @@ impl McpAdapter for StdioAdapter {
                     status = "error",
                     duration_ms = duration_ms,
                     error = %e,
+                    client_name = ?client_name,
+                    client_version = ?client_version,
                     "Tool call failed"
                 ),
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,6 +46,14 @@ pub struct RelayConfig {
     /// socket and adapters keep initializing in the background.
     #[serde(default)]
     pub startup_init_timeout_secs: Option<u64>,
+    /// Maximum number of cached `Mcp-Session-Id` → client-identity entries
+    /// held by the inbound dispatch (see `server.rs`). `None` defers to
+    /// [`DEFAULT_SESSION_IDENTITY_MAX_SESSIONS`]. When the cache is full an
+    /// LRU eviction drops the least-recently-used entry; the per-request
+    /// `User-Agent` / `Origin` fallback still produces a best-effort caller
+    /// label so evicted sessions never block dispatch.
+    #[serde(default)]
+    pub session_identity_max_sessions: Option<usize>,
 }
 
 impl Default for RelayConfig {
@@ -66,6 +74,7 @@ impl Default for RelayConfig {
             allow_insecure_oauth: None,
             toon_output: None,
             startup_init_timeout_secs: None,
+            session_identity_max_sessions: None,
         }
     }
 }
@@ -73,6 +82,12 @@ impl Default for RelayConfig {
 /// Effective default for `RelayConfig::startup_init_timeout_secs` when the
 /// field is omitted from `config.toml`.
 pub const DEFAULT_STARTUP_INIT_TIMEOUT_SECS: u64 = 60;
+
+/// Effective default for `RelayConfig::session_identity_max_sessions` when
+/// the field is omitted from `config.toml`. Caps the inbound session →
+/// `ClientIdentity` cache so a misbehaving client that never reuses its
+/// `Mcp-Session-Id` cannot grow the map unboundedly.
+pub const DEFAULT_SESSION_IDENTITY_MAX_SESSIONS: usize = 1000;
 
 /// Transport type for an endpoint.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
@@ -1107,6 +1122,32 @@ startup_init_timeout_secs = 5
         assert_eq!(config.relay.startup_init_timeout_secs, Some(5));
     }
 
+    #[test]
+    fn session_identity_max_sessions_defaults_to_none() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+"#;
+        let config = parse_and_validate(toml_str).unwrap();
+        assert_eq!(config.relay.session_identity_max_sessions, None);
+    }
+
+    #[test]
+    fn session_identity_max_sessions_nonzero_parses() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+session_identity_max_sessions = 250
+"#;
+        let config = parse_and_validate(toml_str).unwrap();
+        assert_eq!(config.relay.session_identity_max_sessions, Some(250));
+    }
+
+    #[test]
+    fn session_identity_max_sessions_default_const_is_1000() {
+        assert_eq!(DEFAULT_SESSION_IDENTITY_MAX_SESSIONS, 1000);
+    }
+
     // --- Endpoint name format validation tests ---
 
     #[test]
@@ -1585,6 +1626,7 @@ js_execution = false
                 allow_insecure_oauth: None,
                 toon_output: None,
                 startup_init_timeout_secs: None,
+                session_identity_max_sessions: None,
             },
             endpoints,
             profiles: None,

--- a/src/events.rs
+++ b/src/events.rs
@@ -27,6 +27,63 @@ use tracing_subscriber::Layer;
 /// generous 256 events/s without back-pressuring producers.
 pub const DEFAULT_BUS_CAPACITY: usize = 256;
 
+/// Identity of the inbound MCP client making a request.
+///
+/// Populated from the `clientInfo` object sent on `initialize` (locked into a
+/// `Mcp-Session-Id`-keyed session map by the relay), with a per-request
+/// fallback to the `User-Agent` / `Origin` HTTP headers when no session is
+/// known. All fields are `Option<String>` because the source signals are all
+/// independently optional, and the on-wire JSON omits any `None` fields so
+/// the overlay can render `name` / `name + version` / UA-only with the same
+/// rendering code.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClientIdentity {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_agent: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub origin: Option<String>,
+}
+
+impl ClientIdentity {
+    /// Returns `true` when every field is `None`. Used by the serializer
+    /// skip-guard so empty identity objects are omitted from the wire entirely.
+    pub fn is_empty(&self) -> bool {
+        self.name.is_none()
+            && self.version.is_none()
+            && self.user_agent.is_none()
+            && self.origin.is_none()
+    }
+
+    /// Best-effort display label for the calling app, used for the
+    /// `client_name` audit-log field. Returns `clientInfo.name` when present,
+    /// else a concise token derived from the `User-Agent` (the substring
+    /// before the first `/` or whitespace, e.g. `cursor-vscode/0.42 (Cursor
+    /// IDE)` -> `cursor-vscode`), else `None`. This lets UA-only callers still
+    /// surface a label in the logs view.
+    pub fn display_name(&self) -> Option<String> {
+        if let Some(name) = self.name.as_ref() {
+            if !name.is_empty() {
+                return Some(name.clone());
+            }
+        }
+        if let Some(ua) = self.user_agent.as_ref() {
+            let token = ua
+                .split(|c: char| c == '/' || c.is_whitespace())
+                .next()
+                .unwrap_or("")
+                .trim();
+            if !token.is_empty() {
+                return Some(token.to_string());
+            }
+        }
+        None
+    }
+}
+
 /// MCP tool annotations carried on every `started` event so the overlay can
 /// render hint pills (destructive / open-world / read-only / idempotent)
 /// without re-querying `tools/list`. Each field is `Option<bool>` because the
@@ -105,6 +162,12 @@ pub enum ToolCallEvent {
         tool: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         annotations: Option<ToolAnnotations>,
+        /// Identity of the calling MCP client, captured from the surrounding
+        /// `request` tracing span (populated by the inbound dispatch from
+        /// `clientInfo` + `User-Agent`/`Origin`). `None` when no caller
+        /// signal is known (e.g. internal background calls).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        client: Option<ClientIdentity>,
     },
     /// Emitted on `Ok(_)` return from the underlying `tools/call` request.
     Completed {
@@ -196,16 +259,23 @@ pub struct RequestSpanContext {
     /// Profile path segment from `/mcp/{profile}`. `None` for the global
     /// `/mcp` endpoint.
     pub profile: Option<String>,
+    /// Identity of the inbound MCP caller, captured from the `request`
+    /// span's `client` field (a JSON-serialised [`ClientIdentity`] recorded
+    /// by the inbound dispatch). `None` when no `request` span is on the
+    /// stack, when the dispatch recorded no client signal, or when the
+    /// span's `client` field could not be parsed back.
+    pub client: Option<ClientIdentity>,
 }
 
 /// Fields captured per span by [`SpanFieldCaptureLayer`]. Stored in the
 /// span's extensions so [`current_request_context`] can read them back when
-/// an adapter publishes a [`ToolCallEvent`]. Carrying both fields in one
+/// an adapter publishes a [`ToolCallEvent`]. Carrying all fields in one
 /// extension keeps the per-span allocation count to one.
 #[derive(Debug, Default, Clone)]
 struct CapturedSpanFields {
     jsonrpc_id: Option<String>,
     profile: Option<String>,
+    client: Option<ClientIdentity>,
 }
 
 /// Visits a span's recorded fields once at span creation time, capturing the
@@ -239,6 +309,17 @@ impl<'a> CapturingVisitor<'a> {
             // emitter cannot leak a fake id into an event.
             if value != "null" {
                 self.captured.jsonrpc_id = Some(value);
+            }
+        } else if self.is_request && name == "client" {
+            // The `request` span carries `client = %client_json` where
+            // `client_json` is a JSON-serialised `ClientIdentity`. Parse it
+            // back so `current_request_context()` can hand a typed value
+            // to adapter event emitters. Silently ignore parse failures so
+            // a malformed field cannot break dispatch.
+            if let Ok(identity) = serde_json::from_str::<ClientIdentity>(&value) {
+                if !identity.is_empty() {
+                    self.captured.client = Some(identity);
+                }
             }
         } else if self.is_mcp_request && name == "profile" {
             self.captured.profile = Some(value);
@@ -305,6 +386,11 @@ pub fn current_request_context() -> RequestSpanContext {
                         ctx.profile = Some(v.clone());
                     }
                 }
+                if ctx.client.is_none() {
+                    if let Some(v) = &captured.client {
+                        ctx.client = Some(v.clone());
+                    }
+                }
             }
         }
     });
@@ -336,12 +422,28 @@ mod tests {
                 read_only: Some(true),
                 idempotent: Some(true),
             }),
+            client: Some(ClientIdentity {
+                name: Some("claude-ai".into()),
+                version: Some("0.1.0".into()),
+                user_agent: None,
+                origin: None,
+            }),
         };
         let v = serde_json::to_value(&ev).unwrap();
         assert_eq!(v["kind"], "started");
         assert_eq!(v["tool"], "list_issues");
         assert_eq!(v["annotations"]["read_only"], true);
         assert_eq!(v["jsonrpc_id"], "42");
+        assert_eq!(v["client"]["name"], "claude-ai");
+        assert_eq!(v["client"]["version"], "0.1.0");
+        assert!(
+            v["client"].get("user_agent").is_none(),
+            "user_agent should be omitted when None, got {v}"
+        );
+        assert!(
+            v["client"].get("origin").is_none(),
+            "origin should be omitted when None, got {v}"
+        );
     }
 
     #[test]
@@ -357,12 +459,100 @@ mod tests {
             profile: None,
             tool: "list_issues".into(),
             annotations: None,
+            client: None,
         };
         let v = serde_json::to_value(&ev).unwrap();
         assert!(
             v.get("jsonrpc_id").is_none(),
             "jsonrpc_id should be omitted when None, got {v}"
         );
+        assert!(
+            v.get("client").is_none(),
+            "client should be omitted when None, got {v}"
+        );
+    }
+
+    #[test]
+    fn client_identity_round_trip_serialization() {
+        let full = ClientIdentity {
+            name: Some("Claude Desktop".into()),
+            version: Some("0.7.0".into()),
+            user_agent: Some("claude-desktop/0.7.0".into()),
+            origin: Some("https://claude.ai".into()),
+        };
+        let v = serde_json::to_value(&full).unwrap();
+        assert_eq!(v["name"], "Claude Desktop");
+        assert_eq!(v["version"], "0.7.0");
+        assert_eq!(v["user_agent"], "claude-desktop/0.7.0");
+        assert_eq!(v["origin"], "https://claude.ai");
+        let back: ClientIdentity = serde_json::from_value(v).unwrap();
+        assert_eq!(back, full);
+        assert!(!full.is_empty());
+
+        let empty = ClientIdentity::default();
+        let v = serde_json::to_value(&empty).unwrap();
+        assert_eq!(v, json!({}));
+        assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn client_identity_display_name_prefers_name_then_ua_token() {
+        // `clientInfo.name` wins when present.
+        let with_name = ClientIdentity {
+            name: Some("Claude Desktop".into()),
+            version: Some("0.7.0".into()),
+            user_agent: Some("claude-desktop/0.7.0".into()),
+            origin: None,
+        };
+        assert_eq!(with_name.display_name().as_deref(), Some("Claude Desktop"));
+
+        // UA-only callers derive a concise token (before the first `/`).
+        let ua_only = ClientIdentity {
+            name: None,
+            version: None,
+            user_agent: Some("cursor-vscode/0.42 (Cursor IDE)".into()),
+            origin: None,
+        };
+        assert_eq!(ua_only.display_name().as_deref(), Some("cursor-vscode"));
+
+        // UA whose leading token ends at whitespace (no slash).
+        let ua_space = ClientIdentity {
+            name: None,
+            version: None,
+            user_agent: Some("CustomAgent some details".into()),
+            origin: None,
+        };
+        assert_eq!(ua_space.display_name().as_deref(), Some("CustomAgent"));
+
+        // Empty identity yields no label.
+        assert_eq!(ClientIdentity::default().display_name(), None);
+
+        // An empty `name` string falls through to the UA (None here).
+        let empty_name = ClientIdentity {
+            name: Some(String::new()),
+            ..Default::default()
+        };
+        assert_eq!(empty_name.display_name(), None);
+    }
+
+    #[test]
+    fn debug_formatted_client_name_field_is_quoted_for_multiword_names() {
+        // The audit and tool-call log lines emit `client_name = ?value`, which
+        // the tracing fmt layer renders via `Debug`. Confirm a multi-word name
+        // is wrapped in quotes so the desktop `EVENT_FIELD_RE`
+        // (`(\w+)=("([^"]*)"|(\S*))`) captures it intact rather than truncating
+        // at the space.
+        let name = "Claude Desktop";
+        let field = format!("client_name={name:?}");
+        assert_eq!(field, "client_name=\"Claude Desktop\"");
+        let quoted = field.strip_prefix("client_name=").unwrap();
+        assert!(quoted.starts_with('"') && quoted.ends_with('"'));
+        let inner = &quoted[1..quoted.len() - 1];
+        assert_eq!(inner, "Claude Desktop");
+
+        // An empty value still renders as the quoted empty string the desktop
+        // parser treats as "skip".
+        assert_eq!(format!("client_name={:?}", ""), "client_name=\"\"");
     }
 
     #[test]
@@ -540,6 +730,70 @@ mod tests {
                 let span = tracing::info_span!("request", method = "x", id = %id_str);
                 let ctx = async { current_request_context() }.instrument(span).await;
                 assert_eq!(ctx.jsonrpc_id, None);
+            });
+        });
+    }
+
+    /// The `request` span's `client` field carries a JSON-serialised
+    /// [`ClientIdentity`]; [`current_request_context`] must parse it back to
+    /// a typed value so adapter event emitters can populate
+    /// [`ToolCallEvent::Started::client`] without re-deriving it.
+    #[test]
+    fn current_request_context_captures_client_from_request_span() {
+        use tracing::Instrument;
+        use tracing_subscriber::prelude::*;
+
+        let subscriber = tracing_subscriber::registry().with(SpanFieldCaptureLayer);
+        tracing::subscriber::with_default(subscriber, || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                let identity = ClientIdentity {
+                    name: Some("claude-ai".into()),
+                    version: Some("0.1.0".into()),
+                    user_agent: Some("claude-ai/0.1.0".into()),
+                    origin: None,
+                };
+                let client_json = serde_json::to_string(&identity).unwrap();
+                let id_str = "9".to_string();
+                let span = tracing::info_span!(
+                    "request",
+                    method = "tools/call",
+                    id = %id_str,
+                    client = %client_json,
+                );
+                let ctx = async { current_request_context() }.instrument(span).await;
+                assert_eq!(ctx.jsonrpc_id.as_deref(), Some("9"));
+                assert_eq!(ctx.client.as_ref(), Some(&identity));
+            });
+        });
+    }
+
+    /// A malformed `client` field on the `request` span must not propagate;
+    /// the visitor silently drops the value so dispatch stays resilient.
+    #[test]
+    fn current_request_context_ignores_malformed_client_field() {
+        use tracing::Instrument;
+        use tracing_subscriber::prelude::*;
+        let subscriber = tracing_subscriber::registry().with(SpanFieldCaptureLayer);
+        tracing::subscriber::with_default(subscriber, || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                let client_str = "not-json".to_string();
+                let id_str = "1".to_string();
+                let span = tracing::info_span!(
+                    "request",
+                    method = "tools/call",
+                    id = %id_str,
+                    client = %client_str,
+                );
+                let ctx = async { current_request_context() }.instrument(span).await;
+                assert_eq!(ctx.client, None);
             });
         });
     }

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -12,6 +12,7 @@ use boa_engine::{Context, JsError, JsNativeError, JsResult, JsValue, NativeFunct
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::sync::RwLock;
+use tracing::Instrument;
 
 use crate::adapter::{AdapterError, ToolInfo};
 use crate::registry::MetaToolRegistry;
@@ -91,6 +92,14 @@ struct SandboxState {
     /// Defaults to `false`, which preserves the existing zero-backoff override
     /// that keeps the test suite fast.
     use_real_backoff: bool,
+    /// JSON-serialised [`crate::events::ClientIdentity`] of the outer inbound
+    /// request, captured before the sandbox hops onto the blocking thread.
+    /// Empty when no caller identity is known. Used to re-establish a
+    /// `request{client=...}` span around each inner `route_tool_call` so
+    /// `SpanFieldCaptureLayer` / `current_request_context()` can surface the
+    /// caller to the upstream adapter's event emitters and log lines — the
+    /// blocking-thread hop otherwise drops the outer request span.
+    client_json: String,
 }
 
 thread_local! {
@@ -113,6 +122,11 @@ pub struct JsSandbox {
     /// schedule. Production callers leave this at `false` because production
     /// builds always apply the real schedule regardless.
     use_real_backoff: bool,
+    /// JSON-serialised [`crate::events::ClientIdentity`] of the outer inbound
+    /// request. Defaults to empty (no caller identity); set via
+    /// [`Self::with_client`] by [`MetaToolHandler::execute_tools`] so inner
+    /// upstream tool calls re-establish the caller's `request` span.
+    client_json: String,
 }
 
 impl JsSandbox {
@@ -144,7 +158,18 @@ impl JsSandbox {
             registry,
             timeout,
             use_real_backoff: false,
+            client_json: String::new(),
         }
+    }
+
+    /// Attach the outer inbound request's JSON-serialised
+    /// [`crate::events::ClientIdentity`] so inner upstream tool calls
+    /// re-establish a `request{client=...}` span on the sandbox's blocking
+    /// thread. An empty string degrades to no caller identity. Used by
+    /// [`MetaToolHandler::execute_tools`].
+    pub fn with_client(mut self, client_json: String) -> Self {
+        self.client_json = client_json;
+        self
     }
 
     /// Test-only: opt this sandbox into the real backoff schedule. Without
@@ -161,6 +186,7 @@ impl JsSandbox {
         let registry = self.registry.clone();
         let timeout = self.timeout;
         let use_real_backoff = self.use_real_backoff;
+        let client_json = self.client_json.clone();
         let script = script.to_string();
         let handle = tokio::runtime::Handle::current();
         let catalog = self.registry.merged_catalog().await;
@@ -175,6 +201,7 @@ impl JsSandbox {
                     &handle,
                     timeout,
                     use_real_backoff,
+                    client_json,
                 )
             }),
         )
@@ -199,6 +226,7 @@ fn execute_in_sandbox(
     handle: &tokio::runtime::Handle,
     sandbox_timeout: Duration,
     use_real_backoff: bool,
+    client_json: String,
 ) -> Result<Value, JsSandboxError> {
     let deadline = std::time::Instant::now() + sandbox_timeout;
     SANDBOX_STATE.with(|cell| {
@@ -207,6 +235,7 @@ fn execute_in_sandbox(
             handle: handle.clone(),
             deadline,
             use_real_backoff,
+            client_json,
         });
     });
     let result = run_js(script, catalog);
@@ -214,6 +243,31 @@ fn execute_in_sandbox(
         *cell.borrow_mut() = None;
     });
     result
+}
+
+/// Drive `fut` to completion on the sandbox's blocking thread, re-establishing
+/// the outer inbound request's `request{client=...}` span when a caller
+/// identity was captured.
+///
+/// `JsSandbox::execute` hops onto a `spawn_blocking` thread, which does not
+/// inherit the inbound `request` span. Without re-entering it here, the
+/// upstream adapter's `current_request_context()` resolves no caller for
+/// sandbox-driven tool calls, so the "Tool call completed/failed" log lines
+/// and `ToolCallEvent::Started.client` lose the aggregating client. Entering a
+/// fresh `request` span carrying `client = %client_json` lets
+/// `SpanFieldCaptureLayer` re-capture the identity exactly as the direct path
+/// does. An empty `client_json` runs the future without an extra span so
+/// callers with no identity signal degrade cleanly.
+fn block_on_with_client<F>(handle: &tokio::runtime::Handle, client_json: &str, fut: F) -> F::Output
+where
+    F: std::future::Future,
+{
+    if client_json.is_empty() {
+        handle.block_on(fut)
+    } else {
+        let span = tracing::info_span!("request", method = "tools/call", client = %client_json);
+        handle.block_on(fut.instrument(span))
+    }
 }
 
 fn run_js(script: &str, catalog: &[ToolInfo]) -> Result<Value, JsSandboxError> {
@@ -336,13 +390,14 @@ fn call_tool_native(_this: &JsValue, args: &[JsValue], context: &mut Context) ->
         if let Some(msg) = validate_tool_args(tool, &arguments) {
             return Err(JsError::from(JsNativeError::error().with_message(msg)));
         }
-        let res = state
-            .handle
-            .block_on(state.registry.route_tool_call(&tool_name, arguments))
-            .map_err(|e| {
-                JsNativeError::error()
-                    .with_message(format!("tool call '{}' failed: {}", tool_name, e))
-            })?;
+        let res = block_on_with_client(
+            &state.handle,
+            &state.client_json,
+            state.registry.route_tool_call(&tool_name, arguments),
+        )
+        .map_err(|e| {
+            JsNativeError::error().with_message(format!("tool call '{}' failed: {}", tool_name, e))
+        })?;
         Ok::<Value, JsError>(res)
     })?;
 
@@ -432,20 +487,21 @@ fn call_tool_with_retry_native(
         let registry = state.registry.clone();
         let deadline = state.deadline;
         let use_real_backoff = state.use_real_backoff;
-        let res = state
-            .handle
-            .block_on(call_tool_with_retry_loop(
+        let res = block_on_with_client(
+            &state.handle,
+            &state.client_json,
+            call_tool_with_retry_loop(
                 registry.as_ref(),
                 &tool_name,
                 arguments,
                 max_retries,
                 deadline,
                 use_real_backoff,
-            ))
-            .map_err(|e| {
-                JsNativeError::error()
-                    .with_message(format!("tool call '{}' failed: {}", tool_name, e))
-            })?;
+            ),
+        )
+        .map_err(|e| {
+            JsNativeError::error().with_message(format!("tool call '{}' failed: {}", tool_name, e))
+        })?;
         Ok::<Value, JsError>(res)
     })?;
 
@@ -1261,8 +1317,20 @@ impl MetaToolHandler {
     /// `execute_tools` — run JS in sandbox. The sandbox inherits the
     /// handler's [`MetaToolRegistry`] backing, so a per-profile handler
     /// gives the script a profile-filtered `tools.call()`.
-    pub async fn execute_tools(&self, script: &str) -> Result<Value, JsSandboxError> {
-        let sandbox = JsSandbox::from_dyn(self.registry.clone(), self.sandbox_timeout);
+    ///
+    /// `client_json` is the JSON-serialised [`crate::events::ClientIdentity`]
+    /// of the outer inbound request (empty when no caller identity is known).
+    /// It is threaded into the sandbox so inner upstream tool calls
+    /// re-establish the caller's `request{client=...}` span across the
+    /// blocking-thread hop — keeping the caller visible on the aggregated
+    /// "Tool call completed/failed" log lines and `ToolCallEvent::Started`.
+    pub async fn execute_tools(
+        &self,
+        script: &str,
+        client_json: &str,
+    ) -> Result<Value, JsSandboxError> {
+        let sandbox = JsSandbox::from_dyn(self.registry.clone(), self.sandbox_timeout)
+            .with_client(client_json.to_string());
         sandbox.execute(script).await
     }
 }
@@ -3030,6 +3098,175 @@ mod tests {
             elapsed < Duration::from_millis(150),
             "retry loop should abort before first real sleep, took {:?}",
             elapsed
+        );
+    }
+
+    /// R1.2: a sandbox-driven upstream tool call must re-establish the outer
+    /// inbound request's caller identity across the `spawn_blocking` thread
+    /// hop. [`block_on_with_client`] enters a fresh `request{client=...}` span
+    /// before driving [`MetaToolRegistry::route_tool_call`], so the adapter's
+    /// `current_request_context().client` (the same signal feeding the "Tool
+    /// call completed/failed" log lines and `ToolCallEvent::Started.client`)
+    /// resolves the aggregating client rather than `None`. This is the exact
+    /// failure the task reproduced live before the fix.
+    #[test]
+    fn sandbox_tool_call_reestablishes_client_context() {
+        use crate::events::{current_request_context, ClientIdentity, SpanFieldCaptureLayer};
+        use std::sync::Mutex;
+        use tracing_subscriber::prelude::*;
+
+        // Adapter that records the caller identity visible via the request
+        // span at `call_tool` time, proving the span was re-established.
+        struct ClientCapturingAdapter {
+            tools: Vec<ToolInfo>,
+            seen: Arc<Mutex<Option<ClientIdentity>>>,
+        }
+
+        #[async_trait]
+        impl McpAdapter for ClientCapturingAdapter {
+            async fn initialize(&mut self) -> Result<(), AdapterError> {
+                Ok(())
+            }
+            async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
+                Ok(self.tools.clone())
+            }
+            async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
+                *self.seen.lock().unwrap() = current_request_context().client;
+                Ok(json!({ "called": name, "args": arguments }))
+            }
+            fn health(&self) -> HealthStatus {
+                HealthStatus::Healthy
+            }
+            async fn shutdown(&mut self) -> Result<(), AdapterError> {
+                Ok(())
+            }
+        }
+
+        let seen = Arc::new(Mutex::new(None));
+        let seen_clone = Arc::clone(&seen);
+        let subscriber = tracing_subscriber::registry().with(SpanFieldCaptureLayer);
+        tracing::subscriber::with_default(subscriber, || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            let registry = rt.block_on(async {
+                let registry = AdapterRegistry::new();
+                registry
+                    .register(
+                        "ep".into(),
+                        Box::new(ClientCapturingAdapter {
+                            tools: vec![make_tool("echo", "Echo tool")],
+                            seen: seen_clone,
+                        }),
+                        "stdio".into(),
+                        None,
+                        None,
+                    )
+                    .await;
+                Arc::new(registry)
+            });
+
+            let identity = ClientIdentity {
+                name: Some("Claude Desktop".into()),
+                version: Some("0.1.0".into()),
+                user_agent: None,
+                origin: None,
+            };
+            let client_json = serde_json::to_string(&identity).unwrap();
+            let reg: Arc<dyn MetaToolRegistry> = registry;
+            let result = block_on_with_client(
+                rt.handle(),
+                &client_json,
+                reg.route_tool_call("echo", json!({})),
+            );
+            assert!(result.is_ok(), "tool call should succeed: {:?}", result);
+        });
+
+        let captured = seen.lock().unwrap().clone();
+        assert_eq!(
+            captured,
+            Some(ClientIdentity {
+                name: Some("Claude Desktop".into()),
+                version: Some("0.1.0".into()),
+                user_agent: None,
+                origin: None,
+            }),
+            "sandbox-driven tool call must re-establish the caller identity \
+             in the request context"
+        );
+    }
+
+    /// With no caller identity captured (empty `client_json`),
+    /// [`block_on_with_client`] must skip the extra span and drive the future
+    /// directly, leaving `current_request_context().client` as `None` rather
+    /// than fabricating an empty identity.
+    #[test]
+    fn sandbox_tool_call_without_client_leaves_context_none() {
+        use crate::events::{current_request_context, ClientIdentity, SpanFieldCaptureLayer};
+        use std::sync::Mutex;
+        use tracing_subscriber::prelude::*;
+
+        struct ClientCapturingAdapter {
+            tools: Vec<ToolInfo>,
+            seen: Arc<Mutex<Option<ClientIdentity>>>,
+        }
+
+        #[async_trait]
+        impl McpAdapter for ClientCapturingAdapter {
+            async fn initialize(&mut self) -> Result<(), AdapterError> {
+                Ok(())
+            }
+            async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
+                Ok(self.tools.clone())
+            }
+            async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
+                *self.seen.lock().unwrap() = current_request_context().client;
+                Ok(json!({ "called": name, "args": arguments }))
+            }
+            fn health(&self) -> HealthStatus {
+                HealthStatus::Healthy
+            }
+            async fn shutdown(&mut self) -> Result<(), AdapterError> {
+                Ok(())
+            }
+        }
+
+        let seen = Arc::new(Mutex::new(Some(ClientIdentity::default())));
+        let seen_clone = Arc::clone(&seen);
+        let subscriber = tracing_subscriber::registry().with(SpanFieldCaptureLayer);
+        tracing::subscriber::with_default(subscriber, || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            let registry = rt.block_on(async {
+                let registry = AdapterRegistry::new();
+                registry
+                    .register(
+                        "ep".into(),
+                        Box::new(ClientCapturingAdapter {
+                            tools: vec![make_tool("echo", "Echo tool")],
+                            seen: seen_clone,
+                        }),
+                        "stdio".into(),
+                        None,
+                        None,
+                    )
+                    .await;
+                Arc::new(registry)
+            });
+
+            let reg: Arc<dyn MetaToolRegistry> = registry;
+            let result =
+                block_on_with_client(rt.handle(), "", reg.route_tool_call("echo", json!({})));
+            assert!(result.is_ok(), "tool call should succeed: {:?}", result);
+        });
+
+        assert_eq!(
+            *seen.lock().unwrap(),
+            None,
+            "empty client_json must not fabricate a caller identity"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -619,6 +619,13 @@ async fn main() {
                 cfg.relay.toon_output.unwrap_or(true)
             };
             info!(toon_enabled, "TOON output conversion configured");
+            let session_identities = Arc::new(std::sync::Mutex::new(
+                server::SessionIdentityStore::with_capacity(
+                    cfg.relay
+                        .session_identity_max_sessions
+                        .unwrap_or(config::DEFAULT_SESSION_IDENTITY_MAX_SESSIONS),
+                ),
+            ));
             let state = AppState {
                 registry: (*registry).clone(),
                 js_execution_mode: js_execution_mode.clone(),
@@ -630,6 +637,7 @@ async fn main() {
                 setup_manager: Some(setup_manager.clone()),
                 started_at: std::time::Instant::now(),
                 toon_enabled,
+                session_identities,
             };
             // Shared config handle: a single `Arc<RwLock<Config>>` that both
             // `ManagementState` (read by `/api/*` handlers) and `ConfigWatcher`

--- a/src/management.rs
+++ b/src/management.rs
@@ -3793,6 +3793,7 @@ mod tests {
                 allow_insecure_oauth: None,
                 toon_output: None,
                 startup_init_timeout_secs: None,
+                session_identity_max_sessions: None,
             },
             endpoints: vec![EndpointConfig {
                 name: "echo".to_string(),
@@ -5974,6 +5975,7 @@ command = "echo"
                 allow_insecure_oauth: None,
                 toon_output: None,
                 startup_init_timeout_secs: None,
+                session_identity_max_sessions: None,
             },
             endpoints: vec![EndpointConfig {
                 name: name.to_string(),
@@ -6175,6 +6177,7 @@ command = "echo"
                 allow_insecure_oauth: Some(true),
                 toon_output: None,
                 startup_init_timeout_secs: None,
+                session_identity_max_sessions: None,
             },
             endpoints: vec![EndpointConfig {
                 name: name.to_string(),
@@ -6589,6 +6592,7 @@ command = "echo"
                 allow_insecure_oauth: Some(allow_insecure_oauth),
                 toon_output: None,
                 startup_init_timeout_secs: None,
+                session_identity_max_sessions: None,
             },
             endpoints: vec![EndpointConfig {
                 name: name.to_string(),
@@ -6706,6 +6710,7 @@ client_id = "client123"
                 allow_insecure_oauth: Some(false),
                 toon_output: None,
                 startup_init_timeout_secs: None,
+                session_identity_max_sessions: None,
             },
             endpoints: vec![],
             profiles: None,
@@ -6767,6 +6772,7 @@ client_id = "client123"
                 allow_insecure_oauth: None,
                 toon_output: None,
                 startup_init_timeout_secs: None,
+                session_identity_max_sessions: None,
             },
             endpoints: endpoint_names
                 .iter()
@@ -7321,6 +7327,7 @@ client_id = "client123"
                 allow_insecure_oauth: None,
                 toon_output: None,
                 startup_init_timeout_secs: None,
+                session_identity_max_sessions: None,
             },
             endpoints: vec![EndpointConfig {
                 name: "existing".to_string(),

--- a/src/profile_registry.rs
+++ b/src/profile_registry.rs
@@ -736,7 +736,7 @@ mod tests {
             }
         "#;
         let result = handler
-            .execute_tools(script)
+            .execute_tools(script, "")
             .await
             .expect("execute_tools should return the script's error value");
         let err_msg = result

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -726,6 +726,7 @@ impl AdapterRegistry {
                 profile: span_ctx.profile.clone(),
                 tool,
                 annotations: None,
+                client: span_ctx.client.clone(),
             });
             bus.send(ToolCallEvent::Failed {
                 request_id,

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,3 +1,5 @@
+use crate::config::DEFAULT_SESSION_IDENTITY_MAX_SESSIONS;
+use crate::events::ClientIdentity;
 use crate::js_sandbox::MetaToolHandler;
 use crate::oauth::{OAuthFlowManager, OAuthSetupManager};
 use crate::profile_registry::{ProfileContext, ProfileRegistry};
@@ -6,7 +8,7 @@ use crate::token_manager::TokenManager;
 use crate::OAuthAdapterInners;
 use axum::{
     extract::{Path, Query, State},
-    http::{HeaderMap, HeaderValue, Method, StatusCode},
+    http::{HeaderMap, HeaderName, HeaderValue, Method, StatusCode},
     response::{
         sse::{Event, KeepAlive},
         Html, IntoResponse, Response, Sse,
@@ -16,16 +18,24 @@ use axum::{
 };
 use serde::Deserialize;
 use serde_json::{json, Value};
+use std::collections::{BTreeMap, HashMap};
 use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tokio::net::TcpListener;
 
 use tokio_stream::wrappers::ReceiverStream;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tracing::{error, info, warn, Instrument};
+
+/// Inbound MCP session header name. Returned by `initialize` so the client
+/// can echo the same identifier on every follow-up request, and looked up
+/// by [`SessionIdentityStore`] to recover the previously-captured
+/// [`ClientIdentity`]. Matches the casing used by the MCP Streamable HTTP
+/// spec.
+pub(crate) const MCP_SESSION_ID_HEADER: &str = "mcp-session-id";
 
 /// Application state shared across all routes.
 #[derive(Clone)]
@@ -51,6 +61,205 @@ pub struct AppState {
     /// Notation) before they reach the MCP client. Computed at startup from
     /// `RelayConfig::toon_output` and the `--no-toon` CLI flag.
     pub toon_enabled: bool,
+    /// Bounded LRU map of `Mcp-Session-Id` → [`ClientIdentity`] captured
+    /// from each inbound `initialize` request. Looked up on every follow-up
+    /// JSON-RPC message that echoes the session header so audit logs and
+    /// the tool-call event bus can identify the caller without re-parsing
+    /// `clientInfo`. Wrapped in `Arc<Mutex<_>>` so [`AppState`] stays
+    /// `Clone` and cheap to pass through axum extractors.
+    pub session_identities: Arc<Mutex<SessionIdentityStore>>,
+}
+
+/// Bounded LRU cache of `Mcp-Session-Id` → [`ClientIdentity`] entries.
+///
+/// Capacity defaults to [`DEFAULT_SESSION_IDENTITY_MAX_SESSIONS`]; on
+/// insert, the least-recently-used entry is evicted so a misbehaving
+/// client that never reuses its session id cannot grow the map
+/// unboundedly. Recency is tracked with a monotonically-increasing
+/// counter and a [`BTreeMap`] indexed by that counter — both `get` and
+/// `insert` re-stamp the entry as most-recently-used in `O(log n)`.
+#[derive(Debug)]
+pub struct SessionIdentityStore {
+    capacity: usize,
+    next_seq: u64,
+    /// `session_id → (identity, recency seq)`. The seq is duplicated in
+    /// [`recency`] so the LRU pop is `O(log n)` rather than `O(n)`.
+    entries: HashMap<String, (ClientIdentity, u64)>,
+    /// `recency seq → session_id`. The smallest key is the least-
+    /// recently-used entry; `pop_first` evicts it in `O(log n)`.
+    recency: BTreeMap<u64, String>,
+}
+
+impl SessionIdentityStore {
+    /// Build a store with the given capacity. A zero capacity is clamped
+    /// to `1` because the dispatch path always wants at least one slot
+    /// (the just-inserted entry) — operators who want to disable the
+    /// cache entirely can do so at the config layer, not by setting `0`.
+    pub fn with_capacity(capacity: usize) -> Self {
+        let capacity = capacity.max(1);
+        Self {
+            capacity,
+            next_seq: 0,
+            entries: HashMap::with_capacity(capacity),
+            recency: BTreeMap::new(),
+        }
+    }
+
+    fn next_seq(&mut self) -> u64 {
+        let s = self.next_seq;
+        self.next_seq = self.next_seq.saturating_add(1);
+        s
+    }
+
+    /// Insert or refresh an entry. Evicts the least-recently-used entry
+    /// when the store is at capacity. The returned `Option` is the
+    /// previously-stored identity for the same session id (typically
+    /// `None`; a `Some` value indicates a session-id collision between
+    /// two `initialize` calls and is overwritten).
+    pub fn insert(
+        &mut self,
+        session_id: String,
+        identity: ClientIdentity,
+    ) -> Option<ClientIdentity> {
+        let new_seq = self.next_seq();
+        let previous = if let Some((prev_id, prev_seq)) = self.entries.remove(&session_id) {
+            self.recency.remove(&prev_seq);
+            Some(prev_id)
+        } else {
+            None
+        };
+        while self.entries.len() >= self.capacity {
+            let Some((evict_seq, evict_key)) = self.recency.pop_first() else {
+                break;
+            };
+            self.entries.remove(&evict_key);
+            // Defensive: drop the matching entries-table slot even if the
+            // counters somehow drifted out of sync.
+            let _ = evict_seq;
+        }
+        self.recency.insert(new_seq, session_id.clone());
+        self.entries.insert(session_id, (identity, new_seq));
+        previous
+    }
+
+    /// Resolve the [`ClientIdentity`] for a session id and mark the entry
+    /// as most-recently-used.
+    pub fn get(&mut self, session_id: &str) -> Option<ClientIdentity> {
+        let (identity, prev_seq) = self.entries.get(session_id).cloned()?;
+        self.recency.remove(&prev_seq);
+        let new_seq = self.next_seq();
+        self.recency.insert(new_seq, session_id.to_string());
+        self.entries
+            .insert(session_id.to_string(), (identity.clone(), new_seq));
+        Some(identity)
+    }
+
+    /// Number of live entries. Exposed for unit tests that exercise the
+    /// LRU eviction path and for operators that inspect the store via
+    /// future introspection hooks.
+    #[allow(dead_code)]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns `true` when no sessions are cached. Paired with [`len`] so
+    /// clippy's `len_without_is_empty` lint stays satisfied.
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Effective capacity (after the `0 → 1` clamp). Surfaces the
+    /// configured limit for tests and operator introspection.
+    #[allow(dead_code)]
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+}
+
+impl Default for SessionIdentityStore {
+    fn default() -> Self {
+        Self::with_capacity(DEFAULT_SESSION_IDENTITY_MAX_SESSIONS)
+    }
+}
+
+/// Read the first header value as a UTF-8 string, returning `None` for
+/// missing or non-ASCII headers. Identity headers are best-effort signals,
+/// so a malformed value is silently dropped rather than rejected.
+fn header_str<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
+    headers.get(name).and_then(|v| v.to_str().ok())
+}
+
+/// Extract a [`ClientIdentity`] from the per-request HTTP headers. Populated
+/// from `User-Agent` and `Origin`; the structured `name` / `version` fields
+/// stay `None` because no MCP-level clientInfo is available without an
+/// `initialize` body.
+fn identity_from_headers(headers: &HeaderMap) -> ClientIdentity {
+    ClientIdentity {
+        name: None,
+        version: None,
+        user_agent: header_str(headers, "user-agent").map(|s| s.to_string()),
+        origin: header_str(headers, "origin").map(|s| s.to_string()),
+    }
+}
+
+/// Extract a [`ClientIdentity`] from the `initialize` request's
+/// `params.clientInfo` object. Per the MCP spec, `clientInfo.name` is
+/// required but the relay treats every field as optional so a malformed
+/// payload (missing `params`, non-object `clientInfo`, etc.) degrades to an
+/// empty identity rather than rejecting the request.
+fn identity_from_initialize_params(params: Option<&Value>) -> ClientIdentity {
+    let Some(info) = params.and_then(|p| p.get("clientInfo")) else {
+        return ClientIdentity::default();
+    };
+    ClientIdentity {
+        name: info
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        version: info
+            .get("version")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        user_agent: None,
+        origin: None,
+    }
+}
+
+/// Fold `fallback`'s non-empty fields into `primary` so structured
+/// `clientInfo` (name/version from `initialize`) wins over the per-request
+/// `User-Agent`/`Origin` headers when both are present.
+fn merge_identity(primary: ClientIdentity, fallback: ClientIdentity) -> ClientIdentity {
+    ClientIdentity {
+        name: primary.name.or(fallback.name),
+        version: primary.version.or(fallback.version),
+        user_agent: primary.user_agent.or(fallback.user_agent),
+        origin: primary.origin.or(fallback.origin),
+    }
+}
+
+/// Resolve the caller's [`ClientIdentity`] for a non-`initialize` inbound
+/// message. Looks up `Mcp-Session-Id` in [`SessionIdentityStore`] first
+/// (the value cached at `initialize` time wins because it carries the
+/// structured `clientInfo`), then merges in the per-request
+/// `User-Agent`/`Origin` headers as a fallback. Returns `None` only when
+/// every signal is empty so adapter event-emission can omit the `client`
+/// field entirely.
+fn resolve_inbound_identity(state: &AppState, headers: &HeaderMap) -> Option<ClientIdentity> {
+    let header_identity = identity_from_headers(headers);
+    let session_identity = header_str(headers, MCP_SESSION_ID_HEADER).and_then(|sid| {
+        let mut guard = state.session_identities.lock().ok()?;
+        guard.get(sid)
+    });
+    let merged = match session_identity {
+        Some(s) => merge_identity(s, header_identity),
+        None => header_identity,
+    };
+    if merged.is_empty() {
+        None
+    } else {
+        Some(merged)
+    }
 }
 
 /// JSON-RPC request body expected by MCP routes.
@@ -366,7 +575,18 @@ async fn mcp_tools_call(
                 .get("script")
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
-            match handler.execute_tools(script).await {
+            // Recover the outer inbound request's identity from the
+            // surrounding `request{client=...}` span (seeded by
+            // `handle_single_message` / the logged wrappers) and re-serialise
+            // it so the sandbox can re-establish the caller's span around each
+            // inner upstream tool call across the blocking-thread hop. Without
+            // this, aggregated `execute_tools` calls emit an empty client.
+            let client_json = crate::events::current_request_context()
+                .client
+                .filter(|c| !c.is_empty())
+                .map(|c| serde_json::to_string(&c).unwrap_or_default())
+                .unwrap_or_default();
+            match handler.execute_tools(script, &client_json).await {
                 Ok(result) => {
                     return Ok(jsonrpc_response(
                         body.id,
@@ -423,6 +643,7 @@ async fn handle_single_message(
     msg: Value,
     headers_str: &str,
     profile_ctx: Option<&ProfileContext>,
+    client_identity: Option<&ClientIdentity>,
 ) -> Option<Value> {
     let method = msg
         .get("method")
@@ -433,7 +654,27 @@ async fn handle_single_message(
         .get("id")
         .map(|v| v.to_string())
         .unwrap_or_else(|| "null".to_string());
-    let span = tracing::info_span!("request", method = %method, id = %id_str);
+    // JSON-encode the identity so `SpanFieldCaptureLayer` can deserialise it
+    // back into a typed [`ClientIdentity`] via `current_request_context()`
+    // without changing the `McpAdapter::call_tool` trait signature. An empty
+    // identity is rendered as an empty `""` field so the capture visitor
+    // silently drops it.
+    let client_json = client_identity
+        .filter(|c| !c.is_empty())
+        .map(|c| serde_json::to_string(c).unwrap_or_default())
+        .unwrap_or_default();
+    let client_name = client_identity
+        .and_then(|c| c.display_name())
+        .unwrap_or_default();
+    let client_version = client_identity
+        .and_then(|c| c.version.clone())
+        .unwrap_or_default();
+    let span = tracing::info_span!(
+        "request",
+        method = %method,
+        id = %id_str,
+        client = %client_json,
+    );
     async move {
         let start = Instant::now();
         let is_notification = msg.get("id").is_none() || msg.get("id") == Some(&Value::Null);
@@ -449,6 +690,8 @@ async fn handle_single_message(
                 resp_bytes = 0,
                 status = 202,
                 headers = %headers_str,
+                client_name = ?client_name,
+                client_version = ?client_version,
                 "MCP notification"
             );
             return None;
@@ -488,6 +731,8 @@ async fn handle_single_message(
                     resp_bytes = resp_bytes,
                     status = 200,
                     headers = %headers_str,
+                    client_name = ?client_name,
+                    client_version = ?client_version,
                     "MCP request"
                 );
                 resp
@@ -503,6 +748,8 @@ async fn handle_single_message(
                         resp_bytes = resp_bytes,
                         status = status_code,
                         headers = %headers_str,
+                        client_name = ?client_name,
+                        client_version = ?client_version,
                         "MCP request"
                     );
                 } else if status_code == 200 {
@@ -514,6 +761,8 @@ async fn handle_single_message(
                         resp_bytes = resp_bytes,
                         status = status_code,
                         headers = %headers_str,
+                        client_name = ?client_name,
+                        client_version = ?client_version,
                         "MCP request"
                     );
                 } else {
@@ -524,6 +773,8 @@ async fn handle_single_message(
                         resp_bytes = resp_bytes,
                         status = status_code,
                         headers = %headers_str,
+                        client_name = ?client_name,
+                        client_version = ?client_version,
                         "MCP request"
                     );
                 }
@@ -592,6 +843,13 @@ async fn mcp_unified_profiled(
 /// is `None` for the global `/mcp` route and `Some(...)` for
 /// `/mcp/{profile}`; see [`handle_single_message`] for how it is threaded
 /// through to per-message dispatch.
+///
+/// Per-message identity resolution: an `initialize` request seeds the
+/// `Mcp-Session-Id` → [`ClientIdentity`] cache from `params.clientInfo` and
+/// echoes the new session id back on the response so the client can
+/// correlate follow-up calls. Every other message resolves its caller via
+/// [`resolve_inbound_identity`] (session lookup with per-request
+/// `User-Agent`/`Origin` fallback) before dispatch.
 async fn mcp_unified_impl(
     state: AppState,
     headers: HeaderMap,
@@ -604,29 +862,35 @@ async fn mcp_unified_impl(
         .collect::<Vec<_>>()
         .join(" ");
     let profile_ctx_ref = profile_ctx.as_deref();
+    // Collected here so a batch that opens with an `initialize` still
+    // bubbles the new session id up to the HTTP response headers. The MCP
+    // spec singleton case is the common path; the batch path is defensive.
+    let mut emitted_session_id: Option<String> = None;
 
     match body {
         Value::Array(messages) => {
             if messages.is_empty() {
-                return (
-                    StatusCode::OK,
-                    [(
-                        axum::http::header::CONTENT_TYPE,
-                        HeaderValue::from_static("application/json"),
-                    )],
-                    Json(json!({
-                        "jsonrpc": "2.0",
-                        "error": { "code": -32600, "message": "Invalid Request: empty batch" },
-                        "id": null,
-                    })),
-                )
-                    .into_response();
+                return json_response(json!({
+                    "jsonrpc": "2.0",
+                    "error": { "code": -32600, "message": "Invalid Request: empty batch" },
+                    "id": null,
+                }));
             }
 
             let mut responses: Vec<Value> = Vec::new();
             for msg in messages {
-                if let Some(resp) =
-                    handle_single_message(&state, msg, &headers_str, profile_ctx_ref).await
+                let (identity, new_session) = resolve_identity_for_message(&state, &headers, &msg);
+                if emitted_session_id.is_none() {
+                    emitted_session_id = new_session;
+                }
+                if let Some(resp) = handle_single_message(
+                    &state,
+                    msg,
+                    &headers_str,
+                    profile_ctx_ref,
+                    identity.as_ref(),
+                )
+                .await
                 {
                     responses.push(resp);
                 }
@@ -634,47 +898,102 @@ async fn mcp_unified_impl(
 
             if responses.is_empty() {
                 // All messages were notifications
-                StatusCode::ACCEPTED.into_response()
+                with_session_header(StatusCode::ACCEPTED.into_response(), emitted_session_id)
             } else {
-                (
-                    StatusCode::OK,
-                    [(
-                        axum::http::header::CONTENT_TYPE,
-                        HeaderValue::from_static("application/json"),
-                    )],
-                    Json(Value::Array(responses)),
-                )
-                    .into_response()
+                with_session_header(json_response(Value::Array(responses)), emitted_session_id)
             }
         }
         Value::Object(_) => {
-            match handle_single_message(&state, body, &headers_str, profile_ctx_ref).await {
-                Some(resp) => (
-                    StatusCode::OK,
-                    [(
-                        axum::http::header::CONTENT_TYPE,
-                        HeaderValue::from_static("application/json"),
-                    )],
-                    Json(resp),
-                )
-                    .into_response(),
-                None => StatusCode::ACCEPTED.into_response(),
+            let (identity, new_session) = resolve_identity_for_message(&state, &headers, &body);
+            emitted_session_id = new_session;
+            match handle_single_message(
+                &state,
+                body,
+                &headers_str,
+                profile_ctx_ref,
+                identity.as_ref(),
+            )
+            .await
+            {
+                Some(resp) => with_session_header(json_response(resp), emitted_session_id),
+                None => {
+                    with_session_header(StatusCode::ACCEPTED.into_response(), emitted_session_id)
+                }
             }
         }
-        _ => (
-            StatusCode::OK,
-            [(
-                axum::http::header::CONTENT_TYPE,
-                HeaderValue::from_static("application/json"),
-            )],
-            Json(json!({
-                "jsonrpc": "2.0",
-                "error": { "code": -32600, "message": "Invalid Request: expected object or array" },
-                "id": null,
-            })),
-        )
-            .into_response(),
+        _ => json_response(json!({
+            "jsonrpc": "2.0",
+            "error": { "code": -32600, "message": "Invalid Request: expected object or array" },
+            "id": null,
+        })),
     }
+}
+
+/// Build a `200 OK` JSON response body. Used by [`mcp_unified_impl`] for the
+/// non-error branches; pairs with [`with_session_header`] to attach the
+/// optional `Mcp-Session-Id` header without duplicating the `Content-Type`
+/// boilerplate at every callsite.
+fn json_response(body: Value) -> Response {
+    (
+        StatusCode::OK,
+        [(
+            axum::http::header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        )],
+        Json(body),
+    )
+        .into_response()
+}
+
+/// Attach `Mcp-Session-Id: <session>` to an existing response when an
+/// `initialize` in the same request issued a new session id. The header is
+/// only set when `session_id` is `Some` so non-`initialize` responses stay
+/// untouched.
+fn with_session_header(mut response: Response, session_id: Option<String>) -> Response {
+    if let Some(sid) = session_id {
+        if let Ok(val) = HeaderValue::from_str(&sid) {
+            response
+                .headers_mut()
+                .insert(HeaderName::from_static(MCP_SESSION_ID_HEADER), val);
+        }
+    }
+    response
+}
+
+/// Per-message identity resolution shared by the singleton and batch
+/// branches of [`mcp_unified_impl`]. Returns the [`ClientIdentity`] to
+/// associate with `msg` and (for `initialize` messages) the newly-issued
+/// session id so the HTTP response can echo it back.
+fn resolve_identity_for_message(
+    state: &AppState,
+    headers: &HeaderMap,
+    msg: &Value,
+) -> (Option<ClientIdentity>, Option<String>) {
+    let is_initialize = msg.get("method").and_then(|v| v.as_str()) == Some("initialize");
+    if !is_initialize {
+        return (resolve_inbound_identity(state, headers), None);
+    }
+    // `initialize`: issue a fresh session id unconditionally so the
+    // client can echo it on follow-ups, even when it sent no
+    // `clientInfo`. Only cache the structured `clientInfo` (name /
+    // version) — the per-request `User-Agent`/`Origin` fallback covers
+    // the empty case on later requests without polluting the LRU with
+    // zero-signal entries.
+    let init_identity = identity_from_initialize_params(msg.get("params"));
+    let header_identity = identity_from_headers(headers);
+    let session_id = uuid::Uuid::new_v4().to_string();
+    if !init_identity.is_empty() {
+        if let Ok(mut guard) = state.session_identities.lock() {
+            guard.insert(session_id.clone(), init_identity.clone());
+        }
+    }
+    let merged = merge_identity(init_identity, header_identity);
+    let identity = if merged.is_empty() {
+        None
+    } else {
+        Some(merged)
+    };
+    (identity, Some(session_id))
 }
 
 /// JSON 404 body returned by profile-scoped routes when the URL `{profile}`
@@ -1171,31 +1490,86 @@ async fn oauth_callback(
 }
 
 /// Logged wrapper for POST /mcp/initialize (direct route).
-async fn mcp_initialize_logged(state: State<AppState>, body: Json<JsonRpcBody>) -> Json<Value> {
-    let span = tracing::info_span!("request", method = "initialize", id = ?body.id);
+///
+/// Mirrors the unified `/mcp` route: parses `clientInfo`, mints a fresh
+/// `Mcp-Session-Id`, seeds the [`SessionIdentityStore`] when structured
+/// identity is present, and echoes the new session id back on the response
+/// so the client can correlate follow-up calls. The resolved identity is
+/// embedded on the `request` span and surfaced on the audit log line.
+async fn mcp_initialize_logged(
+    state: State<AppState>,
+    headers: HeaderMap,
+    body: Json<JsonRpcBody>,
+) -> Response {
+    let body_value = serde_json::to_value(&body.0).unwrap_or(Value::Null);
+    let (identity, new_session) = resolve_identity_for_message(&state.0, &headers, &body_value);
+    let client_json = identity
+        .as_ref()
+        .filter(|c| !c.is_empty())
+        .map(|c| serde_json::to_string(c).unwrap_or_default())
+        .unwrap_or_default();
+    let client_name = identity
+        .as_ref()
+        .and_then(|c| c.display_name())
+        .unwrap_or_default();
+    let client_version = identity
+        .as_ref()
+        .and_then(|c| c.version.clone())
+        .unwrap_or_default();
+    let span = tracing::info_span!(
+        "request",
+        method = "initialize",
+        id = ?body.id,
+        client = %client_json,
+    );
     async move {
         let start = Instant::now();
         let req_bytes = serde_json::to_string(&body.0).map(|s| s.len()).unwrap_or(0);
-        let resp = mcp_initialize(state, body, None).await;
+        let Json(resp) = mcp_initialize(state, body, None).await;
         let elapsed_ms = start.elapsed().as_millis() as u64;
-        let resp_bytes = serde_json::to_string(&resp.0).map(|s| s.len()).unwrap_or(0);
+        let resp_bytes = serde_json::to_string(&resp).map(|s| s.len()).unwrap_or(0);
         info!(
             method = "initialize",
             elapsed_ms = elapsed_ms,
             req_bytes = req_bytes,
             resp_bytes = resp_bytes,
             status = 200,
+            client_name = ?client_name,
+            client_version = ?client_version,
             "MCP request"
         );
-        resp
+        with_session_header(json_response(resp), new_session)
     }
     .instrument(span)
     .await
 }
 
 /// Logged wrapper for POST /mcp/tools/list (direct route).
-async fn mcp_tools_list_logged(state: State<AppState>, body: Json<JsonRpcBody>) -> Json<Value> {
-    let span = tracing::info_span!("request", method = "tools/list", id = ?body.id);
+async fn mcp_tools_list_logged(
+    state: State<AppState>,
+    headers: HeaderMap,
+    body: Json<JsonRpcBody>,
+) -> Json<Value> {
+    let identity = resolve_inbound_identity(&state.0, &headers);
+    let client_json = identity
+        .as_ref()
+        .filter(|c| !c.is_empty())
+        .map(|c| serde_json::to_string(c).unwrap_or_default())
+        .unwrap_or_default();
+    let client_name = identity
+        .as_ref()
+        .and_then(|c| c.display_name())
+        .unwrap_or_default();
+    let client_version = identity
+        .as_ref()
+        .and_then(|c| c.version.clone())
+        .unwrap_or_default();
+    let span = tracing::info_span!(
+        "request",
+        method = "tools/list",
+        id = ?body.id,
+        client = %client_json,
+    );
     async move {
         let start = Instant::now();
         let req_bytes = serde_json::to_string(&body.0).map(|s| s.len()).unwrap_or(0);
@@ -1208,6 +1582,8 @@ async fn mcp_tools_list_logged(state: State<AppState>, body: Json<JsonRpcBody>) 
             req_bytes = req_bytes,
             resp_bytes = resp_bytes,
             status = 200,
+            client_name = ?client_name,
+            client_version = ?client_version,
             "MCP request"
         );
         resp
@@ -1219,9 +1595,29 @@ async fn mcp_tools_list_logged(state: State<AppState>, body: Json<JsonRpcBody>) 
 /// Logged wrapper for POST /mcp/tools/call (direct route).
 async fn mcp_tools_call_logged(
     state: State<AppState>,
+    headers: HeaderMap,
     body: Json<JsonRpcBody>,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
-    let span = tracing::info_span!("request", method = "tools/call", id = ?body.id);
+    let identity = resolve_inbound_identity(&state.0, &headers);
+    let client_json = identity
+        .as_ref()
+        .filter(|c| !c.is_empty())
+        .map(|c| serde_json::to_string(c).unwrap_or_default())
+        .unwrap_or_default();
+    let client_name = identity
+        .as_ref()
+        .and_then(|c| c.display_name())
+        .unwrap_or_default();
+    let client_version = identity
+        .as_ref()
+        .and_then(|c| c.version.clone())
+        .unwrap_or_default();
+    let span = tracing::info_span!(
+        "request",
+        method = "tools/call",
+        id = ?body.id,
+        client = %client_json,
+    );
     async move {
         let start = Instant::now();
         let req_bytes = serde_json::to_string(&body.0).map(|s| s.len()).unwrap_or(0);
@@ -1236,6 +1632,8 @@ async fn mcp_tools_call_logged(
                     req_bytes = req_bytes,
                     resp_bytes = resp_bytes,
                     status = 200,
+                    client_name = ?client_name,
+                    client_version = ?client_version,
                     "MCP request"
                 );
             }
@@ -1249,6 +1647,8 @@ async fn mcp_tools_call_logged(
                         req_bytes = req_bytes,
                         resp_bytes = resp_bytes,
                         status = status_code,
+                        client_name = ?client_name,
+                        client_version = ?client_version,
                         "MCP request"
                     );
                 } else if status_code == 200 {
@@ -1259,6 +1659,8 @@ async fn mcp_tools_call_logged(
                         req_bytes = req_bytes,
                         resp_bytes = resp_bytes,
                         status = status_code,
+                        client_name = ?client_name,
+                        client_version = ?client_version,
                         "MCP request"
                     );
                 } else {
@@ -1268,6 +1670,8 @@ async fn mcp_tools_call_logged(
                         req_bytes = req_bytes,
                         resp_bytes = resp_bytes,
                         status = status_code,
+                        client_name = ?client_name,
+                        client_version = ?client_version,
                         "MCP request"
                     );
                 }
@@ -1520,7 +1924,256 @@ mod tests {
             setup_manager: None,
             started_at: Instant::now(),
             toon_enabled: false,
+            session_identities: Arc::new(Mutex::new(SessionIdentityStore::default())),
         }
+    }
+
+    fn identity(name: &str, version: &str) -> ClientIdentity {
+        ClientIdentity {
+            name: Some(name.to_string()),
+            version: Some(version.to_string()),
+            user_agent: None,
+            origin: None,
+        }
+    }
+
+    #[test]
+    fn session_identity_store_default_capacity_matches_const() {
+        let store = SessionIdentityStore::default();
+        assert_eq!(store.capacity(), DEFAULT_SESSION_IDENTITY_MAX_SESSIONS);
+        assert_eq!(store.len(), 0);
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn session_identity_store_zero_capacity_clamps_to_one() {
+        let mut store = SessionIdentityStore::with_capacity(0);
+        assert_eq!(store.capacity(), 1);
+        store.insert("s1".into(), identity("a", "1"));
+        assert_eq!(store.len(), 1);
+        store.insert("s2".into(), identity("b", "2"));
+        // Capacity-1 store evicts the previous entry to make room.
+        assert_eq!(store.len(), 1);
+        assert_eq!(store.get("s1"), None);
+        assert_eq!(store.get("s2"), Some(identity("b", "2")));
+    }
+
+    #[test]
+    fn session_identity_store_get_returns_inserted_identity() {
+        let mut store = SessionIdentityStore::with_capacity(4);
+        store.insert("sid".into(), identity("claude-ai", "0.1.0"));
+        assert_eq!(store.get("sid"), Some(identity("claude-ai", "0.1.0")));
+        assert_eq!(store.get("missing"), None);
+    }
+
+    #[test]
+    fn session_identity_store_evicts_lru_when_at_capacity() {
+        let mut store = SessionIdentityStore::with_capacity(3);
+        store.insert("s1".into(), identity("a", "1"));
+        store.insert("s2".into(), identity("b", "2"));
+        store.insert("s3".into(), identity("c", "3"));
+        // Touch s1 so it becomes most-recently-used.
+        assert_eq!(store.get("s1"), Some(identity("a", "1")));
+        // s4 forces eviction of the LRU entry, which is now s2.
+        store.insert("s4".into(), identity("d", "4"));
+        assert_eq!(store.len(), 3);
+        assert_eq!(store.get("s2"), None, "s2 should have been evicted");
+        assert_eq!(store.get("s1"), Some(identity("a", "1")));
+        assert_eq!(store.get("s3"), Some(identity("c", "3")));
+        assert_eq!(store.get("s4"), Some(identity("d", "4")));
+    }
+
+    #[test]
+    fn session_identity_store_refresh_does_not_grow() {
+        let mut store = SessionIdentityStore::with_capacity(2);
+        store.insert("s1".into(), identity("a", "1"));
+        store.insert("s1".into(), identity("a", "2"));
+        assert_eq!(store.len(), 1);
+        assert_eq!(store.get("s1"), Some(identity("a", "2")));
+    }
+
+    #[test]
+    fn identity_from_initialize_params_extracts_name_and_version() {
+        let params = json!({
+            "clientInfo": { "name": "claude-ai", "version": "0.1.0" },
+            "protocolVersion": "2025-03-26",
+        });
+        let id = identity_from_initialize_params(Some(&params));
+        assert_eq!(id.name.as_deref(), Some("claude-ai"));
+        assert_eq!(id.version.as_deref(), Some("0.1.0"));
+        assert!(id.user_agent.is_none());
+        assert!(id.origin.is_none());
+    }
+
+    #[test]
+    fn identity_from_initialize_params_missing_client_info_is_empty() {
+        let params = json!({ "protocolVersion": "2025-03-26" });
+        let id = identity_from_initialize_params(Some(&params));
+        assert!(id.is_empty());
+        let id = identity_from_initialize_params(None);
+        assert!(id.is_empty());
+    }
+
+    #[test]
+    fn identity_from_headers_picks_user_agent_and_origin() {
+        let mut headers = HeaderMap::new();
+        headers.insert("user-agent", HeaderValue::from_static("claude-desktop/0.7"));
+        headers.insert("origin", HeaderValue::from_static("https://claude.ai"));
+        let id = identity_from_headers(&headers);
+        assert_eq!(id.user_agent.as_deref(), Some("claude-desktop/0.7"));
+        assert_eq!(id.origin.as_deref(), Some("https://claude.ai"));
+        assert!(id.name.is_none());
+        assert!(id.version.is_none());
+    }
+
+    #[test]
+    fn merge_identity_prefers_primary_then_fills_from_fallback() {
+        let primary = ClientIdentity {
+            name: Some("claude-ai".into()),
+            version: None,
+            user_agent: None,
+            origin: None,
+        };
+        let fallback = ClientIdentity {
+            name: Some("ignored".into()),
+            version: Some("0.1.0".into()),
+            user_agent: Some("claude-desktop/0.7".into()),
+            origin: Some("https://claude.ai".into()),
+        };
+        let merged = merge_identity(primary, fallback);
+        assert_eq!(merged.name.as_deref(), Some("claude-ai"));
+        assert_eq!(merged.version.as_deref(), Some("0.1.0"));
+        assert_eq!(merged.user_agent.as_deref(), Some("claude-desktop/0.7"));
+        assert_eq!(merged.origin.as_deref(), Some("https://claude.ai"));
+    }
+
+    #[tokio::test]
+    async fn resolve_identity_for_message_initialize_stores_and_emits_session_id() {
+        let state = test_app_state();
+        let mut headers = HeaderMap::new();
+        headers.insert("user-agent", HeaderValue::from_static("claude-desktop/0.7"));
+        let msg = json!({
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "id": 1,
+            "params": {
+                "clientInfo": { "name": "claude-ai", "version": "0.1.0" },
+            },
+        });
+        let (identity, session_id) = resolve_identity_for_message(&state, &headers, &msg);
+        let identity = identity.expect("initialize should resolve an identity");
+        let session_id = session_id.expect("initialize should mint a session id");
+        // Merged identity carries clientInfo + User-Agent fallback.
+        assert_eq!(identity.name.as_deref(), Some("claude-ai"));
+        assert_eq!(identity.version.as_deref(), Some("0.1.0"));
+        assert_eq!(identity.user_agent.as_deref(), Some("claude-desktop/0.7"));
+        // The store is seeded with the structured (name/version) identity only.
+        let stored = state
+            .session_identities
+            .lock()
+            .unwrap()
+            .get(&session_id)
+            .expect("session id should resolve in the store");
+        assert_eq!(stored.name.as_deref(), Some("claude-ai"));
+        assert_eq!(stored.version.as_deref(), Some("0.1.0"));
+        assert!(stored.user_agent.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_identity_for_message_initialize_without_client_info_skips_store() {
+        let state = test_app_state();
+        let headers = HeaderMap::new();
+        let msg = json!({"jsonrpc":"2.0","method":"initialize","id":1});
+        let (identity, session_id) = resolve_identity_for_message(&state, &headers, &msg);
+        // Identity stays `None` when neither clientInfo nor headers say
+        // anything; a session id is still issued for future correlation.
+        assert!(identity.is_none());
+        assert!(session_id.is_some());
+        // Empty identities are not cached.
+        assert!(state.session_identities.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn resolve_inbound_identity_uses_session_then_header_fallback() {
+        let state = test_app_state();
+        // Seed the store with the identity that initialize would have cached.
+        let sid = "fixed-session";
+        state
+            .session_identities
+            .lock()
+            .unwrap()
+            .insert(sid.into(), identity("claude-ai", "0.1.0"));
+
+        // Follow-up request echoes the session header AND carries its own UA.
+        let mut headers = HeaderMap::new();
+        headers.insert(MCP_SESSION_ID_HEADER, HeaderValue::from_static(sid));
+        headers.insert("user-agent", HeaderValue::from_static("claude-desktop/0.7"));
+        headers.insert("origin", HeaderValue::from_static("https://claude.ai"));
+        let resolved = resolve_inbound_identity(&state, &headers).expect("identity must resolve");
+        assert_eq!(resolved.name.as_deref(), Some("claude-ai"));
+        assert_eq!(resolved.version.as_deref(), Some("0.1.0"));
+        assert_eq!(resolved.user_agent.as_deref(), Some("claude-desktop/0.7"));
+        assert_eq!(resolved.origin.as_deref(), Some("https://claude.ai"));
+
+        // Same request without the session header falls back to header-only
+        // identity (no name/version because no clientInfo was cached).
+        let mut headers = HeaderMap::new();
+        headers.insert("user-agent", HeaderValue::from_static("claude-desktop/0.7"));
+        let resolved = resolve_inbound_identity(&state, &headers).unwrap();
+        assert!(resolved.name.is_none());
+        assert_eq!(resolved.user_agent.as_deref(), Some("claude-desktop/0.7"));
+
+        // Bare request with no signals at all degrades to `None` so adapter
+        // event-emission can omit the `client` field entirely.
+        assert!(resolve_inbound_identity(&state, &HeaderMap::new()).is_none());
+    }
+
+    #[tokio::test]
+    async fn initialize_response_round_trip_resolves_identity_on_follow_up() {
+        use axum::body::Body;
+        use tower::ServiceExt;
+        let state = test_app_state();
+        let router = build_router(state.clone());
+
+        let init_req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/mcp")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::to_vec(&json!({
+                    "jsonrpc": "2.0",
+                    "method": "initialize",
+                    "id": 1,
+                    "params": {
+                        "clientInfo": {"name": "claude-ai", "version": "0.1.0"},
+                    },
+                }))
+                .unwrap(),
+            ))
+            .unwrap();
+        let init_resp = router.clone().oneshot(init_req).await.unwrap();
+        assert_eq!(init_resp.status(), StatusCode::OK);
+        let sid_header = init_resp
+            .headers()
+            .get(MCP_SESSION_ID_HEADER)
+            .expect("initialize must emit Mcp-Session-Id")
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(!sid_header.is_empty(), "session id must be non-empty");
+
+        // Re-resolve via the public helper to confirm the store was seeded
+        // and that follow-up requests can recover the identity by echoing
+        // the same header back.
+        let mut follow_up_headers = HeaderMap::new();
+        follow_up_headers.insert(
+            MCP_SESSION_ID_HEADER,
+            HeaderValue::from_str(&sid_header).unwrap(),
+        );
+        let resolved =
+            resolve_inbound_identity(&state, &follow_up_headers).expect("identity must resolve");
+        assert_eq!(resolved.name.as_deref(), Some("claude-ai"));
+        assert_eq!(resolved.version.as_deref(), Some("0.1.0"));
     }
 
     #[test]

--- a/tests/health_endpoint_integration.rs
+++ b/tests/health_endpoint_integration.rs
@@ -7,7 +7,7 @@
 use endara_relay::js_sandbox::MetaToolHandler;
 use endara_relay::profile_registry::ProfileRegistry;
 use endara_relay::registry::AdapterRegistry;
-use endara_relay::server::{build_router, start_server, AppState};
+use endara_relay::server::{build_router, start_server, AppState, SessionIdentityStore};
 use std::net::SocketAddr;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -27,6 +27,7 @@ async fn setup_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
         setup_manager: None,
         started_at: std::time::Instant::now(),
         toon_enabled: false,
+        session_identities: Arc::new(std::sync::Mutex::new(SessionIdentityStore::default())),
     };
     let router = build_router(state);
     let addr: SocketAddr = ([127, 0, 0, 1], 0).into();

--- a/tests/hot_reload_integration.rs
+++ b/tests/hot_reload_integration.rs
@@ -62,6 +62,7 @@ async fn test_config_diff_add_endpoint() {
             allow_insecure_oauth: None,
             toon_output: None,
             startup_init_timeout_secs: None,
+            session_identity_max_sessions: None,
         },
         endpoints: vec![config::EndpointConfig {
             name: "echo-ep".to_string(),
@@ -93,6 +94,7 @@ async fn test_config_diff_add_endpoint() {
             allow_insecure_oauth: None,
             toon_output: None,
             startup_init_timeout_secs: None,
+            session_identity_max_sessions: None,
         },
         endpoints: vec![
             config::EndpointConfig {
@@ -224,6 +226,7 @@ async fn test_config_diff_remove_endpoint() {
             allow_insecure_oauth: None,
             toon_output: None,
             startup_init_timeout_secs: None,
+            session_identity_max_sessions: None,
         },
         endpoints: vec![
             config::EndpointConfig {
@@ -276,6 +279,7 @@ async fn test_config_diff_remove_endpoint() {
             allow_insecure_oauth: None,
             toon_output: None,
             startup_init_timeout_secs: None,
+            session_identity_max_sessions: None,
         },
         endpoints: vec![config::EndpointConfig {
             name: "echo-ep".to_string(),

--- a/tests/js_execution_integration.rs
+++ b/tests/js_execution_integration.rs
@@ -9,7 +9,7 @@ use endara_relay::adapter::McpAdapter;
 use endara_relay::js_sandbox::MetaToolHandler;
 use endara_relay::profile_registry::ProfileRegistry;
 use endara_relay::registry::AdapterRegistry;
-use endara_relay::server::{build_router, start_server, AppState};
+use endara_relay::server::{build_router, start_server, AppState, SessionIdentityStore};
 use serde_json::json;
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -58,6 +58,7 @@ async fn setup_js_server(js_mode: bool) -> (SocketAddr, tokio::task::JoinHandle<
         setup_manager: None,
         started_at: std::time::Instant::now(),
         toon_enabled: false,
+        session_identities: Arc::new(std::sync::Mutex::new(SessionIdentityStore::default())),
     };
     let router = build_router(state);
     let addr: SocketAddr = ([127, 0, 0, 1], 0).into();

--- a/tests/management_api_integration.rs
+++ b/tests/management_api_integration.rs
@@ -86,6 +86,7 @@ fn test_config() -> Config {
             allow_insecure_oauth: None,
             toon_output: None,
             startup_init_timeout_secs: None,
+            session_identity_max_sessions: None,
         },
         endpoints: vec![EndpointConfig {
             name: "echo".to_string(),

--- a/tests/mcp_server_integration.rs
+++ b/tests/mcp_server_integration.rs
@@ -5,7 +5,7 @@ use endara_relay::config::ProfileConfig;
 use endara_relay::js_sandbox::MetaToolHandler;
 use endara_relay::profile_registry::ProfileRegistry;
 use endara_relay::registry::AdapterRegistry;
-use endara_relay::server::{build_router, start_server, AppState};
+use endara_relay::server::{build_router, start_server, AppState, SessionIdentityStore};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -55,6 +55,7 @@ async fn setup_server() -> (SocketAddr, AdapterRegistry, tokio::task::JoinHandle
         setup_manager: None,
         started_at: std::time::Instant::now(),
         toon_enabled: false,
+        session_identities: Arc::new(std::sync::Mutex::new(SessionIdentityStore::default())),
     };
     let router = build_router(state);
     // Bind to port 0 to get a random available port
@@ -243,6 +244,7 @@ async fn setup_native_toon_server(toon_enabled: bool) -> (SocketAddr, tokio::tas
         setup_manager: None,
         started_at: std::time::Instant::now(),
         toon_enabled,
+        session_identities: Arc::new(std::sync::Mutex::new(SessionIdentityStore::default())),
     };
     let router = build_router(state);
     let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
@@ -414,6 +416,7 @@ async fn profile_tools_list_excludes_out_of_profile_tools() {
         setup_manager: None,
         started_at: std::time::Instant::now(),
         toon_enabled: false,
+        session_identities: Arc::new(std::sync::Mutex::new(SessionIdentityStore::default())),
     };
     let router = build_router(state);
     let addr: SocketAddr = ([127, 0, 0, 1], 0).into();

--- a/tests/multi_endpoint_integration.rs
+++ b/tests/multi_endpoint_integration.rs
@@ -9,7 +9,7 @@ use endara_relay::adapter::McpAdapter;
 use endara_relay::js_sandbox::MetaToolHandler;
 use endara_relay::profile_registry::ProfileRegistry;
 use endara_relay::registry::AdapterRegistry;
-use endara_relay::server::{build_router, start_server, AppState};
+use endara_relay::server::{build_router, start_server, AppState, SessionIdentityStore};
 use serde_json::json;
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -91,6 +91,7 @@ async fn setup_multi_endpoint_server() -> (SocketAddr, AdapterRegistry, tokio::t
         setup_manager: None,
         started_at: std::time::Instant::now(),
         toon_enabled: false,
+        session_identities: Arc::new(std::sync::Mutex::new(SessionIdentityStore::default())),
     };
     let router = build_router(state);
     let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
@@ -241,6 +242,7 @@ async fn test_multi_endpoint_overlapping_tool_names() {
         setup_manager: None,
         started_at: std::time::Instant::now(),
         toon_enabled: false,
+        session_identities: Arc::new(std::sync::Mutex::new(SessionIdentityStore::default())),
     };
     let router = build_router(state);
     let addr: SocketAddr = ([127, 0, 0, 1], 0).into();

--- a/tests/oauth_setup_integration.rs
+++ b/tests/oauth_setup_integration.rs
@@ -27,6 +27,7 @@ fn empty_config() -> Config {
             allow_insecure_oauth: Some(true),
             toon_output: None,
             startup_init_timeout_secs: None,
+            session_identity_max_sessions: None,
         },
         endpoints: vec![EndpointConfig {
             name: "echo".to_string(),


### PR DESCRIPTION
## Summary

Identify the calling MCP app for each inbound request using client-supplied `initialize.clientInfo` plus HTTP headers (`User-Agent`/`Origin`), and surface that identity in the relay's audit/structured logs and on the tool-call event bus consumed by the desktop overlay.

## What changed

- **`ClientIdentity` capture** — on inbound `initialize`, the relay generates a UUID `Mcp-Session-Id`, stores a `ClientIdentity { name, version, user_agent, origin }`, and returns the id via the `Mcp-Session-Id` response header (Streamable HTTP spec). Later requests resolve identity from the request header; stateless/SSE/legacy routes fall back to per-request `User-Agent`/`Origin`.
- **Bounded session store** — `session_identity_max_sessions` config key under `[relay]` (default **1000**), LRU eviction. Follows the existing `startup_init_timeout_secs` pattern.
- **Audit logs** — `"MCP request"` / `"MCP notification"` and the adapter `"Tool call completed/failed"` lines now emit quoted flat `client_name`/`client_version` fields (UA-derived fallback when `clientInfo.name` is absent).
- **Event bus** — `ToolCallEvent::Started` gains an optional `client` object (skip-if-empty), captured via span context.
- **JS sandbox** — client identity propagated into JS sandbox tool calls.

Identity is advisory (client-controlled / spoofable) — appropriate for audit + display. Local-PID identification is out of scope.

## Tests

18+ new unit/integration tests. `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` all pass.

## Notes

Rebased onto current `main`; merge with #97 (`[relay]` defaulting now includes `session_identity_max_sessions`) and #98 (profile-scoped `tools/list` preserved) resolved.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author