### PR TITLE
feat(events): mint per-HTTP-request request_uid for collision-free log keying

### DIFF
--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -874,6 +874,7 @@ impl McpAdapter for HttpAdapter {
                 bus.send(ToolCallEvent::Started {
                     request_id: request_id.clone(),
                     jsonrpc_id: span_ctx.jsonrpc_id.clone(),
+                    request_uid: span_ctx.request_uid.clone(),
                     ts: iso8601_now(),
                     endpoint: self.config.endpoint_name.clone(),
                     transport: "http".into(),

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -788,6 +788,7 @@ impl McpAdapter for SseAdapter {
                 bus.send(ToolCallEvent::Started {
                     request_id: request_id.clone(),
                     jsonrpc_id: span_ctx.jsonrpc_id.clone(),
+                    request_uid: span_ctx.request_uid.clone(),
                     ts: iso8601_now(),
                     endpoint: self.config.endpoint_name.clone(),
                     transport: "sse".into(),

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -896,6 +896,7 @@ impl McpAdapter for StdioAdapter {
                 bus.send(ToolCallEvent::Started {
                     request_id: request_id.clone(),
                     jsonrpc_id: span_ctx.jsonrpc_id.clone(),
+                    request_uid: span_ctx.request_uid.clone(),
                     ts: iso8601_now(),
                     endpoint: self.config.endpoint_name.clone(),
                     transport: "stdio".into(),

--- a/src/events.rs
+++ b/src/events.rs
@@ -212,6 +212,10 @@ pub fn annotations_from_value(value: &Value) -> Option<ToolAnnotations> {
 /// can branch on a single field.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
+// `Started` carries the full caller/identity payload while `Completed`/`Failed`
+// stay terse; the size gap is intentional for these short-lived, bus-delivered
+// events, so boxing a field to shrink the enum is not worth the indirection.
+#[allow(clippy::large_enum_variant)]
 pub enum ToolCallEvent {
     /// Emitted at `call_tool` entry, before any network/process I/O.
     Started {
@@ -223,6 +227,14 @@ pub enum ToolCallEvent {
         /// is on the stack (e.g. internal callers).
         #[serde(skip_serializing_if = "Option::is_none")]
         jsonrpc_id: Option<String>,
+        /// Canonical per-inbound-HTTP-request UID minted in
+        /// `handle_single_message` and propagated via the `request` tracing
+        /// span. This is the desktop's collision-free row/overlay key; unlike
+        /// `jsonrpc_id` (which a client controls and may reuse), this UID is
+        /// unique per inbound request. `None` when no `request` span is on the
+        /// stack (e.g. internal callers / older replays).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        request_uid: Option<String>,
         ts: String,
         endpoint: String,
         transport: String,
@@ -329,6 +341,10 @@ pub struct RequestSpanContext {
     /// `request` span is on the stack or when the id was the literal
     /// `"null"` sentinel (notifications, which don't reach `call_tool`).
     pub jsonrpc_id: Option<String>,
+    /// Canonical per-inbound-HTTP-request UID captured from the `request`
+    /// span's `request_uid` field (minted in `handle_single_message`). `None`
+    /// when no `request` span is on the stack or the field was empty.
+    pub request_uid: Option<String>,
     /// Profile path segment from `/mcp/{profile}`. `None` for the global
     /// `/mcp` endpoint.
     pub profile: Option<String>,
@@ -347,6 +363,7 @@ pub struct RequestSpanContext {
 #[derive(Debug, Default, Clone)]
 struct CapturedSpanFields {
     jsonrpc_id: Option<String>,
+    request_uid: Option<String>,
     profile: Option<String>,
     client: Option<ClientIdentity>,
 }
@@ -393,6 +410,14 @@ impl<'a> CapturingVisitor<'a> {
                 if !identity.is_empty() {
                     self.captured.client = Some(identity);
                 }
+            }
+        } else if self.is_request && name == "request_uid" {
+            // The `request` span carries `request_uid = %request_uid`, the
+            // per-inbound-request UID minted in `handle_single_message`. An
+            // empty value means no UID was minted (degraded callers); skip it
+            // so `current_request_context()` surfaces `None` rather than `""`.
+            if !value.is_empty() {
+                self.captured.request_uid = Some(value);
             }
         } else if self.is_mcp_request && name == "profile" {
             self.captured.profile = Some(value);
@@ -454,6 +479,11 @@ pub fn current_request_context() -> RequestSpanContext {
                         ctx.jsonrpc_id = Some(v.clone());
                     }
                 }
+                if ctx.request_uid.is_none() {
+                    if let Some(v) = &captured.request_uid {
+                        ctx.request_uid = Some(v.clone());
+                    }
+                }
                 if ctx.profile.is_none() {
                     if let Some(v) = &captured.profile {
                         ctx.profile = Some(v.clone());
@@ -482,6 +512,7 @@ mod tests {
         let ev = ToolCallEvent::Started {
             request_id: "rid-1".into(),
             jsonrpc_id: Some("42".into()),
+            request_uid: Some("uid-abc".into()),
             ts: "2026-05-27T04:36:29.710Z".into(),
             endpoint: "github".into(),
             transport: "stdio".into(),
@@ -507,6 +538,7 @@ mod tests {
         assert_eq!(v["tool"], "list_issues");
         assert_eq!(v["annotations"]["read_only"], true);
         assert_eq!(v["jsonrpc_id"], "42");
+        assert_eq!(v["request_uid"], "uid-abc");
         assert_eq!(v["client"]["name"], "claude-ai");
         assert_eq!(v["client"]["version"], "0.1.0");
         assert!(
@@ -524,6 +556,7 @@ mod tests {
         let ev = ToolCallEvent::Started {
             request_id: "rid-1".into(),
             jsonrpc_id: None,
+            request_uid: None,
             ts: "t".into(),
             endpoint: "github".into(),
             transport: "stdio".into(),
@@ -538,6 +571,10 @@ mod tests {
         assert!(
             v.get("jsonrpc_id").is_none(),
             "jsonrpc_id should be omitted when None, got {v}"
+        );
+        assert!(
+            v.get("request_uid").is_none(),
+            "request_uid should be omitted when None, got {v}"
         );
         assert!(
             v.get("client").is_none(),
@@ -831,6 +868,7 @@ mod tests {
                 .unwrap();
             rt.block_on(async {
                 let id_str = "7".to_string();
+                let request_uid = "uid-7".to_string();
                 let profile = "work".to_string();
                 let outer = tracing::info_span!("mcp_request", profile = %profile);
                 let captured = async {
@@ -838,12 +876,14 @@ mod tests {
                         "request",
                         method = "tools/call",
                         id = %id_str,
+                        request_uid = %request_uid,
                     );
                     async { current_request_context() }.instrument(inner).await
                 }
                 .instrument(outer)
                 .await;
                 assert_eq!(captured.jsonrpc_id.as_deref(), Some("7"));
+                assert_eq!(captured.request_uid.as_deref(), Some("uid-7"));
                 assert_eq!(captured.profile.as_deref(), Some("work"));
             });
         });

--- a/src/events.rs
+++ b/src/events.rs
@@ -227,12 +227,13 @@ pub enum ToolCallEvent {
         /// is on the stack (e.g. internal callers).
         #[serde(skip_serializing_if = "Option::is_none")]
         jsonrpc_id: Option<String>,
-        /// Canonical per-inbound-HTTP-request UID minted in
-        /// `handle_single_message` and propagated via the `request` tracing
-        /// span. This is the desktop's collision-free row/overlay key; unlike
-        /// `jsonrpc_id` (which a client controls and may reuse), this UID is
-        /// unique per inbound request. `None` when no `request` span is on the
-        /// stack (e.g. internal callers / older replays).
+        /// Canonical UID minted per inbound JSON-RPC message in
+        /// `handle_single_message` (once per element of a batch array) and
+        /// propagated via the `request` tracing span. This is the desktop's
+        /// collision-free row/overlay key; unlike `jsonrpc_id` (which a client
+        /// controls and may reuse), this UID is unique per message. `None` when
+        /// no `request` span is on the stack (e.g. internal callers / older
+        /// replays).
         #[serde(skip_serializing_if = "Option::is_none")]
         request_uid: Option<String>,
         ts: String,
@@ -341,9 +342,10 @@ pub struct RequestSpanContext {
     /// `request` span is on the stack or when the id was the literal
     /// `"null"` sentinel (notifications, which don't reach `call_tool`).
     pub jsonrpc_id: Option<String>,
-    /// Canonical per-inbound-HTTP-request UID captured from the `request`
-    /// span's `request_uid` field (minted in `handle_single_message`). `None`
-    /// when no `request` span is on the stack or the field was empty.
+    /// Canonical per-JSON-RPC-message UID captured from the `request` span's
+    /// `request_uid` field (minted in `handle_single_message`, once per
+    /// element of a batch array). `None` when no `request` span is on the
+    /// stack or the field was empty.
     pub request_uid: Option<String>,
     /// Profile path segment from `/mcp/{profile}`. `None` for the global
     /// `/mcp` endpoint.

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -108,6 +108,14 @@ struct SandboxState {
     /// (`ToolCallEvent::Started.jsonrpc_id`) — the blocking-thread hop otherwise
     /// drops the outer request span.
     jsonrpc_id: String,
+    /// Canonical per-inbound-request UID of the outer inbound request,
+    /// captured before the sandbox hops onto the blocking thread. Empty when
+    /// no UID was minted. Used to re-establish a `request{request_uid=...}`
+    /// span around each inner `route_tool_call` so `SpanFieldCaptureLayer` /
+    /// `current_request_context()` surface the UID to the upstream adapter's
+    /// event emitters (`ToolCallEvent::Started.request_uid`) — the
+    /// blocking-thread hop otherwise drops the outer request span.
+    request_uid: String,
 }
 
 thread_local! {
@@ -140,6 +148,11 @@ pub struct JsSandbox {
     /// [`MetaToolHandler::execute_tools`] so inner upstream tool calls
     /// re-establish the outer request's `request{id=...}` span.
     jsonrpc_id: String,
+    /// Canonical per-inbound-request UID of the outer inbound request.
+    /// Defaults to empty (no UID); set via [`Self::with_request_uid`] by
+    /// [`MetaToolHandler::execute_tools`] so inner upstream tool calls
+    /// re-establish the outer request's `request{request_uid=...}` span.
+    request_uid: String,
 }
 
 impl JsSandbox {
@@ -173,6 +186,7 @@ impl JsSandbox {
             use_real_backoff: false,
             client_json: String::new(),
             jsonrpc_id: String::new(),
+            request_uid: String::new(),
         }
     }
 
@@ -195,6 +209,15 @@ impl JsSandbox {
         self
     }
 
+    /// Attach the outer inbound request's canonical `request_uid` so inner
+    /// upstream tool calls re-establish a `request{request_uid=...}` span on
+    /// the sandbox's blocking thread. An empty string degrades to no UID.
+    /// Used by [`MetaToolHandler::execute_tools`].
+    pub fn with_request_uid(mut self, request_uid: String) -> Self {
+        self.request_uid = request_uid;
+        self
+    }
+
     /// Test-only: opt this sandbox into the real backoff schedule. Without
     /// this, `cfg(test)` builds short-circuit retry sleeps to zero so the
     /// suite stays fast. Used by the deadline-budget test.
@@ -211,6 +234,7 @@ impl JsSandbox {
         let use_real_backoff = self.use_real_backoff;
         let client_json = self.client_json.clone();
         let jsonrpc_id = self.jsonrpc_id.clone();
+        let request_uid = self.request_uid.clone();
         let script = script.to_string();
         let handle = tokio::runtime::Handle::current();
         let catalog = self.registry.merged_catalog().await;
@@ -227,6 +251,7 @@ impl JsSandbox {
                     use_real_backoff,
                     client_json,
                     jsonrpc_id,
+                    request_uid,
                 )
             }),
         )
@@ -254,6 +279,7 @@ fn execute_in_sandbox(
     use_real_backoff: bool,
     client_json: String,
     jsonrpc_id: String,
+    request_uid: String,
 ) -> Result<Value, JsSandboxError> {
     let deadline = std::time::Instant::now() + sandbox_timeout;
     SANDBOX_STATE.with(|cell| {
@@ -264,6 +290,7 @@ fn execute_in_sandbox(
             use_real_backoff,
             client_json,
             jsonrpc_id,
+            request_uid,
         });
     });
     let result = run_js(script, catalog);
@@ -274,35 +301,39 @@ fn execute_in_sandbox(
 }
 
 /// Drive `fut` to completion on the sandbox's blocking thread, re-establishing
-/// the outer inbound request's `request{id=...,client=...}` span when either of
-/// those signals was captured.
+/// the outer inbound request's `request{id=...,request_uid=...,client=...}`
+/// span when any of those signals was captured.
 ///
 /// `JsSandbox::execute` hops onto a `spawn_blocking` thread, which does not
 /// inherit the inbound `request` span. Without re-entering it here, the
-/// upstream adapter's `current_request_context()` resolves no JSON-RPC id and
-/// no caller for sandbox-driven tool calls, so the "Tool call completed/failed"
-/// log lines and `ToolCallEvent::Started.{jsonrpc_id,client}` lose those
-/// signals. Entering a fresh `request` span carrying `id = %jsonrpc_id` and
-/// `client = %client_json` lets `SpanFieldCaptureLayer` re-capture them exactly
-/// as the direct path does. `SpanFieldCaptureLayer`'s visitor skips empty
-/// `id`/`client` values, so a missing signal records no field; when both are
-/// empty the future runs without an extra span.
+/// upstream adapter's `current_request_context()` resolves no JSON-RPC id, no
+/// request UID and no caller for sandbox-driven tool calls, so the "Tool call
+/// completed/failed" log lines and
+/// `ToolCallEvent::Started.{jsonrpc_id,request_uid,client}` lose those signals.
+/// Entering a fresh `request` span carrying `id = %jsonrpc_id`,
+/// `request_uid = %request_uid` and `client = %client_json` lets
+/// `SpanFieldCaptureLayer` re-capture them exactly as the direct path does.
+/// `SpanFieldCaptureLayer`'s visitor skips empty `id`/`request_uid`/`client`
+/// values, so a missing signal records no field; when all three are empty the
+/// future runs without an extra span.
 fn block_on_with_request_context<F>(
     handle: &tokio::runtime::Handle,
     client_json: &str,
     jsonrpc_id: &str,
+    request_uid: &str,
     fut: F,
 ) -> F::Output
 where
     F: std::future::Future,
 {
-    if jsonrpc_id.is_empty() && client_json.is_empty() {
+    if jsonrpc_id.is_empty() && client_json.is_empty() && request_uid.is_empty() {
         return handle.block_on(fut);
     }
     let span = tracing::info_span!(
         "request",
         method = "tools/call",
         id = %jsonrpc_id,
+        request_uid = %request_uid,
         client = %client_json,
     );
     handle.block_on(fut.instrument(span))
@@ -426,6 +457,7 @@ fn call_tool_native(_this: &JsValue, args: &[JsValue], context: &mut Context) ->
             &state.handle,
             &state.client_json,
             &state.jsonrpc_id,
+            &state.request_uid,
             state.registry.route_tool_call(&tool_name, arguments),
         )
         .map_err(|e| {
@@ -522,6 +554,7 @@ fn call_tool_with_retry_native(
             &state.handle,
             &state.client_json,
             &state.jsonrpc_id,
+            &state.request_uid,
             call_tool_with_retry_loop(
                 registry.as_ref(),
                 &tool_name,
@@ -1291,22 +1324,26 @@ impl MetaToolHandler {
     /// gives the script a profile-filtered `tools.call()`.
     ///
     /// `client_json` is the JSON-serialised [`crate::events::ClientIdentity`]
-    /// of the outer inbound request (empty when no caller identity is known)
-    /// and `jsonrpc_id` is the outer request's JSON-RPC envelope id (empty when
-    /// none is known). Both are threaded into the sandbox so inner upstream
-    /// tool calls re-establish the caller's `request{id=...,client=...}` span
-    /// across the blocking-thread hop — keeping the id and caller visible on
-    /// the aggregated "Tool call completed/failed" log lines and
+    /// of the outer inbound request (empty when no caller identity is known),
+    /// `jsonrpc_id` is the outer request's JSON-RPC envelope id (empty when
+    /// none is known) and `request_uid` is the outer request's canonical
+    /// collision-free UID (empty when none was minted). All three are threaded
+    /// into the sandbox so inner upstream tool calls re-establish the caller's
+    /// `request{id=...,request_uid=...,client=...}` span across the
+    /// blocking-thread hop — keeping the id, UID and caller visible on the
+    /// aggregated "Tool call completed/failed" log lines and
     /// `ToolCallEvent::Started`.
     pub async fn execute_tools(
         &self,
         script: &str,
         client_json: &str,
         jsonrpc_id: &str,
+        request_uid: &str,
     ) -> Result<Value, JsSandboxError> {
         let sandbox = JsSandbox::from_dyn(self.registry.clone(), self.sandbox_timeout)
             .with_client(client_json.to_string())
-            .with_jsonrpc_id(jsonrpc_id.to_string());
+            .with_jsonrpc_id(jsonrpc_id.to_string())
+            .with_request_uid(request_uid.to_string());
         sandbox.execute(script).await
     }
 }
@@ -3175,6 +3212,7 @@ mod tests {
                 rt.handle(),
                 &client_json,
                 "",
+                "",
                 reg.route_tool_call("echo", json!({})),
             );
             assert!(result.is_ok(), "tool call should succeed: {:?}", result);
@@ -3265,6 +3303,7 @@ mod tests {
                 rt.handle(),
                 "",
                 "42",
+                "",
                 reg.route_tool_call("echo", json!({})),
             );
             assert!(result.is_ok(), "tool call should succeed: {:?}", result);
@@ -3278,11 +3317,96 @@ mod tests {
         );
     }
 
-    /// With no caller identity captured (empty `client_json`) and no id (empty
-    /// `jsonrpc_id`), [`block_on_with_request_context`] must skip the extra
-    /// span and drive the future directly, leaving
-    /// `current_request_context().client` as `None` rather than fabricating an
-    /// empty identity.
+    /// A sandbox-driven upstream tool call must re-establish the outer inbound
+    /// request's canonical `request_uid` across the `spawn_blocking` thread
+    /// hop. [`block_on_with_request_context`] enters a fresh
+    /// `request{request_uid=...}` span before driving
+    /// [`MetaToolRegistry::route_tool_call`], so the adapter's
+    /// `current_request_context().request_uid` (the signal feeding
+    /// `ToolCallEvent::Started.request_uid` and the desktop's collision-free
+    /// row/overlay key) resolves the outer UID rather than `None`.
+    #[test]
+    fn sandbox_tool_call_reestablishes_request_uid() {
+        use crate::events::{current_request_context, SpanFieldCaptureLayer};
+        use std::sync::Mutex;
+        use tracing_subscriber::prelude::*;
+
+        // Adapter that records the request UID visible via the request span at
+        // `call_tool` time, proving the span was re-established.
+        struct UidCapturingAdapter {
+            tools: Vec<ToolInfo>,
+            seen: Arc<Mutex<Option<String>>>,
+        }
+
+        #[async_trait]
+        impl McpAdapter for UidCapturingAdapter {
+            async fn initialize(&mut self) -> Result<(), AdapterError> {
+                Ok(())
+            }
+            async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
+                Ok(self.tools.clone())
+            }
+            async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
+                *self.seen.lock().unwrap() = current_request_context().request_uid;
+                Ok(json!({ "called": name, "args": arguments }))
+            }
+            fn health(&self) -> HealthStatus {
+                HealthStatus::Healthy
+            }
+            async fn shutdown(&mut self) -> Result<(), AdapterError> {
+                Ok(())
+            }
+        }
+
+        let seen = Arc::new(Mutex::new(None));
+        let seen_clone = Arc::clone(&seen);
+        let subscriber = tracing_subscriber::registry().with(SpanFieldCaptureLayer);
+        tracing::subscriber::with_default(subscriber, || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            let registry = rt.block_on(async {
+                let registry = AdapterRegistry::new();
+                registry
+                    .register(
+                        "ep".into(),
+                        Box::new(UidCapturingAdapter {
+                            tools: vec![make_tool("echo", "Echo tool")],
+                            seen: seen_clone,
+                        }),
+                        "stdio".into(),
+                        None,
+                        None,
+                    )
+                    .await;
+                Arc::new(registry)
+            });
+
+            let reg: Arc<dyn MetaToolRegistry> = registry;
+            let result = block_on_with_request_context(
+                rt.handle(),
+                "",
+                "",
+                "req-uid-123",
+                reg.route_tool_call("echo", json!({})),
+            );
+            assert!(result.is_ok(), "tool call should succeed: {:?}", result);
+        });
+
+        assert_eq!(
+            *seen.lock().unwrap(),
+            Some("req-uid-123".to_string()),
+            "sandbox-driven tool call must re-establish the outer request_uid \
+             in the request context"
+        );
+    }
+
+    /// With no caller identity captured (empty `client_json`), no id (empty
+    /// `jsonrpc_id`) and no UID (empty `request_uid`),
+    /// [`block_on_with_request_context`] must skip the extra span and drive the
+    /// future directly, leaving `current_request_context().client` as `None`
+    /// rather than fabricating an empty identity.
     #[test]
     fn sandbox_tool_call_without_client_leaves_context_none() {
         use crate::events::{current_request_context, ClientIdentity, SpanFieldCaptureLayer};
@@ -3342,6 +3466,7 @@ mod tests {
             let reg: Arc<dyn MetaToolRegistry> = registry;
             let result = block_on_with_request_context(
                 rt.handle(),
+                "",
                 "",
                 "",
                 reg.route_tool_call("echo", json!({})),

--- a/src/profile_registry.rs
+++ b/src/profile_registry.rs
@@ -813,7 +813,7 @@ mod tests {
             }
         "#;
         let result = handler
-            .execute_tools(script, "", "")
+            .execute_tools(script, "", "", "")
             .await
             .expect("execute_tools should return the script's error value");
         let err_msg = result

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -789,6 +789,7 @@ impl AdapterRegistry {
             bus.send(ToolCallEvent::Started {
                 request_id: request_id.clone(),
                 jsonrpc_id: span_ctx.jsonrpc_id.clone(),
+                request_uid: span_ctx.request_uid.clone(),
                 ts: iso8601_now(),
                 endpoint,
                 transport,
@@ -835,6 +836,7 @@ impl AdapterRegistry {
             bus.send(ToolCallEvent::Started {
                 request_id: request_id.clone(),
                 jsonrpc_id: span_ctx.jsonrpc_id.clone(),
+                request_uid: span_ctx.request_uid.clone(),
                 ts: iso8601_now(),
                 endpoint,
                 transport,

--- a/src/server.rs
+++ b/src/server.rs
@@ -696,8 +696,9 @@ async fn mcp_tools_call(
                 .map(|c| serde_json::to_string(&c).unwrap_or_default())
                 .unwrap_or_default();
             let jsonrpc_id = request_ctx.jsonrpc_id.unwrap_or_default();
+            let request_uid = request_ctx.request_uid.unwrap_or_default();
             match handler
-                .execute_tools(script, &client_json, &jsonrpc_id)
+                .execute_tools(script, &client_json, &jsonrpc_id, &request_uid)
                 .await
             {
                 Ok(result) => {
@@ -767,6 +768,13 @@ async fn handle_single_message(
         .get("id")
         .map(|v| v.to_string())
         .unwrap_or_else(|| "null".to_string());
+    // Canonical per-inbound-HTTP-request UID. Unlike the client-controlled
+    // JSON-RPC `id` (which collides across clients and across reconnects when
+    // a client resets its counter), this UUID is unique per inbound request,
+    // so every log line and `ToolCallEvent` produced while processing this
+    // request shares one collision-free key for the desktop's row/overlay
+    // keying. `jsonrpc_id` stays on the wire for diagnostic context.
+    let request_uid = uuid::Uuid::new_v4().to_string();
     // JSON-encode the identity so `SpanFieldCaptureLayer` can deserialise it
     // back into a typed [`ClientIdentity`] via `current_request_context()`
     // without changing the `McpAdapter::call_tool` trait signature. An empty
@@ -786,6 +794,7 @@ async fn handle_single_message(
         "request",
         method = %method,
         id = %id_str,
+        request_uid = %request_uid,
         client = %client_json,
     );
     async move {
@@ -798,6 +807,7 @@ async fn handle_single_message(
             let elapsed_ms = start.elapsed().as_millis() as u64;
             info!(
                 method = %method,
+                request_uid = %request_uid,
                 elapsed_ms = elapsed_ms,
                 req_bytes = req_bytes,
                 resp_bytes = 0,
@@ -839,6 +849,7 @@ async fn handle_single_message(
                 let resp_bytes = serde_json::to_string(&resp).map(|s| s.len()).unwrap_or(0);
                 info!(
                     method = %method,
+                    request_uid = %request_uid,
                     elapsed_ms = elapsed_ms,
                     req_bytes = req_bytes,
                     resp_bytes = resp_bytes,
@@ -856,6 +867,7 @@ async fn handle_single_message(
                 if status_code >= 500 {
                     error!(
                         method = %method,
+                        request_uid = %request_uid,
                         elapsed_ms = elapsed_ms,
                         req_bytes = req_bytes,
                         resp_bytes = resp_bytes,
@@ -869,6 +881,7 @@ async fn handle_single_message(
                     // JSON-RPC 2.0: errors are returned with HTTP 200, not a sign of trouble.
                     info!(
                         method = %method,
+                        request_uid = %request_uid,
                         elapsed_ms = elapsed_ms,
                         req_bytes = req_bytes,
                         resp_bytes = resp_bytes,
@@ -881,6 +894,7 @@ async fn handle_single_message(
                 } else {
                     warn!(
                         method = %method,
+                        request_uid = %request_uid,
                         elapsed_ms = elapsed_ms,
                         req_bytes = req_bytes,
                         resp_bytes = resp_bytes,

--- a/src/server.rs
+++ b/src/server.rs
@@ -768,12 +768,15 @@ async fn handle_single_message(
         .get("id")
         .map(|v| v.to_string())
         .unwrap_or_else(|| "null".to_string());
-    // Canonical per-inbound-HTTP-request UID. Unlike the client-controlled
-    // JSON-RPC `id` (which collides across clients and across reconnects when
-    // a client resets its counter), this UUID is unique per inbound request,
-    // so every log line and `ToolCallEvent` produced while processing this
-    // request shares one collision-free key for the desktop's row/overlay
-    // keying. `jsonrpc_id` stays on the wire for diagnostic context.
+    // Canonical per-JSON-RPC-message UID. `handle_single_message` runs once
+    // per inbound JSON-RPC message — including once per element of a batch
+    // array — so each logical request gets its own UID. Unlike the
+    // client-controlled JSON-RPC `id` (which collides across clients and
+    // across reconnects when a client resets its counter), this UUID is unique
+    // per message, so every log line and `ToolCallEvent` produced while
+    // processing this message shares one collision-free key for the desktop's
+    // row/overlay keying. `jsonrpc_id` stays on the wire for diagnostic
+    // context.
     let request_uid = uuid::Uuid::new_v4().to_string();
     // JSON-encode the identity so `SpanFieldCaptureLayer` can deserialise it
     // back into a typed [`ClientIdentity`] via `current_request_context()`


### PR DESCRIPTION
## Problem

The desktop overlay keys log rows and notification cards on the inbound JSON-RPC `id` from the MCP request envelope. Two MCP clients (e.g. Cursor + Claude Desktop) both happen to send `id=1` concurrently — the rows collide and clicking a card highlights both clusters. Same problem can occur within a single client that restarts its id counter on reconnect.

The relay already mints separate `request_id` UUIDs for per-tool-call events, but the row/card key still comes from the client-controlled JSON-RPC id, which has no uniqueness guarantee.

## Fix

Mint a relay-generated `request_uid` (UUID v4) per inbound HTTP request and propagate it everywhere the JSON-RPC id flows today, so the desktop can switch to it as the canonical key in a follow-up PR.

- `server.rs::handle_single_message`: mint `request_uid` and attach it to the `request{...}` tracing span and the five MCP-request log lines.
- `events.rs`: add `request_uid: Option<String>` to `RequestSpanContext`, `CapturedSpanFields`, and `ToolCallEvent::Started` (serde-skipped when `None`). `CapturingVisitor` captures it.
- `js_sandbox.rs`: thread through `SandboxState` / `JsSandbox` (new `with_request_uid` builder) / `execute` / both `call_tool` native bridges / `execute_tools`. Collapsed `block_on_with_request_context` to a single-span form (visitor hardened to skip empty `id` / `request_uid` / `client` strings).
- All five production `ToolCallEvent::Started` construction sites now set `request_uid: span_ctx.request_uid.clone()`.
- Added `#[allow(clippy::large_enum_variant)]` on `ToolCallEvent` — the new field tipped the size-gap lint; boxing would ripple into every construction/match site (out of scope for this change).

## Verification

- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test --lib` ✅ (884 tests, including the new `sandbox_tool_call_reestablishes_request_uid`)

There is one pre-existing parallelism-flaky test (`watcher::tests::adapter_init_warns_when_falling_back_to_toml_secret`) confirmed by the implementor to fail 5/5 on a clean main when run under parallel scheduling, and to pass in isolation. Unrelated to this PR.

## Wire compatibility

`request_uid` is internal to relay/desktop and never sent upstream to MCP clients. The per-tool-call adapter `request_id` and the diagnostic `jsonrpc_id` are untouched, and a single inbound request shares one `request_uid` across the `execute_tools` fan-out so all inner tool calls correlate to the same row.

## Follow-ups

- Desktop-side consumer PR (already implemented locally on `panghy/desktop-request-uid`): re-source `requestId` from `request_uid` instead of JSON-RPC `id`. Will be opened against `endara-desktop` after this PR merges.
- Removing `jsonrpc_id` from the wire format entirely is intentionally deferred.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author