### PR TITLE
feat(oauth): just-in-time upstream OAuth sign-in (add-time probe + runtime 401 interception)

### DIFF
--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -298,8 +298,13 @@ impl HttpAdapter {
         {
             Ok(authorize_url) => Ok(jit::surface_authorize_url(&authorize_url)),
             Err(e) => {
-                warn!(error = %e, "JIT OAuth self-initiation failed; forwarding original error");
-                result
+                // The raw upstream 401 / WWW-Authenticate challenge must NEVER
+                // reach the downstream client. When self-initiation fails we
+                // still swallow the 401 and surface a sanitized, actionable
+                // sign-in-unavailable result; the underlying error stays in the
+                // server-side log only.
+                warn!(error = %e, "JIT OAuth self-initiation failed; surfacing sanitized sign-in-unavailable result");
+                Ok(jit::surface_oauth_unavailable())
             }
         }
     }

--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -1,3 +1,4 @@
+use super::oauth::jit::{self, JitInterceptor};
 use super::server_name::{sanitize_server_name, ServerNameError};
 use super::server_type_resolution::{effective_server_type, strip_mcp_server_suffix};
 use super::stdio::{iso8601_now, RingBuffer};
@@ -108,6 +109,17 @@ pub struct HttpAdapter {
     /// upstreams that don't issue a session ID — those servers continue to
     /// work without the header.
     session_id: Arc<RwLock<Option<String>>>,
+    /// Optional just-in-time OAuth interceptor. `None` for every adapter built
+    /// today, so the call path is behaviorally unchanged. When attached (by
+    /// follow-up task 098e0e03), a hard `HTTP 401` + `WWW-Authenticate: Bearer`
+    /// on a tool call is swallowed and self-initiates the OAuth flow instead of
+    /// being forwarded downstream.
+    jit_interceptor: Option<Arc<JitInterceptor>>,
+    /// Most recent `WWW-Authenticate` header observed on a `401` response,
+    /// captured before the response body is consumed so [`Self::call_tool`] can
+    /// hand it to the JIT interceptor. Per-host challenges are effectively
+    /// constant, so a concurrent overwrite is harmless.
+    last_www_authenticate: Arc<RwLock<Option<String>>>,
 }
 
 /// HTTP header name reqwest reads/writes for the MCP session ID. Reqwest's
@@ -176,6 +188,8 @@ impl HttpAdapter {
             event_bus: Arc::new(OnceLock::new()),
             tool_annotations_cache: Arc::new(RwLock::new(HashMap::new())),
             session_id: Arc::new(RwLock::new(None)),
+            jit_interceptor: None,
+            last_www_authenticate: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -222,6 +236,8 @@ impl HttpAdapter {
             event_bus: Arc::new(OnceLock::new()),
             tool_annotations_cache: Arc::new(RwLock::new(HashMap::new())),
             session_id: Arc::new(RwLock::new(None)),
+            jit_interceptor: None,
+            last_www_authenticate: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -231,6 +247,61 @@ impl HttpAdapter {
     /// `OnceLock` cell across every inner adapter it rebuilds.
     pub(crate) fn set_event_bus_handle(&mut self, handle: Arc<OnceLock<ToolCallEventBus>>) {
         self.event_bus = handle;
+    }
+
+    /// Attach a just-in-time OAuth interceptor. Wired by follow-up task
+    /// 098e0e03; unused today (every adapter is built without one).
+    #[allow(dead_code)]
+    pub(crate) fn set_jit_interceptor(&mut self, interceptor: Arc<JitInterceptor>) {
+        self.jit_interceptor = Some(interceptor);
+    }
+
+    /// Apply the JIT 401 interception policy to a tool-call outcome.
+    ///
+    /// When a JIT interceptor is attached and the upstream returned a hard
+    /// `HTTP 401` (per [`jit::should_intercept_outcome`]) with a `Bearer`
+    /// `WWW-Authenticate` challenge, the 401 is SWALLOWED — never forwarded
+    /// downstream — and the OAuth flow is self-initiated. Otherwise the
+    /// original outcome (including 200-`isError` results) is returned
+    /// unchanged.
+    ///
+    /// On a successful self-initiation the produced authorize URL is SURFACED to
+    /// the downstream client as an actionable tool result (`isError: true` with
+    /// an "open this to sign in" instruction) via [`jit::surface_authorize_url`],
+    /// rather than a protocol-level error — the model/CLI can act on it directly.
+    ///
+    /// Retry seam (chosen approach): the client re-issues the same tool call
+    /// after completing the loopback `/oauth/callback`. The next call carries the
+    /// now-persisted bearer (injected in [`Self::send_request`]) and succeeds.
+    /// This "client re-issue" path fits the request/response adapter with the
+    /// least surprise — no blocking the first call on a human-in-the-loop
+    /// browser round-trip, and no hidden server-side retry state machine.
+    async fn maybe_intercept_401(
+        &self,
+        result: Result<Value, AdapterError>,
+    ) -> Result<Value, AdapterError> {
+        let Some(ref interceptor) = self.jit_interceptor else {
+            return result;
+        };
+        if !jit::should_intercept_outcome(&result) {
+            return result;
+        }
+        let Some(challenge) = self.last_www_authenticate.read().await.clone() else {
+            return result;
+        };
+        if jit::parse_bearer_challenge(&challenge).is_none() {
+            return result;
+        }
+        match interceptor
+            .intercept(&self.config.url, &challenge, &self.config.endpoint_name)
+            .await
+        {
+            Ok(authorize_url) => Ok(jit::surface_authorize_url(&authorize_url)),
+            Err(e) => {
+                warn!(error = %e, "JIT OAuth self-initiation failed; forwarding original error");
+                result
+            }
+        }
     }
 
     fn next_id(&self) -> u64 {
@@ -390,6 +461,21 @@ impl HttpAdapter {
                 builder = builder.header(MCP_SESSION_ID_HEADER.clone(), val);
             }
         }
+        // JIT retry-after-sign-in seam: when a JIT interceptor is attached and a
+        // valid bearer has been persisted for this endpoint (after the human
+        // completed the loopback `/oauth/callback`), inject it so a re-issued
+        // tool call uses the held token and succeeds instead of re-triggering
+        // the JIT flow. No-op when no interceptor is attached or no valid token
+        // is stored, leaving the default request path unchanged.
+        if let Some(ref interceptor) = self.jit_interceptor {
+            if let Some(token) = interceptor.current_bearer(&self.config.endpoint_name).await {
+                if let Ok(val) =
+                    reqwest::header::HeaderValue::from_str(&format!("Bearer {}", token))
+                {
+                    builder = builder.header(reqwest::header::AUTHORIZATION, val);
+                }
+            }
+        }
         let resp = builder.send().await.map_err(|e| {
             if e.is_timeout() {
                 AdapterError::Timeout(self.config.timeout_secs)
@@ -405,6 +491,20 @@ impl HttpAdapter {
 
         let status = resp.status();
         if !status.is_success() {
+            // Capture the `WWW-Authenticate` challenge BEFORE consuming the
+            // body so the JIT 401 interceptor (if attached) can self-initiate
+            // OAuth. Only meaningful on a 401; cleared otherwise so a stale
+            // challenge can't leak into a later unrelated error.
+            if status == reqwest::StatusCode::UNAUTHORIZED {
+                let challenge = resp
+                    .headers()
+                    .get(reqwest::header::WWW_AUTHENTICATE)
+                    .and_then(|v| v.to_str().ok())
+                    .map(|s| s.to_string());
+                *self.last_www_authenticate.write().await = challenge;
+            } else {
+                *self.last_www_authenticate.write().await = None;
+            }
             let body = resp.text().await.unwrap_or_default();
             return Err(AdapterError::HttpError {
                 status: status.as_u16(),
@@ -892,6 +992,10 @@ impl McpAdapter for HttpAdapter {
             });
             let start = Instant::now();
             let result = self.send_request("tools/call", Some(params)).await;
+            // JIT 401 interception: swallow a hard 401 + Bearer challenge and
+            // self-initiate OAuth instead of forwarding it downstream. No-op
+            // unless a JIT interceptor is attached (none are today).
+            let result = self.maybe_intercept_401(result).await;
             let duration_ms = start.elapsed().as_millis();
             let now = chrono::Utc::now()
                 .format("%Y-%m-%dT%H:%M:%S%.3fZ")
@@ -1672,6 +1776,249 @@ mod tests {
             .expect("send_request succeeds without a session header");
         assert_eq!(result["ok"], true);
 
+        server.abort();
+    }
+
+    // --- JIT 401 interception (Wave 2 Path B) ---
+
+    /// Fixture whose `POST /mcp` gates every call with a hard 401 + Bearer
+    /// `WWW-Authenticate`, and which also advertises full standard OAuth so the
+    /// attached [`JitInterceptor`] can self-initiate the flow.
+    async fn spawn_gated_mcp_fixture() -> (String, tokio::task::JoinHandle<()>) {
+        use axum::extract::State;
+        use axum::http::{header::WWW_AUTHENTICATE, StatusCode};
+        use axum::response::IntoResponse;
+        use axum::routing::{get, post};
+        use axum::{Json, Router};
+
+        async fn mcp(State(base): State<String>) -> impl IntoResponse {
+            let val = format!(
+                "Bearer realm=\"Test\", resource_metadata=\"{}/.well-known/oauth-protected-resource\"",
+                base
+            );
+            (
+                StatusCode::UNAUTHORIZED,
+                [(WWW_AUTHENTICATE, val)],
+                "unauthorized",
+            )
+        }
+        async fn protected_resource(State(base): State<String>) -> Json<serde_json::Value> {
+            Json(json!({ "resource": base, "authorization_servers": [base] }))
+        }
+        async fn auth_server(State(base): State<String>) -> Json<serde_json::Value> {
+            Json(json!({
+                "issuer": base,
+                "authorization_endpoint": format!("{}/authorize", base),
+                "token_endpoint": format!("{}/token", base),
+                "registration_endpoint": format!("{}/register", base),
+                "code_challenge_methods_supported": ["S256"],
+            }))
+        }
+        async fn register() -> Json<serde_json::Value> {
+            Json(json!({ "client_id": "jit-cid", "client_secret": "jit-secret" }))
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let base = format!("http://127.0.0.1:{}", addr.port());
+        let router = Router::new()
+            .route("/mcp", post(mcp))
+            .route(
+                "/.well-known/oauth-protected-resource",
+                get(protected_resource),
+            )
+            .route("/.well-known/oauth-authorization-server", get(auth_server))
+            .route("/register", post(register))
+            .with_state(base.clone());
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        (base, handle)
+    }
+
+    /// Fixture whose `POST /mcp` returns `200 {ok:true}` ONLY when the request
+    /// carries `Authorization: Bearer <expected>`; otherwise it returns a hard
+    /// 401 + Bearer `WWW-Authenticate`. Models the authenticated-retry upstream:
+    /// after the human signs in, the persisted bearer is injected and the call
+    /// succeeds.
+    async fn spawn_bearer_gated_mcp_fixture(
+        expected_token: &str,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        use axum::extract::State;
+        use axum::http::{header::AUTHORIZATION, header::WWW_AUTHENTICATE, StatusCode};
+        use axum::response::IntoResponse;
+        use axum::routing::post;
+        use axum::{Json, Router};
+
+        #[derive(Clone)]
+        struct FixtureState {
+            base: String,
+            expected: String,
+        }
+
+        async fn mcp(
+            State(st): State<FixtureState>,
+            req: axum::extract::Request,
+        ) -> axum::response::Response {
+            let authed = req
+                .headers()
+                .get(AUTHORIZATION)
+                .and_then(|v| v.to_str().ok())
+                .map(|v| v == format!("Bearer {}", st.expected))
+                .unwrap_or(false);
+            if authed {
+                // The application/json response path does not validate the
+                // JSON-RPC id, so a fixed-id success result is sufficient.
+                Json(json!({"jsonrpc": "2.0", "result": {"ok": true}, "id": 1})).into_response()
+            } else {
+                let val = format!(
+                    "Bearer realm=\"Test\", resource_metadata=\"{}/.well-known/oauth-protected-resource\"",
+                    st.base
+                );
+                (
+                    StatusCode::UNAUTHORIZED,
+                    [(WWW_AUTHENTICATE, val)],
+                    "unauthorized",
+                )
+                    .into_response()
+            }
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let base = format!("http://127.0.0.1:{}", addr.port());
+        let st = FixtureState {
+            base: base.clone(),
+            expected: expected_token.to_string(),
+        };
+        let router = Router::new().route("/mcp", post(mcp)).with_state(st);
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        (base, handle)
+    }
+
+    /// With a JIT interceptor attached, a gated tool call's 401 is SWALLOWED
+    /// (never forwarded as a raw `HttpError { 401 }`) and the produced authorize
+    /// URL is SURFACED to the downstream client as an actionable tool result
+    /// (`isError: true` with an "open this to sign in" instruction). The raw
+    /// upstream challenge is never leaked.
+    #[tokio::test]
+    async fn call_tool_401_with_interceptor_surfaces_authorize_url() {
+        use crate::adapter::oauth::jit::JitInterceptor;
+        use crate::oauth::OAuthFlowManager;
+
+        let (base, server) = spawn_gated_mcp_fixture().await;
+        let flow_mgr = Arc::new(OAuthFlowManager::new());
+        let interceptor = Arc::new(JitInterceptor::new(9400, flow_mgr, None, true));
+
+        let mut adapter = HttpAdapter::new(HttpConfig::new(format!("{}/mcp", base)));
+        adapter.set_jit_interceptor(interceptor.clone());
+
+        let result = adapter.call_tool("search", json!({})).await;
+        let value = match result {
+            Ok(v) => v,
+            other => panic!("expected surfaced Ok result, got {:?}", other),
+        };
+
+        // Surfaced as a tool-error result, not a forwarded protocol failure.
+        assert_eq!(value["isError"], true);
+        let text = value["content"][0]["text"]
+            .as_str()
+            .expect("surfaced content text");
+        // Carries the composed authorize URL and a sign-in instruction.
+        assert!(
+            text.contains(&format!("{}/authorize?", base)),
+            "surfaced text should contain the authorize URL, got: {}",
+            text
+        );
+        assert!(text.to_lowercase().contains("sign-in"));
+        // The raw upstream 401 / WWW-Authenticate challenge is never leaked.
+        assert!(!text.contains("401"));
+        assert!(!text.contains("WWW-Authenticate"));
+
+        // State machine advanced and the URL is also stored on the interceptor.
+        assert_eq!(
+            interceptor.state().await,
+            crate::adapter::oauth::OAuthState::NeedsLogin
+        );
+        assert!(interceptor.pending_authorize_url().await.is_some());
+
+        server.abort();
+    }
+
+    /// Once a valid bearer token has been persisted for the endpoint (the state
+    /// after the loopback `/oauth/callback` completes the code→token exchange),
+    /// the tool-call path injects it and a re-issued call SUCCEEDS — without
+    /// re-triggering the JIT flow. This exercises the retry-after-sign-in seam.
+    #[tokio::test]
+    async fn call_tool_uses_persisted_bearer_and_does_not_retrigger_jit() {
+        use crate::adapter::oauth::jit::JitInterceptor;
+        use crate::oauth::OAuthFlowManager;
+        use crate::token_manager::{TokenManager, TokenSet};
+
+        let token = "good-access-token";
+        let (base, server) = spawn_bearer_gated_mcp_fixture(token).await;
+
+        // Persist a valid (unexpired) token under the endpoint name, exactly as
+        // the `/oauth/callback` handler does after the human signs in.
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        tm.save(
+            "ep-retry",
+            &TokenSet {
+                access_token: token.to_string(),
+                refresh_token: None,
+                expires_at: Some(now + 3600),
+                token_type: "Bearer".to_string(),
+                scope: None,
+                issued_at: Some(now),
+            },
+        )
+        .await
+        .unwrap();
+
+        let flow_mgr = Arc::new(OAuthFlowManager::new());
+        let interceptor = Arc::new(JitInterceptor::new(9400, flow_mgr, Some(tm), true));
+
+        let mut config = HttpConfig::new(format!("{}/mcp", base));
+        config.endpoint_name = "ep-retry".to_string();
+        let mut adapter = HttpAdapter::new(config);
+        adapter.set_jit_interceptor(interceptor.clone());
+
+        let result = adapter.call_tool("search", json!({})).await;
+        match result {
+            Ok(v) => assert_eq!(v["ok"], true),
+            other => panic!("expected authenticated success, got {:?}", other),
+        }
+
+        // The JIT flow was never triggered: no NeedsLogin transition, no URL.
+        assert_ne!(
+            interceptor.state().await,
+            crate::adapter::oauth::OAuthState::NeedsLogin
+        );
+        assert!(interceptor.pending_authorize_url().await.is_none());
+
+        server.abort();
+    }
+
+    /// Without an interceptor (the default for every adapter today), a 401 is
+    /// forwarded unchanged — confirming the wiring is dormant by default.
+    #[tokio::test]
+    async fn call_tool_401_without_interceptor_is_forwarded_unchanged() {
+        let (base, server) = spawn_gated_mcp_fixture().await;
+        let adapter = HttpAdapter::new(HttpConfig::new(format!("{}/mcp", base)));
+        let result = adapter.call_tool("search", json!({})).await;
+        match result {
+            Err(AdapterError::HttpError { status: 401, .. }) => {}
+            other => panic!("expected HttpError {{ 401 }}, got {:?}", other),
+        }
         server.abort();
     }
 }

--- a/src/adapter/oauth/jit.rs
+++ b/src/adapter/oauth/jit.rs
@@ -1,0 +1,521 @@
+//! Just-in-time (JIT) OAuth interception for plain HTTP MCP endpoints.
+//!
+//! When an upstream MCP server gates a tool call behind OAuth and signals it
+//! with a hard `HTTP 401` + `WWW-Authenticate: Bearer ...` (RFC 6750 / 9728),
+//! the relay must NOT forward that challenge downstream. Instead it becomes the
+//! OAuth client: it discovers the authorization server (RFC 9728 → 8414),
+//! dynamically registers a client (RFC 7591) and composes a PKCE authorize URL
+//! pointing back at the relay's loopback callback.
+//!
+//! This module is the DETECTION + self-initiation half of Wave 2 Path B. It
+//! deliberately triggers ONLY on a hard 401 + `WWW-Authenticate`; 200-`isError`
+//! tool results are passed through unchanged (see [`should_intercept_outcome`]).
+//!
+//! Surfacing the produced `authorize_url` to a headless client and retrying the
+//! tool call after the loopback callback completes builds on this module:
+//! [`surface_authorize_url`] formats the actionable downstream tool result and
+//! [`JitInterceptor::current_bearer`] supplies the persisted bearer for the
+//! authenticated retry (wired into the live call path in
+//! [`crate::adapter::http::HttpAdapter`]).
+
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::{info, warn};
+use url::Url;
+
+use super::state::OAuthState;
+use crate::adapter::AdapterError;
+use crate::oauth::dcr::{self, ClientRegistrationResponse};
+use crate::oauth::discovery::{self, DiscoveryError, DiscoveryResult};
+use crate::oauth::{OAuthFlowManager, PkceChallenge};
+use crate::token_manager::{DcrCredentials, TokenManager};
+use serde_json::{json, Value};
+
+/// A parsed `WWW-Authenticate: Bearer ...` challenge.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BearerChallenge {
+    pub realm: Option<String>,
+    /// RFC 9728 `resource_metadata` URL pointing at the protected-resource doc.
+    pub resource_metadata: Option<String>,
+}
+
+/// Parse a `WWW-Authenticate` header value, returning `Some` only for a
+/// `Bearer` challenge (the only scheme the relay self-initiates on). Quoted
+/// `auth-param` values are unquoted; commas inside quoted values are not
+/// expected here (the relevant params are realms and URLs).
+pub fn parse_bearer_challenge(header: &str) -> Option<BearerChallenge> {
+    let trimmed = header.trim();
+    if trimmed.len() < 6 || !trimmed[..6].eq_ignore_ascii_case("bearer") {
+        return None;
+    }
+    let rest = &trimmed[6..];
+    // The scheme must be delimited by whitespace (or be the whole value), so
+    // that e.g. "BearerToken" is not mistaken for the Bearer scheme.
+    if let Some(c) = rest.chars().next() {
+        if !c.is_whitespace() {
+            return None;
+        }
+    }
+    let mut realm = None;
+    let mut resource_metadata = None;
+    for part in rest.split(',') {
+        if let Some((k, v)) = part.split_once('=') {
+            let key = k.trim().to_ascii_lowercase();
+            let val = v.trim().trim_matches('"').to_string();
+            match key.as_str() {
+                "realm" => realm = Some(val),
+                "resource_metadata" => resource_metadata = Some(val),
+                _ => {}
+            }
+        }
+    }
+    Some(BearerChallenge {
+        realm,
+        resource_metadata,
+    })
+}
+
+/// The 401-only interception policy: a tool-call outcome is intercepted ONLY
+/// when it is a hard `HTTP 401`. Everything else — including a 200 JSON-RPC
+/// result carrying `isError: true` (which surfaces as `Ok(_)`) — is passed
+/// through unchanged. This is the deliberate "no 200-`isError` body sniffing"
+/// rule from the spec.
+pub fn should_intercept_outcome(result: &Result<Value, AdapterError>) -> bool {
+    matches!(result, Err(AdapterError::HttpError { status: 401, .. }))
+}
+
+/// Build the downstream-facing tool result that surfaces an `authorize_url` to
+/// a headless client.
+///
+/// Returns an MCP `CallToolResult`-shaped value with `isError: true` so the
+/// model/CLI sees an actionable "open this to sign in" instruction instead of a
+/// protocol-level failure. The same URL is surfaced regardless of how it is
+/// opened (desktop auto-open vs a printed line). The raw upstream `401` /
+/// `WWW-Authenticate` challenge is deliberately NOT included — downstream
+/// clients must never see the upstream credential challenge.
+pub fn surface_authorize_url(authorize_url: &str) -> Value {
+    let text = format!(
+        "Sign-in required to use this tool. Open the following URL in a browser to authorize, \
+         then retry the tool call:\n\n{}",
+        authorize_url
+    );
+    json!({
+        "content": [{ "type": "text", "text": text }],
+        "isError": true,
+    })
+}
+
+/// Errors raised while self-initiating the OAuth flow.
+#[derive(Debug, thiserror::Error)]
+pub enum JitError {
+    #[error("WWW-Authenticate is not a Bearer challenge")]
+    NotABearerChallenge,
+
+    #[error("OAuth discovery failed: {0}")]
+    Discovery(#[from] DiscoveryError),
+
+    #[error("Dynamic client registration failed: {0}")]
+    Dcr(#[from] dcr::DcrError),
+
+    #[error("no client credentials: server does not support DCR and none are stored")]
+    NoClientCredentials,
+}
+
+/// Self-initiation engine for a single endpoint. Holds the relay loopback port
+/// and shared OAuth machinery so that [`JitInterceptor::intercept`] can run the
+/// full discovery → DCR → authorize-URL flow without the desktop.
+pub struct JitInterceptor {
+    relay_port: u16,
+    flow_manager: Arc<OAuthFlowManager>,
+    token_manager: Option<Arc<TokenManager>>,
+    allow_insecure_oauth: bool,
+    state: RwLock<OAuthState>,
+    authorize_url: RwLock<Option<String>>,
+}
+
+impl JitInterceptor {
+    /// Construct a new interceptor.
+    #[allow(dead_code)] // wired into the live call path by follow-up task 098e0e03
+    pub fn new(
+        relay_port: u16,
+        flow_manager: Arc<OAuthFlowManager>,
+        token_manager: Option<Arc<TokenManager>>,
+        allow_insecure_oauth: bool,
+    ) -> Self {
+        Self {
+            relay_port,
+            flow_manager,
+            token_manager,
+            allow_insecure_oauth,
+            state: RwLock::new(OAuthState::Disconnected),
+            authorize_url: RwLock::new(None),
+        }
+    }
+
+    /// Current lifecycle state. Becomes [`OAuthState::NeedsLogin`] after a
+    /// successful intercept. SEAM (098e0e03): the follow-up reads this.
+    #[allow(dead_code)]
+    pub async fn state(&self) -> OAuthState {
+        self.state.read().await.clone()
+    }
+
+    /// The authorize URL produced by the most recent successful intercept.
+    /// SEAM (098e0e03): the follow-up surfaces this to the client + retries.
+    #[allow(dead_code)]
+    pub async fn pending_authorize_url(&self) -> Option<String> {
+        self.authorize_url.read().await.clone()
+    }
+
+    /// The retry-after-sign-in seam: load the currently stored bearer access
+    /// token for `endpoint_name`, if a valid (unexpired) one has been persisted.
+    ///
+    /// After the human completes the loopback `/oauth/callback`, the callback
+    /// handler exchanges the code for tokens and saves them to disk via the
+    /// shared [`TokenManager`] keyed by the endpoint name. A subsequent retry of
+    /// the same tool call then picks the token up here and injects it as a
+    /// `Bearer` header (see `HttpAdapter::send_request`), so the call succeeds
+    /// without re-triggering the JIT flow. Returns `None` when no token manager
+    /// is attached, no token is stored, or the stored token has expired.
+    pub async fn current_bearer(&self, endpoint_name: &str) -> Option<String> {
+        let tm = self.token_manager.as_ref()?;
+        let tokens = tm.load(endpoint_name).await.ok().flatten()?;
+        if !tokens.is_valid() {
+            return None;
+        }
+        Some(tokens.access_token)
+    }
+
+    /// Self-initiate the OAuth flow for a gated 401.
+    ///
+    /// Runs RFC 9728 → 8414 discovery against the resource (preferring the
+    /// `resource_metadata` origin from the challenge), dynamically registers a
+    /// client (RFC 7591) when needed, composes a PKCE authorize URL with the
+    /// relay loopback `redirect_uri`, and registers the pending flow so the
+    /// `/oauth/callback` handler can complete the exchange. On success the
+    /// interceptor transitions to [`OAuthState::NeedsLogin`] and stores the
+    /// authorize URL; the URL is also returned for convenience.
+    pub async fn intercept(
+        &self,
+        resource_url: &str,
+        www_authenticate: &str,
+        endpoint_name: &str,
+    ) -> Result<String, JitError> {
+        let challenge =
+            parse_bearer_challenge(www_authenticate).ok_or(JitError::NotABearerChallenge)?;
+
+        // Prefer the RFC 9728 `resource_metadata` origin as the discovery base;
+        // `discover_oauth_server` re-derives the conventional well-known path
+        // from it. Fall back to the resource (endpoint) URL when the challenge
+        // carries no `resource_metadata`.
+        let discovery_base = challenge
+            .resource_metadata
+            .as_deref()
+            .and_then(|m| Url::parse(m).ok())
+            .map(|u| u.origin().ascii_serialization())
+            .unwrap_or_else(|| resource_url.to_string());
+
+        let disc =
+            discovery::discover_oauth_server(&discovery_base, self.allow_insecure_oauth).await?;
+
+        let redirect_uri = format!("http://127.0.0.1:{}/oauth/callback", self.relay_port);
+
+        let (client_id, client_secret) = self
+            .resolve_client(&disc, &redirect_uri, endpoint_name)
+            .await?;
+
+        let pkce = PkceChallenge::generate();
+        let code_challenge = pkce.code_challenge.clone();
+        let state_param = self
+            .flow_manager
+            .start_flow(
+                endpoint_name,
+                &disc.token_endpoint,
+                &client_id,
+                client_secret.as_deref(),
+                pkce,
+                &redirect_uri,
+            )
+            .await;
+
+        let mut authorize_url = format!(
+            "{}?response_type=code&client_id={}&redirect_uri={}&state={}&code_challenge={}&code_challenge_method=S256",
+            disc.authorization_endpoint,
+            urlencoding(&client_id),
+            urlencoding(&redirect_uri),
+            urlencoding(&state_param),
+            urlencoding(&code_challenge),
+        );
+        if !disc.scopes_supported.is_empty() {
+            authorize_url.push_str(&format!(
+                "&scope={}",
+                urlencoding(&disc.scopes_supported.join(" "))
+            ));
+        }
+
+        info!(
+            endpoint = %endpoint_name,
+            "JIT OAuth self-initiated on upstream 401; authorize URL composed"
+        );
+        *self.state.write().await = OAuthState::NeedsLogin;
+        *self.authorize_url.write().await = Some(authorize_url.clone());
+        Ok(authorize_url)
+    }
+
+    /// Resolve `(client_id, client_secret)` for the flow: reuse persisted DCR
+    /// credentials when present, otherwise dynamically register. The RETURNED
+    /// auth method/secret is honored (some servers issue a `client_secret`
+    /// even when `none` was requested), and freshly registered credentials are
+    /// persisted when a token manager is available.
+    async fn resolve_client(
+        &self,
+        disc: &DiscoveryResult,
+        redirect_uri: &str,
+        endpoint_name: &str,
+    ) -> Result<(String, Option<String>), JitError> {
+        if let Some(ref tm) = self.token_manager {
+            if let Ok(Some(creds)) = tm.load_dcr(endpoint_name).await {
+                return Ok((creds.client_id, creds.client_secret));
+            }
+        }
+
+        let Some(ref reg_endpoint) = disc.registration_endpoint else {
+            return Err(JitError::NoClientCredentials);
+        };
+
+        let resp: ClientRegistrationResponse = dcr::register_client(
+            reg_endpoint,
+            redirect_uri,
+            endpoint_name,
+            self.allow_insecure_oauth,
+        )
+        .await?;
+
+        if let Some(ref tm) = self.token_manager {
+            let creds = DcrCredentials {
+                client_id: resp.client_id.clone(),
+                client_secret: resp.client_secret.clone(),
+                client_secret_expires_at: resp.client_secret_expires_at,
+                registered_at: now_secs(),
+            };
+            if let Err(e) = tm.save_dcr(endpoint_name, &creds).await {
+                warn!(error = %e, "failed to persist JIT-registered DCR credentials");
+            }
+        }
+
+        Ok((resp.client_id, resp.client_secret))
+    }
+}
+
+fn urlencoding(s: &str) -> String {
+    url::form_urlencoded::byte_serialize(s.as_bytes()).collect()
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // --- parse_bearer_challenge ---
+
+    #[test]
+    fn parse_bearer_with_realm_and_resource_metadata() {
+        let h = r#"Bearer realm="FlightPoints", resource_metadata="https://mcpv1.flightpoints.com/.well-known/oauth-protected-resource""#;
+        let c = parse_bearer_challenge(h).unwrap();
+        assert_eq!(c.realm.as_deref(), Some("FlightPoints"));
+        assert_eq!(
+            c.resource_metadata.as_deref(),
+            Some("https://mcpv1.flightpoints.com/.well-known/oauth-protected-resource")
+        );
+    }
+
+    #[test]
+    fn parse_bearer_scheme_only() {
+        let c = parse_bearer_challenge("Bearer").unwrap();
+        assert!(c.realm.is_none());
+        assert!(c.resource_metadata.is_none());
+    }
+
+    #[test]
+    fn parse_bearer_case_insensitive() {
+        let c = parse_bearer_challenge(
+            "bearer resource_metadata=https://x/.well-known/oauth-protected-resource",
+        )
+        .unwrap();
+        assert_eq!(
+            c.resource_metadata.as_deref(),
+            Some("https://x/.well-known/oauth-protected-resource")
+        );
+    }
+
+    #[test]
+    fn parse_rejects_non_bearer() {
+        assert!(parse_bearer_challenge("Basic realm=\"x\"").is_none());
+        // A token that merely starts with "Bearer" but isn't the scheme.
+        assert!(parse_bearer_challenge("BearerToken foo=bar").is_none());
+        assert!(parse_bearer_challenge("").is_none());
+    }
+
+    // --- should_intercept_outcome: the 401-only policy ---
+
+    #[test]
+    fn intercept_only_on_http_401() {
+        assert!(should_intercept_outcome(&Err(AdapterError::HttpError {
+            status: 401,
+            body: String::new(),
+        })));
+        assert!(!should_intercept_outcome(&Err(AdapterError::HttpError {
+            status: 403,
+            body: String::new(),
+        })));
+    }
+
+    /// A 200 JSON-RPC result carrying `isError: true` surfaces as `Ok(_)` and
+    /// MUST be passed through unchanged (NOT intercepted) — the deliberate
+    /// 401-only policy with no 200-`isError` body sniffing.
+    #[test]
+    fn two_hundred_is_error_is_not_intercepted() {
+        let ok = Ok(json!({
+            "isError": true,
+            "content": [{ "type": "text", "text": "Sign in required… sign in via OAuth" }]
+        }));
+        assert!(!should_intercept_outcome(&ok));
+    }
+
+    // --- self-initiation engine integration ---
+
+    /// Spawn an axum fixture on `127.0.0.1:0` advertising full standard OAuth:
+    /// RFC 9728 protected-resource metadata, RFC 8414 AS metadata (S256), and
+    /// an RFC 7591 registration endpoint that — like Flightpoints — returns a
+    /// `client_secret` even though `none` was requested.
+    async fn spawn_oauth_fixture() -> (String, tokio::task::JoinHandle<()>) {
+        use axum::extract::State;
+        use axum::routing::{get, post};
+        use axum::{Json, Router};
+
+        async fn protected_resource(State(base): State<String>) -> Json<Value> {
+            Json(json!({
+                "resource": base,
+                "authorization_servers": [base],
+                "bearer_methods_supported": ["header"],
+            }))
+        }
+        async fn auth_server(State(base): State<String>) -> Json<Value> {
+            Json(json!({
+                "issuer": base,
+                "authorization_endpoint": format!("{}/authorize", base),
+                "token_endpoint": format!("{}/token", base),
+                "registration_endpoint": format!("{}/register", base),
+                "code_challenge_methods_supported": ["S256"],
+                "scopes_supported": ["read", "write"],
+            }))
+        }
+        async fn register() -> Json<Value> {
+            Json(json!({
+                "client_id": "jit-client-123",
+                "client_secret": "jit-secret-456",
+                "client_secret_expires_at": 0,
+            }))
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let base = format!("http://127.0.0.1:{}", addr.port());
+        let router = Router::new()
+            .route(
+                "/.well-known/oauth-protected-resource",
+                get(protected_resource),
+            )
+            .route("/.well-known/oauth-authorization-server", get(auth_server))
+            .route("/register", post(register))
+            .with_state(base.clone());
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        (base, handle)
+    }
+
+    #[tokio::test]
+    async fn intercept_401_transitions_to_needs_login_and_produces_authorize_url() {
+        let (base, server) = spawn_oauth_fixture().await;
+        let flow_mgr = Arc::new(OAuthFlowManager::new());
+        // allow_insecure_oauth=true so the loopback fixture passes the SSRF guard.
+        let interceptor = JitInterceptor::new(9400, flow_mgr.clone(), None, true);
+
+        // Precondition: not yet in NeedsLogin.
+        assert_ne!(interceptor.state().await, OAuthState::NeedsLogin);
+
+        let www_authenticate = format!(
+            "Bearer realm=\"Test\", resource_metadata=\"{}/.well-known/oauth-protected-resource\"",
+            base
+        );
+        let resource_url = format!("{}/mcp", base);
+        let authorize_url = interceptor
+            .intercept(&resource_url, &www_authenticate, "flightpoints")
+            .await
+            .expect("intercept should self-initiate the OAuth flow");
+
+        // Transitioned to NeedsLogin and stored the URL (the follow-up seam).
+        assert_eq!(interceptor.state().await, OAuthState::NeedsLogin);
+        assert_eq!(
+            interceptor.pending_authorize_url().await.as_deref(),
+            Some(authorize_url.as_str())
+        );
+
+        // The authorize URL targets the discovered endpoint and carries PKCE.
+        assert!(
+            authorize_url.starts_with(&format!("{}/authorize?", base)),
+            "got: {}",
+            authorize_url
+        );
+        let url = Url::parse(&authorize_url).unwrap();
+        let q: std::collections::HashMap<_, _> = url.query_pairs().into_owned().collect();
+        assert_eq!(q.get("response_type").map(String::as_str), Some("code"));
+        assert_eq!(
+            q.get("client_id").map(String::as_str),
+            Some("jit-client-123")
+        );
+        assert_eq!(
+            q.get("code_challenge_method").map(String::as_str),
+            Some("S256")
+        );
+        assert_eq!(
+            q.get("redirect_uri").map(String::as_str),
+            Some("http://127.0.0.1:9400/oauth/callback")
+        );
+        assert!(q.contains_key("code_challenge"));
+        let state_param = q.get("state").expect("state param present").clone();
+
+        // The pending flow carries the DCR-issued client_secret (honored even
+        // though `none` was requested) and the discovered token endpoint.
+        let flow = flow_mgr
+            .consume_flow(&state_param)
+            .await
+            .expect("pending flow registered");
+        assert_eq!(flow.endpoint_name, "flightpoints");
+        assert_eq!(flow.client_id, "jit-client-123");
+        assert_eq!(flow.client_secret.as_deref(), Some("jit-secret-456"));
+        assert_eq!(flow.token_endpoint, format!("{}/token", base));
+        assert_eq!(flow.redirect_uri, "http://127.0.0.1:9400/oauth/callback");
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn intercept_rejects_non_bearer_challenge() {
+        let flow_mgr = Arc::new(OAuthFlowManager::new());
+        let interceptor = JitInterceptor::new(9400, flow_mgr, None, true);
+        let err = interceptor
+            .intercept("http://127.0.0.1:1/mcp", "Basic realm=\"x\"", "ep")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, JitError::NotABearerChallenge));
+    }
+}

--- a/src/adapter/oauth/jit.rs
+++ b/src/adapter/oauth/jit.rs
@@ -105,6 +105,25 @@ pub fn surface_authorize_url(authorize_url: &str) -> Value {
     })
 }
 
+/// Build the downstream-facing tool result for when a sign-in is required but
+/// the relay could not start the OAuth flow (e.g. discovery or DCR failed).
+///
+/// Like [`surface_authorize_url`], this returns an MCP `CallToolResult`-shaped
+/// value with `isError: true` carrying an actionable, sanitized message. The
+/// raw upstream `401` status and `WWW-Authenticate` challenge are deliberately
+/// NOT included — downstream clients must never see the upstream credential
+/// challenge. The underlying error is logged server-side (see
+/// [`crate::adapter::http::HttpAdapter`]) rather than surfaced here.
+pub fn surface_oauth_unavailable() -> Value {
+    let text = "Sign-in is required to use this tool, but the sign-in flow could not be started \
+         right now. Please retry in a moment; if the problem persists, contact the server \
+         administrator.";
+    json!({
+        "content": [{ "type": "text", "text": text }],
+        "isError": true,
+    })
+}
+
 /// Errors raised while self-initiating the OAuth flow.
 #[derive(Debug, thiserror::Error)]
 pub enum JitError {
@@ -203,19 +222,27 @@ impl JitInterceptor {
         let challenge =
             parse_bearer_challenge(www_authenticate).ok_or(JitError::NotABearerChallenge)?;
 
-        // Prefer the RFC 9728 `resource_metadata` origin as the discovery base;
-        // `discover_oauth_server` re-derives the conventional well-known path
-        // from it. Fall back to the resource (endpoint) URL when the challenge
-        // carries no `resource_metadata`.
-        let discovery_base = challenge
+        // Prefer the RFC 9728 `resource_metadata` URL from the challenge and
+        // honor its FULL path: per RFC 9728 the protected-resource metadata may
+        // live at a path-based location (e.g.
+        // `…/.well-known/oauth-protected-resource/<resource-path>`), so we fetch
+        // the exact document the server pointed us at rather than re-deriving
+        // the conventional well-known location from its origin. Fall back to the
+        // resource (endpoint) URL when the challenge carries no parseable
+        // `resource_metadata`.
+        let metadata_url = challenge
             .resource_metadata
             .as_deref()
-            .and_then(|m| Url::parse(m).ok())
-            .map(|u| u.origin().ascii_serialization())
-            .unwrap_or_else(|| resource_url.to_string());
+            .filter(|m| Url::parse(m).is_ok());
 
-        let disc =
-            discovery::discover_oauth_server(&discovery_base, self.allow_insecure_oauth).await?;
+        let disc = match metadata_url {
+            Some(m) => {
+                discovery::discover_oauth_server_from_metadata(m, self.allow_insecure_oauth).await?
+            }
+            None => {
+                discovery::discover_oauth_server(resource_url, self.allow_insecure_oauth).await?
+            }
+        };
 
         let redirect_uri = format!("http://127.0.0.1:{}/oauth/callback", self.relay_port);
 
@@ -237,9 +264,20 @@ impl JitInterceptor {
             )
             .await;
 
+        // Choose the query separator based on whether the discovered
+        // authorization endpoint already carries a query string; appending a
+        // bare `?` to an endpoint that already has one would yield a malformed
+        // double-`?` URL. Subsequent params (including `&scope=`) always use `&`
+        // because at least one query param is present after this point.
+        let sep = if disc.authorization_endpoint.contains('?') {
+            '&'
+        } else {
+            '?'
+        };
         let mut authorize_url = format!(
-            "{}?response_type=code&client_id={}&redirect_uri={}&state={}&code_challenge={}&code_challenge_method=S256",
+            "{}{}response_type=code&client_id={}&redirect_uri={}&state={}&code_challenge={}&code_challenge_method=S256",
             disc.authorization_endpoint,
+            sep,
             urlencoding(&client_id),
             urlencoding(&redirect_uri),
             urlencoding(&state_param),
@@ -388,6 +426,32 @@ mod tests {
         assert!(!should_intercept_outcome(&ok));
     }
 
+    // --- surface_oauth_unavailable: sanitized failure surface ---
+
+    /// The sign-in-unavailable surface must be an actionable `isError: true`
+    /// tool result that NEVER leaks the raw upstream `401` status or the
+    /// `WWW-Authenticate` challenge text downstream.
+    #[test]
+    fn surface_oauth_unavailable_is_sanitized() {
+        let v = surface_oauth_unavailable();
+        assert_eq!(v["isError"], json!(true));
+        let text = v["content"][0]["text"]
+            .as_str()
+            .expect("text content present");
+        let lower = text.to_ascii_lowercase();
+        assert!(!text.contains("401"), "must not leak status code: {}", text);
+        assert!(
+            !lower.contains("www-authenticate"),
+            "must not leak challenge header: {}",
+            text
+        );
+        assert!(
+            lower.contains("sign-in") || lower.contains("sign in"),
+            "should be actionable: {}",
+            text
+        );
+    }
+
     // --- self-initiation engine integration ---
 
     /// Spawn an axum fixture on `127.0.0.1:0` advertising full standard OAuth:
@@ -517,5 +581,151 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, JitError::NotABearerChallenge));
+    }
+
+    /// Spawn an OAuth fixture that additionally serves RFC 9728
+    /// protected-resource metadata at a PATH-based well-known location
+    /// (`/.well-known/oauth-protected-resource/{*tail}`) and lets the AS
+    /// `authorization_endpoint` optionally carry a pre-existing query string.
+    async fn spawn_oauth_fixture_ex(
+        authorize_query: Option<&'static str>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        use axum::extract::State;
+        use axum::routing::{get, post};
+        use axum::{Json, Router};
+
+        #[derive(Clone)]
+        struct Cfg {
+            base: String,
+            authorize_query: Option<&'static str>,
+        }
+
+        async fn protected_resource(State(cfg): State<Cfg>) -> Json<Value> {
+            Json(json!({
+                "resource": cfg.base,
+                "authorization_servers": [cfg.base],
+                "bearer_methods_supported": ["header"],
+            }))
+        }
+        async fn auth_server(State(cfg): State<Cfg>) -> Json<Value> {
+            let authorization_endpoint = match cfg.authorize_query {
+                Some(q) => format!("{}/authorize?{}", cfg.base, q),
+                None => format!("{}/authorize", cfg.base),
+            };
+            Json(json!({
+                "issuer": cfg.base,
+                "authorization_endpoint": authorization_endpoint,
+                "token_endpoint": format!("{}/token", cfg.base),
+                "registration_endpoint": format!("{}/register", cfg.base),
+                "code_challenge_methods_supported": ["S256"],
+                "scopes_supported": ["read", "write"],
+            }))
+        }
+        async fn register() -> Json<Value> {
+            Json(json!({
+                "client_id": "jit-client-123",
+                "client_secret": "jit-secret-456",
+                "client_secret_expires_at": 0,
+            }))
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let base = format!("http://127.0.0.1:{}", addr.port());
+        let cfg = Cfg {
+            base: base.clone(),
+            authorize_query,
+        };
+        let router = Router::new()
+            .route(
+                "/.well-known/oauth-protected-resource",
+                get(protected_resource),
+            )
+            .route(
+                "/.well-known/oauth-protected-resource/{*tail}",
+                get(protected_resource),
+            )
+            .route("/.well-known/oauth-authorization-server", get(auth_server))
+            .route("/register", post(register))
+            .with_state(cfg);
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        (base, handle)
+    }
+
+    /// Finding 2 (RFC 9728 path): when the challenge supplies a PATH-based
+    /// `resource_metadata` URL, discovery must fetch that EXACT document — not
+    /// the origin-rooted well-known location (which the fixture does NOT serve
+    /// at root for this path), so honoring the path is what makes it succeed.
+    #[tokio::test]
+    async fn intercept_honors_path_based_resource_metadata() {
+        let (base, server) = spawn_oauth_fixture_ex(None).await;
+        let flow_mgr = Arc::new(OAuthFlowManager::new());
+        let interceptor = JitInterceptor::new(9400, flow_mgr.clone(), None, true);
+
+        let metadata_url = format!("{}/.well-known/oauth-protected-resource/tenant-a", base);
+        let www_authenticate = format!("Bearer resource_metadata=\"{}\"", metadata_url);
+        let resource_url = format!("{}/mcp", base);
+
+        let authorize_url = interceptor
+            .intercept(&resource_url, &www_authenticate, "tenant-a")
+            .await
+            .expect("intercept should honor the path-based resource_metadata URL");
+
+        assert!(
+            authorize_url.starts_with(&format!("{}/authorize?", base)),
+            "got: {}",
+            authorize_url
+        );
+        assert_eq!(interceptor.state().await, OAuthState::NeedsLogin);
+
+        server.abort();
+    }
+
+    /// Finding 3 (authorize-URL query separator): when the discovered
+    /// `authorization_endpoint` already contains a `?query`, the composed
+    /// authorize URL must remain valid — exactly one `?`, the pre-existing
+    /// param preserved, and all PKCE params present.
+    #[tokio::test]
+    async fn intercept_authorize_endpoint_with_existing_query_stays_valid() {
+        let (base, server) = spawn_oauth_fixture_ex(Some("audience=test-aud")).await;
+        let flow_mgr = Arc::new(OAuthFlowManager::new());
+        let interceptor = JitInterceptor::new(9400, flow_mgr.clone(), None, true);
+
+        let www_authenticate = format!(
+            "Bearer resource_metadata=\"{}/.well-known/oauth-protected-resource\"",
+            base
+        );
+        let resource_url = format!("{}/mcp", base);
+
+        let authorize_url = interceptor
+            .intercept(&resource_url, &www_authenticate, "ep")
+            .await
+            .expect("intercept should self-initiate the OAuth flow");
+
+        assert_eq!(
+            authorize_url.matches('?').count(),
+            1,
+            "exactly one '?' expected, got: {}",
+            authorize_url
+        );
+        let url = Url::parse(&authorize_url).expect("authorize URL must be parseable");
+        let q: std::collections::HashMap<_, _> = url.query_pairs().into_owned().collect();
+        assert_eq!(q.get("audience").map(String::as_str), Some("test-aud"));
+        assert_eq!(q.get("response_type").map(String::as_str), Some("code"));
+        assert_eq!(
+            q.get("client_id").map(String::as_str),
+            Some("jit-client-123")
+        );
+        assert_eq!(
+            q.get("code_challenge_method").map(String::as_str),
+            Some("S256")
+        );
+        assert!(q.contains_key("code_challenge"));
+        assert!(q.contains_key("scope"));
+
+        server.abort();
     }
 }

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -1,4 +1,5 @@
 mod heartbeat;
+pub mod jit;
 pub mod metrics;
 mod state;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -510,16 +510,30 @@ async fn main() {
             let settled_inits = Arc::new(std::sync::atomic::AtomicUsize::new(0));
             let mut init_handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
             let allow_insecure_oauth = cfg.relay.allow_insecure_oauth.unwrap_or(false);
+            // JIT wiring for plain-`http` adapters built during initial load —
+            // the same bundle the config watcher uses for hot-reloads. The
+            // loopback redirect_uri uses the runtime `port`, never hardcoded.
+            let jit = watcher::JitWiring {
+                relay_port: port,
+                flow_manager: oauth_flow_manager.clone(),
+            };
             for ep in deferred_init {
                 let reg = registry.clone();
                 let tm = token_manager.clone();
                 let oai = oauth_adapter_inners.clone();
                 let settled = settled_inits.clone();
                 let bus = event_bus.clone();
+                let jit_ep = jit.clone();
                 let handle = tokio::spawn(async move {
-                    let adapter =
-                        watcher::create_adapter(&ep, &tm, &oai, allow_insecure_oauth, Some(&bus))
-                            .await;
+                    let adapter = watcher::create_adapter(
+                        &ep,
+                        &tm,
+                        &oai,
+                        allow_insecure_oauth,
+                        Some(&bus),
+                        Some(&jit_ep),
+                    )
+                    .await;
                     let mut entries = reg.entries().write().await;
                     if let Some(entry) = entries.get_mut(ep.name.as_str()) {
                         entry.adapter = adapter;
@@ -794,6 +808,7 @@ async fn main() {
                         profile_registry.clone(),
                         token_manager.clone(),
                         oauth_flow_manager.clone(),
+                        port,
                         oauth_adapter_inners.clone(),
                         shared_config.clone(),
                         Some(event_bus.clone()),

--- a/src/management.rs
+++ b/src/management.rs
@@ -385,6 +385,11 @@ async fn restart_endpoint(
     let token_manager = state.token_manager.clone();
     let oauth_adapter_inners = state.oauth_adapter_inners.clone();
     let event_bus = state.event_bus.clone();
+    // Captured for JIT wiring of a rebuilt plain-`http` adapter (mirrors the
+    // initial-load and hot-reload paths). The loopback redirect_uri uses the
+    // live relay_port; if no flow manager is configured, JIT stays dormant.
+    let oauth_flow_manager = state.oauth_flow_manager.clone();
+    let relay_port = state.relay_port;
     let task_name = name.clone();
 
     tokio::spawn(async move {
@@ -420,8 +425,21 @@ async fn restart_endpoint(
                 )))
             });
             let oai = oauth_adapter_inners.unwrap_or_else(|| Arc::new(RwLock::new(HashMap::new())));
-            crate::watcher::create_adapter(&ep, &tm, &oai, allow_insecure_oauth, event_bus.as_ref())
-                .await
+            let jit = oauth_flow_manager
+                .as_ref()
+                .map(|fm| crate::watcher::JitWiring {
+                    relay_port,
+                    flow_manager: fm.clone(),
+                });
+            crate::watcher::create_adapter(
+                &ep,
+                &tm,
+                &oai,
+                allow_insecure_oauth,
+                event_bus.as_ref(),
+                jit.as_ref(),
+            )
+            .await
         } else {
             // Endpoint not in config: re-initialize the previous adapter in
             // place. On failure, surface the error via FailedAdapter so the
@@ -622,6 +640,13 @@ async fn reload_config(State(state): State<ManagementState>) -> Json<ActionRespo
         .clone()
         .unwrap_or_else(|| Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())));
 
+    let jit = state
+        .oauth_flow_manager
+        .as_ref()
+        .map(|fm| crate::watcher::JitWiring {
+            relay_port: state.relay_port,
+            flow_manager: fm.clone(),
+        });
     crate::watcher::apply_diff_graceful(
         &diff,
         &state.registry,
@@ -631,6 +656,7 @@ async fn reload_config(State(state): State<ManagementState>) -> Json<ActionRespo
         &oauth_adapter_inners,
         new_config.relay.allow_insecure_oauth.unwrap_or(false),
         state.event_bus.as_ref(),
+        jit.as_ref(),
     )
     .await;
 
@@ -1712,6 +1738,90 @@ async fn oauth_metrics(
     };
 
     Json(inner.metrics.snapshot()).into_response()
+}
+
+// ---------------------------------------------------------------------------
+// OAuth capability probe (add-time)
+// ---------------------------------------------------------------------------
+
+/// Request body for POST /api/oauth/probe
+#[derive(Deserialize)]
+struct OAuthProbeRequest {
+    /// The MCP server URL to probe for OAuth support.
+    url: String,
+}
+
+/// Response for POST /api/oauth/probe.
+///
+/// JSON contract (consumed by the desktop add-server flow):
+///   Request:  `{ "url": "<mcp server url>" }`
+///   Response: `{ "oauth_supported": bool,
+///               "authorization_server"?: string,
+///               "scopes_supported"?: [string] }`
+///
+/// `authorization_server` and `scopes_supported` are present only when
+/// `oauth_supported` is `true` (and `scopes_supported` only when non-empty).
+#[derive(Serialize)]
+struct OAuthProbeResponse {
+    oauth_supported: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    authorization_server: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scopes_supported: Option<Vec<String>>,
+}
+
+/// POST /api/oauth/probe
+///
+/// Best-effort check of whether an MCP server supports OAuth (RFC 9728 →
+/// RFC 8414), used by the desktop add-server flow to decide whether to start
+/// an OAuth setup or proceed with a plain HTTP add. This runs discovery only —
+/// it does NOT start a flow, perform DCR, or persist anything.
+///
+/// JSON contract:
+///   Request:  `{ "url": "<mcp server url>" }`
+///   Response: `{ "oauth_supported": bool,
+///               "authorization_server"?: string,
+///               "scopes_supported"?: [string] }`
+///
+/// Any discovery failure (no metadata, 404, connection error, timeout) is
+/// reported as a normal HTTP 200 with `oauth_supported: false` so the caller
+/// can fall back to a plain (non-OAuth) add without treating it as an error.
+async fn oauth_probe(
+    State(state): State<ManagementState>,
+    Json(body): Json<OAuthProbeRequest>,
+) -> impl IntoResponse {
+    use crate::oauth::discovery;
+
+    let allow_insecure_oauth = {
+        let config = state.config.read().await;
+        config.relay.allow_insecure_oauth.unwrap_or(false)
+    };
+
+    // Bound the overall probe so a slow/unreachable well-known endpoint can
+    // never stall the caller. Discovery performs up to two sequential fetches
+    // (each with its own 10s timeout); cap the whole operation here as a
+    // backstop.
+    let probe = discovery::discover_oauth_server(body.url.trim(), allow_insecure_oauth);
+    let result = tokio::time::timeout(std::time::Duration::from_secs(15), probe).await;
+
+    match result {
+        Ok(Ok(disc)) => Json(OAuthProbeResponse {
+            oauth_supported: true,
+            authorization_server: Some(disc.auth_server_url),
+            scopes_supported: if disc.scopes_supported.is_empty() {
+                None
+            } else {
+                Some(disc.scopes_supported)
+            },
+        })
+        .into_response(),
+        Ok(Err(_)) | Err(_) => Json(OAuthProbeResponse {
+            oauth_supported: false,
+            authorization_server: None,
+            scopes_supported: None,
+        })
+        .into_response(),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -3358,6 +3468,13 @@ async fn apply_endpoint_change(
         .oauth_adapter_inners
         .clone()
         .unwrap_or_else(|| Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())));
+    let jit = state
+        .oauth_flow_manager
+        .as_ref()
+        .map(|fm| crate::watcher::JitWiring {
+            relay_port: state.relay_port,
+            flow_manager: fm.clone(),
+        });
     crate::watcher::apply_diff_graceful(
         &diff,
         &state.registry,
@@ -3367,6 +3484,7 @@ async fn apply_endpoint_change(
         &oauth_adapter_inners,
         new_cfg.relay.allow_insecure_oauth.unwrap_or(false),
         state.event_bus.as_ref(),
+        jit.as_ref(),
     )
     .await;
 
@@ -3523,6 +3641,8 @@ pub fn management_routes(state: ManagementState) -> Router {
         .route("/api/endpoints/{name}/oauth/revoke", post(oauth_revoke))
         .route("/api/endpoints/{name}/oauth/refresh", post(oauth_refresh))
         .route("/api/endpoints/{name}/oauth/metrics", get(oauth_metrics))
+        // OAuth capability probe (add-time)
+        .route("/api/oauth/probe", post(oauth_probe))
         // OAuth setup (preflight) routes
         .route("/api/oauth/setup", post(oauth_setup))
         .route(
@@ -6360,6 +6480,101 @@ command = "echo"
             .find(|(k, _)| k == "state")
             .map(|(_, v)| v.into_owned())
             .expect("authorize URL has state param")
+    }
+
+    // -----------------------------------------------------------------------
+    // oauth_probe: add-time OAuth-capability probe (RFC 9728 → 8414)
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn oauth_probe_reports_supported_when_metadata_present() {
+        // Bind first so the protected-resource metadata can point its
+        // authorization_servers at this same mock origin.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let base = format!("http://127.0.0.1:{}", addr.port());
+
+        async fn protected_resource(State(base): State<String>) -> Json<Value> {
+            Json(serde_json::json!({
+                "resource": base,
+                "authorization_servers": [base],
+                "scopes_supported": ["read", "write"],
+            }))
+        }
+        async fn auth_server(State(base): State<String>) -> Json<Value> {
+            Json(serde_json::json!({
+                "issuer": base,
+                "authorization_endpoint": format!("{}/authorize", base),
+                "token_endpoint": format!("{}/token", base),
+                "code_challenge_methods_supported": ["S256"],
+                "scopes_supported": ["read", "write"],
+            }))
+        }
+        let router = Router::new()
+            .route(
+                "/.well-known/oauth-protected-resource",
+                get(protected_resource),
+            )
+            .route("/.well-known/oauth-authorization-server", get(auth_server))
+            .with_state(base.clone());
+        let _server = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        let state = test_state(vec![]).await;
+        state.config.write().await.relay.allow_insecure_oauth = Some(true);
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/oauth/probe")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::json!({ "url": base }).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["oauth_supported"], true);
+        assert_eq!(body["authorization_server"], base);
+        assert_eq!(
+            body["scopes_supported"],
+            serde_json::json!(["read", "write"])
+        );
+    }
+
+    #[tokio::test]
+    async fn oauth_probe_reports_unsupported_on_404() {
+        // Mock server returns 404 for the well-known endpoints → discovery
+        // fails and the probe must report oauth_supported:false as a 200.
+        async fn not_found() -> StatusCode {
+            StatusCode::NOT_FOUND
+        }
+        let router = Router::new()
+            .route("/.well-known/oauth-protected-resource", get(not_found))
+            .route("/.well-known/oauth-authorization-server", get(not_found));
+        let (base_url, _server) = spawn_mock_as(router).await;
+
+        let state = test_state(vec![]).await;
+        state.config.write().await.relay.allow_insecure_oauth = Some(true);
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/oauth/probe")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "url": base_url }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["oauth_supported"], false);
+        assert!(body.get("authorization_server").is_none());
+        assert!(body.get("scopes_supported").is_none());
     }
 
     #[tokio::test]

--- a/src/oauth/discovery.rs
+++ b/src/oauth/discovery.rs
@@ -182,6 +182,42 @@ pub async fn discover_oauth_server(
     discover_authorization_server(&auth_server_url, allow_insecure).await
 }
 
+/// Discover OAuth server metadata starting from an EXPLICIT RFC 9728
+/// protected-resource metadata URL (e.g. the `resource_metadata` value of a
+/// `WWW-Authenticate: Bearer` challenge).
+///
+/// Unlike [`discover_oauth_server`], the protected-resource metadata document
+/// is fetched at the EXACT given URL — its full path is honored — rather than
+/// re-deriving the conventional well-known location from an origin. RFC 9728
+/// permits path-based protected-resource metadata
+/// (e.g. `https://host/.well-known/oauth-protected-resource/<resource-path>`),
+/// so when the server points us at a specific document we must fetch that one.
+///
+/// The URL is validated through [`url_guard`] before any HTTP request is sent,
+/// and the request uses a per-host pinned client. After parsing, the first
+/// listed authorization server is resolved via
+/// [`discover_authorization_server`] (RFC 8414).
+pub async fn discover_oauth_server_from_metadata(
+    resource_metadata_url: &str,
+    allow_insecure: bool,
+) -> Result<DiscoveryResult, DiscoveryError> {
+    let resource_client =
+        url_guard::validated_client(resource_metadata_url, allow_insecure).await?;
+    let resource_meta: ProtectedResourceMetadata =
+        fetch_well_known(&resource_client, resource_metadata_url)
+            .await?
+            .json()
+            .await?;
+
+    let auth_server_url = resource_meta
+        .authorization_servers
+        .first()
+        .ok_or(DiscoveryError::NoAuthorizationServer)?
+        .clone();
+
+    discover_authorization_server(&auth_server_url, allow_insecure).await
+}
+
 /// Discover OAuth authorization server metadata directly (RFC 8414 only).
 ///
 /// Unlike [`discover_oauth_server`], this skips the RFC 9728 protected

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,4 +1,5 @@
 use crate::adapter::http::{HttpAdapter, HttpConfig};
+use crate::adapter::oauth::jit::JitInterceptor;
 use crate::adapter::oauth::{OAuthAdapter, OAuthAdapterConfig};
 use crate::adapter::sse::{SseAdapter, SseConfig};
 use crate::adapter::stdio::{IsolationMode, StdioAdapter, StdioConfig};
@@ -39,11 +40,20 @@ impl ConfigWatcher {
         js_execution_mode: Arc<AtomicBool>,
         profile_registry: Arc<ProfileRegistry>,
         token_manager: Arc<TokenManager>,
-        _oauth_flow_manager: Arc<OAuthFlowManager>,
+        oauth_flow_manager: Arc<OAuthFlowManager>,
+        relay_port: u16,
         oauth_adapter_inners: OAuthAdapterInners,
         shared_config: Arc<RwLock<Config>>,
         event_bus: Option<ToolCallEventBus>,
     ) -> JoinHandle<()> {
+        // Bundle the JIT wiring so plain-`http` adapters rebuilt during a
+        // hot-reload get a `JitInterceptor` attached, mirroring the
+        // initial-load path in `main.rs`. The loopback `redirect_uri` uses the
+        // live `relay_port`, never a hardcoded value.
+        let jit = Some(JitWiring {
+            relay_port,
+            flow_manager: oauth_flow_manager,
+        });
         tokio::spawn(async move {
             if let Err(e) = watch_loop(
                 config_path,
@@ -55,6 +65,7 @@ impl ConfigWatcher {
                 oauth_adapter_inners,
                 shared_config,
                 event_bus,
+                jit,
             )
             .await
             {
@@ -75,6 +86,7 @@ async fn watch_loop(
     oauth_adapter_inners: OAuthAdapterInners,
     shared_config: Arc<RwLock<Config>>,
     event_bus: Option<ToolCallEventBus>,
+    jit: Option<JitWiring>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let (tx, mut rx) = tokio::sync::mpsc::channel(16);
 
@@ -130,6 +142,7 @@ async fn watch_loop(
             &token_manager,
             &oauth_adapter_inners,
             event_bus.as_ref(),
+            jit.as_ref(),
         )
         .await;
     }
@@ -160,6 +173,7 @@ async fn reload_and_apply(
     token_manager: &Arc<TokenManager>,
     oauth_adapter_inners: &OAuthAdapterInners,
     event_bus: Option<&ToolCallEventBus>,
+    jit: Option<&JitWiring>,
 ) -> Result<(), config::ConfigError> {
     // Parse new config gracefully. Fatal errors (parse failure or
     // fail-fast profile-validation failure) bail out without touching the
@@ -195,6 +209,7 @@ async fn reload_and_apply(
         oauth_adapter_inners,
         new_config.relay.allow_insecure_oauth.unwrap_or(false),
         event_bus,
+        jit,
     )
     .await;
 
@@ -245,6 +260,7 @@ pub async fn apply_diff(
     oauth_adapter_inners: &OAuthAdapterInners,
     allow_insecure_oauth: bool,
     event_bus: Option<&ToolCallEventBus>,
+    jit: Option<&JitWiring>,
 ) {
     // Remove endpoints
     for name in &diff.removed {
@@ -305,11 +321,19 @@ pub async fn apply_diff(
         let tm = token_manager.clone();
         let oai = oauth_adapter_inners.clone();
         let bus = event_bus.cloned();
+        let jit_owned = jit.cloned();
         let init_span = tracing::info_span!("endpoint_init", endpoint = %name_clone);
         tokio::spawn(
             async move {
-                let adapter =
-                    create_adapter(&ep_clone, &tm, &oai, allow_insecure_oauth, bus.as_ref()).await;
+                let adapter = create_adapter(
+                    &ep_clone,
+                    &tm,
+                    &oai,
+                    allow_insecure_oauth,
+                    bus.as_ref(),
+                    jit_owned.as_ref(),
+                )
+                .await;
                 let mut entries = reg.entries().write().await;
                 if let Some(entry) = entries.get_mut(name_clone.as_str()) {
                     entry.adapter = adapter;
@@ -356,11 +380,19 @@ pub async fn apply_diff(
         let tm = token_manager.clone();
         let oai = oauth_adapter_inners.clone();
         let bus = event_bus.cloned();
+        let jit_owned = jit.cloned();
         let init_span = tracing::info_span!("endpoint_init", endpoint = %ep_clone.name);
         tokio::spawn(
             async move {
-                let adapter =
-                    create_adapter(&ep_clone, &tm, &oai, allow_insecure_oauth, bus.as_ref()).await;
+                let adapter = create_adapter(
+                    &ep_clone,
+                    &tm,
+                    &oai,
+                    allow_insecure_oauth,
+                    bus.as_ref(),
+                    jit_owned.as_ref(),
+                )
+                .await;
                 let mut entries = reg.entries().write().await;
                 if let Some(entry) = entries.get_mut(ep_clone.name.as_str()) {
                     entry.adapter = adapter;
@@ -399,6 +431,7 @@ pub async fn apply_diff_graceful(
     oauth_adapter_inners: &OAuthAdapterInners,
     allow_insecure_oauth: bool,
     event_bus: Option<&ToolCallEventBus>,
+    jit: Option<&JitWiring>,
 ) {
     // Build warning message map
     let warning_messages: std::collections::HashMap<String, String> = {
@@ -498,11 +531,19 @@ pub async fn apply_diff_graceful(
         let tm = token_manager.clone();
         let oai = oauth_adapter_inners.clone();
         let bus = event_bus.cloned();
+        let jit_owned = jit.cloned();
         let init_span = tracing::info_span!("endpoint_init", endpoint = %name_clone);
         tokio::spawn(
             async move {
-                let adapter =
-                    create_adapter(&ep_clone, &tm, &oai, allow_insecure_oauth, bus.as_ref()).await;
+                let adapter = create_adapter(
+                    &ep_clone,
+                    &tm,
+                    &oai,
+                    allow_insecure_oauth,
+                    bus.as_ref(),
+                    jit_owned.as_ref(),
+                )
+                .await;
                 let mut entries = reg.entries().write().await;
                 if let Some(entry) = entries.get_mut(name_clone.as_str()) {
                     entry.adapter = adapter;
@@ -576,11 +617,19 @@ pub async fn apply_diff_graceful(
         let tm = token_manager.clone();
         let oai = oauth_adapter_inners.clone();
         let bus = event_bus.cloned();
+        let jit_owned = jit.cloned();
         let init_span = tracing::info_span!("endpoint_init", endpoint = %ep_clone.name);
         tokio::spawn(
             async move {
-                let adapter =
-                    create_adapter(&ep_clone, &tm, &oai, allow_insecure_oauth, bus.as_ref()).await;
+                let adapter = create_adapter(
+                    &ep_clone,
+                    &tm,
+                    &oai,
+                    allow_insecure_oauth,
+                    bus.as_ref(),
+                    jit_owned.as_ref(),
+                )
+                .await;
                 let mut entries = reg.entries().write().await;
                 if let Some(entry) = entries.get_mut(ep_clone.name.as_str()) {
                     entry.adapter = adapter;
@@ -713,6 +762,18 @@ pub(crate) async fn resolve_oauth_client_creds(
     }
 }
 
+/// Dependencies needed to attach a [`JitInterceptor`] to a production-built
+/// plain-`http` adapter. Threaded as an `Option` through the construction
+/// chain so unit tests pass `None` (JIT dormant) while the real relay passes
+/// `Some` from `main.rs` (initial load), the config watcher (hot-reload) and
+/// the management restart path. The loopback `redirect_uri` always uses the
+/// runtime `relay_port` — never a hardcoded value.
+#[derive(Clone)]
+pub struct JitWiring {
+    pub relay_port: u16,
+    pub flow_manager: Arc<OAuthFlowManager>,
+}
+
 /// Create an adapter from an endpoint configuration.
 ///
 /// Always returns an adapter. If initialization fails, returns a [`FailedAdapter`]
@@ -723,6 +784,7 @@ pub(crate) async fn create_adapter(
     oauth_adapter_inners: &OAuthAdapterInners,
     allow_insecure_oauth: bool,
     event_bus: Option<&ToolCallEventBus>,
+    jit: Option<&JitWiring>,
 ) -> Box<dyn McpAdapter> {
     match ep.transport {
         Transport::Stdio => {
@@ -781,6 +843,19 @@ pub(crate) async fn create_adapter(
             let mut adapter = HttpAdapter::new(http_config);
             if let Some(bus) = event_bus {
                 adapter.set_event_bus(bus.clone());
+            }
+            // Attach a JIT interceptor so a hard 401 + Bearer challenge on a
+            // tool call self-initiates the OAuth flow instead of being
+            // forwarded downstream. Only reached for plain `http` endpoints;
+            // `transport=oauth` uses `OAuthAdapter` and handles auth itself,
+            // so it never gets a JIT interceptor (no double-handling).
+            if let Some(jit) = jit {
+                adapter.set_jit_interceptor(Arc::new(JitInterceptor::new(
+                    jit.relay_port,
+                    jit.flow_manager.clone(),
+                    Some(token_manager.clone()),
+                    allow_insecure_oauth,
+                )));
             }
             match adapter.initialize().await {
                 Ok(()) => Box::new(adapter),
@@ -973,6 +1048,180 @@ mod tests {
         (token_manager, inners)
     }
 
+    fn http_endpoint(name: &str, url: &str) -> EndpointConfig {
+        EndpointConfig {
+            name: name.to_string(),
+            description: None,
+            tool_prefix: None,
+            transport: Transport::Http,
+            command: None,
+            args: None,
+            url: Some(url.to_string()),
+            env: None,
+            headers: None,
+            disabled: false,
+            disabled_tools: Vec::new(),
+            oauth_server_url: None,
+            client_id: None,
+            client_secret: None,
+            scopes: None,
+            token_endpoint: None,
+            server_type_override: None,
+            isolation: Some("none".to_string()),
+            container_image: None,
+            mounts: None,
+        }
+    }
+
+    /// Spawn an upstream MCP fixture whose handshake (`initialize` +
+    /// `tools/list`) SUCCEEDS but whose `tools/call` is gated behind a hard
+    /// `401` + Bearer `WWW-Authenticate`. It also advertises full standard
+    /// OAuth (RFC 9728 → 8414 + DCR) so an attached `JitInterceptor` can
+    /// self-initiate the flow. Returns the base URL and the server task handle.
+    async fn spawn_handshake_ok_call_gated_fixture() -> (String, tokio::task::JoinHandle<()>) {
+        use axum::extract::State;
+        use axum::http::{header::WWW_AUTHENTICATE, StatusCode};
+        use axum::response::IntoResponse;
+        use axum::routing::{get, post};
+        use axum::{Json, Router};
+
+        async fn mcp(
+            State(base): State<String>,
+            Json(body): Json<serde_json::Value>,
+        ) -> axum::response::Response {
+            let method = body.get("method").and_then(|m| m.as_str()).unwrap_or("");
+            let id = body.get("id").cloned();
+            match method {
+                "initialize" => Json(json!({
+                    "jsonrpc": "2.0",
+                    "result": {
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {},
+                        "serverInfo": {"name": "gated-http", "version": "0.0.0"}
+                    },
+                    "id": id,
+                }))
+                .into_response(),
+                "tools/list" => Json(json!({
+                    "jsonrpc": "2.0",
+                    "result": {"tools": [
+                        {"name": "search", "description": "s", "inputSchema": {"type": "object"}}
+                    ]},
+                    "id": id,
+                }))
+                .into_response(),
+                "tools/call" => {
+                    let val = format!(
+                        "Bearer realm=\"Test\", resource_metadata=\"{}/.well-known/oauth-protected-resource\"",
+                        base
+                    );
+                    (
+                        StatusCode::UNAUTHORIZED,
+                        [(WWW_AUTHENTICATE, val)],
+                        "unauthorized",
+                    )
+                        .into_response()
+                }
+                // notifications/initialized and any other notification (no id).
+                _ => (StatusCode::ACCEPTED, "").into_response(),
+            }
+        }
+        async fn protected_resource(State(base): State<String>) -> Json<serde_json::Value> {
+            Json(json!({ "resource": base, "authorization_servers": [base] }))
+        }
+        async fn auth_server(State(base): State<String>) -> Json<serde_json::Value> {
+            Json(json!({
+                "issuer": base,
+                "authorization_endpoint": format!("{}/authorize", base),
+                "token_endpoint": format!("{}/token", base),
+                "registration_endpoint": format!("{}/register", base),
+                "code_challenge_methods_supported": ["S256"],
+            }))
+        }
+        async fn register() -> Json<serde_json::Value> {
+            Json(json!({ "client_id": "jit-cid", "client_secret": "jit-secret" }))
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let base = format!("http://127.0.0.1:{}", addr.port());
+        let router = Router::new()
+            .route("/mcp", post(mcp))
+            .route(
+                "/.well-known/oauth-protected-resource",
+                get(protected_resource),
+            )
+            .route("/.well-known/oauth-authorization-server", get(auth_server))
+            .route("/register", post(register))
+            .with_state(base.clone());
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        (base, handle)
+    }
+
+    /// Production-path JIT wiring: an `http` endpoint built through
+    /// `create_adapter` WITH a `JitWiring` (not via a manual
+    /// `set_jit_interceptor` in the test) must intercept a gated `tools/call`
+    /// 401 and surface an actionable authorize URL instead of forwarding the
+    /// raw challenge. This is the live construction path used by `main.rs`, the
+    /// config watcher, and the management restart/reload endpoints.
+    #[tokio::test]
+    async fn create_adapter_http_wires_jit_interceptor_and_intercepts_401() {
+        let (base, server) = spawn_handshake_ok_call_gated_fixture().await;
+        let (tm, inners) = test_oauth_infra();
+        let ep = http_endpoint("jit_http", &format!("{}/mcp", base));
+        let jit = JitWiring {
+            relay_port: 9400,
+            flow_manager: Arc::new(crate::oauth::OAuthFlowManager::new()),
+        };
+
+        // PRODUCTION construction path — the interceptor is attached inside
+        // create_adapter, never by the test.
+        let adapter = create_adapter(&ep, &tm, &inners, true, None, Some(&jit)).await;
+        assert!(matches!(adapter.health(), HealthStatus::Healthy));
+
+        let result = adapter.call_tool("search", json!({})).await;
+        let value = match result {
+            Ok(v) => v,
+            other => panic!("expected surfaced Ok result, got {:?}", other),
+        };
+        assert_eq!(value["isError"], true);
+        let text = value["content"][0]["text"]
+            .as_str()
+            .expect("surfaced content text");
+        assert!(
+            text.contains(&format!("{}/authorize?", base)),
+            "surfaced text should carry the authorize URL, got: {}",
+            text
+        );
+        // The raw upstream 401 / challenge is never leaked downstream.
+        assert!(!text.contains("401"));
+        assert!(!text.contains("WWW-Authenticate"));
+
+        server.abort();
+    }
+
+    /// Control: the same `http` endpoint built WITHOUT JIT wiring (`None`)
+    /// forwards the raw 401 unchanged — proving the interception above comes
+    /// from the production wiring, not from `HttpAdapter` itself.
+    #[tokio::test]
+    async fn create_adapter_http_without_jit_forwards_401() {
+        let (base, server) = spawn_handshake_ok_call_gated_fixture().await;
+        let (tm, inners) = test_oauth_infra();
+        let ep = http_endpoint("plain_http", &format!("{}/mcp", base));
+
+        let adapter = create_adapter(&ep, &tm, &inners, true, None, None).await;
+        let result = adapter.call_tool("search", json!({})).await;
+        match result {
+            Err(AdapterError::HttpError { status: 401, .. }) => {}
+            other => panic!("expected forwarded HttpError 401, got {:?}", other),
+        }
+
+        server.abort();
+    }
+
     #[tokio::test]
     async fn apply_diff_empty_is_noop() {
         let registry = Arc::new(AdapterRegistry::new());
@@ -988,7 +1237,7 @@ mod tests {
             )
             .await;
 
-        apply_diff(&empty_diff(), &registry, &tm, &inners, false, None).await;
+        apply_diff(&empty_diff(), &registry, &tm, &inners, false, None, None).await;
 
         // Existing adapter should still be there, not shut down
         assert!(!shutdown.load(std::sync::atomic::Ordering::SeqCst));
@@ -1015,7 +1264,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &inners, false, None).await;
+        apply_diff(&diff, &registry, &tm, &inners, false, None, None).await;
 
         assert!(shutdown.load(std::sync::atomic::Ordering::SeqCst));
         assert!(registry.merged_catalog().await.is_empty());
@@ -1031,7 +1280,7 @@ mod tests {
         };
 
         // Should not panic
-        apply_diff(&diff, &registry, &tm, &inners, false, None).await;
+        apply_diff(&diff, &registry, &tm, &inners, false, None, None).await;
     }
 
     #[tokio::test]
@@ -1078,7 +1327,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &inners, false, None).await;
+        apply_diff(&diff, &registry, &tm, &inners, false, None, None).await;
 
         // Old adapter should have been shut down
         assert!(shutdown.load(std::sync::atomic::Ordering::SeqCst));
@@ -1116,7 +1365,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &inners, false, None).await;
+        apply_diff(&diff, &registry, &tm, &inners, false, None, None).await;
 
         // Wait for background initialization to complete
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -1168,7 +1417,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &inners, false, None).await;
+        apply_diff(&diff, &registry, &tm, &inners, false, None, None).await;
 
         // "keep" should still be alive
         assert!(!shutdown_keep.load(std::sync::atomic::Ordering::SeqCst));
@@ -1212,7 +1461,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &inners, false, None).await;
+        apply_diff(&diff, &registry, &tm, &inners, false, None, None).await;
 
         // Wait for background initialization to complete
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -1284,7 +1533,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &inners, true, None).await;
+        apply_diff(&diff, &registry, &tm, &inners, true, None, None).await;
 
         // Wait for background initialization to register the OAuth adapter inner.
         let stop = std::time::Instant::now() + std::time::Duration::from_secs(2);
@@ -1331,6 +1580,7 @@ mod tests {
             &tm,
             &inners,
             false,
+            None,
             None,
         )
         .await;
@@ -1379,7 +1629,7 @@ mod tests {
             warnings.iter().map(|w| w.endpoint_name.clone()).collect();
 
         apply_diff_graceful(
-            &diff, &registry, &warnings, &warned, &tm, &inners, false, None,
+            &diff, &registry, &warnings, &warned, &tm, &inners, false, None, None,
         )
         .await;
 
@@ -1432,7 +1682,7 @@ mod tests {
         let warned: std::collections::HashSet<String> = ["ep".to_string()].into_iter().collect();
 
         apply_diff_graceful(
-            &diff, &registry, &warnings, &warned, &tm, &inners, false, None,
+            &diff, &registry, &warnings, &warned, &tm, &inners, false, None, None,
         )
         .await;
 
@@ -1488,7 +1738,7 @@ mod tests {
         let warned: std::collections::HashSet<String> = std::collections::HashSet::new();
 
         apply_diff_graceful(
-            &diff, &registry, &warnings, &warned, &tm, &inners, true, None,
+            &diff, &registry, &warnings, &warned, &tm, &inners, true, None, None,
         )
         .await;
 
@@ -1948,6 +2198,7 @@ toon_output = true
                     &tm,
                     &inners,
                     None,
+                    None,
                 )
                 .await
                 .expect("reload should succeed");
@@ -1990,6 +2241,7 @@ toon_output = true
                     &profile_registry,
                     &tm,
                     &inners,
+                    None,
                     None,
                 )
                 .await
@@ -2049,6 +2301,7 @@ toon_output = true
                     &profile_registry,
                     &tm,
                     &inners,
+                    None,
                     None,
                 )
                 .await
@@ -2248,6 +2501,7 @@ command = "/bin/true"
                     &tm,
                     &inners,
                     None,
+                    None,
                 )
                 .await
                 .expect("reload should succeed");
@@ -2423,6 +2677,7 @@ validate_inputs = false
                     &tm,
                     &inners,
                     None,
+                    None,
                 )
                 .await
                 .expect("reload disabling validation should succeed");
@@ -2445,6 +2700,7 @@ validate_inputs = false
                     &profile_registry,
                     &tm,
                     &inners,
+                    None,
                     None,
                 )
                 .await
@@ -2567,6 +2823,7 @@ command = "/bin/true"
                     &profile_registry,
                     &token_manager,
                     &inners,
+                    None,
                     None,
                 )
                 .await

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1196,9 +1196,17 @@ mod tests {
             "surfaced text should carry the authorize URL, got: {}",
             text
         );
-        // The raw upstream 401 / challenge is never leaked downstream.
-        assert!(!text.contains("401"));
-        assert!(!text.contains("WWW-Authenticate"));
+        // The raw upstream 401 / challenge is never leaked downstream. Scope
+        // these checks to the message PROSE (everything before the authorize
+        // URL): the relay-composed authorize URL legitimately embeds a random
+        // ephemeral port and base64url PKCE challenge/state, any of which can
+        // contain "401" by chance — asserting over the whole string is flaky.
+        let prose = text
+            .split(&format!("{}/authorize?", base))
+            .next()
+            .expect("prose segment before authorize URL");
+        assert!(!prose.contains("401"));
+        assert!(!prose.contains("WWW-Authenticate"));
 
         server.abort();
     }

--- a/tests/hot_reload_integration.rs
+++ b/tests/hot_reload_integration.rs
@@ -169,6 +169,7 @@ async fn test_config_diff_add_endpoint() {
         &oauth_adapter_inners,
         false,
         None,
+        None,
     )
     .await;
 
@@ -343,6 +344,7 @@ async fn test_config_diff_remove_endpoint() {
         &token_manager2,
         &oauth_adapter_inners2,
         false,
+        None,
         None,
     )
     .await;


### PR DESCRIPTION
## Summary

Adds relay support for upstream MCP servers that gate access behind OAuth, in two complementary tracks:

- **Add-time probe** — `POST /api/oauth/probe` reuses `discovery::discover_oauth_server` (RFC 9728 protected-resource → RFC 8414 metadata) with a 15s timeout backstop to report whether an `http` endpoint advertises OAuth. Discovery failures return `200 {oauth_supported:false}`. Powers the desktop add-time escalation prompt.
- **Runtime JIT 401 interception** — a new `JitInterceptor` (`src/adapter/oauth/jit.rs`): on a hard upstream `HTTP 401` + `Bearer` `WWW-Authenticate`, the 401 is **swallowed** (never forwarded downstream), the OAuth flow is self-initiated, and the authorize URL is surfaced to the headless client as an actionable `CallToolResult`. After the human completes the loopback `/oauth/callback`, the persisted bearer is injected on retry so the re-issued tool call succeeds. `200`-`isError` results pass through unchanged.
- **Production wiring** — the interceptor is attached at `watcher::create_adapter` (Http arm only), live on all three production paths: `main.rs` initial load, config-watcher hot-reload, and management upsert/restart. `transport=oauth` is excluded.

## Design invariants

- The downstream AI client never sees the raw 401 or upstream credentials — the relay terminates OAuth.
- Runtime interception is strictly **401-only**; `200`-`isError` is handled at add-time only.
- `redirect_uri` uses the dynamic `relay_port`.

## Verification

- `cargo fmt --check` clean.
- `cargo test` green (lib + integration); includes a production-path test exercising `create_adapter(Some(jit))` that asserts a 401 is surfaced as an authorize URL with no leaked `401`/`WWW-Authenticate`, and a `None` control that forwards the raw 401.

## Out of scope (by design)

- SSE runtime interception (no seam yet).
- Track 2 opaque-bearer servers.
- Remote-relay redirect (Phase 2).

Desktop counterpart PR (add-time escalation prompt + reauthorize-bar debounce) opened separately on `endara-ai/endara-desktop`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author