### PR TITLE
fix(stdio): capture and surface child stderr in endpoint logs and crash error

### DIFF
--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -24,10 +24,12 @@ use tracing::{debug, error, info, warn, Instrument};
 /// does not specify a `container_image`.
 pub const DEFAULT_CONTAINER_IMAGE: &str = "ghcr.io/endara-ai/mcp-runner:latest";
 
-/// Number of recent child stderr lines appended to a crash error message so
-/// the UI surfaces the server's actual failure reason (e.g. a missing config
-/// file) instead of only "stdout channel closed".
-const CRASH_STDERR_TAIL_LINES: usize = 5;
+/// Short, user-facing message recorded on an [`AdapterError::ProcessCrashed`]
+/// when a stdio child fails to start or exits unexpectedly. The child's actual
+/// failure output is surfaced as individual `[stderr]` rows in the endpoint's
+/// Logs tab (see the stderr reader and [`StdioAdapter::stderr_lines`]), so the
+/// crash banner stays a single readable sentence instead of a stderr dump.
+const CRASH_USER_MESSAGE: &str = "Server failed to start. See Logs tab for details.";
 
 /// Process isolation mode for a stdio endpoint.
 ///
@@ -591,16 +593,27 @@ impl StdioAdapter {
             }
         });
 
-        // Set up stderr ring buffer reader
+        // Set up the stderr reader. Each line is BOTH pushed into the ring
+        // buffer (the Logs-tab historical seed served by `stderr_lines`) AND
+        // emitted as a WARN tracing event inside the endpoint span, so it
+        // streams live into the desktop Logs tab as its own `[stderr]` row,
+        // interleaved with the relay's own tracing lines right where the user
+        // looks for the failure reason. Instrumenting with the endpoint span is
+        // what tags the line with `endpoint=NAME` so it survives the
+        // StdioAdapter → FailedAdapter swap on an init crash.
         let stderr_buf = self.stderr_buffer.clone();
-        let stderr_handle = tokio::spawn(async move {
-            let reader = BufReader::new(stderr);
-            let mut lines = reader.lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                debug!(stderr_line = %line, "MCP server stderr");
-                stderr_buf.write().await.push(line);
+        let stderr_span = self.span.clone();
+        let stderr_handle = tokio::spawn(
+            async move {
+                let reader = BufReader::new(stderr);
+                let mut lines = reader.lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    warn!("[stderr] {}", line);
+                    stderr_buf.write().await.push(line);
+                }
             }
-        });
+            .instrument(stderr_span),
+        );
 
         *self.child.lock().await = Some(child);
         *self.stdin_writer.lock().await = Some(stdin);
@@ -612,37 +625,25 @@ impl StdioAdapter {
     }
 
     /// Wait briefly for the stderr reader task to drain to EOF (the child has
-    /// exited, so its stderr pipe is closed and the reader will finish), then
-    /// return the last [`CRASH_STDERR_TAIL_LINES`] captured stderr lines.
+    /// exited, so its stderr pipe is closed and the reader will finish).
     ///
-    /// Awaiting the reader closes the race where the child exits and the
-    /// stdout side reports the crash before the final stderr lines — which
-    /// usually carry the real failure reason — have been pushed into the
-    /// buffer. The wait is bounded so a still-open stderr pipe can't stall the
-    /// caller on a non-fatal write error.
-    async fn crash_stderr_tail(&self) -> Vec<String> {
+    /// Awaiting the reader closes the race where the child exits and the stdout
+    /// side reports the crash before the final stderr lines — which usually
+    /// carry the real failure reason — have been emitted into the Logs tab and
+    /// pushed into the ring buffer. The wait is bounded so a still-open stderr
+    /// pipe can't stall the caller on a non-fatal write error.
+    async fn await_stderr_flush(&self) {
         if let Some(handle) = self._stderr_handle.lock().await.take() {
             let _ = tokio::time::timeout(Duration::from_millis(500), handle).await;
         }
-        let buf = self.stderr_buffer.read().await;
-        let lines = buf.lines();
-        let start = lines.len().saturating_sub(CRASH_STDERR_TAIL_LINES);
-        lines[start..].iter().map(|s| s.to_string()).collect()
     }
 
-    /// Build an [`AdapterError::ProcessCrashed`] message, appending the child's
-    /// recent stderr (the actual failure reason) when any was captured. Falls
-    /// back to `base` alone when no stderr is available.
-    fn crashed_error(base: &str, stderr_tail: &[String]) -> AdapterError {
-        if stderr_tail.is_empty() {
-            AdapterError::ProcessCrashed(base.to_string())
-        } else {
-            AdapterError::ProcessCrashed(format!(
-                "{}\nrecent stderr:\n{}",
-                base,
-                stderr_tail.join("\n")
-            ))
-        }
+    /// Build an [`AdapterError::ProcessCrashed`] carrying the short, user-facing
+    /// [`CRASH_USER_MESSAGE`]. The child's actual stderr is surfaced as
+    /// individual `[stderr]` rows in the endpoint's Logs tab, so the crash
+    /// banner stays one readable sentence instead of a multi-line stderr dump.
+    fn crashed_error() -> AdapterError {
+        AdapterError::ProcessCrashed(CRASH_USER_MESSAGE.to_string())
     }
 
     /// Send a JSON-RPC request and wait for the response.
@@ -676,19 +677,15 @@ impl StdioAdapter {
             })?;
             if let Err(e) = writer.write_all(line.as_bytes()).await {
                 self.pending_requests.lock().await.remove(&id);
-                let tail = self.crash_stderr_tail().await;
-                return Err(Self::crashed_error(
-                    &format!("stdin write failed: {}", e),
-                    &tail,
-                ));
+                debug!(error = %e, "stdin write failed");
+                self.await_stderr_flush().await;
+                return Err(Self::crashed_error());
             }
             if let Err(e) = writer.flush().await {
                 self.pending_requests.lock().await.remove(&id);
-                let tail = self.crash_stderr_tail().await;
-                return Err(Self::crashed_error(
-                    &format!("stdin flush failed: {}", e),
-                    &tail,
-                ));
+                debug!(error = %e, "stdin flush failed");
+                self.await_stderr_flush().await;
+                return Err(Self::crashed_error());
             }
         }
 
@@ -697,10 +694,13 @@ impl StdioAdapter {
             Ok(Ok(line)) => line,
             Ok(Err(_)) => {
                 // Sender was dropped (stdout reader shut down) — the child has
-                // exited, so surface its recent stderr as the likely cause.
+                // exited. Its recent stderr (the likely cause) flows into the
+                // endpoint's Logs tab; wait for that to drain, then surface the
+                // short crash banner.
                 self.pending_requests.lock().await.remove(&id);
-                let tail = self.crash_stderr_tail().await;
-                return Err(Self::crashed_error("stdout channel closed", &tail));
+                debug!("stdout channel closed");
+                self.await_stderr_flush().await;
+                return Err(Self::crashed_error());
             }
             Err(_) => {
                 // Timeout — clean up the pending entry
@@ -743,18 +743,14 @@ impl StdioAdapter {
         let mut writer_guard = self.stdin_writer.lock().await;
         let writer = writer_guard.as_mut().ok_or(AdapterError::NotInitialized)?;
         if let Err(e) = writer.write_all(line.as_bytes()).await {
-            let tail = self.crash_stderr_tail().await;
-            return Err(Self::crashed_error(
-                &format!("stdin write failed: {}", e),
-                &tail,
-            ));
+            debug!(error = %e, "stdin write failed");
+            self.await_stderr_flush().await;
+            return Err(Self::crashed_error());
         }
         if let Err(e) = writer.flush().await {
-            let tail = self.crash_stderr_tail().await;
-            return Err(Self::crashed_error(
-                &format!("stdin flush failed: {}", e),
-                &tail,
-            ));
+            debug!(error = %e, "stdin flush failed");
+            self.await_stderr_flush().await;
+            return Err(Self::crashed_error());
         }
         Ok(())
     }
@@ -1712,10 +1708,11 @@ for line in sys.stdin:
     }
 
     #[tokio::test]
-    async fn test_stdio_crash_error_includes_stderr_tail() {
+    async fn test_stdio_crash_error_is_short_user_message() {
         // A child that prints a diagnostic to stderr and exits without ever
-        // responding on stdout. The crash error must surface that stderr line
-        // (the real root cause) instead of just "stdout channel closed".
+        // responding on stdout. The crash error must now be the SHORT
+        // user-facing banner — the stderr root cause is surfaced as its own
+        // `[stderr]` rows in the Logs tab, NOT embedded in the error.
         let mut adapter = StdioAdapter::new(StdioConfig {
             command: "sh".to_string(),
             args: vec![
@@ -1728,29 +1725,38 @@ for line in sys.stdin:
         adapter.spawn_process().await.unwrap();
 
         // Either the stdin write fails (child already gone) or the response
-        // channel closes — both paths now enrich the error with stderr.
+        // channel closes — both paths now return the short crash banner.
         let result = adapter.send_request("initialize", None).await;
         match result {
             Err(AdapterError::ProcessCrashed(msg)) => {
-                assert!(
-                    msg.contains("OAuth keys file not found"),
-                    "crash error should include child stderr, got: {msg}"
+                assert_eq!(
+                    msg, CRASH_USER_MESSAGE,
+                    "crash error should be the short user-facing banner, got: {msg}"
                 );
                 assert!(
-                    msg.contains("recent stderr:"),
-                    "crash error should label the stderr tail, got: {msg}"
+                    !msg.contains("recent stderr:") && !msg.contains("OAuth keys file not found"),
+                    "crash error must not embed child stderr, got: {msg}"
                 );
             }
-            other => panic!("expected ProcessCrashed with stderr, got: {other:?}"),
+            other => panic!("expected ProcessCrashed, got: {other:?}"),
         }
+
+        // The stderr root cause is still captured for the Logs tab buffer.
+        let lines = adapter.stderr_lines().await;
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("OAuth keys file not found")),
+            "child stderr should still be captured for the Logs tab, got: {lines:?}"
+        );
 
         adapter.shutdown().await.unwrap();
     }
 
     #[tokio::test]
-    async fn test_stdio_crash_error_falls_back_without_stderr() {
-        // A child that exits abnormally but writes nothing to stderr must keep
-        // the bare crash message (no dangling "recent stderr:" section).
+    async fn test_stdio_crash_error_short_message_without_stderr() {
+        // A child that exits abnormally but writes nothing to stderr must still
+        // yield the same short crash banner (no embedded stderr section).
         let mut adapter = StdioAdapter::new(StdioConfig {
             command: "sh".to_string(),
             args: vec!["-c".to_string(), "exit 1".to_string()],
@@ -1762,9 +1768,9 @@ for line in sys.stdin:
         let result = adapter.send_request("initialize", None).await;
         match result {
             Err(AdapterError::ProcessCrashed(msg)) => {
-                assert!(
-                    !msg.contains("recent stderr:"),
-                    "no captured stderr should fall back to the bare message, got: {msg}"
+                assert_eq!(
+                    msg, CRASH_USER_MESSAGE,
+                    "crash error should be the short user-facing banner, got: {msg}"
                 );
             }
             other => panic!("expected ProcessCrashed, got: {other:?}"),

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -24,6 +24,11 @@ use tracing::{debug, error, info, warn, Instrument};
 /// does not specify a `container_image`.
 pub const DEFAULT_CONTAINER_IMAGE: &str = "ghcr.io/endara-ai/mcp-runner:latest";
 
+/// Number of recent child stderr lines appended to a crash error message so
+/// the UI surfaces the server's actual failure reason (e.g. a missing config
+/// file) instead of only "stdout channel closed".
+const CRASH_STDERR_TAIL_LINES: usize = 5;
+
 /// Process isolation mode for a stdio endpoint.
 ///
 /// `Container` spawns the server through a detected container runtime
@@ -606,6 +611,40 @@ impl StdioAdapter {
         Ok(())
     }
 
+    /// Wait briefly for the stderr reader task to drain to EOF (the child has
+    /// exited, so its stderr pipe is closed and the reader will finish), then
+    /// return the last [`CRASH_STDERR_TAIL_LINES`] captured stderr lines.
+    ///
+    /// Awaiting the reader closes the race where the child exits and the
+    /// stdout side reports the crash before the final stderr lines — which
+    /// usually carry the real failure reason — have been pushed into the
+    /// buffer. The wait is bounded so a still-open stderr pipe can't stall the
+    /// caller on a non-fatal write error.
+    async fn crash_stderr_tail(&self) -> Vec<String> {
+        if let Some(handle) = self._stderr_handle.lock().await.take() {
+            let _ = tokio::time::timeout(Duration::from_millis(500), handle).await;
+        }
+        let buf = self.stderr_buffer.read().await;
+        let lines = buf.lines();
+        let start = lines.len().saturating_sub(CRASH_STDERR_TAIL_LINES);
+        lines[start..].iter().map(|s| s.to_string()).collect()
+    }
+
+    /// Build an [`AdapterError::ProcessCrashed`] message, appending the child's
+    /// recent stderr (the actual failure reason) when any was captured. Falls
+    /// back to `base` alone when no stderr is available.
+    fn crashed_error(base: &str, stderr_tail: &[String]) -> AdapterError {
+        if stderr_tail.is_empty() {
+            AdapterError::ProcessCrashed(base.to_string())
+        } else {
+            AdapterError::ProcessCrashed(format!(
+                "{}\nrecent stderr:\n{}",
+                base,
+                stderr_tail.join("\n")
+            ))
+        }
+    }
+
     /// Send a JSON-RPC request and wait for the response.
     async fn send_request(
         &self,
@@ -637,17 +676,19 @@ impl StdioAdapter {
             })?;
             if let Err(e) = writer.write_all(line.as_bytes()).await {
                 self.pending_requests.lock().await.remove(&id);
-                return Err(AdapterError::ProcessCrashed(format!(
-                    "stdin write failed: {}",
-                    e
-                )));
+                let tail = self.crash_stderr_tail().await;
+                return Err(Self::crashed_error(
+                    &format!("stdin write failed: {}", e),
+                    &tail,
+                ));
             }
             if let Err(e) = writer.flush().await {
                 self.pending_requests.lock().await.remove(&id);
-                return Err(AdapterError::ProcessCrashed(format!(
-                    "stdin flush failed: {}",
-                    e
-                )));
+                let tail = self.crash_stderr_tail().await;
+                return Err(Self::crashed_error(
+                    &format!("stdin flush failed: {}", e),
+                    &tail,
+                ));
             }
         }
 
@@ -655,9 +696,11 @@ impl StdioAdapter {
         let response_line = match tokio::time::timeout(Duration::from_secs(30), rx).await {
             Ok(Ok(line)) => line,
             Ok(Err(_)) => {
-                // Sender was dropped (stdout reader shut down)
+                // Sender was dropped (stdout reader shut down) — the child has
+                // exited, so surface its recent stderr as the likely cause.
                 self.pending_requests.lock().await.remove(&id);
-                return Err(AdapterError::ProcessCrashed("stdout channel closed".into()));
+                let tail = self.crash_stderr_tail().await;
+                return Err(Self::crashed_error("stdout channel closed", &tail));
             }
             Err(_) => {
                 // Timeout — clean up the pending entry
@@ -700,16 +743,18 @@ impl StdioAdapter {
         let mut writer_guard = self.stdin_writer.lock().await;
         let writer = writer_guard.as_mut().ok_or(AdapterError::NotInitialized)?;
         if let Err(e) = writer.write_all(line.as_bytes()).await {
-            return Err(AdapterError::ProcessCrashed(format!(
-                "stdin write failed: {}",
-                e
-            )));
+            let tail = self.crash_stderr_tail().await;
+            return Err(Self::crashed_error(
+                &format!("stdin write failed: {}", e),
+                &tail,
+            ));
         }
         if let Err(e) = writer.flush().await {
-            return Err(AdapterError::ProcessCrashed(format!(
-                "stdin flush failed: {}",
-                e
-            )));
+            let tail = self.crash_stderr_tail().await;
+            return Err(Self::crashed_error(
+                &format!("stdin flush failed: {}", e),
+                &tail,
+            ));
         }
         Ok(())
     }
@@ -970,12 +1015,15 @@ impl McpAdapter for StdioAdapter {
     }
 
     async fn stderr_lines(&self) -> Vec<String> {
+        // Tag each line with a WARN level and a `[stderr]` marker so the
+        // desktop log parser renders captured child stderr as a distinct pill,
+        // set apart from the relay's own tracing lines in the Logs tab.
         self.stderr_buffer
             .read()
             .await
             .lines()
             .iter()
-            .map(|s| s.to_string())
+            .map(|s| format!("WARN [stderr] {}", s))
             .collect()
     }
 
@@ -1659,6 +1707,95 @@ for line in sys.stdin:
             Err(_) => {}                            // our 2s timeout
             other => panic!("unexpected result: {:?}", other),
         }
+
+        adapter.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_stdio_crash_error_includes_stderr_tail() {
+        // A child that prints a diagnostic to stderr and exits without ever
+        // responding on stdout. The crash error must surface that stderr line
+        // (the real root cause) instead of just "stdout channel closed".
+        let mut adapter = StdioAdapter::new(StdioConfig {
+            command: "sh".to_string(),
+            args: vec![
+                "-c".to_string(),
+                "echo 'Error: OAuth keys file not found' >&2; exit 1".to_string(),
+            ],
+            env: HashMap::new(),
+            ..Default::default()
+        });
+        adapter.spawn_process().await.unwrap();
+
+        // Either the stdin write fails (child already gone) or the response
+        // channel closes — both paths now enrich the error with stderr.
+        let result = adapter.send_request("initialize", None).await;
+        match result {
+            Err(AdapterError::ProcessCrashed(msg)) => {
+                assert!(
+                    msg.contains("OAuth keys file not found"),
+                    "crash error should include child stderr, got: {msg}"
+                );
+                assert!(
+                    msg.contains("recent stderr:"),
+                    "crash error should label the stderr tail, got: {msg}"
+                );
+            }
+            other => panic!("expected ProcessCrashed with stderr, got: {other:?}"),
+        }
+
+        adapter.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_stdio_crash_error_falls_back_without_stderr() {
+        // A child that exits abnormally but writes nothing to stderr must keep
+        // the bare crash message (no dangling "recent stderr:" section).
+        let mut adapter = StdioAdapter::new(StdioConfig {
+            command: "sh".to_string(),
+            args: vec!["-c".to_string(), "exit 1".to_string()],
+            env: HashMap::new(),
+            ..Default::default()
+        });
+        adapter.spawn_process().await.unwrap();
+
+        let result = adapter.send_request("initialize", None).await;
+        match result {
+            Err(AdapterError::ProcessCrashed(msg)) => {
+                assert!(
+                    !msg.contains("recent stderr:"),
+                    "no captured stderr should fall back to the bare message, got: {msg}"
+                );
+            }
+            other => panic!("expected ProcessCrashed, got: {other:?}"),
+        }
+
+        adapter.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_stdio_stderr_lines_tagged_for_logs() {
+        // Captured stderr surfaced to the Logs tab must be tagged distinctly so
+        // the desktop parser renders it apart from the relay's own logs.
+        let mut adapter = StdioAdapter::new(StdioConfig {
+            command: "sh".to_string(),
+            args: vec![
+                "-c".to_string(),
+                "echo 'hello from stderr' >&2; sleep 0.2".to_string(),
+            ],
+            env: HashMap::new(),
+            ..Default::default()
+        });
+        adapter.spawn_process().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        let lines = adapter.stderr_lines().await;
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.starts_with("WARN [stderr] ") && l.contains("hello from stderr")),
+            "stderr lines should be tagged for the UI, got: {lines:?}"
+        );
 
         adapter.shutdown().await.unwrap();
     }


### PR DESCRIPTION
## Problem

When a stdio MCP server (direct **or** containerized) exits, its stderr —
which usually carries the actual failure reason (e.g. `Error: OAuth keys file
not found...`) — was effectively lost from the user's perspective:

- The crash surfaced to the UI as just `process crashed: stdout channel
  closed`, with no hint at the root cause.
- Captured stderr was rendered in the endpoint Logs tab indistinguishably from
  the relay's own tracing lines (no level/tag).
- A race meant the final, most relevant stderr lines could be missed: the
  stdout reader reports the crash the instant the pipe closes, before the
  stderr reader task has drained the child's last lines into the buffer.

## Changes (`src/adapter/stdio.rs` only)

- **Tag stderr for the Logs tab.** `stderr_lines()` now prefixes each captured
  line with `WARN [stderr] ` so the desktop log parser renders it as a distinct
  WARN pill, set apart from relay logs.
- **Enrich crash errors.** New `crash_stderr_tail()` awaits the stderr reader to
  EOF (bounded to 500ms so a still-open pipe can't stall the caller) before
  reading the buffer — closing the flush race — then returns the last
  `CRASH_STDERR_TAIL_LINES` (5) lines. All `send_request` / `send_notification`
  `ProcessCrashed` paths now append this tail via `crashed_error()`, falling
  back to the bare message when no stderr was captured.

## Tests

- `test_stdio_crash_error_includes_stderr_tail` — child writes to stderr then
  exits; crash error contains the stderr line and a `recent stderr:` section.
- `test_stdio_crash_error_falls_back_without_stderr` — abnormal exit with no
  stderr keeps the bare message.
- `test_stdio_stderr_lines_tagged_for_logs` — `stderr_lines()` output is tagged
  `WARN [stderr] `.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and the full
`cargo test` suite all pass.

## Verification

Configure a containerized stdio endpoint that fails (e.g. the Gmail server in
the task repro). The Logs tab now shows the stderr line, and the red
Initialization Error banner includes the OAuth-keys message instead of only
`stdout channel closed`.
