### PR TITLE
fix(watcher): rename async init spans to endpoint_init

### DIFF
--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -293,7 +293,7 @@ pub async fn apply_diff(
         let tm = token_manager.clone();
         let oai = oauth_adapter_inners.clone();
         let bus = event_bus.cloned();
-        let init_span = tracing::info_span!("endpoint", endpoint = %name_clone);
+        let init_span = tracing::info_span!("endpoint_init", endpoint = %name_clone);
         tokio::spawn(
             async move {
                 let adapter =
@@ -308,7 +308,7 @@ pub async fn apply_diff(
                 drop(entries);
                 reg.rewire_tools_changed_listener(&name_clone).await;
                 reg.invalidate_endpoint_tool_cache(&name_clone).await;
-                info!("Changed endpoint initialized");
+                info!(endpoint = %name_clone, "Changed endpoint initialized");
             }
             .instrument(init_span),
         );
@@ -344,7 +344,7 @@ pub async fn apply_diff(
         let tm = token_manager.clone();
         let oai = oauth_adapter_inners.clone();
         let bus = event_bus.cloned();
-        let init_span = tracing::info_span!("endpoint", endpoint = %ep_clone.name);
+        let init_span = tracing::info_span!("endpoint_init", endpoint = %ep_clone.name);
         tokio::spawn(
             async move {
                 let adapter =
@@ -359,7 +359,7 @@ pub async fn apply_diff(
                 drop(entries);
                 reg.rewire_tools_changed_listener(&ep_clone.name).await;
                 reg.invalidate_endpoint_tool_cache(&ep_clone.name).await;
-                info!("New endpoint initialized");
+                info!(endpoint = %ep_clone.name, "New endpoint initialized");
             }
             .instrument(init_span),
         );
@@ -486,7 +486,7 @@ pub async fn apply_diff_graceful(
         let tm = token_manager.clone();
         let oai = oauth_adapter_inners.clone();
         let bus = event_bus.cloned();
-        let init_span = tracing::info_span!("endpoint", endpoint = %name_clone);
+        let init_span = tracing::info_span!("endpoint_init", endpoint = %name_clone);
         tokio::spawn(
             async move {
                 let adapter =
@@ -501,7 +501,7 @@ pub async fn apply_diff_graceful(
                 drop(entries);
                 reg.rewire_tools_changed_listener(&name_clone).await;
                 reg.invalidate_endpoint_tool_cache(&name_clone).await;
-                info!("Changed endpoint initialized");
+                info!(endpoint = %name_clone, "Changed endpoint initialized");
             }
             .instrument(init_span),
         );
@@ -564,7 +564,7 @@ pub async fn apply_diff_graceful(
         let tm = token_manager.clone();
         let oai = oauth_adapter_inners.clone();
         let bus = event_bus.cloned();
-        let init_span = tracing::info_span!("endpoint", endpoint = %ep_clone.name);
+        let init_span = tracing::info_span!("endpoint_init", endpoint = %ep_clone.name);
         tokio::spawn(
             async move {
                 let adapter =
@@ -579,7 +579,7 @@ pub async fn apply_diff_graceful(
                 drop(entries);
                 reg.rewire_tools_changed_listener(&ep_clone.name).await;
                 reg.invalidate_endpoint_tool_cache(&ep_clone.name).await;
-                info!("New endpoint initialized");
+                info!(endpoint = %ep_clone.name, "New endpoint initialized");
             }
             .instrument(init_span),
         );


### PR DESCRIPTION
## Summary

Renames the four async `info_span!("endpoint", endpoint = %name)` wrappers in `watcher.rs` to `info_span!("endpoint_init", ...)` so they stop colliding with every adapter's own per-endpoint span. Removes the nested `endpoint{...}:endpoint{...}:` prefix from compact/text-format relay logs.

## Background

All four adapters (`StdioAdapter`, `HttpAdapter`, `SseAdapter`, `OAuthAdapter`) construct an `info_span!("endpoint", endpoint = ..., transport = ..., server_type = ...)` at construction time and `.instrument()` their async bodies with it. The watcher additionally wrapped the background `tokio::spawn` calls that drive `create_adapter` with its own `info_span!("endpoint", endpoint = %name)`. While the adapter's `initialize()` ran inside both, the compact format rendered:

```
endpoint{endpoint=Foo}:endpoint{endpoint=Foo transport=stdio ...}: MCP server process spawned ...
```

Rename only the four async wrappers (lines 296, 347, 489, 567) to `"endpoint_init"` so they no longer share the name. The two synchronous `info_span!("endpoint", ...)` at lines 319 and 370 wrap pre-adapter events ("Adding new endpoint", "Endpoint unchanged") that never nest, so they are intentionally left alone.

## Change

Per site:

```diff
- let init_span = tracing::info_span!("endpoint", endpoint = %name_clone);
+ let init_span = tracing::info_span!("endpoint_init", endpoint = %name_clone);
  // ...
- info!("Changed endpoint initialized");
+ info!(endpoint = %name_clone, "Changed endpoint initialized");
```

The two wrapper info events (`"Changed endpoint initialized"` and `"New endpoint initialized"`) previously relied on the wrapper span's name for endpoint context. Adding an explicit `endpoint = %name` field keeps JSON-log consumers working via the standard `fields.endpoint` fallback (e.g. `packages/desktop/src/lib/logParser.ts` line 164: `endpointSpan.endpoint ?? fields.endpoint`).

## Scope

- 4 async `init_span` sites renamed (apply_diff: changed + added; apply_diff_graceful: changed + added).
- 4 wrapper `info!` events get an explicit `endpoint` field.
- Synchronous spans untouched.
- Adapter spans (`stdio.rs:212`, `http.rs:157/189`, `sse.rs:199`, `oauth/mod.rs:846`) untouched — they are the canonical per-endpoint spans the rest of the stack consumes.

Diff: +8 / -8 in one file.

## Verification

```
cargo fmt --check       # clean
cargo test              # all suites pass
```

One integration test (`test_oauth_fresh_login_flow`) was flaky on a 30s socket-ready wait but passes in isolation on rerun; unrelated to the span rename.

## Companion desktop PR

The desktop-side text-parser already strips any combination of leading colons (companion PR [endara-ai/endara-desktop#120](https://github.com/endara-ai/endara-desktop/pull/120)) so the user-visible stray `::` is gone even without this relay change. This PR additionally cleans up the on-disk `relay.log` file format and any other text-format consumer.
