### PR TITLE
chore(events): remove jsonrpc_id from ToolCallEvent wire

### DIFF
--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -873,7 +873,6 @@ impl McpAdapter for HttpAdapter {
                     .and_then(|v| v.as_ref().and_then(annotations_from_value));
                 bus.send(ToolCallEvent::Started {
                     request_id: request_id.clone(),
-                    jsonrpc_id: span_ctx.jsonrpc_id.clone(),
                     request_uid: span_ctx.request_uid.clone(),
                     ts: iso8601_now(),
                     endpoint: self.config.endpoint_name.clone(),
@@ -942,14 +941,12 @@ impl McpAdapter for HttpAdapter {
                 match &result {
                     Ok(_) => bus.send(ToolCallEvent::Completed {
                         request_id,
-                        jsonrpc_id: span_ctx.jsonrpc_id.clone(),
                         ts,
                         duration_ms: duration_ms_u64,
                         status: "ok".into(),
                     }),
                     Err(e) => bus.send(ToolCallEvent::Failed {
                         request_id,
-                        jsonrpc_id: span_ctx.jsonrpc_id.clone(),
                         ts,
                         duration_ms: duration_ms_u64,
                         status: "error".into(),

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -1001,9 +1001,9 @@ impl McpAdapter for OAuthAdapter {
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
         // NB: do NOT wrap the inner adapter's `call_tool` invocations in
         // `.instrument(self.inner.span)`. The inner `HttpAdapter::call_tool`
-        // captures the caller's per-request span context (`request{id}`,
+        // captures the caller's per-request span context (`request{request_uid}`,
         // `mcp_request{profile}`) BEFORE entering its own span so it can
-        // attach `jsonrpc_id`/`profile` to the published `ToolCallEvent`s.
+        // attach `request_uid`/`profile` to the published `ToolCallEvent`s.
         // OAuth's `inner.span` is the persistent endpoint span built at init
         // time with no parent linkage to per-request spans, so wrapping the
         // inner call here would zero out those fields on every OAuth-routed
@@ -2749,21 +2749,21 @@ mod tests {
 
     /// Regression: a `call_tool` routed through `OAuthAdapter` (which wraps an
     /// inner `HttpAdapter`) must publish a [`ToolCallEvent::Started`] whose
-    /// `jsonrpc_id` and `profile` fields are populated from the caller's
-    /// per-request span scope (`mcp_request{profile}` > `request{id}`).
+    /// `request_uid` and `profile` fields are populated from the caller's
+    /// per-request span scope (`mcp_request{profile}` > `request{request_uid}`).
     ///
     /// Before the fix, `OAuthAdapter::call_tool` wrapped the inner-adapter
     /// invocation in `.instrument(self.inner.span)` — the OAuth endpoint span
     /// has no parent linkage to the per-request spans, so the inner
     /// `HttpAdapter::call_tool`'s `current_request_context()` walk found
-    /// neither field and emitted `jsonrpc_id: None` / `profile: None` for
+    /// neither field and emitted `request_uid: None` / `profile: None` for
     /// every OAuth-authenticated endpoint.
     ///
     /// `#[test]` (not `#[tokio::test]`) because we install the capture layer
     /// via `with_default(...)` and drive an inner current-thread runtime so
     /// the dispatcher stays attached across `tokio::spawn`'d tasks.
     #[test]
-    fn call_tool_publishes_jsonrpc_id_and_profile_from_request_span() {
+    fn call_tool_publishes_request_uid_and_profile_from_request_span() {
         use crate::events::{SpanFieldCaptureLayer, ToolCallEvent, ToolCallEventBus};
         use tracing::Instrument;
         use tracing_subscriber::prelude::*;
@@ -2798,14 +2798,13 @@ mod tests {
                     })
                     .await;
 
-                let id_str = "42".to_string();
+                let uid_str = "uid-42".to_string();
                 let profile_str = "test".to_string();
                 let mcp_span = tracing::info_span!(
                     "mcp_request",
                     profile = %profile_str,
                 );
-                let req_span =
-                    tracing::info_span!(parent: &mcp_span, "request", method = "tools/call", id = %id_str);
+                let req_span = tracing::info_span!(parent: &mcp_span, "request", method = "tools/call", request_uid = %uid_str);
 
                 let result =
                     async { adapter.call_tool("ping", serde_json::json!({})).await }
@@ -2816,12 +2815,12 @@ mod tests {
                 let started = rx.try_recv().expect("started event must be buffered");
                 match started {
                     ToolCallEvent::Started {
-                        jsonrpc_id,
+                        request_uid,
                         profile,
                         transport,
                         ..
                     } => {
-                        assert_eq!(jsonrpc_id.as_deref(), Some("42"));
+                        assert_eq!(request_uid.as_deref(), Some("uid-42"));
                         assert_eq!(profile.as_deref(), Some("test"));
                         // Inner is HttpAdapter, so transport should be "http".
                         assert_eq!(transport, "http");
@@ -2830,9 +2829,7 @@ mod tests {
                 }
                 let completed = rx.try_recv().expect("completed event must be buffered");
                 match completed {
-                    ToolCallEvent::Completed { jsonrpc_id, .. } => {
-                        assert_eq!(jsonrpc_id.as_deref(), Some("42"));
-                    }
+                    ToolCallEvent::Completed { .. } => {}
                     other => panic!("expected Completed event, got {other:?}"),
                 }
 

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -1003,13 +1003,15 @@ impl McpAdapter for OAuthAdapter {
         // `.instrument(self.inner.span)`. The inner `HttpAdapter::call_tool`
         // captures the caller's per-request span context (`request{request_uid}`,
         // `mcp_request{profile}`) BEFORE entering its own span so it can
-        // attach `request_uid`/`profile` to the published `ToolCallEvent`s.
+        // attach `request_uid`/`profile` to the `ToolCallEvent::Started` it
+        // publishes (the matching `Completed`/`Failed` are terse and correlate
+        // back via the shared per-call `request_id`).
         // OAuth's `inner.span` is the persistent endpoint span built at init
         // time with no parent linkage to per-request spans, so wrapping the
-        // inner call here would zero out those fields on every OAuth-routed
-        // tool call. The OAuth endpoint span is still applied around the
-        // refresh / state-transition branches below where it actually adds
-        // useful context.
+        // inner call here would zero out those fields on the `Started` event for
+        // every OAuth-routed tool call. The OAuth endpoint span is still applied
+        // around the refresh / state-transition branches below where it actually
+        // adds useful context.
         let guard = self.inner.inner_adapter.read().await;
         let adapter = match guard.as_ref() {
             Some(a) => a,

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -787,7 +787,6 @@ impl McpAdapter for SseAdapter {
                     .and_then(|v| v.as_ref().and_then(annotations_from_value));
                 bus.send(ToolCallEvent::Started {
                     request_id: request_id.clone(),
-                    jsonrpc_id: span_ctx.jsonrpc_id.clone(),
                     request_uid: span_ctx.request_uid.clone(),
                     ts: iso8601_now(),
                     endpoint: self.config.endpoint_name.clone(),
@@ -856,14 +855,12 @@ impl McpAdapter for SseAdapter {
                 match &result {
                     Ok(_) => bus.send(ToolCallEvent::Completed {
                         request_id,
-                        jsonrpc_id: span_ctx.jsonrpc_id.clone(),
                         ts,
                         duration_ms: duration_ms_u64,
                         status: "ok".into(),
                     }),
                     Err(e) => bus.send(ToolCallEvent::Failed {
                         request_id,
-                        jsonrpc_id: span_ctx.jsonrpc_id.clone(),
                         ts,
                         duration_ms: duration_ms_u64,
                         status: "error".into(),

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -895,7 +895,6 @@ impl McpAdapter for StdioAdapter {
                     .and_then(|v| v.as_ref().and_then(annotations_from_value));
                 bus.send(ToolCallEvent::Started {
                     request_id: request_id.clone(),
-                    jsonrpc_id: span_ctx.jsonrpc_id.clone(),
                     request_uid: span_ctx.request_uid.clone(),
                     ts: iso8601_now(),
                     endpoint: self.config.endpoint_name.clone(),
@@ -950,14 +949,12 @@ impl McpAdapter for StdioAdapter {
                 match &result {
                     Ok(_) => bus.send(ToolCallEvent::Completed {
                         request_id,
-                        jsonrpc_id: span_ctx.jsonrpc_id.clone(),
                         ts,
                         duration_ms: duration_ms_u64,
                         status: "ok".into(),
                     }),
                     Err(e) => bus.send(ToolCallEvent::Failed {
                         request_id,
-                        jsonrpc_id: span_ctx.jsonrpc_id.clone(),
                         ts,
                         duration_ms: duration_ms_u64,
                         status: "error".into(),
@@ -2082,17 +2079,17 @@ with open(record_path, "w") as rec:
         assert_eq!(frames[2]["method"].as_str(), Some("tools/list"));
     }
 
-    /// End-to-end sanity check that `jsonrpc_id` flows from the surrounding
+    /// End-to-end sanity check that `request_uid` flows from the surrounding
     /// `request` tracing span into the published [`ToolCallEvent::Started`]
-    /// and [`ToolCallEvent::Failed`] events. Uses a non-spawned `StdioAdapter`
-    /// so `send_request` returns `AdapterError::NotInitialized` immediately —
-    /// the `Started` event still publishes before the network attempt, and
-    /// the `Failed` event publishes on the resulting `Err`.
+    /// event. Uses a non-spawned `StdioAdapter` so `send_request` returns
+    /// `AdapterError::NotInitialized` immediately — the `Started` event still
+    /// publishes before the network attempt, and the `Failed` event publishes
+    /// on the resulting `Err`.
     ///
     /// `#[test]` (not `#[tokio::test]`) because we install the capture layer
     /// via `with_default(...)` and drive an inner current-thread runtime.
     #[test]
-    fn call_tool_publishes_jsonrpc_id_from_request_span() {
+    fn call_tool_publishes_request_uid_from_request_span() {
         use crate::events::{SpanFieldCaptureLayer, ToolCallEvent, ToolCallEventBus};
         use tracing::Instrument;
         use tracing_subscriber::prelude::*;
@@ -2114,8 +2111,9 @@ with open(record_path, "w") as rec:
                 adapter.set_event_bus(bus.clone());
                 let mut rx = bus.subscribe();
 
-                let id_str = "99".to_string();
-                let span = tracing::info_span!("request", method = "tools/call", id = %id_str);
+                let uid_str = "uid-99".to_string();
+                let span =
+                    tracing::info_span!("request", method = "tools/call", request_uid = %uid_str);
                 let result = async { adapter.call_tool("nope", serde_json::json!({})).await }
                     .instrument(span)
                     .await;
@@ -2126,16 +2124,14 @@ with open(record_path, "w") as rec:
 
                 let started = rx.try_recv().expect("started event must be buffered");
                 match started {
-                    ToolCallEvent::Started { jsonrpc_id, .. } => {
-                        assert_eq!(jsonrpc_id.as_deref(), Some("99"));
+                    ToolCallEvent::Started { request_uid, .. } => {
+                        assert_eq!(request_uid.as_deref(), Some("uid-99"));
                     }
                     other => panic!("expected Started event, got {other:?}"),
                 }
                 let failed = rx.try_recv().expect("failed event must be buffered");
                 match failed {
-                    ToolCallEvent::Failed { jsonrpc_id, .. } => {
-                        assert_eq!(jsonrpc_id.as_deref(), Some("99"));
-                    }
+                    ToolCallEvent::Failed { .. } => {}
                     other => panic!("expected Failed event, got {other:?}"),
                 }
             });

--- a/src/events.rs
+++ b/src/events.rs
@@ -220,18 +220,10 @@ pub enum ToolCallEvent {
     /// Emitted at `call_tool` entry, before any network/process I/O.
     Started {
         request_id: String,
-        /// JSON-RPC envelope id (as serialised by `serde_json::Value::to_string`)
-        /// extracted from the surrounding `request` tracing span. Used by the
-        /// desktop overlay to click-to-jump from an overlay card to the
-        /// matching `request{id="..."}` log row. `None` when no `request` span
-        /// is on the stack (e.g. internal callers).
-        #[serde(skip_serializing_if = "Option::is_none")]
-        jsonrpc_id: Option<String>,
         /// Canonical UID minted per inbound JSON-RPC message in
         /// `handle_single_message` (once per element of a batch array) and
         /// propagated via the `request` tracing span. This is the desktop's
-        /// collision-free row/overlay key; unlike `jsonrpc_id` (which a client
-        /// controls and may reuse), this UID is unique per message. `None` when
+        /// collision-free row/overlay key, unique per message. `None` when
         /// no `request` span is on the stack (e.g. internal callers / older
         /// replays).
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -258,8 +250,6 @@ pub enum ToolCallEvent {
     /// Emitted on `Ok(_)` return from the underlying `tools/call` request.
     Completed {
         request_id: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        jsonrpc_id: Option<String>,
         ts: String,
         duration_ms: u64,
         /// Always `"ok"` for completed events; carried so the overlay can use
@@ -270,8 +260,6 @@ pub enum ToolCallEvent {
     /// overlay can render the failure reason without re-querying logs.
     Failed {
         request_id: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        jsonrpc_id: Option<String>,
         ts: String,
         duration_ms: u64,
         /// Always `"error"` for failed events.
@@ -332,16 +320,11 @@ impl Default for ToolCallEventBus {
 /// Subset of the `request{...}` and `mcp_request{...}` span fields captured
 /// into span extensions by [`SpanFieldCaptureLayer`] and surfaced to adapter
 /// code via [`current_request_context`]. Adapters use this to populate
-/// `jsonrpc_id` (from the inner `request` span) and `profile` (from the outer
+/// `request_uid` (from the inner `request` span) and `profile` (from the outer
 /// `mcp_request` span) on every emitted [`ToolCallEvent`] without taking a
 /// breaking change to the [`crate::adapter::McpAdapter::call_tool`] signature.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct RequestSpanContext {
-    /// JSON-RPC envelope id as serialised by `Value::to_string` (numbers
-    /// render unquoted, strings render with quotes). `None` when no
-    /// `request` span is on the stack or when the id was the literal
-    /// `"null"` sentinel (notifications, which don't reach `call_tool`).
-    pub jsonrpc_id: Option<String>,
     /// Canonical per-JSON-RPC-message UID captured from the `request` span's
     /// `request_uid` field (minted in `handle_single_message`, once per
     /// element of a batch array). `None` when no `request` span is on the
@@ -364,15 +347,14 @@ pub struct RequestSpanContext {
 /// extension keeps the per-span allocation count to one.
 #[derive(Debug, Default, Clone)]
 struct CapturedSpanFields {
-    jsonrpc_id: Option<String>,
     request_uid: Option<String>,
     profile: Option<String>,
     client: Option<ClientIdentity>,
 }
 
 /// Visits a span's recorded fields once at span creation time, capturing the
-/// JSON-RPC id from the `request` span and the profile path from the
-/// `mcp_request` span. Other fields are ignored.
+/// caller identity and canonical UID from the `request` span and the profile
+/// path from the `mcp_request` span. Other fields are ignored.
 struct CapturingVisitor<'a> {
     captured: &'a mut CapturedSpanFields,
     is_request: bool,
@@ -394,15 +376,7 @@ impl<'a> Visit for CapturingVisitor<'a> {
 
 impl<'a> CapturingVisitor<'a> {
     fn record(&mut self, name: &str, value: String) {
-        if self.is_request && name == "id" {
-            // The `request` span uses `id = %id_str` where `id_str` is
-            // `"null"` for notifications. `call_tool` is never reached for
-            // notifications, but we still skip the sentinel so a stray
-            // emitter cannot leak a fake id into an event.
-            if value != "null" && !value.is_empty() {
-                self.captured.jsonrpc_id = Some(value);
-            }
-        } else if self.is_request && name == "client" {
+        if self.is_request && name == "client" {
             // The `request` span carries `client = %client_json` where
             // `client_json` is a JSON-serialised `ClientIdentity`. Parse it
             // back so `current_request_context()` can hand a typed value
@@ -427,10 +401,10 @@ impl<'a> CapturingVisitor<'a> {
     }
 }
 
-/// Tracing [`Layer`] that captures the JSON-RPC id and profile fields from
-/// the relay's `request` and `mcp_request` spans into span extensions so
-/// [`current_request_context`] can surface them to adapter code without a
-/// trait-level signature change. Install once at process start in
+/// Tracing [`Layer`] that captures the caller identity, canonical UID and
+/// profile fields from the relay's `request` and `mcp_request` spans into span
+/// extensions so [`current_request_context`] can surface them to adapter code
+/// without a trait-level signature change. Install once at process start in
 /// `main.rs` via `tracing_subscriber::registry().with(SpanFieldCaptureLayer)`.
 pub struct SpanFieldCaptureLayer;
 
@@ -458,12 +432,13 @@ where
     }
 }
 
-/// Walk the current tracing span scope and pull the JSON-RPC id (from the
-/// nearest `request` span) and profile (from the nearest `mcp_request`
-/// span) previously captured by [`SpanFieldCaptureLayer`]. Returns a
-/// fully-`None` [`RequestSpanContext`] when no subscriber is installed (e.g.
-/// in unit tests that do not configure tracing) or when the capture layer is
-/// not in the layer stack — adapters degrade to omitting both fields.
+/// Walk the current tracing span scope and pull the canonical UID and caller
+/// identity (from the nearest `request` span) and profile (from the nearest
+/// `mcp_request` span) previously captured by [`SpanFieldCaptureLayer`].
+/// Returns a fully-`None` [`RequestSpanContext`] when no subscriber is
+/// installed (e.g. in unit tests that do not configure tracing) or when the
+/// capture layer is not in the layer stack — adapters degrade to omitting the
+/// fields.
 pub fn current_request_context() -> RequestSpanContext {
     let mut ctx = RequestSpanContext::default();
     tracing::Span::current().with_subscriber(|(id, sub)| {
@@ -476,11 +451,6 @@ pub fn current_request_context() -> RequestSpanContext {
         for s in span.scope() {
             let ext = s.extensions();
             if let Some(captured) = ext.get::<CapturedSpanFields>() {
-                if ctx.jsonrpc_id.is_none() {
-                    if let Some(v) = &captured.jsonrpc_id {
-                        ctx.jsonrpc_id = Some(v.clone());
-                    }
-                }
                 if ctx.request_uid.is_none() {
                     if let Some(v) = &captured.request_uid {
                         ctx.request_uid = Some(v.clone());
@@ -513,7 +483,6 @@ mod tests {
     fn started_event_serializes_with_kind_tag() {
         let ev = ToolCallEvent::Started {
             request_id: "rid-1".into(),
-            jsonrpc_id: Some("42".into()),
             request_uid: Some("uid-abc".into()),
             ts: "2026-05-27T04:36:29.710Z".into(),
             endpoint: "github".into(),
@@ -539,7 +508,6 @@ mod tests {
         assert_eq!(v["kind"], "started");
         assert_eq!(v["tool"], "list_issues");
         assert_eq!(v["annotations"]["read_only"], true);
-        assert_eq!(v["jsonrpc_id"], "42");
         assert_eq!(v["request_uid"], "uid-abc");
         assert_eq!(v["client"]["name"], "claude-ai");
         assert_eq!(v["client"]["version"], "0.1.0");
@@ -554,10 +522,9 @@ mod tests {
     }
 
     #[test]
-    fn started_event_omits_jsonrpc_id_when_none() {
+    fn started_event_omits_optional_fields_when_none() {
         let ev = ToolCallEvent::Started {
             request_id: "rid-1".into(),
-            jsonrpc_id: None,
             request_uid: None,
             ts: "t".into(),
             endpoint: "github".into(),
@@ -570,10 +537,6 @@ mod tests {
             client: None,
         };
         let v = serde_json::to_value(&ev).unwrap();
-        assert!(
-            v.get("jsonrpc_id").is_none(),
-            "jsonrpc_id should be omitted when None, got {v}"
-        );
         assert!(
             v.get("request_uid").is_none(),
             "request_uid should be omitted when None, got {v}"
@@ -743,14 +706,12 @@ mod tests {
     fn completed_and_failed_serialize_with_status() {
         let completed = ToolCallEvent::Completed {
             request_id: "rid-1".into(),
-            jsonrpc_id: Some("\"abc\"".into()),
             ts: "t".into(),
             duration_ms: 12,
             status: "ok".into(),
         };
         let failed = ToolCallEvent::Failed {
             request_id: "rid-2".into(),
-            jsonrpc_id: None,
             ts: "t".into(),
             duration_ms: 9,
             status: "error".into(),
@@ -760,14 +721,9 @@ mod tests {
         let f = serde_json::to_value(&failed).unwrap();
         assert_eq!(c["kind"], "completed");
         assert_eq!(c["status"], "ok");
-        assert_eq!(c["jsonrpc_id"], "\"abc\"");
         assert_eq!(f["kind"], "failed");
         assert_eq!(f["status"], "error");
         assert_eq!(f["error_message"], "boom");
-        assert!(
-            f.get("jsonrpc_id").is_none(),
-            "failed jsonrpc_id None should be omitted, got {f}"
-        );
     }
 
     #[test]
@@ -800,7 +756,6 @@ mod tests {
         let mut b = bus.subscribe();
         bus.send(ToolCallEvent::Completed {
             request_id: "r".into(),
-            jsonrpc_id: None,
             ts: "t".into(),
             duration_ms: 1,
             status: "ok".into(),
@@ -821,7 +776,6 @@ mod tests {
         for i in 0..10 {
             bus.send(ToolCallEvent::Completed {
                 request_id: format!("r-{i}"),
-                jsonrpc_id: None,
                 ts: "t".into(),
                 duration_ms: i,
                 status: "ok".into(),
@@ -846,7 +800,6 @@ mod tests {
         assert_eq!(bus.receiver_count(), 0);
         bus.send(ToolCallEvent::Completed {
             request_id: "r".into(),
-            jsonrpc_id: None,
             ts: "t".into(),
             duration_ms: 1,
             status: "ok".into(),
@@ -854,9 +807,9 @@ mod tests {
     }
 
     /// With [`SpanFieldCaptureLayer`] installed, an adapter running inside an
-    /// `mcp_request{profile=...}` > `request{id=...}` scope can pull both
-    /// values via [`current_request_context`] — this is the foundation for
-    /// per-event `jsonrpc_id` plumbing without a `call_tool` trait change.
+    /// `mcp_request{profile=...}` > `request{request_uid=...}` scope can pull
+    /// both values via [`current_request_context`] — this is the foundation for
+    /// per-event `request_uid` plumbing without a `call_tool` trait change.
     #[test]
     fn current_request_context_walks_request_and_mcp_request_spans() {
         use tracing::Instrument;
@@ -869,7 +822,6 @@ mod tests {
                 .build()
                 .unwrap();
             rt.block_on(async {
-                let id_str = "7".to_string();
                 let request_uid = "uid-7".to_string();
                 let profile = "work".to_string();
                 let outer = tracing::info_span!("mcp_request", profile = %profile);
@@ -877,14 +829,12 @@ mod tests {
                     let inner = tracing::info_span!(
                         "request",
                         method = "tools/call",
-                        id = %id_str,
                         request_uid = %request_uid,
                     );
                     async { current_request_context() }.instrument(inner).await
                 }
                 .instrument(outer)
                 .await;
-                assert_eq!(captured.jsonrpc_id.as_deref(), Some("7"));
                 assert_eq!(captured.request_uid.as_deref(), Some("uid-7"));
                 assert_eq!(captured.profile.as_deref(), Some("work"));
             });
@@ -901,27 +851,6 @@ mod tests {
         tracing::subscriber::with_default(subscriber, || {
             let ctx = current_request_context();
             assert_eq!(ctx, RequestSpanContext::default());
-        });
-    }
-
-    /// Sanity-check the "null" id sentinel: notifications would record
-    /// `id = "null"`; the visitor must not propagate that as a real id.
-    #[test]
-    fn null_jsonrpc_id_is_ignored_by_capture_visitor() {
-        use tracing::Instrument;
-        use tracing_subscriber::prelude::*;
-        let subscriber = tracing_subscriber::registry().with(SpanFieldCaptureLayer);
-        tracing::subscriber::with_default(subscriber, || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap();
-            rt.block_on(async {
-                let id_str = "null".to_string();
-                let span = tracing::info_span!("request", method = "x", id = %id_str);
-                let ctx = async { current_request_context() }.instrument(span).await;
-                assert_eq!(ctx.jsonrpc_id, None);
-            });
         });
     }
 
@@ -948,15 +877,12 @@ mod tests {
                     origin: None,
                 };
                 let client_json = serde_json::to_string(&identity).unwrap();
-                let id_str = "9".to_string();
                 let span = tracing::info_span!(
                     "request",
                     method = "tools/call",
-                    id = %id_str,
                     client = %client_json,
                 );
                 let ctx = async { current_request_context() }.instrument(span).await;
-                assert_eq!(ctx.jsonrpc_id.as_deref(), Some("9"));
                 assert_eq!(ctx.client.as_ref(), Some(&identity));
             });
         });

--- a/src/events.rs
+++ b/src/events.rs
@@ -321,8 +321,12 @@ impl Default for ToolCallEventBus {
 /// into span extensions by [`SpanFieldCaptureLayer`] and surfaced to adapter
 /// code via [`current_request_context`]. Adapters use this to populate
 /// `request_uid` (from the inner `request` span) and `profile` (from the outer
-/// `mcp_request` span) on every emitted [`ToolCallEvent`] without taking a
-/// breaking change to the [`crate::adapter::McpAdapter::call_tool`] signature.
+/// `mcp_request` span) on the [`ToolCallEvent::Started`] they emit, without
+/// taking a breaking change to the [`crate::adapter::McpAdapter::call_tool`]
+/// signature. Only `Started` carries these fields; the matching
+/// [`ToolCallEvent::Completed`]/[`ToolCallEvent::Failed`] stay terse and are
+/// correlated back to their `Started` (and thus to that `request_uid`) via the
+/// shared per-call `request_id`.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct RequestSpanContext {
     /// Canonical per-JSON-RPC-message UID captured from the `request` span's

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -100,14 +100,6 @@ struct SandboxState {
     /// caller to the upstream adapter's event emitters and log lines — the
     /// blocking-thread hop otherwise drops the outer request span.
     client_json: String,
-    /// JSON-RPC envelope id of the outer inbound request, captured before the
-    /// sandbox hops onto the blocking thread. Empty when no id is known. Used
-    /// to re-establish a `request{id=...}` span around each inner
-    /// `route_tool_call` so `SpanFieldCaptureLayer` / `current_request_context()`
-    /// surface the id to the upstream adapter's event emitters
-    /// (`ToolCallEvent::Started.jsonrpc_id`) — the blocking-thread hop otherwise
-    /// drops the outer request span.
-    jsonrpc_id: String,
     /// Canonical per-inbound-request UID of the outer inbound request,
     /// captured before the sandbox hops onto the blocking thread. Empty when
     /// no UID was minted. Used to re-establish a `request{request_uid=...}`
@@ -143,11 +135,6 @@ pub struct JsSandbox {
     /// [`Self::with_client`] by [`MetaToolHandler::execute_tools`] so inner
     /// upstream tool calls re-establish the caller's `request` span.
     client_json: String,
-    /// JSON-RPC envelope id of the outer inbound request. Defaults to empty
-    /// (no id); set via [`Self::with_jsonrpc_id`] by
-    /// [`MetaToolHandler::execute_tools`] so inner upstream tool calls
-    /// re-establish the outer request's `request{id=...}` span.
-    jsonrpc_id: String,
     /// Canonical per-inbound-request UID of the outer inbound request.
     /// Defaults to empty (no UID); set via [`Self::with_request_uid`] by
     /// [`MetaToolHandler::execute_tools`] so inner upstream tool calls
@@ -185,7 +172,6 @@ impl JsSandbox {
             timeout,
             use_real_backoff: false,
             client_json: String::new(),
-            jsonrpc_id: String::new(),
             request_uid: String::new(),
         }
     }
@@ -197,15 +183,6 @@ impl JsSandbox {
     /// [`MetaToolHandler::execute_tools`].
     pub fn with_client(mut self, client_json: String) -> Self {
         self.client_json = client_json;
-        self
-    }
-
-    /// Attach the outer inbound request's JSON-RPC envelope id so inner
-    /// upstream tool calls re-establish a `request{id=...}` span on the
-    /// sandbox's blocking thread. An empty string degrades to no id. Used by
-    /// [`MetaToolHandler::execute_tools`].
-    pub fn with_jsonrpc_id(mut self, jsonrpc_id: String) -> Self {
-        self.jsonrpc_id = jsonrpc_id;
         self
     }
 
@@ -233,7 +210,6 @@ impl JsSandbox {
         let timeout = self.timeout;
         let use_real_backoff = self.use_real_backoff;
         let client_json = self.client_json.clone();
-        let jsonrpc_id = self.jsonrpc_id.clone();
         let request_uid = self.request_uid.clone();
         let script = script.to_string();
         let handle = tokio::runtime::Handle::current();
@@ -250,7 +226,6 @@ impl JsSandbox {
                     timeout,
                     use_real_backoff,
                     client_json,
-                    jsonrpc_id,
                     request_uid,
                 )
             }),
@@ -278,7 +253,6 @@ fn execute_in_sandbox(
     sandbox_timeout: Duration,
     use_real_backoff: bool,
     client_json: String,
-    jsonrpc_id: String,
     request_uid: String,
 ) -> Result<Value, JsSandboxError> {
     let deadline = std::time::Instant::now() + sandbox_timeout;
@@ -289,7 +263,6 @@ fn execute_in_sandbox(
             deadline,
             use_real_backoff,
             client_json,
-            jsonrpc_id,
             request_uid,
         });
     });
@@ -301,38 +274,35 @@ fn execute_in_sandbox(
 }
 
 /// Drive `fut` to completion on the sandbox's blocking thread, re-establishing
-/// the outer inbound request's `request{id=...,request_uid=...,client=...}`
-/// span when any of those signals was captured.
+/// the outer inbound request's `request{request_uid=...,client=...}` span when
+/// either of those signals was captured.
 ///
 /// `JsSandbox::execute` hops onto a `spawn_blocking` thread, which does not
 /// inherit the inbound `request` span. Without re-entering it here, the
-/// upstream adapter's `current_request_context()` resolves no JSON-RPC id, no
-/// request UID and no caller for sandbox-driven tool calls, so the "Tool call
+/// upstream adapter's `current_request_context()` resolves no request UID and
+/// no caller for sandbox-driven tool calls, so the "Tool call
 /// completed/failed" log lines and
-/// `ToolCallEvent::Started.{jsonrpc_id,request_uid,client}` lose those signals.
-/// Entering a fresh `request` span carrying `id = %jsonrpc_id`,
-/// `request_uid = %request_uid` and `client = %client_json` lets
-/// `SpanFieldCaptureLayer` re-capture them exactly as the direct path does.
-/// `SpanFieldCaptureLayer`'s visitor skips empty `id`/`request_uid`/`client`
-/// values, so a missing signal records no field; when all three are empty the
-/// future runs without an extra span.
+/// `ToolCallEvent::Started.{request_uid,client}` lose those signals.
+/// Entering a fresh `request` span carrying `request_uid = %request_uid` and
+/// `client = %client_json` lets `SpanFieldCaptureLayer` re-capture them exactly
+/// as the direct path does. `SpanFieldCaptureLayer`'s visitor skips empty
+/// `request_uid`/`client` values, so a missing signal records no field; when
+/// both are empty the future runs without an extra span.
 fn block_on_with_request_context<F>(
     handle: &tokio::runtime::Handle,
     client_json: &str,
-    jsonrpc_id: &str,
     request_uid: &str,
     fut: F,
 ) -> F::Output
 where
     F: std::future::Future,
 {
-    if jsonrpc_id.is_empty() && client_json.is_empty() && request_uid.is_empty() {
+    if client_json.is_empty() && request_uid.is_empty() {
         return handle.block_on(fut);
     }
     let span = tracing::info_span!(
         "request",
         method = "tools/call",
-        id = %jsonrpc_id,
         request_uid = %request_uid,
         client = %client_json,
     );
@@ -456,7 +426,6 @@ fn call_tool_native(_this: &JsValue, args: &[JsValue], context: &mut Context) ->
         let res = block_on_with_request_context(
             &state.handle,
             &state.client_json,
-            &state.jsonrpc_id,
             &state.request_uid,
             state.registry.route_tool_call(&tool_name, arguments),
         )
@@ -553,7 +522,6 @@ fn call_tool_with_retry_native(
         let res = block_on_with_request_context(
             &state.handle,
             &state.client_json,
-            &state.jsonrpc_id,
             &state.request_uid,
             call_tool_with_retry_loop(
                 registry.as_ref(),
@@ -1324,25 +1292,21 @@ impl MetaToolHandler {
     /// gives the script a profile-filtered `tools.call()`.
     ///
     /// `client_json` is the JSON-serialised [`crate::events::ClientIdentity`]
-    /// of the outer inbound request (empty when no caller identity is known),
-    /// `jsonrpc_id` is the outer request's JSON-RPC envelope id (empty when
-    /// none is known) and `request_uid` is the outer request's canonical
-    /// collision-free UID (empty when none was minted). All three are threaded
-    /// into the sandbox so inner upstream tool calls re-establish the caller's
-    /// `request{id=...,request_uid=...,client=...}` span across the
-    /// blocking-thread hop — keeping the id, UID and caller visible on the
-    /// aggregated "Tool call completed/failed" log lines and
-    /// `ToolCallEvent::Started`.
+    /// of the outer inbound request (empty when no caller identity is known)
+    /// and `request_uid` is the outer request's canonical collision-free UID
+    /// (empty when none was minted). Both are threaded into the sandbox so
+    /// inner upstream tool calls re-establish the caller's
+    /// `request{request_uid=...,client=...}` span across the blocking-thread
+    /// hop — keeping the UID and caller visible on the aggregated "Tool call
+    /// completed/failed" log lines and `ToolCallEvent::Started`.
     pub async fn execute_tools(
         &self,
         script: &str,
         client_json: &str,
-        jsonrpc_id: &str,
         request_uid: &str,
     ) -> Result<Value, JsSandboxError> {
         let sandbox = JsSandbox::from_dyn(self.registry.clone(), self.sandbox_timeout)
             .with_client(client_json.to_string())
-            .with_jsonrpc_id(jsonrpc_id.to_string())
             .with_request_uid(request_uid.to_string());
         sandbox.execute(script).await
     }
@@ -3212,7 +3176,6 @@ mod tests {
                 rt.handle(),
                 &client_json,
                 "",
-                "",
                 reg.route_tool_call("echo", json!({})),
             );
             assert!(result.is_ok(), "tool call should succeed: {:?}", result);
@@ -3228,91 +3191,6 @@ mod tests {
                 origin: None,
             }),
             "sandbox-driven tool call must re-establish the caller identity \
-             in the request context"
-        );
-    }
-
-    /// A sandbox-driven upstream tool call must re-establish the outer inbound
-    /// request's JSON-RPC id across the `spawn_blocking` thread hop.
-    /// [`block_on_with_request_context`] enters a fresh `request{id=...}` span
-    /// before driving [`MetaToolRegistry::route_tool_call`], so the adapter's
-    /// `current_request_context().jsonrpc_id` (the signal feeding
-    /// `ToolCallEvent::Started.jsonrpc_id` and the desktop overlay's `log_id`)
-    /// resolves the outer id rather than `None`. This is the exact failure the
-    /// task reproduced live before the fix.
-    #[test]
-    fn sandbox_tool_call_reestablishes_jsonrpc_id() {
-        use crate::events::{current_request_context, SpanFieldCaptureLayer};
-        use std::sync::Mutex;
-        use tracing_subscriber::prelude::*;
-
-        // Adapter that records the JSON-RPC id visible via the request span at
-        // `call_tool` time, proving the span was re-established.
-        struct IdCapturingAdapter {
-            tools: Vec<ToolInfo>,
-            seen: Arc<Mutex<Option<String>>>,
-        }
-
-        #[async_trait]
-        impl McpAdapter for IdCapturingAdapter {
-            async fn initialize(&mut self) -> Result<(), AdapterError> {
-                Ok(())
-            }
-            async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
-                Ok(self.tools.clone())
-            }
-            async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
-                *self.seen.lock().unwrap() = current_request_context().jsonrpc_id;
-                Ok(json!({ "called": name, "args": arguments }))
-            }
-            fn health(&self) -> HealthStatus {
-                HealthStatus::Healthy
-            }
-            async fn shutdown(&mut self) -> Result<(), AdapterError> {
-                Ok(())
-            }
-        }
-
-        let seen = Arc::new(Mutex::new(None));
-        let seen_clone = Arc::clone(&seen);
-        let subscriber = tracing_subscriber::registry().with(SpanFieldCaptureLayer);
-        tracing::subscriber::with_default(subscriber, || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap();
-            let registry = rt.block_on(async {
-                let registry = AdapterRegistry::new();
-                registry
-                    .register(
-                        "ep".into(),
-                        Box::new(IdCapturingAdapter {
-                            tools: vec![make_tool("echo", "Echo tool")],
-                            seen: seen_clone,
-                        }),
-                        "stdio".into(),
-                        None,
-                        None,
-                    )
-                    .await;
-                Arc::new(registry)
-            });
-
-            let reg: Arc<dyn MetaToolRegistry> = registry;
-            let result = block_on_with_request_context(
-                rt.handle(),
-                "",
-                "42",
-                "",
-                reg.route_tool_call("echo", json!({})),
-            );
-            assert!(result.is_ok(), "tool call should succeed: {:?}", result);
-        });
-
-        assert_eq!(
-            *seen.lock().unwrap(),
-            Some("42".to_string()),
-            "sandbox-driven tool call must re-establish the outer JSON-RPC id \
              in the request context"
         );
     }
@@ -3387,7 +3265,6 @@ mod tests {
             let result = block_on_with_request_context(
                 rt.handle(),
                 "",
-                "",
                 "req-uid-123",
                 reg.route_tool_call("echo", json!({})),
             );
@@ -3402,11 +3279,11 @@ mod tests {
         );
     }
 
-    /// With no caller identity captured (empty `client_json`), no id (empty
-    /// `jsonrpc_id`) and no UID (empty `request_uid`),
-    /// [`block_on_with_request_context`] must skip the extra span and drive the
-    /// future directly, leaving `current_request_context().client` as `None`
-    /// rather than fabricating an empty identity.
+    /// With no caller identity captured (empty `client_json`) and no UID (empty
+    /// `request_uid`), [`block_on_with_request_context`] must skip the extra
+    /// span and drive the future directly, leaving
+    /// `current_request_context().client` as `None` rather than fabricating an
+    /// empty identity.
     #[test]
     fn sandbox_tool_call_without_client_leaves_context_none() {
         use crate::events::{current_request_context, ClientIdentity, SpanFieldCaptureLayer};
@@ -3466,7 +3343,6 @@ mod tests {
             let reg: Arc<dyn MetaToolRegistry> = registry;
             let result = block_on_with_request_context(
                 rt.handle(),
-                "",
                 "",
                 "",
                 reg.route_tool_call("echo", json!({})),

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,11 +157,11 @@ fn init_tracing(
             .boxed(),
     };
 
-    // SpanFieldCaptureLayer captures the JSON-RPC id (from `request` spans)
-    // and profile (from `mcp_request` spans) into per-span extensions so
-    // adapters can populate `jsonrpc_id` / `profile` on every
-    // `ToolCallEvent` without a breaking `McpAdapter::call_tool` signature
-    // change. Cheap: only allocates for the two named spans.
+    // SpanFieldCaptureLayer captures the canonical UID and caller identity
+    // (from `request` spans) and profile (from `mcp_request` spans) into
+    // per-span extensions so adapters can populate `request_uid` / `profile`
+    // on every `ToolCallEvent` without a breaking `McpAdapter::call_tool`
+    // signature change. Cheap: only allocates for the two named spans.
     tracing_subscriber::registry()
         .with(events::SpanFieldCaptureLayer)
         .with(stdout_layer)

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,7 +160,9 @@ fn init_tracing(
     // SpanFieldCaptureLayer captures the canonical UID and caller identity
     // (from `request` spans) and profile (from `mcp_request` spans) into
     // per-span extensions so adapters can populate `request_uid` / `profile`
-    // on every `ToolCallEvent` without a breaking `McpAdapter::call_tool`
+    // on the `ToolCallEvent::Started` they emit (only `Started` carries them;
+    // `Completed`/`Failed` are terse and correlate back via the shared
+    // per-call `request_id`) without a breaking `McpAdapter::call_tool`
     // signature change. Cheap: only allocates for the two named spans.
     tracing_subscriber::registry()
         .with(events::SpanFieldCaptureLayer)

--- a/src/management.rs
+++ b/src/management.rs
@@ -7885,7 +7885,6 @@ client_id = "client123"
         assert!(bus.receiver_count() > 0, "SSE handler should subscribe");
         bus.send(crate::events::ToolCallEvent::Completed {
             request_id: "rid-1".into(),
-            jsonrpc_id: Some("42".into()),
             ts: "2026-05-27T00:00:00.000Z".into(),
             duration_ms: 5,
             status: "ok".into(),
@@ -7917,11 +7916,6 @@ client_id = "client123"
         assert!(
             text.contains("\"request_id\":\"rid-1\""),
             "expected request_id in SSE body, got: {}",
-            text
-        );
-        assert!(
-            text.contains("\"jsonrpc_id\":\"42\""),
-            "expected jsonrpc_id in SSE body, got: {}",
             text
         );
     }

--- a/src/profile_registry.rs
+++ b/src/profile_registry.rs
@@ -813,7 +813,7 @@ mod tests {
             }
         "#;
         let result = handler
-            .execute_tools(script, "", "", "")
+            .execute_tools(script, "", "")
             .await
             .expect("execute_tools should return the script's error value");
         let err_msg = result

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -788,7 +788,6 @@ impl AdapterRegistry {
             // adapter-side ordering.
             bus.send(ToolCallEvent::Started {
                 request_id: request_id.clone(),
-                jsonrpc_id: span_ctx.jsonrpc_id.clone(),
                 request_uid: span_ctx.request_uid.clone(),
                 ts: iso8601_now(),
                 endpoint,
@@ -802,7 +801,6 @@ impl AdapterRegistry {
             });
             bus.send(ToolCallEvent::Failed {
                 request_id,
-                jsonrpc_id: span_ctx.jsonrpc_id,
                 ts: iso8601_now(),
                 duration_ms: 0,
                 status: "error".to_string(),
@@ -835,7 +833,6 @@ impl AdapterRegistry {
             // before it sees `Failed`, matching the adapter-side ordering.
             bus.send(ToolCallEvent::Started {
                 request_id: request_id.clone(),
-                jsonrpc_id: span_ctx.jsonrpc_id.clone(),
                 request_uid: span_ctx.request_uid.clone(),
                 ts: iso8601_now(),
                 endpoint,
@@ -849,7 +846,6 @@ impl AdapterRegistry {
             });
             bus.send(ToolCallEvent::Failed {
                 request_id,
-                jsonrpc_id: span_ctx.jsonrpc_id,
                 ts: iso8601_now(),
                 duration_ms: 0,
                 status: "validation_error".to_string(),

--- a/src/server.rs
+++ b/src/server.rs
@@ -682,23 +682,22 @@ async fn mcp_tools_call(
                 .get("script")
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
-            // Recover the outer inbound request's identity and JSON-RPC id from
-            // the surrounding `request{id=...,client=...}` span (seeded by
-            // `handle_single_message` / the logged wrappers) and re-serialise
-            // them so the sandbox can re-establish the caller's span around each
-            // inner upstream tool call across the blocking-thread hop. Without
-            // this, aggregated `execute_tools` inner calls emit an empty client
-            // and a `None` jsonrpc_id.
+            // Recover the outer inbound request's identity and canonical UID
+            // from the surrounding `request{request_uid=...,client=...}` span
+            // (seeded by `handle_single_message` / the logged wrappers) and
+            // re-serialise them so the sandbox can re-establish the caller's
+            // span around each inner upstream tool call across the
+            // blocking-thread hop. Without this, aggregated `execute_tools`
+            // inner calls emit an empty client and a `None` request_uid.
             let request_ctx = crate::events::current_request_context();
             let client_json = request_ctx
                 .client
                 .filter(|c| !c.is_empty())
                 .map(|c| serde_json::to_string(&c).unwrap_or_default())
                 .unwrap_or_default();
-            let jsonrpc_id = request_ctx.jsonrpc_id.unwrap_or_default();
             let request_uid = request_ctx.request_uid.unwrap_or_default();
             match handler
-                .execute_tools(script, &client_json, &jsonrpc_id, &request_uid)
+                .execute_tools(script, &client_json, &request_uid)
                 .await
             {
                 Ok(result) => {
@@ -775,8 +774,7 @@ async fn handle_single_message(
     // across reconnects when a client resets its counter), this UUID is unique
     // per message, so every log line and `ToolCallEvent` produced while
     // processing this message shares one collision-free key for the desktop's
-    // row/overlay keying. `jsonrpc_id` stays on the wire for diagnostic
-    // context.
+    // row/overlay keying.
     let request_uid = uuid::Uuid::new_v4().to_string();
     // JSON-encode the identity so `SpanFieldCaptureLayer` can deserialise it
     // back into a typed [`ClientIdentity`] via `current_request_context()`


### PR DESCRIPTION
## Problem

Since desktop PR endara-desktop#125 (rc.6) re-sourced log row / overlay card keys from the relay-minted `request_uid`, the `jsonrpc_id` field on `ToolCallEvent` is dead payload on the wire. Relay & desktop ship bundled, so there's no backwards-compatibility concern — `request_uid` is now the only canonical key.

## Fix

Remove `jsonrpc_id` from the wire, the span context capture, and all producers/tests.

## Changes

- `src/events.rs` — dropped `jsonrpc_id` from `ToolCallEvent::{Started,Completed,Failed}`, `RequestSpanContext`, `CapturedSpanFields`, and the `SpanFieldCaptureLayer` capture/visitor logic. Updated unit tests; removed the now-defunct `null_jsonrpc_id_is_ignored_by_capture_visitor` test.
- `src/registry.rs`, `src/adapter/{sse,stdio,http}.rs` — stopped passing `jsonrpc_id` when constructing `ToolCallEvent`.
- `src/adapter/oauth/mod.rs` — converted the regression test to assert `request_uid`; doc comments updated.
- `src/adapter/stdio.rs` — renamed regression test `call_tool_publishes_jsonrpc_id_from_request_span` → `..._request_uid_...`.
- `src/js_sandbox.rs` — removed `jsonrpc_id` from `JsSandbox`/`SandboxState`, the `with_jsonrpc_id` builder, `execute_tools`, `execute_in_sandbox`, and `block_on_with_request_context` signatures + all call sites; deleted the `sandbox_tool_call_reestablishes_jsonrpc_id` test.
- `src/server.rs`, `src/main.rs`, `src/profile_registry.rs`, `src/management.rs` — call sites, comments, and the SSE test updated.

`request_uid` minting + production `request` span are untouched.

## Verification

- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace` ✅ (881 passed)
- `grep -rn "jsonrpc_id" src/` → no references ✅

## Merge sequencing

Companion PR: `endara-ai/endara-desktop#127` (drops the deprecated `jsonrpc_id?` field from desktop's TS types + renames internal `jsonrpcId` → `logId`). They MUST merge bundled in the same rc cycle since they ship together — relay drops the wire field, desktop drops the inbound type.
