### PR TITLE
feat: containerized stdio MCP servers (isolation, runtime detection, container stats)

### DIFF
--- a/.github/workflows/mcp-runner-image.yml
+++ b/.github/workflows/mcp-runner-image.yml
@@ -1,0 +1,53 @@
+name: mcp-runner image
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: mcp-runner-image-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/endara-ai/mcp-runner
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=sha
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/mcp-runner
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker/mcp-runner/Dockerfile
+++ b/docker/mcp-runner/Dockerfile
@@ -1,0 +1,24 @@
+# Runner image for containerized stdio MCP servers (ghcr.io/endara-ai/mcp-runner).
+#
+# Ships Node LTS (`npx`) and uv (`uvx`) so endpoints can run arbitrary
+# `npx -y <pkg>` / `uvx <pkg>` servers without any host-side installs.
+FROM node:22-bookworm-slim
+
+# uv / uvx, copied from the official multi-arch image (pinned).
+COPY --from=ghcr.io/astral-sh/uv:0.7.13 /uv /uvx /usr/local/bin/
+
+# ca-certificates for registry access; git for packages resolved from VCS refs.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates git \
+  && rm -rf /var/lib/apt/lists/*
+
+# Run as the unprivileged `node` user (uid 1000) shipped with the base image.
+USER node
+WORKDIR /home/node
+ENV NPM_CONFIG_UPDATE_NOTIFIER=false
+
+# Pre-install a uv-managed CPython so `uvx` servers don't have to download an
+# interpreter on every container start (`--rm` containers keep no cache).
+RUN uv python install 3.12
+
+CMD ["node", "--version"]

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -183,6 +183,16 @@ pub trait McpAdapter: Send + Sync {
         None
     }
 
+    /// Latest container resource stats for the endpoint.
+    ///
+    /// The default implementation returns `None` (direct-spawn endpoints and
+    /// transports that never run containers). The STDIO adapter overrides
+    /// this with the most recent sample from its background stats poller
+    /// when the endpoint runs inside a container.
+    fn container_stats(&self) -> Option<crate::container_stats::ContainerStats> {
+        None
+    }
+
     /// Wire a shared [`crate::events::ToolCallEventBus`] into the adapter so
     /// `call_tool` can publish typed `started` / `completed` / `failed`
     /// events for the desktop overlay's SSE stream.

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -193,6 +193,16 @@ pub trait McpAdapter: Send + Sync {
         None
     }
 
+    /// Isolation outcome (configured vs actual) of the endpoint's last spawn.
+    ///
+    /// The default implementation returns `None` (transports that never spawn
+    /// processes). The STDIO adapter overrides this with the outcome recorded
+    /// at spawn time, including the configured-container → direct-spawn
+    /// fallback when no container runtime is available.
+    fn isolation_state(&self) -> Option<crate::adapter::stdio::IsolationState> {
+        None
+    }
+
     /// Wire a shared [`crate::events::ToolCallEventBus`] into the adapter so
     /// `call_tool` can publish typed `started` / `completed` / `failed`
     /// events for the desktop overlay's SSE stream.

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -1,6 +1,7 @@
 use super::server_name::{sanitize_server_name, ServerNameError};
 use super::server_type_resolution::{effective_server_type, strip_mcp_server_suffix};
 use super::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
+use crate::container_stats::{self, ContainerStats, StatsSlot};
 use crate::events::{
     annotations_from_value, current_request_context, ToolCallEvent, ToolCallEventBus,
 };
@@ -18,6 +19,38 @@ use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio::time::{Duration, Instant};
 use tracing::{debug, error, info, warn, Instrument};
 
+/// Default OCI image used for containerized stdio servers when the endpoint
+/// does not specify a `container_image`.
+pub const DEFAULT_CONTAINER_IMAGE: &str = "ghcr.io/endara-ai/mcp-runner:latest";
+
+/// Process isolation mode for a stdio endpoint.
+///
+/// `Container` spawns the server through a detected container runtime
+/// (docker/podman); `None` spawns the command directly on the host. The
+/// default is `None` (direct spawn), matching `EndpointConfig`'s
+/// "omitted means none" default that the watcher resolves when it builds
+/// the [`StdioConfig`] — pre-existing configs keep working unchanged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum IsolationMode {
+    Container,
+    #[default]
+    None,
+}
+
+impl IsolationMode {
+    /// Resolve the raw `isolation` config value for a stdio endpoint.
+    /// Only an explicit `"container"` containerizes; omitted (or anything
+    /// other than `"container"`) means direct spawn, so pre-existing configs
+    /// keep working unchanged on upgrade — invalid values are caught earlier
+    /// as validation warnings.
+    pub fn from_config_value(value: Option<&str>) -> Self {
+        match value {
+            Some("container") => IsolationMode::Container,
+            _ => IsolationMode::None,
+        }
+    }
+}
+
 /// Configuration for spawning a STDIO MCP server.
 #[derive(Debug, Clone, Default)]
 pub struct StdioConfig {
@@ -31,6 +64,77 @@ pub struct StdioConfig {
     /// per-endpoint `tracing` span). Defaults to empty for direct test
     /// construction; production paths set this from `EndpointConfig::name`.
     pub endpoint_name: String,
+    /// Isolation mode. Defaults to [`IsolationMode::None`] (direct spawn)
+    /// for direct construction; the watcher sets this from the endpoint's
+    /// `isolation` field (omitted = none).
+    pub isolation: IsolationMode,
+    /// OCI image used when `isolation` is `Container`. `None` means
+    /// [`DEFAULT_CONTAINER_IMAGE`].
+    pub container_image: Option<String>,
+    /// Host bind mounts (`"/host/path:/container/path"`), container mode only.
+    pub mounts: Vec<String>,
+}
+
+/// Container name for an endpoint: `endara-mcp-<sanitized-endpoint>`.
+fn container_name_for(endpoint_name: &str) -> String {
+    let sanitized =
+        crate::prefix::sanitize_name(endpoint_name).unwrap_or_else(|| "endpoint".to_string());
+    format!("endara-mcp-{}", sanitized)
+}
+
+/// Build the argument vector for `docker run` (or podman, same CLI shape):
+/// `run -i --rm --name endara-mcp-<endpoint> [-v mount]* [-e K=V]* <image> <command> <args...>`.
+/// Env vars are sorted by key for deterministic output.
+fn build_container_run_args(config: &StdioConfig) -> Vec<String> {
+    let mut args = vec![
+        "run".to_string(),
+        "-i".to_string(),
+        "--rm".to_string(),
+        "--name".to_string(),
+        container_name_for(&config.endpoint_name),
+    ];
+    for mount in &config.mounts {
+        args.push("-v".to_string());
+        args.push(mount.clone());
+    }
+    let mut env_keys: Vec<&String> = config.env.keys().collect();
+    env_keys.sort();
+    for key in env_keys {
+        args.push("-e".to_string());
+        args.push(format!("{}={}", key, config.env[key]));
+    }
+    args.push(
+        config
+            .container_image
+            .clone()
+            .unwrap_or_else(|| DEFAULT_CONTAINER_IMAGE.to_string()),
+    );
+    args.push(config.command.clone());
+    args.extend(config.args.iter().cloned());
+    args
+}
+
+/// Decide what to actually spawn: the container runtime (when isolation is
+/// `Container` and a runtime was detected) or the direct command (isolation
+/// `None`, or fallback when no runtime is available).
+fn resolve_spawn_plan(config: &StdioConfig, runtime: Option<&str>) -> (String, Vec<String>) {
+    match runtime {
+        Some(rt) if config.isolation == IsolationMode::Container => {
+            (rt.to_string(), build_container_run_args(config))
+        }
+        _ => (config.command.clone(), config.args.clone()),
+    }
+}
+
+/// Detect a usable container runtime CLI via the shared
+/// [`crate::container_runtime`] detector (cached for the process lifetime).
+/// Returns the absolute path to the docker/podman binary, or `None` when no
+/// runtime — or a runtime without a usable CLI (socket-only) — is found.
+pub(crate) fn detect_container_runtime() -> Option<String> {
+    crate::container_runtime::detect_runtime()?
+        .cli_path
+        .as_ref()
+        .map(|p| p.to_string_lossy().into_owned())
 }
 
 /// Ring buffer that stores the last N lines of stderr output.
@@ -200,6 +304,18 @@ pub struct StdioAdapter {
     /// JSON value so the [`annotations_from_value`] helper performs the
     /// MCP-spec key mapping at event-emission time.
     tool_annotations_cache: Arc<RwLock<HashMap<String, Option<Value>>>>,
+    /// When the server was spawned through a container runtime, holds
+    /// `(runtime_cli, container_name)` so shutdown can `rm -f` the container
+    /// as a backstop (killing the CLI client may orphan the container).
+    container: Arc<Mutex<Option<(String, String)>>>,
+    /// Latest container stats sample written by the background stats poller.
+    /// `None` for direct spawns, before the first sample, or when the last
+    /// poll failed. Uses a `std::sync::RwLock` so the sync
+    /// [`McpAdapter::container_stats`] accessor can read it without await.
+    container_stats: StatsSlot,
+    /// Background `stats --no-stream` poll loop for containerized spawns,
+    /// aborted on shutdown / respawn.
+    stats_poller_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
     // Background task handles
     _stderr_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
     _stdout_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
@@ -230,6 +346,9 @@ impl StdioAdapter {
             span,
             event_bus: Arc::new(OnceLock::new()),
             tool_annotations_cache: Arc::new(RwLock::new(HashMap::new())),
+            container: Arc::new(Mutex::new(None)),
+            container_stats: Arc::new(std::sync::RwLock::new(None)),
+            stats_poller_handle: Arc::new(Mutex::new(None)),
             _stderr_handle: Arc::new(Mutex::new(None)),
             _stdout_handle: Arc::new(Mutex::new(None)),
         }
@@ -243,27 +362,90 @@ impl StdioAdapter {
     async fn spawn_process(&self) -> Result<(), AdapterError> {
         *self.health.write().await = HealthStatus::Starting;
 
-        let mut cmd = Command::new(&self.config.command);
-        cmd.args(&self.config.args)
+        // Resolve the container runtime when isolation is requested. No
+        // runtime found → fall back to direct spawn (never hard-fail an
+        // endpoint because Docker/Podman is absent).
+        let runtime = if self.config.isolation == IsolationMode::Container {
+            let rt = detect_container_runtime();
+            if rt.is_none() {
+                warn!(
+                    "no container runtime (docker/podman) detected — falling back to direct \
+                     spawn; install Docker or Podman to run this server isolated"
+                );
+            }
+            rt
+        } else {
+            None
+        };
+
+        if let Some(ref rt) = runtime {
+            // Best-effort removal of a stale container left over from a
+            // previous run (e.g. after a crash where `--rm` didn't fire).
+            let name = container_name_for(&self.config.endpoint_name);
+            let _ = tokio::time::timeout(
+                Duration::from_secs(5),
+                Command::new(rt)
+                    .args(["rm", "-f", &name])
+                    .stdin(Stdio::null())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .status(),
+            )
+            .await;
+        }
+
+        let (program, argv) = resolve_spawn_plan(&self.config, runtime.as_deref());
+
+        let mut cmd = Command::new(&program);
+        cmd.args(&argv)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
-        // Inject the user's login-shell PATH so that commands installed via
-        // nvm, Homebrew, pyenv, etc. are discoverable even when the relay
-        // runs as a Tauri sidecar with a minimal inherited environment.
-        if let Some(shell_path) = shell_env::resolve_shell_path() {
-            if !self.config.env.contains_key("PATH") {
-                cmd.env("PATH", shell_path);
+        if runtime.is_none() {
+            // Direct spawn: inject the user's login-shell PATH so that
+            // commands installed via nvm, Homebrew, pyenv, etc. are
+            // discoverable even when the relay runs as a Tauri sidecar with
+            // a minimal inherited environment.
+            if let Some(shell_path) = shell_env::resolve_shell_path() {
+                if !self.config.env.contains_key("PATH") {
+                    cmd.env("PATH", shell_path);
+                }
+            }
+
+            // User-specified env vars always win (applied after shell PATH).
+            cmd.envs(&self.config.env);
+        }
+        // Container spawn: env vars are passed into the container via `-e`
+        // args (see build_container_run_args); the runtime CLI itself runs
+        // with the relay's own environment.
+
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| AdapterError::ProcessSpawnFailed(format!("{}: {}", program, e)))?;
+
+        *self.container.lock().await = runtime
+            .as_ref()
+            .map(|rt| (rt.clone(), container_name_for(&self.config.endpoint_name)));
+
+        // (Re)start the stats poller for containerized spawns. Clear any
+        // previous sample first so a respawn never serves stale stats.
+        if let Ok(mut stats) = self.container_stats.write() {
+            *stats = None;
+        }
+        {
+            let mut handle = self.stats_poller_handle.lock().await;
+            if let Some(h) = handle.take() {
+                h.abort();
+            }
+            if let Some(rt) = runtime.as_ref() {
+                *handle = Some(container_stats::spawn_stats_poller(
+                    rt.clone(),
+                    container_name_for(&self.config.endpoint_name),
+                    self.container_stats.clone(),
+                ));
             }
         }
-
-        // User-specified env vars always win (applied after shell PATH).
-        cmd.envs(&self.config.env);
-
-        let mut child = cmd.spawn().map_err(|e| {
-            AdapterError::ProcessSpawnFailed(format!("{}: {}", self.config.command, e))
-        })?;
 
         let stdin = child
             .stdin
@@ -673,6 +855,10 @@ impl McpAdapter for StdioAdapter {
         }
     }
 
+    fn container_stats(&self) -> Option<ContainerStats> {
+        self.container_stats.read().ok().and_then(|g| (*g).clone())
+    }
+
     fn server_type(&self) -> Option<String> {
         self.server_type.try_read().ok().and_then(|g| g.clone())
     }
@@ -740,6 +926,30 @@ impl McpAdapter for StdioAdapter {
                         let _ = child.kill().await;
                     }
                 }
+            }
+
+            // Stop the stats poller and drop the last sample so a stopped
+            // endpoint never reports stale container stats.
+            if let Some(h) = self.stats_poller_handle.lock().await.take() {
+                h.abort();
+            }
+            if let Ok(mut stats) = self.container_stats.write() {
+                *stats = None;
+            }
+
+            // Containerized spawn: killing the runtime CLI client may orphan
+            // the container, so remove it by name as a best-effort backstop.
+            if let Some((runtime, name)) = self.container.lock().await.take() {
+                let _ = tokio::time::timeout(
+                    Duration::from_secs(5),
+                    Command::new(&runtime)
+                        .args(["rm", "-f", &name])
+                        .stdin(Stdio::null())
+                        .stdout(Stdio::null())
+                        .stderr(Stdio::null())
+                        .status(),
+                )
+                .await;
             }
 
             // Abort background tasks
@@ -896,6 +1106,157 @@ mod tests {
             rxs.push((id, rx));
         }
         (map, rxs)
+    }
+
+    // -----------------------------------------------------------------------
+    // Containerized spawn plan (no docker needed — pure arg construction)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_isolation_mode_from_config_value() {
+        // Omitted means direct spawn so pre-existing configs keep working
+        // unchanged on upgrade; only an explicit "container" containerizes.
+        assert_eq!(IsolationMode::from_config_value(None), IsolationMode::None);
+        assert_eq!(
+            IsolationMode::from_config_value(Some("container")),
+            IsolationMode::Container
+        );
+        assert_eq!(
+            IsolationMode::from_config_value(Some("none")),
+            IsolationMode::None
+        );
+    }
+
+    #[test]
+    fn test_container_name_sanitizes_endpoint_name() {
+        assert_eq!(container_name_for("my-server"), "endara-mcp-my-server");
+        assert_eq!(container_name_for("My Server!"), "endara-mcp-my_server");
+        assert_eq!(container_name_for("!!!"), "endara-mcp-endpoint");
+    }
+
+    #[test]
+    fn test_build_container_run_args_full_shape() {
+        let mut env = HashMap::new();
+        env.insert("ZED".to_string(), "z".to_string());
+        env.insert("API_KEY".to_string(), "secret".to_string());
+        let config = StdioConfig {
+            command: "npx".to_string(),
+            args: vec!["-y".to_string(), "some-server".to_string()],
+            env,
+            endpoint_name: "github".to_string(),
+            isolation: IsolationMode::Container,
+            container_image: None,
+            mounts: vec!["/host/a:/ctr/a".to_string(), "/host/b:/ctr/b".to_string()],
+            ..Default::default()
+        };
+        let args = build_container_run_args(&config);
+        assert_eq!(
+            args,
+            vec![
+                "run",
+                "-i",
+                "--rm",
+                "--name",
+                "endara-mcp-github",
+                "-v",
+                "/host/a:/ctr/a",
+                "-v",
+                "/host/b:/ctr/b",
+                "-e",
+                "API_KEY=secret",
+                "-e",
+                "ZED=z",
+                DEFAULT_CONTAINER_IMAGE,
+                "npx",
+                "-y",
+                "some-server",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_build_container_run_args_custom_image_no_mounts_no_env() {
+        let config = StdioConfig {
+            command: "uvx".to_string(),
+            args: vec!["mcp-fetch".to_string()],
+            endpoint_name: "fetch".to_string(),
+            isolation: IsolationMode::Container,
+            container_image: Some("example.com/custom:1".to_string()),
+            ..Default::default()
+        };
+        let args = build_container_run_args(&config);
+        assert_eq!(
+            args,
+            vec![
+                "run",
+                "-i",
+                "--rm",
+                "--name",
+                "endara-mcp-fetch",
+                "example.com/custom:1",
+                "uvx",
+                "mcp-fetch",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_resolve_spawn_plan_container_with_runtime() {
+        let config = StdioConfig {
+            command: "npx".to_string(),
+            args: vec!["server".to_string()],
+            endpoint_name: "ep".to_string(),
+            isolation: IsolationMode::Container,
+            ..Default::default()
+        };
+        let (program, argv) = resolve_spawn_plan(&config, Some("/usr/local/bin/docker"));
+        assert_eq!(program, "/usr/local/bin/docker");
+        assert_eq!(argv[0], "run");
+        assert!(argv.contains(&"npx".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_spawn_plan_falls_back_to_direct_without_runtime() {
+        let config = StdioConfig {
+            command: "npx".to_string(),
+            args: vec!["server".to_string()],
+            endpoint_name: "ep".to_string(),
+            isolation: IsolationMode::Container,
+            ..Default::default()
+        };
+        let (program, argv) = resolve_spawn_plan(&config, None);
+        assert_eq!(program, "npx");
+        assert_eq!(argv, vec!["server".to_string()]);
+    }
+
+    #[test]
+    fn test_resolve_spawn_plan_omitted_isolation_spawns_directly() {
+        // Omitted `isolation` resolves to direct spawn even when a container
+        // runtime is available — legacy configs must not be containerized.
+        let config = StdioConfig {
+            command: "npx".to_string(),
+            args: vec!["server".to_string()],
+            endpoint_name: "ep".to_string(),
+            isolation: IsolationMode::from_config_value(None),
+            ..Default::default()
+        };
+        let (program, argv) = resolve_spawn_plan(&config, Some("/usr/local/bin/docker"));
+        assert_eq!(program, "npx");
+        assert_eq!(argv, vec!["server".to_string()]);
+    }
+
+    #[test]
+    fn test_resolve_spawn_plan_isolation_none_ignores_runtime() {
+        let config = StdioConfig {
+            command: "npx".to_string(),
+            args: vec!["server".to_string()],
+            endpoint_name: "ep".to_string(),
+            isolation: IsolationMode::None,
+            ..Default::default()
+        };
+        let (program, argv) = resolve_spawn_plan(&config, Some("/usr/local/bin/docker"));
+        assert_eq!(program, "npx");
+        assert_eq!(argv, vec!["server".to_string()]);
     }
 
     /// Simulate the stdout reader dispatch logic for a single line.

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -8,6 +8,7 @@ use crate::events::{
 use crate::jsonrpc::{self, JsonRpcResponse};
 use crate::shell_env;
 use async_trait::async_trait;
+use serde::Serialize;
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::process::Stdio;
@@ -123,6 +124,61 @@ fn resolve_spawn_plan(config: &StdioConfig, runtime: Option<&str>) -> (String, V
             (rt.to_string(), build_container_run_args(config))
         }
         _ => (config.command.clone(), config.args.clone()),
+    }
+}
+
+/// Per-endpoint isolation outcome reported via the management API.
+///
+/// Records what the endpoint config asked for (`configured`) versus what the
+/// last spawn actually did (`actual`), making the silent
+/// configured-container → direct fallback visible. `runtime`,
+/// `container_name` and `image` are present only when the spawn actually
+/// went through a container runtime.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct IsolationState {
+    /// Configured isolation mode: `"container"` or `"none"`.
+    pub configured: &'static str,
+    /// Actual spawn outcome: `"container"` or `"direct"`.
+    pub actual: &'static str,
+    /// Detected runtime CLI name (`"docker"` / `"podman"`), container only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime: Option<String>,
+    /// Container name (`endara-mcp-<endpoint>`), container only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub container_name: Option<String>,
+    /// OCI image the container runs, container only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
+}
+
+/// Build the [`IsolationState`] matching what [`resolve_spawn_plan`] decided.
+/// `runtime_kind` is the detected runtime's CLI name (`"docker"`/`"podman"`),
+/// `None` when no runtime was found (or isolation was not requested).
+fn resolve_isolation_state(config: &StdioConfig, runtime_kind: Option<&str>) -> IsolationState {
+    let configured = match config.isolation {
+        IsolationMode::Container => "container",
+        IsolationMode::None => "none",
+    };
+    match runtime_kind {
+        Some(kind) if config.isolation == IsolationMode::Container => IsolationState {
+            configured,
+            actual: "container",
+            runtime: Some(kind.to_string()),
+            container_name: Some(container_name_for(&config.endpoint_name)),
+            image: Some(
+                config
+                    .container_image
+                    .clone()
+                    .unwrap_or_else(|| DEFAULT_CONTAINER_IMAGE.to_string()),
+            ),
+        },
+        _ => IsolationState {
+            configured,
+            actual: "direct",
+            runtime: None,
+            container_name: None,
+            image: None,
+        },
     }
 }
 
@@ -316,6 +372,10 @@ pub struct StdioAdapter {
     /// Background `stats --no-stream` poll loop for containerized spawns,
     /// aborted on shutdown / respawn.
     stats_poller_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
+    /// Isolation outcome of the most recent spawn, reported via
+    /// [`McpAdapter::isolation_state`]. `None` until the first spawn. Uses a
+    /// `std::sync::RwLock` so the sync accessor can read it without await.
+    isolation_state: Arc<std::sync::RwLock<Option<IsolationState>>>,
     // Background task handles
     _stderr_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
     _stdout_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
@@ -349,6 +409,7 @@ impl StdioAdapter {
             container: Arc::new(Mutex::new(None)),
             container_stats: Arc::new(std::sync::RwLock::new(None)),
             stats_poller_handle: Arc::new(Mutex::new(None)),
+            isolation_state: Arc::new(std::sync::RwLock::new(None)),
             _stderr_handle: Arc::new(Mutex::new(None)),
             _stdout_handle: Arc::new(Mutex::new(None)),
         }
@@ -427,6 +488,16 @@ impl StdioAdapter {
         *self.container.lock().await = runtime
             .as_ref()
             .map(|rt| (rt.clone(), container_name_for(&self.config.endpoint_name)));
+
+        // Record what this spawn actually did (container vs direct, including
+        // the configured-container → direct fallback) for the management API.
+        let runtime_kind = runtime
+            .as_ref()
+            .and_then(|_| crate::container_runtime::detect_runtime())
+            .map(|info| info.kind.cli_name());
+        if let Ok(mut state) = self.isolation_state.write() {
+            *state = Some(resolve_isolation_state(&self.config, runtime_kind));
+        }
 
         // (Re)start the stats poller for containerized spawns. Clear any
         // previous sample first so a respawn never serves stale stats.
@@ -859,6 +930,10 @@ impl McpAdapter for StdioAdapter {
         self.container_stats.read().ok().and_then(|g| (*g).clone())
     }
 
+    fn isolation_state(&self) -> Option<IsolationState> {
+        self.isolation_state.read().ok().and_then(|g| (*g).clone())
+    }
+
     fn server_type(&self) -> Option<String> {
         self.server_type.try_read().ok().and_then(|g| g.clone())
     }
@@ -1257,6 +1332,106 @@ mod tests {
         let (program, argv) = resolve_spawn_plan(&config, Some("/usr/local/bin/docker"));
         assert_eq!(program, "npx");
         assert_eq!(argv, vec!["server".to_string()]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Isolation-state reporting (configured vs actual spawn outcome)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_isolation_state_container_with_runtime_reports_full_state() {
+        let config = StdioConfig {
+            command: "npx".to_string(),
+            args: vec!["server".to_string()],
+            endpoint_name: "github".to_string(),
+            isolation: IsolationMode::Container,
+            container_image: None,
+            ..Default::default()
+        };
+        let state = resolve_isolation_state(&config, Some("docker"));
+        assert_eq!(state.configured, "container");
+        assert_eq!(state.actual, "container");
+        assert_eq!(state.runtime, Some("docker".to_string()));
+        assert_eq!(state.container_name, Some("endara-mcp-github".to_string()));
+        assert_eq!(state.image, Some(DEFAULT_CONTAINER_IMAGE.to_string()));
+    }
+
+    #[test]
+    fn test_isolation_state_container_reports_custom_image() {
+        let config = StdioConfig {
+            command: "uvx".to_string(),
+            endpoint_name: "fetch".to_string(),
+            isolation: IsolationMode::Container,
+            container_image: Some("example.com/custom:1".to_string()),
+            ..Default::default()
+        };
+        let state = resolve_isolation_state(&config, Some("podman"));
+        assert_eq!(state.actual, "container");
+        assert_eq!(state.runtime, Some("podman".to_string()));
+        assert_eq!(state.image, Some("example.com/custom:1".to_string()));
+    }
+
+    #[test]
+    fn test_isolation_state_direct_configured_reports_direct() {
+        // isolation = none reports configured=none/actual=direct, with no
+        // container details — even when a runtime happens to be available.
+        let config = StdioConfig {
+            command: "npx".to_string(),
+            endpoint_name: "ep".to_string(),
+            isolation: IsolationMode::None,
+            ..Default::default()
+        };
+        let state = resolve_isolation_state(&config, None);
+        assert_eq!(state.configured, "none");
+        assert_eq!(state.actual, "direct");
+        assert_eq!(state.runtime, None);
+        assert_eq!(state.container_name, None);
+        assert_eq!(state.image, None);
+    }
+
+    #[test]
+    fn test_isolation_state_fallback_reports_configured_container_actual_direct() {
+        // Configured container but no runtime detected: the silent fallback
+        // to direct spawn must be visible as configured=container/actual=direct.
+        let config = StdioConfig {
+            command: "npx".to_string(),
+            endpoint_name: "ep".to_string(),
+            isolation: IsolationMode::Container,
+            ..Default::default()
+        };
+        let state = resolve_isolation_state(&config, None);
+        assert_eq!(state.configured, "container");
+        assert_eq!(state.actual, "direct");
+        assert_eq!(state.runtime, None);
+        assert_eq!(state.container_name, None);
+        assert_eq!(state.image, None);
+    }
+
+    #[test]
+    fn test_isolation_state_serialization_omits_absent_container_fields() {
+        let config = StdioConfig {
+            command: "npx".to_string(),
+            endpoint_name: "ep".to_string(),
+            isolation: IsolationMode::Container,
+            ..Default::default()
+        };
+        let fallback = serde_json::to_value(resolve_isolation_state(&config, None)).unwrap();
+        assert_eq!(
+            fallback,
+            json!({ "configured": "container", "actual": "direct" })
+        );
+        let containerized =
+            serde_json::to_value(resolve_isolation_state(&config, Some("docker"))).unwrap();
+        assert_eq!(
+            containerized,
+            json!({
+                "configured": "container",
+                "actual": "container",
+                "runtime": "docker",
+                "container_name": "endara-mcp-ep",
+                "image": DEFAULT_CONTAINER_IMAGE,
+            })
+        );
     }
 
     /// Simulate the stdout reader dispatch logic for a single line.

--- a/src/config.rs
+++ b/src/config.rs
@@ -252,6 +252,21 @@ pub struct EndpointConfig {
     /// Tool-name routing (the `tool_prefix`) is unaffected.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub server_type_override: Option<String>,
+    /// Process isolation mode for stdio endpoints: `"container"` or `"none"`.
+    /// Omitted means `"none"` (direct spawn), so pre-existing configs keep
+    /// working unchanged on upgrade; the desktop writes an explicit
+    /// `isolation = "container"` for newly created endpoints.
+    /// Ignored for non-stdio transports.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub isolation: Option<String>,
+    /// OCI image used when `isolation = "container"`. Defaults to
+    /// `ghcr.io/endara-ai/mcp-runner:latest` when omitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub container_image: Option<String>,
+    /// Host bind mounts (`"/host/path:/container/path"`) applied when
+    /// `isolation = "container"`. Default: no host filesystem access.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mounts: Option<Vec<String>>,
 }
 
 impl EndpointConfig {
@@ -272,6 +287,8 @@ impl EndpointConfig {
 /// `diff_configs` treats an endpoint as "unchanged" when only these fields differ.
 /// Note: `headers` IS included — changing headers should trigger adapter restart.
 /// OAuth fields are included — changing OAuth config should trigger adapter restart.
+/// Isolation fields (`isolation`, `container_image`, `mounts`) are included —
+/// changing them should trigger adapter restart.
 impl PartialEq for EndpointConfig {
     fn eq(&self, other: &Self) -> bool {
         self.name == other.name
@@ -287,6 +304,9 @@ impl PartialEq for EndpointConfig {
             && self.client_secret == other.client_secret
             && self.scopes == other.scopes
             && self.server_type_override == other.server_type_override
+            && self.isolation == other.isolation
+            && self.container_image == other.container_image
+            && self.mounts == other.mounts
     }
 }
 
@@ -795,6 +815,20 @@ fn validate_graceful(config: &Config, warnings: &mut Vec<EndpointValidationWarni
                             message: "oauth transport requires a 'url' field".to_string(),
                         });
                     }
+                }
+            }
+
+            // Validate the isolation mode (relevant for stdio, but any invalid
+            // value is worth flagging regardless of transport).
+            if let Some(ref iso) = ep.isolation {
+                if iso != "container" && iso != "none" {
+                    warnings.push(EndpointValidationWarning {
+                        endpoint_name: ep.name.clone(),
+                        message: format!(
+                            "invalid isolation value '{}' — expected \"container\" or \"none\"",
+                            iso
+                        ),
+                    });
                 }
             }
         }
@@ -1610,6 +1644,9 @@ js_execution = false
             scopes: None,
             token_endpoint: None,
             server_type_override: None,
+            isolation: None,
+            container_image: None,
+            mounts: None,
         }
     }
 
@@ -1632,6 +1669,9 @@ js_execution = false
             scopes: None,
             token_endpoint: None,
             server_type_override: None,
+            isolation: None,
+            container_image: None,
+            mounts: None,
         }
     }
 
@@ -2072,6 +2112,9 @@ scopes = ["openid", "profile", "email"]
             scopes: None,
             token_endpoint: None,
             server_type_override: None,
+            isolation: None,
+            container_image: None,
+            mounts: None,
         };
 
         let mut ep2 = ep1.clone();
@@ -2154,5 +2197,122 @@ command = "echo"
         let new = make_config(vec![ep2]);
         let diff = diff_configs(&old, &new);
         assert_eq!(diff.changed.len(), 1);
+    }
+
+    // --- Isolation / container field tests ---
+
+    #[test]
+    fn isolation_fields_parse_from_toml() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "boxed"
+transport = "stdio"
+command = "npx"
+isolation = "container"
+container_image = "example.com/custom:1"
+mounts = ["/host/a:/ctr/a"]
+"#;
+        let (config, warnings) = parse_and_validate_graceful(toml_str).unwrap();
+        assert!(warnings.is_empty(), "unexpected warnings: {:?}", warnings);
+        let ep = &config.endpoints[0];
+        assert_eq!(ep.isolation.as_deref(), Some("container"));
+        assert_eq!(ep.container_image.as_deref(), Some("example.com/custom:1"));
+        assert_eq!(ep.mounts, Some(vec!["/host/a:/ctr/a".to_string()]));
+    }
+
+    #[test]
+    fn graceful_invalid_isolation_value_returns_warning() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "boxed"
+transport = "stdio"
+command = "echo"
+isolation = "bogus"
+"#;
+        let (config, warnings) = parse_and_validate_graceful(toml_str).unwrap();
+        assert_eq!(config.endpoints.len(), 1);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].message.contains("invalid isolation value"));
+    }
+
+    #[test]
+    fn graceful_valid_isolation_values_no_warning() {
+        for value in ["container", "none"] {
+            let toml_str = format!(
+                r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "boxed"
+transport = "stdio"
+command = "echo"
+isolation = "{}"
+"#,
+                value
+            );
+            let (_, warnings) = parse_and_validate_graceful(&toml_str).unwrap();
+            assert!(
+                warnings.is_empty(),
+                "unexpected warnings for '{}': {:?}",
+                value,
+                warnings
+            );
+        }
+    }
+
+    #[test]
+    fn isolation_change_triggers_config_diff() {
+        let mut ep1 = stdio_ep("boxed", "npx");
+        ep1.isolation = Some("container".to_string());
+        let mut ep2 = stdio_ep("boxed", "npx");
+        ep2.isolation = Some("none".to_string());
+
+        let old = make_config(vec![ep1]);
+        let new = make_config(vec![ep2]);
+        let diff = diff_configs(&old, &new);
+        assert_eq!(
+            diff.changed.len(),
+            1,
+            "isolation change should trigger diff"
+        );
+        assert!(diff.unchanged.is_empty());
+    }
+
+    #[test]
+    fn container_image_change_triggers_config_diff() {
+        let mut ep1 = stdio_ep("boxed", "npx");
+        ep1.container_image = Some("example.com/a:1".to_string());
+        let mut ep2 = stdio_ep("boxed", "npx");
+        ep2.container_image = Some("example.com/b:2".to_string());
+
+        let old = make_config(vec![ep1]);
+        let new = make_config(vec![ep2]);
+        let diff = diff_configs(&old, &new);
+        assert_eq!(
+            diff.changed.len(),
+            1,
+            "container_image change should trigger diff"
+        );
+        assert!(diff.unchanged.is_empty());
+    }
+
+    #[test]
+    fn mounts_change_triggers_config_diff() {
+        let ep1 = stdio_ep("boxed", "npx");
+        let mut ep2 = stdio_ep("boxed", "npx");
+        ep2.mounts = Some(vec!["/host:/ctr".to_string()]);
+
+        let old = make_config(vec![ep1]);
+        let new = make_config(vec![ep2]);
+        let diff = diff_configs(&old, &new);
+        assert_eq!(diff.changed.len(), 1, "mounts change should trigger diff");
+        assert!(diff.unchanged.is_empty());
     }
 }

--- a/src/container_runtime.rs
+++ b/src/container_runtime.rs
@@ -1,0 +1,373 @@
+//! Detects a usable OCI container runtime (Docker or Podman) on the host.
+//!
+//! Probes well-known runtime socket locations (Docker Desktop, OrbStack,
+//! Rancher Desktop, Podman, ...) and the user's login-shell PATH for a
+//! `docker`/`podman` CLI. The result is cached for the process lifetime,
+//! mirroring [`crate::shell_env`].
+
+use crate::shell_env;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use tracing::{info, warn};
+
+/// Which container engine was detected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeKind {
+    Docker,
+    Podman,
+}
+
+impl RuntimeKind {
+    /// CLI binary name for this runtime.
+    pub fn cli_name(&self) -> &'static str {
+        match self {
+            RuntimeKind::Docker => "docker",
+            RuntimeKind::Podman => "podman",
+        }
+    }
+}
+
+/// A detected, usable container runtime. At least one of `cli_path` /
+/// `socket` is always `Some`.
+#[derive(Debug, Clone)]
+pub struct RuntimeInfo {
+    pub kind: RuntimeKind,
+    /// Resolved CLI binary (e.g. `/usr/local/bin/docker`), if found on PATH.
+    pub cli_path: Option<PathBuf>,
+    /// Engine API socket (Unix socket path, or named pipe on Windows).
+    pub socket: Option<PathBuf>,
+    /// CLI client version (e.g. `27.3.1`), if the CLI was found.
+    pub version: Option<String>,
+}
+
+/// Cached detection result (resolved once, reused forever).
+static DETECTED: OnceLock<Option<RuntimeInfo>> = OnceLock::new();
+
+/// Detect a usable container runtime, caching the result for the process
+/// lifetime. Returns `None` when neither a runtime socket nor a
+/// `docker`/`podman` CLI is found.
+pub fn detect_runtime() -> Option<&'static RuntimeInfo> {
+    DETECTED
+        .get_or_init(|| {
+            let path_env = resolve_path_env();
+            let candidates = candidate_sockets(&Probe::from_env());
+            let info = detect_from(&candidates, path_env.as_deref());
+            match &info {
+                Some(i) => info!(
+                    kind = i.kind.cli_name(),
+                    cli = ?i.cli_path,
+                    socket = ?i.socket,
+                    version = ?i.version,
+                    "detected container runtime"
+                ),
+                None => warn!("no container runtime detected (docker/podman)"),
+            }
+            info
+        })
+        .as_ref()
+}
+
+/// Environment inputs for socket-candidate enumeration. Separated from
+/// process globals so unit tests can construct arbitrary probes.
+struct Probe {
+    /// `$ENDARA_DOCKER_SOCKET` override (may carry a `unix://` prefix).
+    env_socket: Option<String>,
+    home: Option<PathBuf>,
+    xdg_runtime_dir: Option<String>,
+}
+
+impl Probe {
+    fn from_env() -> Self {
+        Self {
+            env_socket: std::env::var("ENDARA_DOCKER_SOCKET").ok(),
+            home: dirs::home_dir(),
+            xdg_runtime_dir: std::env::var("XDG_RUNTIME_DIR").ok(),
+        }
+    }
+}
+
+/// PATH used for CLI probing: login-shell PATH when resolvable, otherwise
+/// the inherited process PATH.
+fn resolve_path_env() -> Option<String> {
+    shell_env::resolve_shell_path()
+        .map(str::to_string)
+        .or_else(|| std::env::var("PATH").ok())
+}
+
+/// Well-known runtime socket locations, in priority order.
+fn candidate_sockets(probe: &Probe) -> Vec<(RuntimeKind, PathBuf)> {
+    let mut out = Vec::new();
+    if let Some(s) = &probe.env_socket {
+        let p = s.strip_prefix("unix://").unwrap_or(s);
+        if !p.is_empty() {
+            out.push((RuntimeKind::Docker, PathBuf::from(p)));
+        }
+    }
+    out.push((RuntimeKind::Docker, PathBuf::from("/var/run/docker.sock")));
+    if let Some(home) = &probe.home {
+        out.push((RuntimeKind::Docker, home.join(".docker/run/docker.sock")));
+        out.push((RuntimeKind::Docker, home.join(".orbstack/run/docker.sock")));
+        out.push((RuntimeKind::Docker, home.join(".rd/docker.sock")));
+    }
+    if let Some(xdg) = &probe.xdg_runtime_dir {
+        out.push((
+            RuntimeKind::Podman,
+            Path::new(xdg).join("podman/podman.sock"),
+        ));
+    }
+    if let Some(home) = &probe.home {
+        out.push((
+            RuntimeKind::Podman,
+            home.join(".local/share/containers/podman/machine/podman.sock"),
+        ));
+    }
+    #[cfg(target_os = "windows")]
+    out.push((
+        RuntimeKind::Docker,
+        PathBuf::from(r"\\.\pipe\docker_engine"),
+    ));
+    out
+}
+
+/// Core detection: first existing socket wins (CLI then resolved for that
+/// runtime); otherwise fall back to a pure CLI probe (docker, then podman).
+fn detect_from(
+    candidates: &[(RuntimeKind, PathBuf)],
+    path_env: Option<&str>,
+) -> Option<RuntimeInfo> {
+    if let Some((kind, socket)) = candidates.iter().find(|(_, p)| p.exists()) {
+        let cli_path = find_in_path(kind.cli_name(), path_env);
+        let version = cli_path.as_deref().and_then(cli_version);
+        return Some(RuntimeInfo {
+            kind: *kind,
+            cli_path,
+            socket: Some(socket.clone()),
+            version,
+        });
+    }
+    for kind in [RuntimeKind::Docker, RuntimeKind::Podman] {
+        if let Some(cli_path) = find_in_path(kind.cli_name(), path_env) {
+            let version = cli_version(&cli_path);
+            return Some(RuntimeInfo {
+                kind,
+                cli_path: Some(cli_path),
+                socket: None,
+                version,
+            });
+        }
+    }
+    None
+}
+
+/// Search a PATH-style string for an executable named `name`.
+fn find_in_path(name: &str, path_env: Option<&str>) -> Option<PathBuf> {
+    let path_env = path_env?;
+    for dir in std::env::split_paths(path_env) {
+        if dir.as_os_str().is_empty() {
+            continue;
+        }
+        for candidate in exe_candidates(&dir, name) {
+            if is_executable(&candidate) {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(not(target_os = "windows"))]
+fn exe_candidates(dir: &Path, name: &str) -> Vec<PathBuf> {
+    vec![dir.join(name)]
+}
+
+#[cfg(target_os = "windows")]
+fn exe_candidates(dir: &Path, name: &str) -> Vec<PathBuf> {
+    vec![dir.join(format!("{name}.exe")), dir.join(name)]
+}
+
+#[cfg(not(target_os = "windows"))]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    path.metadata()
+        .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "windows")]
+fn is_executable(path: &Path) -> bool {
+    path.is_file()
+}
+
+/// Run `<cli> --version` and parse out the version number. `--version` only
+/// touches the client binary (never the daemon), so it is fast even when the
+/// engine VM is stopped.
+fn cli_version(cli: &Path) -> Option<String> {
+    let output = std::process::Command::new(cli).arg("--version").output();
+    match output {
+        Ok(out) if out.status.success() => parse_cli_version(&String::from_utf8_lossy(&out.stdout)),
+        Ok(out) => {
+            warn!(cli = %cli.display(), status = ?out.status, "runtime CLI --version failed");
+            None
+        }
+        Err(e) => {
+            warn!(cli = %cli.display(), error = %e, "failed to run runtime CLI --version");
+            None
+        }
+    }
+}
+
+/// Parse version output like `Docker version 27.3.1, build abc123` or
+/// `podman version 5.2.0`.
+fn parse_cli_version(output: &str) -> Option<String> {
+    let mut tokens = output.split_whitespace();
+    while let Some(tok) = tokens.next() {
+        if tok.eq_ignore_ascii_case("version") {
+            return tokens.next().map(|v| v.trim_end_matches(',').to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn probe(env_socket: Option<&str>, home: Option<&Path>, xdg: Option<&str>) -> Probe {
+        Probe {
+            env_socket: env_socket.map(str::to_string),
+            home: home.map(Path::to_path_buf),
+            xdg_runtime_dir: xdg.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn candidate_sockets_priority_order() {
+        let home = PathBuf::from("/home/u");
+        let p = probe(
+            Some("unix:///custom/docker.sock"),
+            Some(&home),
+            Some("/run/user/1000"),
+        );
+        let candidates = candidate_sockets(&p);
+        let paths: Vec<_> = candidates.iter().map(|(_, p)| p.clone()).collect();
+        assert_eq!(paths[0], PathBuf::from("/custom/docker.sock"));
+        assert_eq!(paths[1], PathBuf::from("/var/run/docker.sock"));
+        assert_eq!(paths[2], home.join(".docker/run/docker.sock"));
+        assert_eq!(paths[3], home.join(".orbstack/run/docker.sock"));
+        assert_eq!(paths[4], home.join(".rd/docker.sock"));
+        assert_eq!(paths[5], PathBuf::from("/run/user/1000/podman/podman.sock"));
+        assert_eq!(
+            paths[6],
+            home.join(".local/share/containers/podman/machine/podman.sock")
+        );
+        assert_eq!(candidates[5].0, RuntimeKind::Podman);
+        assert_eq!(candidates[0].0, RuntimeKind::Docker);
+    }
+
+    #[test]
+    fn candidate_sockets_skips_empty_env_socket() {
+        let candidates = candidate_sockets(&probe(Some(""), None, None));
+        assert_eq!(candidates[0].1, PathBuf::from("/var/run/docker.sock"));
+    }
+
+    #[test]
+    fn detect_from_prefers_socket_over_cli() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("podman.sock");
+        std::fs::write(&sock, b"").unwrap();
+        let candidates = vec![
+            (RuntimeKind::Docker, dir.path().join("missing-docker.sock")),
+            (RuntimeKind::Podman, sock.clone()),
+        ];
+        let info = detect_from(&candidates, None).expect("socket should be detected");
+        assert_eq!(info.kind, RuntimeKind::Podman);
+        assert_eq!(info.socket, Some(sock));
+        assert_eq!(info.cli_path, None);
+        assert_eq!(info.version, None);
+    }
+
+    #[test]
+    fn detect_from_returns_none_without_socket_or_cli() {
+        let dir = tempfile::tempdir().unwrap();
+        let candidates = vec![(RuntimeKind::Docker, dir.path().join("missing.sock"))];
+        let empty_path = dir.path().join("empty-bin");
+        std::fs::create_dir_all(&empty_path).unwrap();
+        let info = detect_from(&candidates, Some(empty_path.to_str().unwrap()));
+        assert!(info.is_none());
+    }
+
+    #[cfg(unix)]
+    fn write_cli_stub(dir: &Path, name: &str, stdout: &str) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let path = dir.join(name);
+        std::fs::write(&path, format!("#!/bin/sh\necho \"{stdout}\"\n")).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn detect_from_falls_back_to_cli_probe() {
+        let dir = tempfile::tempdir().unwrap();
+        let stub = write_cli_stub(dir.path(), "docker", "Docker version 27.3.1, build abc123");
+        let candidates = vec![(RuntimeKind::Docker, dir.path().join("missing.sock"))];
+        let info = detect_from(&candidates, Some(dir.path().to_str().unwrap()))
+            .expect("CLI should be detected");
+        assert_eq!(info.kind, RuntimeKind::Docker);
+        assert_eq!(info.cli_path, Some(stub));
+        assert_eq!(info.socket, None);
+        assert_eq!(info.version, Some("27.3.1".to_string()));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn detect_from_socket_resolves_matching_cli() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("docker.sock");
+        std::fs::write(&sock, b"").unwrap();
+        let stub = write_cli_stub(dir.path(), "docker", "Docker version 26.0.0, build def");
+        let candidates = vec![(RuntimeKind::Docker, sock.clone())];
+        let info = detect_from(&candidates, Some(dir.path().to_str().unwrap()))
+            .expect("socket should be detected");
+        assert_eq!(info.kind, RuntimeKind::Docker);
+        assert_eq!(info.socket, Some(sock));
+        assert_eq!(info.cli_path, Some(stub));
+        assert_eq!(info.version, Some("26.0.0".to_string()));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn find_in_path_skips_non_executable_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("docker"), b"not executable").unwrap();
+        assert_eq!(
+            find_in_path("docker", Some(dir.path().to_str().unwrap())),
+            None
+        );
+    }
+
+    #[test]
+    fn find_in_path_handles_missing_path() {
+        assert_eq!(find_in_path("docker", None), None);
+    }
+
+    #[test]
+    fn parse_cli_version_docker_and_podman() {
+        assert_eq!(
+            parse_cli_version("Docker version 27.3.1, build ce12230"),
+            Some("27.3.1".to_string())
+        );
+        assert_eq!(
+            parse_cli_version("podman version 5.2.0"),
+            Some("5.2.0".to_string())
+        );
+        assert_eq!(parse_cli_version("garbage output"), None);
+    }
+
+    #[test]
+    fn detect_runtime_is_cached() {
+        let a = detect_runtime().map(|i| i as *const RuntimeInfo);
+        let b = detect_runtime().map(|i| i as *const RuntimeInfo);
+        assert_eq!(a, b);
+    }
+}

--- a/src/container_stats.rs
+++ b/src/container_stats.rs
@@ -1,0 +1,204 @@
+//! Per-container resource stats polling for containerized stdio endpoints.
+//!
+//! Polls `docker|podman stats --no-stream --format {{json .}} <name>` on a
+//! fixed interval and stores the latest parsed sample in a shared slot that
+//! the management API reads synchronously (`GET /api/endpoints` →
+//! `container_stats`). Failures degrade silently: the slot is cleared and
+//! polling continues — container stats never affect endpoint health.
+
+use serde::Serialize;
+use std::process::Stdio;
+use std::sync::{Arc, RwLock};
+use tokio::process::Command;
+use tokio::time::Duration;
+use tracing::debug;
+
+/// Interval between consecutive `stats` invocations.
+pub const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Hard timeout for a single `stats` invocation.
+const POLL_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Latest resource usage sample for a containerized endpoint.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ContainerStats {
+    pub cpu_percent: f64,
+    pub mem_bytes: u64,
+    pub net_rx_bytes: u64,
+    pub net_tx_bytes: u64,
+}
+
+/// Shared slot holding the most recent stats sample. `None` means no sample
+/// is available (direct spawn, poller not started yet, or last poll failed).
+pub type StatsSlot = Arc<RwLock<Option<ContainerStats>>>;
+
+/// Spawn the background poll loop for one container. The returned handle
+/// must be aborted on adapter shutdown; the slot is cleared on every failed
+/// poll so stale samples are never served.
+pub fn spawn_stats_poller(
+    runtime_cli: String,
+    container_name: String,
+    slot: StatsSlot,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            let sample = poll_once(&runtime_cli, &container_name).await;
+            if sample.is_none() {
+                debug!(container = %container_name, "container stats poll failed");
+            }
+            if let Ok(mut guard) = slot.write() {
+                *guard = sample;
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    })
+}
+
+/// Run a single `stats --no-stream` invocation and parse its first output
+/// line. Any failure (spawn error, timeout, non-zero exit, parse error)
+/// returns `None` — stats are strictly best-effort.
+async fn poll_once(runtime_cli: &str, container_name: &str) -> Option<ContainerStats> {
+    let output = tokio::time::timeout(
+        POLL_TIMEOUT,
+        Command::new(runtime_cli)
+            .args([
+                "stats",
+                "--no-stream",
+                "--format",
+                "{{json .}}",
+                container_name,
+            ])
+            .stdin(Stdio::null())
+            .output(),
+    )
+    .await
+    .ok()?
+    .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_stats_line(stdout.lines().next()?)
+}
+
+/// Parse one line of `stats --no-stream --format {{json .}}` output. Docker
+/// and podman emit the same template keys: `CPUPerc` (e.g. `"0.05%"`),
+/// `MemUsage` (e.g. `"7.293MiB / 7.667GiB"`) and `NetIO` (e.g.
+/// `"1.45kB / 648B"`, rx / tx).
+pub fn parse_stats_line(line: &str) -> Option<ContainerStats> {
+    let v: serde_json::Value = serde_json::from_str(line.trim()).ok()?;
+    let cpu_percent = parse_percent(v.get("CPUPerc")?.as_str()?)?;
+    let mem_bytes = parse_size_bytes(v.get("MemUsage")?.as_str()?.split('/').next()?)?;
+    let netio = v.get("NetIO")?.as_str()?;
+    let mut parts = netio.splitn(2, '/');
+    let net_rx_bytes = parse_size_bytes(parts.next()?)?;
+    let net_tx_bytes = parse_size_bytes(parts.next()?)?;
+    Some(ContainerStats {
+        cpu_percent,
+        mem_bytes,
+        net_rx_bytes,
+        net_tx_bytes,
+    })
+}
+
+/// Parse a percentage like `"0.05%"` into its numeric value.
+fn parse_percent(s: &str) -> Option<f64> {
+    s.trim().trim_end_matches('%').trim().parse::<f64>().ok()
+}
+
+/// Parse a human-readable size like `648B`, `1.45kB`, `7.293MiB` or `2GiB`
+/// into bytes. Decimal prefixes (kB/MB/GB/TB) are powers of 1000; binary
+/// prefixes (KiB/MiB/GiB/TiB) are powers of 1024.
+fn parse_size_bytes(s: &str) -> Option<u64> {
+    let s = s.trim();
+    let idx = s
+        .find(|c: char| !(c.is_ascii_digit() || c == '.'))
+        .unwrap_or(s.len());
+    let value: f64 = s[..idx].parse().ok()?;
+    let multiplier: f64 = match s[idx..].trim() {
+        "" | "B" => 1.0,
+        "kB" | "KB" => 1e3,
+        "MB" => 1e6,
+        "GB" => 1e9,
+        "TB" => 1e12,
+        "KiB" => 1024.0,
+        "MiB" => 1024.0 * 1024.0,
+        "GiB" => 1024.0_f64.powi(3),
+        "TiB" => 1024.0_f64.powi(4),
+        _ => return None,
+    };
+    Some((value * multiplier) as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_docker_stats_json_line() {
+        let line = r#"{"BlockIO":"0B / 0B","CPUPerc":"0.05%","Container":"abc","ID":"abc","MemPerc":"0.10%","MemUsage":"7.293MiB / 7.667GiB","Name":"endara-mcp-foo","NetIO":"1.45kB / 648B","PIDs":"5"}"#;
+        let stats = parse_stats_line(line).expect("docker sample should parse");
+        assert_eq!(
+            stats,
+            ContainerStats {
+                cpu_percent: 0.05,
+                mem_bytes: (7.293 * 1024.0 * 1024.0) as u64,
+                net_rx_bytes: 1450,
+                net_tx_bytes: 648,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_podman_compat_keys_and_zero_values() {
+        // Podman emits the same docker-compat template keys; a freshly
+        // started container reports zeroed counters.
+        let line = r#"{"ID":"deadbeef","Name":"endara-mcp-bar","CPUPerc":"0.00%","MemUsage":"0B / 0B","NetIO":"0B / 0B","BlockIO":"0B / 0B","PIDS":"1"}"#;
+        let stats = parse_stats_line(line).expect("podman sample should parse");
+        assert_eq!(stats.cpu_percent, 0.0);
+        assert_eq!(stats.mem_bytes, 0);
+        assert_eq!(stats.net_rx_bytes, 0);
+        assert_eq!(stats.net_tx_bytes, 0);
+    }
+
+    #[test]
+    fn rejects_non_json_and_missing_fields() {
+        assert_eq!(parse_stats_line("not json"), None);
+        assert_eq!(parse_stats_line(""), None);
+        // Missing NetIO.
+        let line = r#"{"CPUPerc":"1.00%","MemUsage":"1MiB / 1GiB"}"#;
+        assert_eq!(parse_stats_line(line), None);
+        // Malformed CPUPerc.
+        let line = r#"{"CPUPerc":"--","MemUsage":"1MiB / 1GiB","NetIO":"0B / 0B"}"#;
+        assert_eq!(parse_stats_line(line), None);
+    }
+
+    #[test]
+    fn parse_size_bytes_handles_decimal_and_binary_units() {
+        assert_eq!(parse_size_bytes("648B"), Some(648));
+        assert_eq!(parse_size_bytes("0B"), Some(0));
+        assert_eq!(parse_size_bytes("1.45kB"), Some(1450));
+        assert_eq!(parse_size_bytes("2MB"), Some(2_000_000));
+        assert_eq!(parse_size_bytes("3GB"), Some(3_000_000_000));
+        assert_eq!(parse_size_bytes("1TB"), Some(1_000_000_000_000));
+        assert_eq!(parse_size_bytes("1KiB"), Some(1024));
+        assert_eq!(parse_size_bytes("1MiB"), Some(1024 * 1024));
+        assert_eq!(parse_size_bytes("2GiB"), Some(2 * 1024 * 1024 * 1024));
+        assert_eq!(parse_size_bytes("1TiB"), Some(1024u64.pow(4)));
+        // Whitespace tolerated (substrings of "X / Y" pairs).
+        assert_eq!(parse_size_bytes(" 648B "), Some(648));
+        // Bare numbers are treated as bytes.
+        assert_eq!(parse_size_bytes("42"), Some(42));
+        // Unknown units rejected.
+        assert_eq!(parse_size_bytes("5XB"), None);
+        assert_eq!(parse_size_bytes("abc"), None);
+    }
+
+    #[test]
+    fn parse_percent_handles_plain_and_suffixed_values() {
+        assert_eq!(parse_percent("0.05%"), Some(0.05));
+        assert_eq!(parse_percent("100%"), Some(100.0));
+        assert_eq!(parse_percent("12.5"), Some(12.5));
+        assert_eq!(parse_percent("n/a"), None);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod adapter;
 pub mod advertise;
 pub mod config;
+pub mod container_runtime;
+pub mod container_stats;
 pub mod events;
 pub mod js_sandbox;
 pub mod jsonrpc;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,8 @@ mod watcher;
 
 mod adapter;
 mod advertise;
+mod container_runtime;
+mod container_stats;
 mod jsonrpc;
 mod prefix;
 mod profile_registry;

--- a/src/management.rs
+++ b/src/management.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Instant;
 use tokio::sync::RwLock;
 
@@ -75,6 +75,27 @@ pub struct StatusResponse {
     pub uptime_seconds: u64,
     pub endpoint_count: usize,
     pub healthy_count: usize,
+    /// Whether a container runtime (docker/podman) was detected on the host.
+    /// `null` while background detection is still in flight; consumers should
+    /// only treat an explicit `false` as "no runtime available".
+    pub container_runtime_available: Option<bool>,
+}
+
+/// Cached result of container runtime detection, warmed off the async
+/// runtime by [`management_routes`] so the first `/api/status` call never
+/// blocks on shell/CLI probing.
+static CONTAINER_RUNTIME_AVAILABLE: OnceLock<bool> = OnceLock::new();
+
+/// Kick off container runtime detection on a background thread (idempotent;
+/// the detector itself caches for the process lifetime).
+fn warm_container_runtime_detection() {
+    if CONTAINER_RUNTIME_AVAILABLE.get().is_some() {
+        return;
+    }
+    std::thread::spawn(|| {
+        let available = crate::container_runtime::detect_runtime().is_some();
+        let _ = CONTAINER_RUNTIME_AVAILABLE.set(available);
+    });
 }
 
 /// Lifecycle state for an adapter, surfaced in the management API.
@@ -128,6 +149,10 @@ pub struct EndpointInfo {
     pub tool_prefix: Option<String>,
     /// Lifecycle state of the adapter.
     pub lifecycle: Lifecycle,
+    /// Latest resource stats sample for containerized stdio endpoints.
+    /// Omitted for direct-spawn endpoints and when no sample is available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub container_stats: Option<crate::container_stats::ContainerStats>,
 }
 
 #[derive(Serialize)]
@@ -230,6 +255,7 @@ async fn get_status(State(state): State<ManagementState>) -> Json<StatusResponse
         uptime_seconds: state.start_time.elapsed().as_secs(),
         endpoint_count: entries.len(),
         healthy_count,
+        container_runtime_available: CONTAINER_RUNTIME_AVAILABLE.get().copied(),
     })
 }
 
@@ -286,6 +312,7 @@ async fn get_endpoints(State(state): State<ManagementState>) -> Json<Vec<Endpoin
             error,
             tool_prefix: entry.tool_prefix.clone(),
             lifecycle,
+            container_stats: entry.adapter.container_stats(),
         });
     }
     endpoints.sort_by(|a, b| a.name.cmp(&b.name));
@@ -2818,6 +2845,17 @@ pub struct EndpointRequest {
     pub token_endpoint: Option<String>,
     #[serde(default)]
     pub server_type_override: Option<String>,
+    /// Isolation mode for stdio endpoints: `"container"` or `"none"`
+    /// (default when omitted is direct spawn).
+    #[serde(default)]
+    pub isolation: Option<String>,
+    /// OCI image override for containerized stdio endpoints.
+    #[serde(default)]
+    pub container_image: Option<String>,
+    /// Host bind mounts (`"/host/path:/container/path"`) for containerized
+    /// stdio endpoints.
+    #[serde(default)]
+    pub mounts: Option<Vec<String>>,
     // Forbidden fields — present so we can return a precise 400 instead of
     // silently dropping the value when a client mistakenly includes them.
     #[serde(default)]
@@ -2859,6 +2897,12 @@ pub struct EndpointSummary {
     pub token_endpoint: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub server_type_override: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub isolation: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub container_image: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mounts: Option<Vec<String>>,
 }
 
 fn endpoint_summary_from(ep: &crate::config::EndpointConfig) -> EndpointSummary {
@@ -2877,6 +2921,9 @@ fn endpoint_summary_from(ep: &crate::config::EndpointConfig) -> EndpointSummary 
         scopes: ep.scopes.clone().unwrap_or_default(),
         token_endpoint: ep.token_endpoint.clone(),
         server_type_override: ep.server_type_override.clone(),
+        isolation: ep.isolation.clone(),
+        container_image: ep.container_image.clone(),
+        mounts: ep.mounts.clone(),
     }
 }
 
@@ -2973,6 +3020,24 @@ fn validate_endpoint_request(
         _ => None,
     };
 
+    // isolation — must be "container" or "none" when present. Empty /
+    // whitespace-only is treated as omitted (= direct spawn for stdio).
+    let isolation = match req.isolation.as_deref().map(str::trim) {
+        Some(s) if !s.is_empty() => {
+            if s != "container" && s != "none" {
+                return Err(bad_request(
+                    "invalid isolation",
+                    format!(
+                        "Endpoint '{}': invalid isolation value '{}' — expected \"container\" or \"none\"",
+                        req.name, s
+                    ),
+                ));
+            }
+            Some(s.to_string())
+        }
+        _ => None,
+    };
+
     // Uniqueness (case-sensitive exact match, matching delete_endpoint and
     // today's desktop add_endpoint Tauri behaviour). For update, skip the
     // entry currently identified by `original_name`.
@@ -3016,6 +3081,9 @@ fn validate_endpoint_request(
         scopes: scopes_vec,
         token_endpoint: req.token_endpoint.clone(),
         server_type_override,
+        isolation,
+        container_image: req.container_image.clone(),
+        mounts: req.mounts.clone(),
     };
 
     Ok(new_ep)
@@ -3095,6 +3163,21 @@ fn endpoint_to_toml_table(
             "server_type_override".into(),
             toml::Value::String(sto.clone()),
         );
+    }
+    if let Some(ref iso) = ep.isolation {
+        t.insert("isolation".into(), toml::Value::String(iso.clone()));
+    }
+    if let Some(ref img) = ep.container_image {
+        t.insert("container_image".into(), toml::Value::String(img.clone()));
+    }
+    if let Some(ref mounts) = ep.mounts {
+        if !mounts.is_empty() {
+            let arr: Vec<toml::Value> = mounts
+                .iter()
+                .map(|m| toml::Value::String(m.clone()))
+                .collect();
+            t.insert("mounts".into(), toml::Value::Array(arr));
+        }
     }
     t
 }
@@ -3400,6 +3483,7 @@ async fn tool_call_events_sse(State(state): State<ManagementState>) -> axum::res
 
 /// Build the management API router with all /api routes.
 pub fn management_routes(state: ManagementState) -> Router {
+    warm_container_runtime_detection();
     Router::new()
         .route("/api/status", get(get_status))
         .route("/api/endpoints", get(get_endpoints).post(create_endpoint))
@@ -3815,6 +3899,9 @@ mod tests {
                 scopes: None,
                 token_endpoint: None,
                 server_type_override: None,
+                isolation: Some("none".to_string()),
+                container_image: None,
+                mounts: None,
             }],
             profiles: None,
         }
@@ -3874,6 +3961,42 @@ mod tests {
         assert_eq!(body["status"], "ok");
         assert_eq!(body["endpoint_count"], 1);
         assert_eq!(body["healthy_count"], 1);
+        // Field is always serialized (null while detection is in flight).
+        assert!(body
+            .as_object()
+            .unwrap()
+            .contains_key("container_runtime_available"));
+    }
+
+    #[tokio::test]
+    async fn management_status_reports_container_runtime() {
+        let state = test_state(vec![]).await;
+        let app = management_routes(state);
+
+        // Detection runs on a background thread warmed by management_routes;
+        // poll until it resolves to a boolean, then check it matches the
+        // process-cached detector result (host-dependent true/false).
+        let mut value = None;
+        for _ in 0..100 {
+            let resp = app
+                .clone()
+                .oneshot(Request::get("/api/status").body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+            let body = body_json(resp).await;
+            if let Some(b) = body["container_runtime_available"].as_bool() {
+                value = Some(b);
+                break;
+            }
+            assert!(body["container_runtime_available"].is_null());
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        let available = value.expect("container_runtime_available never resolved to a boolean");
+        assert_eq!(
+            available,
+            crate::container_runtime::detect_runtime().is_some()
+        );
     }
 
     #[tokio::test]
@@ -5993,6 +6116,9 @@ command = "echo"
                 scopes: None,
                 token_endpoint: None,
                 server_type_override: None,
+                isolation: None,
+                container_image: None,
+                mounts: None,
             }],
             profiles: None,
         };
@@ -6194,6 +6320,9 @@ command = "echo"
                 scopes: None,
                 token_endpoint: token_endpoint.map(|s| s.to_string()),
                 server_type_override: None,
+                isolation: None,
+                container_image: None,
+                mounts: None,
             }],
             profiles: None,
         };
@@ -6608,6 +6737,9 @@ command = "echo"
                 scopes: None,
                 token_endpoint: None,
                 server_type_override: None,
+                isolation: None,
+                container_image: None,
+                mounts: None,
             }],
             profiles: None,
         }
@@ -6788,6 +6920,9 @@ client_id = "client123"
                     scopes: None,
                     token_endpoint: None,
                     server_type_override: None,
+                    isolation: None,
+                    container_image: None,
+                    mounts: None,
                 })
                 .collect(),
             profiles: None,
@@ -7340,6 +7475,9 @@ client_id = "client123"
                 scopes: None,
                 token_endpoint: None,
                 server_type_override: None,
+                isolation: None,
+                container_image: None,
+                mounts: None,
             }],
             profiles: None,
         };
@@ -7634,6 +7772,9 @@ client_id = "client123"
                 scopes: None,
                 token_endpoint: None,
                 server_type_override: None,
+                isolation: None,
+                container_image: None,
+                mounts: None,
             });
             let toml_str = toml::to_string_pretty(&*cfg).unwrap();
             std::fs::write(&config_file, toml_str).unwrap();

--- a/src/management.rs
+++ b/src/management.rs
@@ -153,6 +153,10 @@ pub struct EndpointInfo {
     /// Omitted for direct-spawn endpoints and when no sample is available.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub container_stats: Option<crate::container_stats::ContainerStats>,
+    /// Isolation outcome (configured vs actual) of the last spawn for stdio
+    /// endpoints. Omitted for non-stdio transports and before the first spawn.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub isolation_state: Option<crate::adapter::stdio::IsolationState>,
 }
 
 #[derive(Serialize)]
@@ -313,6 +317,7 @@ async fn get_endpoints(State(state): State<ManagementState>) -> Json<Vec<Endpoin
             tool_prefix: entry.tool_prefix.clone(),
             lifecycle,
             container_stats: entry.adapter.container_stats(),
+            isolation_state: entry.adapter.isolation_state(),
         });
     }
     endpoints.sort_by(|a, b| a.name.cmp(&b.name));

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,7 +1,7 @@
 use crate::adapter::http::{HttpAdapter, HttpConfig};
 use crate::adapter::oauth::{OAuthAdapter, OAuthAdapterConfig};
 use crate::adapter::sse::{SseAdapter, SseConfig};
-use crate::adapter::stdio::{StdioAdapter, StdioConfig};
+use crate::adapter::stdio::{IsolationMode, StdioAdapter, StdioConfig};
 use crate::adapter::{FailedAdapter, McpAdapter, StartingAdapter};
 use crate::config::{self, Config, ConfigDiff, EndpointConfig, Transport};
 use crate::events::ToolCallEventBus;
@@ -720,6 +720,9 @@ pub(crate) async fn create_adapter(
                 env: ep.env.clone().unwrap_or_default(),
                 server_type_override: ep.server_type_override.clone(),
                 endpoint_name: ep.name.clone(),
+                isolation: IsolationMode::from_config_value(ep.isolation.as_deref()),
+                container_image: ep.container_image.clone(),
+                mounts: ep.mounts.clone().unwrap_or_default(),
             };
             let mut adapter = StdioAdapter::new(stdio_config);
             if let Some(bus) = event_bus {
@@ -934,6 +937,9 @@ mod tests {
             scopes: None,
             token_endpoint: None,
             server_type_override: None,
+            isolation: Some("none".to_string()),
+            container_image: None,
+            mounts: None,
         }
     }
 
@@ -1051,6 +1057,9 @@ mod tests {
             scopes: None,
             token_endpoint: None,
             server_type_override: None,
+            isolation: Some("none".to_string()),
+            container_image: None,
+            mounts: None,
         };
         let diff = ConfigDiff {
             changed: vec![("ep".to_string(), changed_ep)],
@@ -1086,6 +1095,9 @@ mod tests {
             scopes: None,
             token_endpoint: None,
             server_type_override: None,
+            isolation: Some("none".to_string()),
+            container_image: None,
+            mounts: None,
         };
         let diff = ConfigDiff {
             added: vec![new_ep],
@@ -1179,6 +1191,9 @@ mod tests {
             scopes: None,
             token_endpoint: None,
             server_type_override: None,
+            isolation: None,
+            container_image: None,
+            mounts: None,
         };
         let diff = ConfigDiff {
             added: vec![new_ep],
@@ -1248,6 +1263,9 @@ mod tests {
             scopes: None,
             token_endpoint: None,
             server_type_override: None,
+            isolation: None,
+            container_image: None,
+            mounts: None,
         };
         let diff = ConfigDiff {
             added: vec![new_ep],
@@ -1446,6 +1464,9 @@ mod tests {
             scopes: None,
             token_endpoint: None,
             server_type_override: None,
+            isolation: None,
+            container_image: None,
+            mounts: None,
         };
         let diff = ConfigDiff {
             added: vec![new_ep],
@@ -1602,6 +1623,9 @@ mod tests {
             scopes: None,
             token_endpoint: None,
             server_type_override: None,
+            isolation: None,
+            container_image: None,
+            mounts: None,
         }
     }
 
@@ -1725,6 +1749,9 @@ mod tests {
             scopes: None,
             token_endpoint: token_endpoint.map(|s| s.to_string()),
             server_type_override: None,
+            isolation: None,
+            container_image: None,
+            mounts: None,
         }
     }
 
@@ -1868,6 +1895,7 @@ machine_name = "test"
 [[endpoints]]
 name = "ep1"
 transport = "stdio"
+isolation = "none"
 command = "/bin/true"
 "#;
 
@@ -1878,6 +1906,7 @@ machine_name = "test"
 [[endpoints]]
 name = "ep1"
 transport = "stdio"
+isolation = "none"
 command = "/bin/true"
 
 [[profiles]]
@@ -1988,6 +2017,7 @@ machine_name = "test"
 [[endpoints]]
 name = "ep1"
 transport = "stdio"
+isolation = "none"
 command = "/bin/true"
 
 [[profiles]]
@@ -2069,11 +2099,13 @@ machine_name = "test"
 [[endpoints]]
 name = "keep"
 transport = "stdio"
+isolation = "none"
 command = "/bin/true"
 
 [[endpoints]]
 name = "remove_me"
 transport = "stdio"
+isolation = "none"
 command = "/bin/true"
 "#;
 
@@ -2085,11 +2117,13 @@ machine_name = "test"
 [[endpoints]]
 name = "keep"
 transport = "stdio"
+isolation = "none"
 command = "/bin/true"
 
 [[endpoints]]
 name = "add_me"
 transport = "stdio"
+isolation = "none"
 command = "/bin/true"
 "#;
 
@@ -2269,6 +2303,7 @@ machine_name = "test"
 [[endpoints]]
 name = "newserver"
 transport = "stdio"
+isolation = "none"
 command = "/bin/true"
 "#;
 

--- a/tests/common/config.rs
+++ b/tests/common/config.rs
@@ -193,6 +193,12 @@ impl ConfigBuilder {
             out.push_str("[[endpoints]]\n");
             out.push_str(&format!("name = \"{}\"\n", ep.name));
             out.push_str(&format!("transport = \"{}\"\n", ep.transport));
+            // Integration tests spawn fixture binaries/scripts directly on
+            // the host. Omitted `isolation` already means direct spawn; keep
+            // the explicit "none" so the harness is unambiguous.
+            if ep.transport == "stdio" {
+                out.push_str("isolation = \"none\"\n");
+            }
             if let Some(ref cmd) = ep.command {
                 out.push_str(&format!("command = \"{}\"\n", cmd));
             }

--- a/tests/crash_recovery_integration.rs
+++ b/tests/crash_recovery_integration.rs
@@ -26,6 +26,7 @@ async fn test_crash_server_successful_calls_then_failure() {
         env: HashMap::new(),
         server_type_override: None,
         endpoint_name: "crash-test-5".into(),
+        ..Default::default()
     };
 
     let mut adapter = StdioAdapter::new(config);
@@ -93,6 +94,7 @@ async fn test_crash_server_immediate_crash() {
         env: HashMap::new(),
         server_type_override: None,
         endpoint_name: "crash-test-2".into(),
+        ..Default::default()
     };
 
     let mut adapter = StdioAdapter::new(config);

--- a/tests/hot_reload_integration.rs
+++ b/tests/hot_reload_integration.rs
@@ -36,6 +36,7 @@ async fn test_config_diff_add_endpoint() {
         env: HashMap::new(),
         server_type_override: None,
         endpoint_name: "echo-ep".into(),
+        ..Default::default()
     };
     let mut echo_adapter = StdioAdapter::new(echo_config);
     echo_adapter.initialize().await.expect("echo init failed");
@@ -81,6 +82,9 @@ async fn test_config_diff_add_endpoint() {
             scopes: None,
             token_endpoint: None,
             server_type_override: None,
+            isolation: Some("none".to_string()),
+            container_image: None,
+            mounts: None,
         }],
         profiles: None,
     };
@@ -113,6 +117,9 @@ async fn test_config_diff_add_endpoint() {
                 scopes: None,
                 token_endpoint: None,
                 server_type_override: None,
+                isolation: Some("none".to_string()),
+                container_image: None,
+                mounts: None,
             },
             config::EndpointConfig {
                 name: "multi-ep".to_string(),
@@ -132,6 +139,9 @@ async fn test_config_diff_add_endpoint() {
                 scopes: None,
                 token_endpoint: None,
                 server_type_override: None,
+                isolation: Some("none".to_string()),
+                container_image: None,
+                mounts: None,
             },
         ],
         profiles: None,
@@ -180,6 +190,7 @@ async fn test_config_diff_remove_endpoint() {
         env: HashMap::new(),
         server_type_override: None,
         endpoint_name: "echo-ep".into(),
+        ..Default::default()
     };
     let mut echo_adapter = StdioAdapter::new(echo_config);
     echo_adapter.initialize().await.expect("echo init failed");
@@ -199,6 +210,7 @@ async fn test_config_diff_remove_endpoint() {
         env: HashMap::new(),
         server_type_override: None,
         endpoint_name: "multi-ep".into(),
+        ..Default::default()
     };
     let mut multi_adapter = StdioAdapter::new(multi_config);
     multi_adapter.initialize().await.expect("multi init failed");
@@ -244,6 +256,9 @@ async fn test_config_diff_remove_endpoint() {
                 scopes: None,
                 token_endpoint: None,
                 server_type_override: None,
+                isolation: Some("none".to_string()),
+                container_image: None,
+                mounts: None,
             },
             config::EndpointConfig {
                 name: "multi-ep".to_string(),
@@ -263,6 +278,9 @@ async fn test_config_diff_remove_endpoint() {
                 scopes: None,
                 token_endpoint: None,
                 server_type_override: None,
+                isolation: Some("none".to_string()),
+                container_image: None,
+                mounts: None,
             },
         ],
         profiles: None,
@@ -295,6 +313,9 @@ async fn test_config_diff_remove_endpoint() {
             scopes: None,
             token_endpoint: None,
             server_type_override: None,
+            isolation: Some("none".to_string()),
+            container_image: None,
+            mounts: None,
         }],
         profiles: None,
     };

--- a/tests/js_execution_integration.rs
+++ b/tests/js_execution_integration.rs
@@ -33,6 +33,7 @@ async fn setup_js_server(js_mode: bool) -> (SocketAddr, tokio::task::JoinHandle<
         env: HashMap::new(),
         server_type_override: None,
         endpoint_name: "js-test".into(),
+        ..Default::default()
     };
     let mut adapter = StdioAdapter::new(config);
     adapter.initialize().await.expect("adapter init failed");

--- a/tests/management_api_integration.rs
+++ b/tests/management_api_integration.rs
@@ -105,6 +105,9 @@ fn test_config() -> Config {
             scopes: None,
             token_endpoint: None,
             server_type_override: None,
+            isolation: Some("none".to_string()),
+            container_image: None,
+            mounts: None,
         }],
         profiles: None,
     }
@@ -354,6 +357,7 @@ machine_name = "test-machine"
 [[endpoints]]
 name = "echo-ep"
 transport = "stdio"
+isolation = "none"
 command = "echo"
 args = ["hello"]
 "#;
@@ -373,12 +377,14 @@ machine_name = "test-machine"
 [[endpoints]]
 name = "echo-ep"
 transport = "stdio"
+isolation = "none"
 command = "echo"
 args = ["hello"]
 
 [[endpoints]]
 name = "new-ep"
 transport = "stdio"
+isolation = "none"
 command = "cat"
 "#;
     std::fs::write(&config_file, updated_toml).unwrap();
@@ -428,12 +434,14 @@ machine_name = "test-machine"
 [[endpoints]]
 name = "echo-ep"
 transport = "stdio"
+isolation = "none"
 command = "echo"
 args = ["hello"]
 
 [[endpoints]]
 name = "other-ep"
 transport = "stdio"
+isolation = "none"
 command = "cat"
 "#;
     std::fs::write(&config_file, toml_content).unwrap();

--- a/tests/mcp_server_integration.rs
+++ b/tests/mcp_server_integration.rs
@@ -30,6 +30,7 @@ async fn setup_server() -> (SocketAddr, AdapterRegistry, tokio::task::JoinHandle
         env: HashMap::new(),
         server_type_override: None,
         endpoint_name: "mcp-server-test".into(),
+        ..Default::default()
     };
     let mut adapter = StdioAdapter::new(config);
     adapter.initialize().await.expect("adapter init failed");

--- a/tests/multi_endpoint_integration.rs
+++ b/tests/multi_endpoint_integration.rs
@@ -40,6 +40,7 @@ async fn setup_multi_endpoint_server() -> (SocketAddr, AdapterRegistry, tokio::t
         env: HashMap::new(),
         server_type_override: None,
         endpoint_name: "echo-ep".into(),
+        ..Default::default()
     };
     let mut echo_adapter = StdioAdapter::new(echo_config);
     echo_adapter
@@ -63,6 +64,7 @@ async fn setup_multi_endpoint_server() -> (SocketAddr, AdapterRegistry, tokio::t
         env: HashMap::new(),
         server_type_override: None,
         endpoint_name: "multi-ep".into(),
+        ..Default::default()
     };
     let mut multi_adapter = StdioAdapter::new(multi_config);
     multi_adapter
@@ -212,6 +214,7 @@ async fn test_multi_endpoint_overlapping_tool_names() {
             env: HashMap::new(),
             server_type_override: None,
             endpoint_name: (*ep_name).into(),
+            ..Default::default()
         };
         let mut adapter = endara_relay::adapter::stdio::StdioAdapter::new(config);
         adapter

--- a/tests/oauth_setup_integration.rs
+++ b/tests/oauth_setup_integration.rs
@@ -46,6 +46,9 @@ fn empty_config() -> Config {
             scopes: None,
             token_endpoint: None,
             server_type_override: None,
+            isolation: None,
+            container_image: None,
+            mounts: None,
         }],
         profiles: None,
     }

--- a/tests/server_info_name.rs
+++ b/tests/server_info_name.rs
@@ -182,6 +182,7 @@ async fn test_endpoints_api_server_name_raw_independent_of_override() {
          [[endpoints]]\n\
          name = \"good-server\"\n\
          transport = \"stdio\"\n\
+         isolation = \"none\"\n\
          command = \"{}\"\n\
          server_type_override = \"custom-name\"\n",
         bin

--- a/tests/stdio_integration.rs
+++ b/tests/stdio_integration.rs
@@ -19,6 +19,7 @@ async fn test_stdio_full_lifecycle() {
         env: HashMap::new(),
         server_type_override: None,
         endpoint_name: "stdio-test".into(),
+        ..Default::default()
     };
 
     let mut adapter = StdioAdapter::new(config);
@@ -62,6 +63,7 @@ async fn test_stdio_spawn_nonexistent_command() {
         env: HashMap::new(),
         server_type_override: None,
         endpoint_name: "stdio-nonexistent".into(),
+        ..Default::default()
     };
 
     let mut adapter = StdioAdapter::new(config);


### PR DESCRIPTION
# Containerized stdio MCP servers

Runs stdio MCP servers inside an isolated, monitorable container (Docker/Podman) so `npx`/`uvx` servers work even when the host lacks Node or uv, while keeping per-tool-call latency indistinguishable from direct spawning (the docker CLI proxies stdio through the same `Child` pipe plumbing).

## What's included

- **`src/container_runtime.rs`** — runtime detection: probes for a usable Docker/Podman socket or CLI (Docker Desktop, Podman, OrbStack, Rancher Desktop, Colima). Result is background-warmed and cached.
- **Isolation config + containerized spawn path** — new `isolation`, `container_image`, and `mounts` fields on stdio endpoints. With `isolation = "container"`, the endpoint's `command`/`args` run inside `ghcr.io/endara-ai/mcp-runner` via `docker run -i --rm --name endara-mcp-<endpoint>`. Changes to these fields trigger adapter restart through the existing config diff.
- **Stats + status API** — background polling of CPU / memory / network I/O for containerized endpoints, exposed as `container_stats` on the endpoint API; `container_runtime_available` (background-warmed `Option<bool>`) added to `GET /api/status` for the desktop's runtime-missing notice.
- **`docker/mcp-runner` + publish workflow** — slim Debian base with Node LTS (`npx`) and uv (`uvx`), runs as non-root; workflow publishes the multi-arch (amd64/arm64) image to GHCR.

## Defaults and fallback behavior

- **Omitted `isolation` means direct spawn** — pre-existing configs are untouched on upgrade. The desktop writes an explicit `isolation = "container"` (or `"none"`) when creating new stdio endpoints, so only new endpoints containerize by default.
- **Graceful fallback** — if no container runtime is detected, containerized endpoints fall back to direct spawn instead of hard-failing; the desktop surfaces a one-time "install Docker/Podman for isolation" notice via `container_runtime_available`.
- Default network is bridge (isolated, outbound allowed); no host filesystem is mounted unless `mounts` is set explicitly.

## ⚠️ Release sequencing

`ghcr.io/endara-ai/mcp-runner:latest` does **not exist yet** — it is published by the workflow added in this PR. Do **not** cut a release tag until the image is on GHCR, since containerized endpoints reference `mcp-runner:latest` by default.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — all suites green
