### PR TITLE
feat(observability): agent-call observability store, payload buffer, and management API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,6 +733,7 @@ dependencies = [
  "rand 0.10.1",
  "regex",
  "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2",
@@ -774,6 +775,18 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
@@ -1035,6 +1048,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1644,6 +1666,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2008,6 +2041,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -2393,6 +2432,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -3296,6 +3349,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ notify = "7"
 rand = "0.10.1"
 regex = "1.12.3"
 reqwest = { version = "0.13.2", features = ["json", "stream"] }
+rusqlite = { version = "0.37", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,6 +61,11 @@ pub struct RelayConfig {
     /// loose schemas). Hot-reloadable via [`crate::watcher::ConfigWatcher`].
     #[serde(default)]
     pub validate_inputs: Option<bool>,
+    /// Agent-call observability store configuration (`[relay.observability]`).
+    /// `#[serde(default)]` means a `config.toml` that omits the table entirely
+    /// falls back to [`ObservabilityConfig::default`].
+    #[serde(default)]
+    pub observability: ObservabilityConfig,
 }
 
 impl Default for RelayConfig {
@@ -83,6 +88,80 @@ impl Default for RelayConfig {
             startup_init_timeout_secs: None,
             session_identity_max_sessions: None,
             validate_inputs: None,
+            observability: ObservabilityConfig::default(),
+        }
+    }
+}
+
+/// Agent-call observability store configuration, nested under
+/// `[relay.observability]`. Controls the durable metadata store (SQLite) and
+/// the in-memory payload ring buffer. Every field carries a `#[serde(default
+/// = "…")]` so a config that includes the `[relay.observability]` table but
+/// omits individual keys keeps the documented defaults; the struct-level
+/// `#[serde(default)]` on `RelayConfig::observability` covers a fully-omitted
+/// table. This keeps configs that predate the feature working unchanged.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct ObservabilityConfig {
+    /// Master switch for the subsystem. When `false`, no metadata rows are
+    /// recorded and no payloads are buffered. Default: `true`.
+    #[serde(default = "default_observability_enabled")]
+    pub enabled: bool,
+    /// Capture full request/response payloads into the in-memory ring buffer.
+    /// Metadata is still recorded when this is `false`. Default: `true`.
+    #[serde(default = "default_observability_store_payloads")]
+    pub store_payloads: bool,
+    /// How long (minutes) payloads stay retrievable in the ring buffer before
+    /// they expire. Default: `10`.
+    #[serde(default = "default_observability_payload_window_minutes")]
+    pub payload_window_minutes: u64,
+    /// How long (days) metadata rows are retained before eviction. Default: `7`.
+    #[serde(default = "default_observability_record_retention_days")]
+    pub record_retention_days: u64,
+    /// Maximum on-disk size (MB) of the metadata database; oldest rows are
+    /// evicted first once the cap is reached. Default: `1024` (1 GB).
+    #[serde(default = "default_observability_max_db_size_mb")]
+    pub max_db_size_mb: u64,
+    /// Maximum bytes captured per payload; larger payloads are truncated and
+    /// flagged. Default: `262144` (256 KB).
+    #[serde(default = "default_observability_max_payload_bytes")]
+    pub max_payload_bytes: u64,
+    /// Total memory budget (MB) for the payload ring buffer. Default: `128`.
+    #[serde(default = "default_observability_payload_buffer_budget_mb")]
+    pub payload_buffer_budget_mb: u64,
+}
+
+fn default_observability_enabled() -> bool {
+    true
+}
+fn default_observability_store_payloads() -> bool {
+    true
+}
+fn default_observability_payload_window_minutes() -> u64 {
+    10
+}
+fn default_observability_record_retention_days() -> u64 {
+    7
+}
+fn default_observability_max_db_size_mb() -> u64 {
+    1024
+}
+fn default_observability_max_payload_bytes() -> u64 {
+    262144
+}
+fn default_observability_payload_buffer_budget_mb() -> u64 {
+    128
+}
+
+impl Default for ObservabilityConfig {
+    fn default() -> Self {
+        ObservabilityConfig {
+            enabled: default_observability_enabled(),
+            store_payloads: default_observability_store_payloads(),
+            payload_window_minutes: default_observability_payload_window_minutes(),
+            record_retention_days: default_observability_record_retention_days(),
+            max_db_size_mb: default_observability_max_db_size_mb(),
+            max_payload_bytes: default_observability_max_payload_bytes(),
+            payload_buffer_budget_mb: default_observability_payload_buffer_budget_mb(),
         }
     }
 }
@@ -1670,10 +1749,84 @@ js_execution = false
                 startup_init_timeout_secs: None,
                 session_identity_max_sessions: None,
                 validate_inputs: None,
+                observability: ObservabilityConfig::default(),
             },
             endpoints,
             profiles: None,
         }
+    }
+
+    // --- Observability config tests ---
+
+    #[test]
+    fn observability_default_impl_matches_documented_defaults() {
+        let obs = ObservabilityConfig::default();
+        assert!(obs.enabled);
+        assert!(obs.store_payloads);
+        assert_eq!(obs.payload_window_minutes, 10);
+        assert_eq!(obs.record_retention_days, 7);
+        assert_eq!(obs.max_db_size_mb, 1024);
+        assert_eq!(obs.max_payload_bytes, 262144);
+        assert_eq!(obs.payload_buffer_budget_mb, 128);
+    }
+
+    #[test]
+    fn observability_defaults_when_section_omitted() {
+        // No `[relay.observability]` table at all — the struct-level
+        // `#[serde(default)]` on `RelayConfig::observability` applies.
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+"#;
+        let config = parse_and_validate(toml_str).unwrap();
+        assert_eq!(config.relay.observability, ObservabilityConfig::default());
+    }
+
+    #[test]
+    fn observability_partial_section_keeps_other_defaults() {
+        // Table present but only some keys set — omitted keys fall back to the
+        // per-field `#[serde(default = "…")]` values, not bool/u64 zero values.
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[relay.observability]
+enabled = false
+payload_window_minutes = 30
+"#;
+        let config = parse_and_validate(toml_str).unwrap();
+        let obs = &config.relay.observability;
+        assert!(!obs.enabled);
+        assert_eq!(obs.payload_window_minutes, 30);
+        assert!(obs.store_payloads);
+        assert_eq!(obs.record_retention_days, 7);
+        assert_eq!(obs.max_db_size_mb, 1024);
+        assert_eq!(obs.max_payload_bytes, 262144);
+        assert_eq!(obs.payload_buffer_budget_mb, 128);
+    }
+
+    #[test]
+    fn observability_full_round_trip() {
+        let original = ObservabilityConfig {
+            enabled: false,
+            store_payloads: false,
+            payload_window_minutes: 42,
+            record_retention_days: 3,
+            max_db_size_mb: 512,
+            max_payload_bytes: 1024,
+            payload_buffer_budget_mb: 64,
+        };
+        let config = Config {
+            relay: RelayConfig {
+                observability: original.clone(),
+                ..RelayConfig::default()
+            },
+            endpoints: vec![],
+            profiles: None,
+        };
+        let toml_str = toml::to_string_pretty(&config).unwrap();
+        let parsed: Config = toml::from_str(&toml_str).unwrap();
+        assert_eq!(parsed.relay.observability, original);
     }
 
     fn stdio_ep(name: &str, cmd: &str) -> EndpointConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod jsonrpc;
 pub mod management;
 pub mod management_listener;
 pub mod oauth;
+pub mod observability;
 pub mod prefix;
 pub mod profile_registry;
 pub mod registry;

--- a/src/main.rs
+++ b/src/main.rs
@@ -379,7 +379,12 @@ async fn main() {
             // tiers stay bounded without operator intervention. Store ops run on
             // a blocking thread so the SQLite work never stalls the runtime.
             if let Some(obs) = observability.clone().filter(|o| o.is_enabled()) {
-                let retention_days = cfg.relay.observability.record_retention_days as i64;
+                // Saturate rather than wrap on misconfigured retention windows
+                // larger than `i64::MAX`; a wrapped negative value would make
+                // `enforce_retention` treat it as 0 days and prune almost
+                // everything on the next sweep.
+                let retention_days = i64::try_from(cfg.relay.observability.record_retention_days)
+                    .unwrap_or(i64::MAX);
                 let max_db_mb = cfg.relay.observability.max_db_size_mb;
                 tokio::spawn(async move {
                     const RETENTION_SWEEP_INTERVAL_SECS: u64 = 60;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,15 @@ mod js_sandbox;
 mod management;
 mod management_listener;
 mod oauth;
+// R4 wires the ingestion path (`Store::open`, `PayloadStore::new`,
+// `Observability`), but the binary does not yet consume the R5 query API
+// (`Store::query`/`stats`/percentiles) or the R6 retention surface
+// (`purge_all`, `enforce_retention`, `enforce_size_cap`, …). Keep the allow
+// until those land so the binary target stays warning-clean under
+// `clippy --all-targets -D warnings`; the lib target already exercises them
+// via its own tests.
+#[allow(dead_code)]
+mod observability;
 mod token_manager;
 mod watcher;
 
@@ -318,14 +327,112 @@ async fn main() {
             // semantics.
             let event_bus = ToolCallEventBus::with_default_capacity();
 
+            // Observability ingestion pipeline (R4). Open the durable SQLite
+            // metadata store under the data dir and pair it with the in-memory
+            // payload ring buffer, sized from `[relay.observability]`. The
+            // handle spawns its own background consumer when enabled and is a
+            // cheap no-op otherwise. If the store cannot be opened we log and
+            // continue without observability rather than failing relay startup.
+            let observability = {
+                let obs_cfg = &cfg.relay.observability;
+                if let Err(e) = std::fs::create_dir_all(&data_dir_path) {
+                    warn!(error = %e, path = %data_dir_path.display(), "Failed to create data directory for observability store");
+                }
+                match observability::store::Store::open(&data_dir_path) {
+                    Ok(store) => {
+                        let payloads = observability::payloads::PayloadStore::new(
+                            obs_cfg.payload_window_minutes,
+                            obs_cfg.payload_buffer_budget_mb,
+                            obs_cfg.max_payload_bytes as usize,
+                        );
+                        Some(observability::pipeline::Observability::new(
+                            obs_cfg,
+                            Arc::new(store),
+                            Arc::new(payloads),
+                        ))
+                    }
+                    Err(e) => {
+                        error!(error = %e, "Failed to open observability metadata store; observability disabled");
+                        None
+                    }
+                }
+            };
+
             // Create adapter registry. Wire the same bus into the
             // registry so its early-rejection branches in
             // `route_tool_call` (unknown prefix, missing/disabled/unhealthy
             // endpoint, disabled tool) emit `Started` + `Failed` pairs
             // alongside the per-adapter emissions.
-            let registry = AdapterRegistry::new()
+            let mut registry = AdapterRegistry::new()
                 .with_event_bus(event_bus.clone())
                 .with_validate_inputs(cfg.relay.validate_inputs.unwrap_or(true));
+            if let Some(obs) = observability.clone() {
+                registry = registry.with_observability(obs);
+            }
+
+            // R6: periodic retention + size-cap enforcement. When observability
+            // is enabled, evict metadata rows past the configured retention
+            // window, drop oldest rows to stay under the DB size cap, and sweep
+            // expired payloads from the ring buffer on a fixed cadence so both
+            // tiers stay bounded without operator intervention. Store ops run on
+            // a blocking thread so the SQLite work never stalls the runtime.
+            if let Some(obs) = observability.clone().filter(|o| o.is_enabled()) {
+                let retention_days = cfg.relay.observability.record_retention_days as i64;
+                let max_db_mb = cfg.relay.observability.max_db_size_mb;
+                tokio::spawn(async move {
+                    const RETENTION_SWEEP_INTERVAL_SECS: u64 = 60;
+                    let mut ticker =
+                        tokio::time::interval(Duration::from_secs(RETENTION_SWEEP_INTERVAL_SECS));
+                    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                    // Consume the immediate first tick so we don't sweep the
+                    // instant the relay starts.
+                    ticker.tick().await;
+                    loop {
+                        ticker.tick().await;
+                        let store = Arc::clone(obs.store());
+                        let swept = tokio::task::spawn_blocking(move || {
+                            let retention = store.enforce_retention(retention_days);
+                            let size_cap = store.enforce_size_cap(max_db_mb);
+                            (retention, size_cap)
+                        })
+                        .await;
+                        match swept {
+                            Ok((retention, size_cap)) => {
+                                obs.payloads().sweep_expired();
+                                let retention_pruned = match retention {
+                                    Ok(n) => n,
+                                    Err(e) => {
+                                        warn!(error = %e, "observability: retention enforcement failed");
+                                        0
+                                    }
+                                };
+                                match size_cap {
+                                    Ok(result) => {
+                                        if retention_pruned > 0 || result.evicted {
+                                            info!(
+                                                retention_pruned,
+                                                size_evicted = result.deleted_rows,
+                                                oldest_retained_ts = ?result.oldest_retained_ts,
+                                                "observability: retention sweep pruned records"
+                                            );
+                                        } else {
+                                            tracing::debug!(
+                                                "observability: retention sweep, nothing to prune"
+                                            );
+                                        }
+                                    }
+                                    Err(e) => {
+                                        warn!(error = %e, "observability: size-cap enforcement failed")
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                warn!(error = %e, "observability: retention sweep task panicked")
+                            }
+                        }
+                    }
+                });
+            }
 
             // Track duplicate endpoint names: first occurrence wins
             let mut registered_names = std::collections::HashSet::new();

--- a/src/management.rs
+++ b/src/management.rs
@@ -774,46 +774,44 @@ async fn delete_endpoint(
     // the metadata rows BEFORE deleting them, then delete the rows and drop the
     // matching buffered payloads. No-op when observability is unwired/disabled.
     if let Some(obs) = state.registry.observability().filter(|o| o.is_enabled()) {
-        let store = obs.store();
-        let filter = crate::observability::store::QueryFilter {
-            server_name: Some(name.clone()),
-            ..Default::default()
-        };
-        let mut uids: std::collections::HashSet<String> = std::collections::HashSet::new();
-        const UID_PAGE: i64 = 1000;
-        let mut offset = 0i64;
-        loop {
-            match store.query(&filter, UID_PAGE, offset) {
-                Ok(rows) => {
-                    let fetched = rows.len() as i64;
-                    for row in rows {
-                        if let Some(uid) = row.request_uid {
-                            uids.insert(uid);
+        // Exact-match collection (`WHERE server_name = ?1`) so a sibling server
+        // whose name contains this one as a substring (e.g. `foo-staging` when
+        // deleting `foo`) is not over-collected. SQLite work runs on a blocking
+        // thread so it never stalls the async runtime.
+        let store = Arc::clone(obs.store());
+        let server = name.clone();
+        let cascade = tokio::task::spawn_blocking(move || {
+            let uids = store.request_uids_for_server(&server);
+            let removed = store.delete_for_server(&server);
+            (uids, removed)
+        })
+        .await;
+        match cascade {
+            Ok((uids, removed)) => {
+                match removed {
+                    Ok(removed) => {
+                        tracing::debug!(server = %name, removed, "observability: deleted metadata rows for deleted server")
+                    }
+                    Err(e) => {
+                        warn!(error = %e, server = %name, "observability: failed to delete metadata rows for deleted server")
+                    }
+                }
+                match uids {
+                    Ok(uids) => {
+                        if !uids.is_empty() {
+                            let uids: std::collections::HashSet<String> =
+                                uids.into_iter().collect();
+                            obs.payloads().remove_for_server(&uids);
                         }
                     }
-                    if fetched < UID_PAGE {
-                        break;
+                    Err(e) => {
+                        warn!(error = %e, server = %name, "observability: failed to collect request_uids for delete cascade")
                     }
-                    offset += UID_PAGE;
                 }
-                Err(e) => {
-                    warn!(error = %e, server = %name, "observability: failed to collect request_uids for delete cascade");
-                    break;
-                }
-            }
-        }
-
-        match store.delete_for_server(&name) {
-            Ok(removed) => {
-                tracing::debug!(server = %name, removed, "observability: deleted metadata rows for deleted server")
             }
             Err(e) => {
-                warn!(error = %e, server = %name, "observability: failed to delete metadata rows for deleted server")
+                warn!(error = %e, server = %name, "observability: delete cascade task panicked")
             }
-        }
-
-        if !uids.is_empty() {
-            obs.payloads().remove_for_server(&uids);
         }
     }
 
@@ -3797,12 +3795,22 @@ async fn get_observability_calls(
         since: q.since,
         until: q.until,
     };
-    match obs.store().query(&filter, limit, offset) {
-        Ok(rows) => Json(CallsResponse {
+    // Offload the synchronous rusqlite query to a blocking thread so a slow
+    // query never stalls the async runtime serving management + relay tasks.
+    let store = Arc::clone(obs.store());
+    let queried = tokio::task::spawn_blocking(move || store.query(&filter, limit, offset)).await;
+    match queried {
+        Ok(Ok(rows)) => Json(CallsResponse {
             calls: rows.into_iter().map(CallRecordDto::from).collect(),
             limit,
             offset,
         })
+        .into_response(),
+        Ok(Err(e)) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to query observability records",
+            Some(&e.to_string()),
+        )
         .into_response(),
         Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -3844,13 +3852,26 @@ async fn get_observability_call_detail(
     let Some(obs) = state.registry.observability() else {
         return observability_unavailable();
     };
-    let record = match obs.store().get_by_request_uid(&request_uid) {
-        Ok(Some(r)) => r,
-        Ok(None) => {
+    // Offload the synchronous rusqlite lookup to a blocking thread so a slow
+    // query never stalls the async runtime serving management + relay tasks.
+    let store = Arc::clone(obs.store());
+    let uid = request_uid.clone();
+    let looked_up = tokio::task::spawn_blocking(move || store.get_by_request_uid(&uid)).await;
+    let record = match looked_up {
+        Ok(Ok(Some(r))) => r,
+        Ok(Ok(None)) => {
             return error_response(
                 StatusCode::NOT_FOUND,
                 "call record not found",
                 Some(&format!("No record for request_uid {request_uid}")),
+            )
+            .into_response();
+        }
+        Ok(Err(e)) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to load observability record",
+                Some(&e.to_string()),
             )
             .into_response();
         }
@@ -3959,11 +3980,22 @@ async fn get_observability_aggregates(
         payload_buffer_len: obs.payloads().len(),
         payload_buffer_bytes: obs.payloads().total_bytes(),
     };
-    match obs.store().aggregate(bucket_seconds, since, until) {
-        Ok(buckets) => Json(AggregatesResponse {
+    // Offload the synchronous rusqlite aggregation to a blocking thread so a
+    // slow query never stalls the async runtime serving management + relay tasks.
+    let store = Arc::clone(obs.store());
+    let aggregated =
+        tokio::task::spawn_blocking(move || store.aggregate(bucket_seconds, since, until)).await;
+    match aggregated {
+        Ok(Ok(buckets)) => Json(AggregatesResponse {
             buckets: buckets.into_iter().map(AggregateBucketDto::from).collect(),
             summary,
         })
+        .into_response(),
+        Ok(Err(e)) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to aggregate observability records",
+            Some(&e.to_string()),
+        )
         .into_response(),
         Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -3979,13 +4011,28 @@ async fn purge_observability(State(state): State<ManagementState>) -> axum::resp
     let Some(obs) = state.registry.observability() else {
         return observability_unavailable();
     };
-    if let Err(e) = obs.store().purge_all() {
-        return error_response(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "failed to purge observability metadata",
-            Some(&e.to_string()),
-        )
-        .into_response();
+    // Offload the synchronous rusqlite purge to a blocking thread so it never
+    // stalls the async runtime serving management + relay tasks.
+    let store = Arc::clone(obs.store());
+    let purged = tokio::task::spawn_blocking(move || store.purge_all()).await;
+    match purged {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to purge observability metadata",
+                Some(&e.to_string()),
+            )
+            .into_response();
+        }
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to purge observability metadata",
+                Some(&e.to_string()),
+            )
+            .into_response();
+        }
     }
     obs.payloads().purge_all();
     Json(ActionResponse {
@@ -4004,9 +4051,12 @@ async fn get_observability_config(
 }
 
 /// PUT /api/observability/config — persist new `[relay.observability]` settings
-/// to disk (targeted edit, preserving the rest of the file) and swap the
-/// in-memory baseline. Runtime store sizing (windows, budgets, enable/disable)
-/// is re-read on the next relay restart.
+/// to disk and swap the in-memory baseline. Like `persist_disabled_state`, this
+/// reparses the whole config file into a `toml::Table`, replaces the
+/// `[relay.observability]` table, and reserializes the entire file — so
+/// comments/formatting are not preserved and sections may be reordered. Runtime
+/// store sizing (windows, budgets, enable/disable) is re-read on the next relay
+/// restart.
 async fn update_observability_config(
     State(state): State<ManagementState>,
     Json(new_cfg): Json<ObservabilityConfig>,

--- a/src/management.rs
+++ b/src/management.rs
@@ -1,5 +1,5 @@
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     response::IntoResponse,
     routing::{delete, get, post},
@@ -20,9 +20,11 @@ use crate::adapter::oauth::OAuthState;
 use crate::adapter::sse::{SseAdapter, SseConfig};
 use crate::adapter::stdio::{StdioAdapter, StdioConfig};
 use crate::adapter::{FailedAdapter, HealthStatus, McpAdapter, StartingAdapter};
-use crate::config::Config;
+use crate::config::{Config, ObservabilityConfig};
 use crate::events::ToolCallEventBus;
 use crate::oauth::{OAuthFlowManager, OAuthSetupManager, PkceChallenge};
+use crate::observability::payloads::StoredPayloads;
+use crate::observability::store::{AggregateBucket, CallRecord, QueryFilter};
 use crate::profile_registry::ProfileRegistry;
 use crate::registry::AdapterRegistry;
 use crate::token_manager::{DcrCredentials, TokenManager};
@@ -537,6 +539,10 @@ struct SanitizedRelay {
     machine_name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     local_js_execution: Option<bool>,
+    /// Agent-call observability settings (`[relay.observability]`). Exposed so
+    /// the desktop Settings tab can render the Observability section; contains
+    /// no secrets, so it is surfaced verbatim.
+    observability: ObservabilityConfig,
 }
 
 #[derive(Serialize)]
@@ -558,6 +564,7 @@ fn sanitize_config(config: &Config) -> SanitizedConfig {
         relay: SanitizedRelay {
             machine_name: config.relay.machine_name.clone(),
             local_js_execution: config.relay.local_js_execution,
+            observability: config.relay.observability.clone(),
         },
         endpoints: config
             .endpoints
@@ -733,6 +740,55 @@ async fn delete_endpoint(
             Some(&e.to_string()),
         )
         .into_response();
+    }
+
+    // R6: cascade observability cleanup for the deleted server. The metadata
+    // store is keyed by `server_name`, but the in-memory payload buffer is
+    // keyed by `request_uid` — so derive the request_uids for this server from
+    // the metadata rows BEFORE deleting them, then delete the rows and drop the
+    // matching buffered payloads. No-op when observability is unwired/disabled.
+    if let Some(obs) = state.registry.observability().filter(|o| o.is_enabled()) {
+        let store = obs.store();
+        let filter = crate::observability::store::QueryFilter {
+            server_name: Some(name.clone()),
+            ..Default::default()
+        };
+        let mut uids: std::collections::HashSet<String> = std::collections::HashSet::new();
+        const UID_PAGE: i64 = 1000;
+        let mut offset = 0i64;
+        loop {
+            match store.query(&filter, UID_PAGE, offset) {
+                Ok(rows) => {
+                    let fetched = rows.len() as i64;
+                    for row in rows {
+                        if let Some(uid) = row.request_uid {
+                            uids.insert(uid);
+                        }
+                    }
+                    if fetched < UID_PAGE {
+                        break;
+                    }
+                    offset += UID_PAGE;
+                }
+                Err(e) => {
+                    warn!(error = %e, server = %name, "observability: failed to collect request_uids for delete cascade");
+                    break;
+                }
+            }
+        }
+
+        match store.delete_for_server(&name) {
+            Ok(removed) => {
+                tracing::debug!(server = %name, removed, "observability: deleted metadata rows for deleted server")
+            }
+            Err(e) => {
+                warn!(error = %e, server = %name, "observability: failed to delete metadata rows for deleted server")
+            }
+        }
+
+        if !uids.is_empty() {
+            obs.payloads().remove_for_server(&uids);
+        }
     }
 
     // Return success — the config watcher will pick up the file change and
@@ -3483,6 +3539,453 @@ async fn tool_call_events_sse(State(state): State<ManagementState>) -> axum::res
 }
 
 // ---------------------------------------------------------------------------
+// Observability API (R5)
+// ---------------------------------------------------------------------------
+
+/// Serializable view of a [`CallRecord`] for the observability API. Mirrors the
+/// stored metadata row; request/response bodies are surfaced separately on the
+/// drill-through route, never on the list.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CallRecordDto {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    request_uid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    jsonrpc_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    endpoint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    server_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    server_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    transport: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    profile: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    client_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    client_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    client_user_agent: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    client_origin: Option<String>,
+    tool: String,
+    ts_start: i64,
+    ts_end: i64,
+    duration_ms: i64,
+    success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error_message: Option<String>,
+    request_bytes: i64,
+    response_bytes: i64,
+    streamed: bool,
+}
+
+impl From<CallRecord> for CallRecordDto {
+    fn from(r: CallRecord) -> Self {
+        CallRecordDto {
+            id: r.id,
+            request_uid: r.request_uid,
+            jsonrpc_id: r.jsonrpc_id,
+            endpoint: r.endpoint,
+            server_name: r.server_name,
+            server_type: r.server_type,
+            transport: r.transport,
+            profile: r.profile,
+            client_name: r.client_name,
+            client_version: r.client_version,
+            client_user_agent: r.client_user_agent,
+            client_origin: r.client_origin,
+            tool: r.tool,
+            ts_start: r.ts_start,
+            ts_end: r.ts_end,
+            duration_ms: r.duration_ms,
+            success: r.success,
+            error_message: r.error_message,
+            request_bytes: r.request_bytes,
+            response_bytes: r.response_bytes,
+            streamed: r.streamed,
+        }
+    }
+}
+
+/// Query string for `GET /api/observability/calls`. All filters are optional
+/// and ANDed; `since`/`until` bound `ts_start` as epoch milliseconds.
+#[derive(Deserialize)]
+struct CallsQuery {
+    server_name: Option<String>,
+    tool: Option<String>,
+    success: Option<bool>,
+    request_uid: Option<String>,
+    since: Option<i64>,
+    until: Option<i64>,
+    limit: Option<i64>,
+    offset: Option<i64>,
+}
+
+/// Response for `GET /api/observability/calls`.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CallsResponse {
+    calls: Vec<CallRecordDto>,
+    limit: i64,
+    offset: i64,
+}
+
+/// Default and maximum page sizes for the calls list.
+const CALLS_DEFAULT_LIMIT: i64 = 100;
+const CALLS_MAX_LIMIT: i64 = 1000;
+
+/// 503 body used when the observability subsystem is unwired (e.g. the metadata
+/// store failed to open at startup). Distinct from a wired-but-disabled handle:
+/// a disabled handle still answers reads (its store is empty / frozen).
+fn observability_unavailable() -> axum::response::Response {
+    error_response(
+        StatusCode::SERVICE_UNAVAILABLE,
+        "observability not available",
+        Some("The observability subsystem is not initialised."),
+    )
+    .into_response()
+}
+
+/// Current wall-clock time in epoch milliseconds (default `until` bound).
+fn now_epoch_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+/// GET /api/observability/calls — filtered, paged metadata list (payloads
+/// excluded; use the drill-through route for those).
+async fn get_observability_calls(
+    State(state): State<ManagementState>,
+    Query(q): Query<CallsQuery>,
+) -> axum::response::Response {
+    let Some(obs) = state.registry.observability() else {
+        return observability_unavailable();
+    };
+    let limit = q
+        .limit
+        .unwrap_or(CALLS_DEFAULT_LIMIT)
+        .clamp(1, CALLS_MAX_LIMIT);
+    let offset = q.offset.unwrap_or(0).max(0);
+    let filter = QueryFilter {
+        server_name: q.server_name,
+        tool: q.tool,
+        success: q.success,
+        request_uid: q.request_uid,
+        since: q.since,
+        until: q.until,
+    };
+    match obs.store().query(&filter, limit, offset) {
+        Ok(rows) => Json(CallsResponse {
+            calls: rows.into_iter().map(CallRecordDto::from).collect(),
+            limit,
+            offset,
+        })
+        .into_response(),
+        Err(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to query observability records",
+            Some(&e.to_string()),
+        )
+        .into_response(),
+    }
+}
+
+/// Payload availability on the drill-through route.
+#[derive(Serialize)]
+#[serde(rename_all = "lowercase")]
+enum PayloadStatus {
+    /// Payloads are still buffered and returned inline.
+    Stored,
+    /// Payload capture is enabled but the entry aged out of the ring buffer.
+    Expired,
+    /// Payload capture is disabled (`store_payloads = false`).
+    Disabled,
+}
+
+/// Response for `GET /api/observability/calls/{request_uid}`.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CallDetailResponse {
+    record: CallRecordDto,
+    payload_status: PayloadStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    payloads: Option<StoredPayloads>,
+}
+
+/// GET /api/observability/calls/{request_uid} — full metadata row plus buffered
+/// payloads when still retained.
+async fn get_observability_call_detail(
+    State(state): State<ManagementState>,
+    Path(request_uid): Path<String>,
+) -> axum::response::Response {
+    let Some(obs) = state.registry.observability() else {
+        return observability_unavailable();
+    };
+    let record = match obs.store().get_by_request_uid(&request_uid) {
+        Ok(Some(r)) => r,
+        Ok(None) => {
+            return error_response(
+                StatusCode::NOT_FOUND,
+                "call record not found",
+                Some(&format!("No record for request_uid {request_uid}")),
+            )
+            .into_response();
+        }
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to load observability record",
+                Some(&e.to_string()),
+            )
+            .into_response();
+        }
+    };
+    let (payload_status, payloads) = if !obs.store_payloads() {
+        (PayloadStatus::Disabled, None)
+    } else {
+        match obs.payloads().get(&request_uid) {
+            Some(p) => (PayloadStatus::Stored, Some(p)),
+            None => (PayloadStatus::Expired, None),
+        }
+    };
+    Json(CallDetailResponse {
+        record: record.into(),
+        payload_status,
+        payloads,
+    })
+    .into_response()
+}
+
+/// Serializable view of an [`AggregateBucket`] sparkline point.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AggregateBucketDto {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    server: Option<String>,
+    bucket_start: i64,
+    count: u64,
+    error_count: u64,
+    p50_ms: u64,
+    p95_ms: u64,
+}
+
+impl From<AggregateBucket> for AggregateBucketDto {
+    fn from(b: AggregateBucket) -> Self {
+        AggregateBucketDto {
+            server: b.server,
+            bucket_start: b.bucket_start,
+            count: b.count,
+            error_count: b.error_count,
+            p50_ms: b.p50_ms,
+            p95_ms: b.p95_ms,
+        }
+    }
+}
+
+/// Global counters surfaced alongside the sparkline buckets so the desktop can
+/// render overflow and buffer-pressure indicators.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ObservabilitySummary {
+    enabled: bool,
+    store_payloads: bool,
+    dropped: u64,
+    payload_buffer_len: usize,
+    payload_buffer_bytes: usize,
+}
+
+/// Query string for `GET /api/observability/aggregates`.
+#[derive(Deserialize)]
+struct AggregatesQuery {
+    bucket_seconds: Option<i64>,
+    since: Option<i64>,
+    until: Option<i64>,
+}
+
+/// Response for `GET /api/observability/aggregates`.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AggregatesResponse {
+    buckets: Vec<AggregateBucketDto>,
+    summary: ObservabilitySummary,
+}
+
+/// Default sparkline window (1 hour) and bucket width (1 minute).
+const AGGREGATES_DEFAULT_WINDOW_MS: i64 = 3_600_000;
+const AGGREGATES_DEFAULT_BUCKET_SECONDS: i64 = 60;
+
+/// GET /api/observability/aggregates — time-bucketed per-server + global
+/// metrics for the SVG sparklines, plus global overflow / buffer counters.
+async fn get_observability_aggregates(
+    State(state): State<ManagementState>,
+    Query(q): Query<AggregatesQuery>,
+) -> axum::response::Response {
+    let Some(obs) = state.registry.observability() else {
+        return observability_unavailable();
+    };
+    let until = q.until.unwrap_or_else(now_epoch_ms);
+    let since = q.since.unwrap_or(until - AGGREGATES_DEFAULT_WINDOW_MS);
+    let bucket_seconds = q
+        .bucket_seconds
+        .unwrap_or(AGGREGATES_DEFAULT_BUCKET_SECONDS)
+        .max(1);
+    let summary = ObservabilitySummary {
+        enabled: obs.is_enabled(),
+        store_payloads: obs.store_payloads(),
+        dropped: obs.dropped(),
+        payload_buffer_len: obs.payloads().len(),
+        payload_buffer_bytes: obs.payloads().total_bytes(),
+    };
+    match obs.store().aggregate(bucket_seconds, since, until) {
+        Ok(buckets) => Json(AggregatesResponse {
+            buckets: buckets.into_iter().map(AggregateBucketDto::from).collect(),
+            summary,
+        })
+        .into_response(),
+        Err(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to aggregate observability records",
+            Some(&e.to_string()),
+        )
+        .into_response(),
+    }
+}
+
+/// POST /api/observability/purge — drop every buffered payload and metadata row.
+async fn purge_observability(State(state): State<ManagementState>) -> axum::response::Response {
+    let Some(obs) = state.registry.observability() else {
+        return observability_unavailable();
+    };
+    if let Err(e) = obs.store().purge_all() {
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to purge observability metadata",
+            Some(&e.to_string()),
+        )
+        .into_response();
+    }
+    obs.payloads().purge_all();
+    Json(ActionResponse {
+        ok: true,
+        message: "observability records purged".to_string(),
+    })
+    .into_response()
+}
+
+/// GET /api/observability/config — current `[relay.observability]` settings.
+async fn get_observability_config(
+    State(state): State<ManagementState>,
+) -> Json<ObservabilityConfig> {
+    let config = state.config.read().await;
+    Json(config.relay.observability.clone())
+}
+
+/// PUT /api/observability/config — persist new `[relay.observability]` settings
+/// to disk (targeted edit, preserving the rest of the file) and swap the
+/// in-memory baseline. Runtime store sizing (windows, budgets, enable/disable)
+/// is re-read on the next relay restart.
+async fn update_observability_config(
+    State(state): State<ManagementState>,
+    Json(new_cfg): Json<ObservabilityConfig>,
+) -> axum::response::Response {
+    let Some(config_path) = &state.config_path else {
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "config_path not configured",
+            Some("The management API was not initialised with a config file path."),
+        )
+        .into_response();
+    };
+    let resolved = crate::config::expand_tilde(config_path);
+
+    let contents = match std::fs::read_to_string(&resolved) {
+        Ok(c) => c,
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to read config file",
+                Some(&e.to_string()),
+            )
+            .into_response();
+        }
+    };
+    let mut parsed: toml::Table = match contents.parse() {
+        Ok(t) => t,
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to parse config file",
+                Some(&e.to_string()),
+            )
+            .into_response();
+        }
+    };
+
+    let obs_value = match toml::Value::try_from(&new_cfg) {
+        Ok(v) => v,
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to serialize observability config",
+                Some(&e.to_string()),
+            )
+            .into_response();
+        }
+    };
+
+    // Insert/replace `[relay.observability]`, creating `[relay]` if absent.
+    let relay_tbl = parsed
+        .entry("relay".to_string())
+        .or_insert_with(|| toml::Value::Table(toml::Table::new()));
+    let Some(relay_tbl) = relay_tbl.as_table_mut() else {
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "invalid config file",
+            Some("`relay` is not a table"),
+        )
+        .into_response();
+    };
+    relay_tbl.insert("observability".to_string(), obs_value);
+
+    let new_contents = match toml::to_string_pretty(&parsed) {
+        Ok(s) => s,
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to serialize config",
+                Some(&e.to_string()),
+            )
+            .into_response();
+        }
+    };
+    if let Err(e) = crate::config::write_config_file(&resolved, &new_contents) {
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to write config file",
+            Some(&e.to_string()),
+        )
+        .into_response();
+    }
+
+    // Swap the in-memory baseline so `GET /api/config` and
+    // `GET /api/observability/config` reflect the change immediately.
+    {
+        let mut config = state.config.write().await;
+        config.relay.observability = new_cfg.clone();
+    }
+
+    Json(new_cfg).into_response()
+}
+
+// ---------------------------------------------------------------------------
 // Router builder
 // ---------------------------------------------------------------------------
 
@@ -3549,6 +4052,23 @@ pub fn management_routes(state: ManagementState) -> Router {
         )
         // Desktop overlay's typed tool-call event SSE stream.
         .route("/api/events/tool-calls", get(tool_call_events_sse))
+        // Observability tab (R5): query, drill-through, aggregates, purge,
+        // config, and a live SSE feed reusing the tool-call event bus.
+        .route("/api/observability/calls", get(get_observability_calls))
+        .route(
+            "/api/observability/calls/{request_uid}",
+            get(get_observability_call_detail),
+        )
+        .route(
+            "/api/observability/aggregates",
+            get(get_observability_aggregates),
+        )
+        .route("/api/observability/purge", post(purge_observability))
+        .route(
+            "/api/observability/config",
+            get(get_observability_config).put(update_observability_config),
+        )
+        .route("/api/observability/events", get(tool_call_events_sse))
         // No CORS layer: this router is served exclusively over a Unix-domain
         // socket / Windows named pipe (see `management_listener`), which is not
         // reachable from a browser and has no cross-origin attack surface.
@@ -3884,6 +4404,7 @@ mod tests {
                 startup_init_timeout_secs: None,
                 session_identity_max_sessions: None,
                 validate_inputs: None,
+                observability: crate::config::ObservabilityConfig::default(),
             },
             endpoints: vec![EndpointConfig {
                 name: "echo".to_string(),
@@ -4635,6 +5156,119 @@ command = "cat"
         assert!(updated.contains("keep-me"));
 
         // Clean up
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn management_delete_endpoint_cascades_observability() {
+        use crate::observability::payloads::PayloadStore;
+        use crate::observability::pipeline::Observability;
+        use crate::observability::store::{CallRecord, QueryFilter, Store};
+
+        // Two endpoints on disk; we delete one and assert the other's
+        // observability data survives.
+        let dir =
+            std::env::temp_dir().join(format!("relay-test-delete-cascade-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let config_file = dir.join("config.toml");
+        let toml_content = r#"[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "echo"
+transport = "stdio"
+command = "echo"
+
+[[endpoints]]
+name = "keep-me"
+transport = "stdio"
+command = "cat"
+"#;
+        std::fs::write(&config_file, toml_content).unwrap();
+
+        // Seed the metadata store + payload buffer for both servers, keyed by
+        // request_uid.
+        let store = Arc::new(Store::open_in_memory().unwrap());
+        let payloads = Arc::new(PayloadStore::new(10, 128, 256 * 1024));
+        let row = |uid: &str, server: &str| CallRecord {
+            request_uid: Some(uid.to_string()),
+            server_name: Some(server.to_string()),
+            tool: format!("{server}__do"),
+            ts_start: 1000,
+            ts_end: 1005,
+            duration_ms: 5,
+            success: true,
+            ..Default::default()
+        };
+        store
+            .insert_batch(&[
+                row("echo-1", "echo"),
+                row("echo-2", "echo"),
+                row("keep-1", "keep-me"),
+                row("keep-2", "keep-me"),
+            ])
+            .unwrap();
+        for uid in ["echo-1", "echo-2", "keep-1", "keep-2"] {
+            payloads.insert(
+                uid,
+                &serde_json::json!({"q": uid}),
+                &serde_json::json!({"ok": true}),
+                false,
+            );
+        }
+
+        let obs = Observability::new(
+            &crate::config::ObservabilityConfig::default(),
+            Arc::clone(&store),
+            Arc::clone(&payloads),
+        );
+        let registry = AdapterRegistry::new().with_observability(obs);
+
+        let mut state = test_state(vec![]).await;
+        state.registry = Arc::new(registry);
+        state.config_path = Some(config_file.clone());
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::delete("/api/endpoints/echo")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // The deleted server's metadata + payloads are gone.
+        let echo_rows = store
+            .query(
+                &QueryFilter {
+                    server_name: Some("echo".to_string()),
+                    ..Default::default()
+                },
+                100,
+                0,
+            )
+            .unwrap();
+        assert!(echo_rows.is_empty(), "echo metadata rows should be deleted");
+        assert!(payloads.get("echo-1").is_none());
+        assert!(payloads.get("echo-2").is_none());
+
+        // The surviving server is untouched.
+        let keep_rows = store
+            .query(
+                &QueryFilter {
+                    server_name: Some("keep-me".to_string()),
+                    ..Default::default()
+                },
+                100,
+                0,
+            )
+            .unwrap();
+        assert_eq!(keep_rows.len(), 2, "keep-me metadata rows should survive");
+        assert!(payloads.get("keep-1").is_some());
+        assert!(payloads.get("keep-2").is_some());
+
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -6106,6 +6740,7 @@ command = "echo"
                 startup_init_timeout_secs: None,
                 session_identity_max_sessions: None,
                 validate_inputs: None,
+                observability: crate::config::ObservabilityConfig::default(),
             },
             endpoints: vec![EndpointConfig {
                 name: name.to_string(),
@@ -6312,6 +6947,7 @@ command = "echo"
                 startup_init_timeout_secs: None,
                 session_identity_max_sessions: None,
                 validate_inputs: None,
+                observability: crate::config::ObservabilityConfig::default(),
             },
             endpoints: vec![EndpointConfig {
                 name: name.to_string(),
@@ -6731,6 +7367,7 @@ command = "echo"
                 startup_init_timeout_secs: None,
                 session_identity_max_sessions: None,
                 validate_inputs: None,
+                observability: crate::config::ObservabilityConfig::default(),
             },
             endpoints: vec![EndpointConfig {
                 name: name.to_string(),
@@ -6853,6 +7490,7 @@ client_id = "client123"
                 startup_init_timeout_secs: None,
                 session_identity_max_sessions: None,
                 validate_inputs: None,
+                observability: crate::config::ObservabilityConfig::default(),
             },
             endpoints: vec![],
             profiles: None,
@@ -6916,6 +7554,7 @@ client_id = "client123"
                 startup_init_timeout_secs: None,
                 session_identity_max_sessions: None,
                 validate_inputs: None,
+                observability: crate::config::ObservabilityConfig::default(),
             },
             endpoints: endpoint_names
                 .iter()
@@ -7475,6 +8114,7 @@ client_id = "client123"
                 startup_init_timeout_secs: None,
                 session_identity_max_sessions: None,
                 validate_inputs: None,
+                observability: crate::config::ObservabilityConfig::default(),
             },
             endpoints: vec![EndpointConfig {
                 name: "existing".to_string(),

--- a/src/management.rs
+++ b/src/management.rs
@@ -3671,8 +3671,6 @@ struct CallRecordDto {
     #[serde(skip_serializing_if = "Option::is_none")]
     request_uid: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    jsonrpc_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     endpoint: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     server_name: Option<String>,
@@ -3707,7 +3705,6 @@ impl From<CallRecord> for CallRecordDto {
         CallRecordDto {
             id: r.id,
             request_uid: r.request_uid,
-            jsonrpc_id: r.jsonrpc_id,
             endpoint: r.endpoint,
             server_name: r.server_name,
             server_type: r.server_type,

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -1,0 +1,13 @@
+//! Agent call observability: a two-tier store keyed by `request_uid`.
+//!
+//! - [`store`] persists per-`tools/call` metadata in SQLite (durable, indexed,
+//!   retention- and size-capped).
+//! - [`payloads`] holds full request/response bodies in an in-memory ring
+//!   buffer (ephemeral, time- and memory-capped).
+//!
+//! - [`pipeline`] is the async ingestion pipeline (R4) feeding both tiers: a
+//!   bounded, overflow-dropping channel drained by a background consumer.
+
+pub mod payloads;
+pub mod pipeline;
+pub mod store;

--- a/src/observability/payloads.rs
+++ b/src/observability/payloads.rs
@@ -1,0 +1,358 @@
+//! Ephemeral, thread-safe payload ring buffer for the observability store.
+//!
+//! Tier-2 of the two-tier store: full request/response payloads are kept in RAM
+//! only, keyed by `request_uid`. Entries are bounded by an age window and by a
+//! total memory budget (oldest-first eviction), and each payload is truncated to
+//! `max_payload_bytes` with a `truncated` flag. Nothing here is persisted to disk.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use chrono::Utc;
+use serde::Serialize;
+use serde_json::Value;
+
+/// A captured request/response pair retained in memory for the payload window.
+#[derive(Clone, Debug, Serialize)]
+pub struct StoredPayloads {
+    /// Serialized request payload (JSON), possibly truncated.
+    pub request: String,
+    /// Serialized response payload (JSON), possibly truncated.
+    pub response: String,
+    /// Set when the request payload exceeded `max_payload_bytes`.
+    pub request_truncated: bool,
+    /// Set when the response payload exceeded `max_payload_bytes`.
+    pub response_truncated: bool,
+    /// Whether the response was aggregated from a streamed/SSE result.
+    pub streamed: bool,
+    /// Capture time in Unix epoch milliseconds (UTC).
+    pub captured_at_ms: i64,
+}
+
+struct Entry {
+    payloads: StoredPayloads,
+    instant: Instant,
+    size: usize,
+}
+
+struct Inner {
+    entries: HashMap<String, Entry>,
+    order: VecDeque<String>,
+    total_bytes: usize,
+}
+
+/// In-memory, time- and budget-bounded payload store keyed by `request_uid`.
+pub struct PayloadStore {
+    inner: Mutex<Inner>,
+    window: Duration,
+    budget_bytes: usize,
+    max_payload_bytes: usize,
+}
+
+impl PayloadStore {
+    /// Create a store with the configured payload window (minutes), memory budget
+    /// (megabytes), and per-payload truncation cap (bytes).
+    pub fn new(window_minutes: u64, budget_mb: u64, max_payload_bytes: usize) -> Self {
+        let budget_bytes = (budget_mb as usize).saturating_mul(1024 * 1024);
+        Self::from_raw(
+            Duration::from_secs(window_minutes.saturating_mul(60)),
+            budget_bytes,
+            max_payload_bytes,
+        )
+    }
+
+    fn from_raw(window: Duration, budget_bytes: usize, max_payload_bytes: usize) -> Self {
+        PayloadStore {
+            inner: Mutex::new(Inner {
+                entries: HashMap::new(),
+                order: VecDeque::new(),
+                total_bytes: 0,
+            }),
+            window,
+            budget_bytes,
+            max_payload_bytes,
+        }
+    }
+
+    /// Insert (or overwrite) the payloads for a `request_uid`. Triggers age and
+    /// budget eviction. Both payloads are truncated to `max_payload_bytes`.
+    pub fn insert(
+        &self,
+        request_uid: impl Into<String>,
+        request: &Value,
+        response: &Value,
+        streamed: bool,
+    ) {
+        self.insert_at(
+            request_uid.into(),
+            request,
+            response,
+            streamed,
+            Instant::now(),
+        );
+    }
+
+    fn insert_at(
+        &self,
+        uid: String,
+        request: &Value,
+        response: &Value,
+        streamed: bool,
+        instant: Instant,
+    ) {
+        let (request, request_truncated) = self.truncate(request);
+        let (response, response_truncated) = self.truncate(response);
+        let size = request.len() + response.len() + uid.len();
+        let payloads = StoredPayloads {
+            request,
+            response,
+            request_truncated,
+            response_truncated,
+            streamed,
+            captured_at_ms: Utc::now().timestamp_millis(),
+        };
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(old) = inner.entries.remove(&uid) {
+            inner.total_bytes = inner.total_bytes.saturating_sub(old.size);
+            inner.order.retain(|k| k != &uid);
+        }
+        inner.entries.insert(
+            uid.clone(),
+            Entry {
+                payloads,
+                instant,
+                size,
+            },
+        );
+        inner.order.push_back(uid);
+        inner.total_bytes += size;
+        Self::evict_expired_locked(&mut inner, self.window, instant);
+        Self::evict_over_budget_locked(&mut inner, self.budget_bytes);
+    }
+
+    /// Fetch payloads for a `request_uid`, evicting expired entries first.
+    pub fn get(&self, request_uid: &str) -> Option<StoredPayloads> {
+        let mut inner = self.inner.lock().unwrap();
+        Self::evict_expired_locked(&mut inner, self.window, Instant::now());
+        inner.entries.get(request_uid).map(|e| e.payloads.clone())
+    }
+
+    /// Evict every entry older than the configured window. Safe to call from a
+    /// background sweep task (R6).
+    pub fn sweep_expired(&self) {
+        let mut inner = self.inner.lock().unwrap();
+        Self::evict_expired_locked(&mut inner, self.window, Instant::now());
+    }
+
+    /// Drop all buffered payloads (global purge).
+    pub fn purge_all(&self) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.entries.clear();
+        inner.order.clear();
+        inner.total_bytes = 0;
+    }
+
+    /// Drop buffered payloads for the given set of `request_uid`s. The buffer is
+    /// keyed by `request_uid`, so callers (R4/R6) supply the request_uid→server
+    /// mapping and pass the set of UIDs belonging to the deleted server.
+    pub fn remove_for_server(&self, drop_uids: &HashSet<String>) {
+        self.remove_where(|uid| drop_uids.contains(uid));
+    }
+
+    /// Drop every buffered payload whose `request_uid` matches the predicate.
+    pub fn remove_where<F: Fn(&str) -> bool>(&self, predicate: F) {
+        let mut inner = self.inner.lock().unwrap();
+        let drop: Vec<String> = inner
+            .entries
+            .keys()
+            .filter(|k| predicate(k))
+            .cloned()
+            .collect();
+        for k in drop {
+            if let Some(old) = inner.entries.remove(&k) {
+                inner.total_bytes = inner.total_bytes.saturating_sub(old.size);
+            }
+        }
+        let Inner { entries, order, .. } = &mut *inner;
+        order.retain(|k| entries.contains_key(k));
+    }
+
+    /// Number of buffered entries.
+    pub fn len(&self) -> usize {
+        self.inner.lock().unwrap().entries.len()
+    }
+
+    /// Whether the buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Total bytes currently accounted toward the memory budget.
+    pub fn total_bytes(&self) -> usize {
+        self.inner.lock().unwrap().total_bytes
+    }
+
+    /// Configured age window.
+    pub fn window(&self) -> Duration {
+        self.window
+    }
+
+    /// Configured memory budget in bytes.
+    pub fn budget_bytes(&self) -> usize {
+        self.budget_bytes
+    }
+
+    /// Configured per-payload truncation cap in bytes.
+    pub fn max_payload_bytes(&self) -> usize {
+        self.max_payload_bytes
+    }
+
+    fn truncate(&self, value: &Value) -> (String, bool) {
+        let s = value.to_string();
+        if s.len() <= self.max_payload_bytes {
+            return (s, false);
+        }
+        let mut end = self.max_payload_bytes;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        (s[..end].to_string(), true)
+    }
+
+    fn evict_expired_locked(inner: &mut Inner, window: Duration, now: Instant) {
+        while let Some(front) = inner.order.front() {
+            let expired = inner
+                .entries
+                .get(front)
+                .map(|e| now.saturating_duration_since(e.instant) > window)
+                .unwrap_or(true);
+            if !expired {
+                break;
+            }
+            let key = inner.order.pop_front().unwrap();
+            if let Some(old) = inner.entries.remove(&key) {
+                inner.total_bytes = inner.total_bytes.saturating_sub(old.size);
+            }
+        }
+    }
+
+    fn evict_over_budget_locked(inner: &mut Inner, budget_bytes: usize) {
+        while inner.total_bytes > budget_bytes && inner.order.len() > 1 {
+            let key = match inner.order.pop_front() {
+                Some(k) => k,
+                None => break,
+            };
+            if let Some(old) = inner.entries.remove(&key) {
+                inner.total_bytes = inner.total_bytes.saturating_sub(old.size);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn store_bytes(
+        window: Duration,
+        budget_bytes: usize,
+        max_payload_bytes: usize,
+    ) -> PayloadStore {
+        PayloadStore::from_raw(window, budget_bytes, max_payload_bytes)
+    }
+
+    #[test]
+    fn get_hit_returns_stored_payloads() {
+        let store = PayloadStore::new(10, 128, 256 * 1024);
+        store.insert("uid-1", &json!({"a": 1}), &json!({"ok": true}), true);
+        let got = store.get("uid-1").expect("present");
+        assert_eq!(got.request, "{\"a\":1}");
+        assert_eq!(got.response, "{\"ok\":true}");
+        assert!(got.streamed);
+        assert!(!got.request_truncated);
+        assert!(!got.response_truncated);
+        assert!(store.get("missing").is_none());
+    }
+
+    #[test]
+    fn per_payload_truncation_sets_flag() {
+        let store = store_bytes(Duration::from_secs(600), 1024 * 1024, 10);
+        let big = json!("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+        store.insert("uid", &big, &json!(null), false);
+        let got = store.get("uid").expect("present");
+        assert!(got.request_truncated);
+        assert!(got.request.len() <= 10);
+        assert!(!got.response_truncated);
+        assert_eq!(got.response, "null");
+    }
+
+    #[test]
+    fn age_eviction_drops_expired_entries() {
+        let store = store_bytes(Duration::from_secs(600), 1024 * 1024, 1024);
+        let stale = Instant::now()
+            .checked_sub(Duration::from_secs(601))
+            .expect("instant");
+        store.insert_at("old".into(), &json!({"x": 1}), &json!(null), false, stale);
+        store.insert("fresh", &json!({"y": 2}), &json!(null), false);
+        store.sweep_expired();
+        assert!(store.get("old").is_none());
+        assert!(store.get("fresh").is_some());
+        assert_eq!(store.len(), 1);
+    }
+
+    #[test]
+    fn miss_after_expiry() {
+        let store = store_bytes(Duration::from_secs(60), 1024 * 1024, 1024);
+        let stale = Instant::now()
+            .checked_sub(Duration::from_secs(120))
+            .expect("instant");
+        store.insert_at("uid".into(), &json!({"x": 1}), &json!(null), false, stale);
+        assert!(store.get("uid").is_none());
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn budget_eviction_drops_oldest_first() {
+        let store = store_bytes(Duration::from_secs(600), 40, 1024);
+        let req = json!({"k": "v"});
+        let resp = json!({"k": "v"});
+        store.insert("a", &req, &resp, false);
+        store.insert("b", &req, &resp, false);
+        assert!(store.get("a").is_some());
+        assert!(store.get("b").is_some());
+        store.insert("c", &req, &resp, false);
+        assert!(store.get("a").is_none());
+        assert!(store.get("b").is_some());
+        assert!(store.get("c").is_some());
+        assert!(store.total_bytes() <= store.budget_bytes());
+    }
+
+    #[test]
+    fn remove_for_server_drops_matching_uids() {
+        let store = PayloadStore::new(10, 128, 256 * 1024);
+        store.insert("s1-a", &json!(1), &json!(2), false);
+        store.insert("s1-b", &json!(1), &json!(2), false);
+        store.insert("s2-a", &json!(1), &json!(2), false);
+        let drop: HashSet<String> = ["s1-a".to_string(), "s1-b".to_string()]
+            .into_iter()
+            .collect();
+        store.remove_for_server(&drop);
+        assert!(store.get("s1-a").is_none());
+        assert!(store.get("s1-b").is_none());
+        assert!(store.get("s2-a").is_some());
+        assert_eq!(store.len(), 1);
+    }
+
+    #[test]
+    fn purge_all_clears_buffer() {
+        let store = PayloadStore::new(10, 128, 256 * 1024);
+        store.insert("a", &json!(1), &json!(2), false);
+        store.insert("b", &json!(1), &json!(2), false);
+        store.purge_all();
+        assert!(store.is_empty());
+        assert_eq!(store.total_bytes(), 0);
+        assert!(store.get("a").is_none());
+    }
+}

--- a/src/observability/pipeline.rs
+++ b/src/observability/pipeline.rs
@@ -1,0 +1,322 @@
+//! Async ingestion pipeline tying the capture hot path to the two-tier store.
+//!
+//! The hot request path (`registry::route_tool_call`) builds a
+//! [`CaptureRecord`] and hands it to [`Observability::capture`], which
+//! `try_send`s onto a bounded channel and **never blocks**: when the channel is
+//! full the record is dropped and the [`Observability`]-owned `dropped` counter
+//! is bumped. A background consumer task drains the channel, batch-writes
+//! metadata into the SQLite [`Store`] (R2) and inserts payloads into the
+//! in-memory [`PayloadStore`] (R3), both keyed by `request_uid`.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use serde_json::Value;
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+use crate::config::ObservabilityConfig;
+
+use super::payloads::PayloadStore;
+use super::store::{CallRecord, Store};
+
+/// Bounded capacity of the capture channel. Sized so brief bursts are absorbed
+/// without backpressure on the request path; sustained overflow drops + counts.
+const CAPTURE_CHANNEL_CAPACITY: usize = 1024;
+
+/// Maximum metadata rows coalesced into a single SQLite transaction by the
+/// background consumer before re-checking the channel.
+const METADATA_BATCH_MAX: usize = 128;
+
+/// Full request/response bodies captured alongside a [`CallRecord`]. Present
+/// only when payload capture is enabled (`store_payloads`).
+pub struct CapturedPayloads {
+    pub request: Value,
+    pub response: Value,
+    pub streamed: bool,
+}
+
+/// A single captured `tools/call`, enqueued by the hot path for the background
+/// consumer to persist. `record.request_uid` is the correlation key shared by
+/// the metadata row and the buffered payloads.
+pub struct CaptureRecord {
+    pub record: CallRecord,
+    pub payloads: Option<CapturedPayloads>,
+}
+
+struct ObservabilityInner {
+    enabled: bool,
+    store_payloads: bool,
+    tx: mpsc::Sender<CaptureRecord>,
+    dropped: AtomicU64,
+    store: Arc<Store>,
+    payloads: Arc<PayloadStore>,
+}
+
+/// Cheaply-cloneable handle to the observability ingestion pipeline. Owns the
+/// metadata [`Store`], the [`PayloadStore`], the bounded capture channel sender
+/// and the overflow `dropped` counter (R4-owned, not in R2/R3).
+#[derive(Clone)]
+pub struct Observability {
+    inner: Arc<ObservabilityInner>,
+}
+
+impl Observability {
+    /// Construct the handle from config and the two stores, spawning the
+    /// background consumer when `config.enabled`. When disabled, no consumer is
+    /// spawned and [`Observability::capture`] is a cheap no-op.
+    pub fn new(
+        config: &ObservabilityConfig,
+        store: Arc<Store>,
+        payloads: Arc<PayloadStore>,
+    ) -> Self {
+        let (tx, rx) = mpsc::channel(CAPTURE_CHANNEL_CAPACITY);
+        if config.enabled {
+            tokio::spawn(run_consumer(rx, Arc::clone(&store), Arc::clone(&payloads)));
+        }
+        Self {
+            inner: Arc::new(ObservabilityInner {
+                enabled: config.enabled,
+                store_payloads: config.store_payloads,
+                tx,
+                dropped: AtomicU64::new(0),
+                store,
+                payloads,
+            }),
+        }
+    }
+
+    /// Hot-path enqueue. Non-blocking: `try_send` drops + counts on a full
+    /// channel and returns immediately. No-op when the subsystem is disabled.
+    pub fn capture(&self, record: CaptureRecord) {
+        if !self.inner.enabled {
+            return;
+        }
+        if self.inner.tx.try_send(record).is_err() {
+            self.inner.dropped.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Whether the subsystem is enabled (capture records metadata + payloads).
+    pub fn is_enabled(&self) -> bool {
+        self.inner.enabled
+    }
+
+    /// Whether request/response payloads are captured into the ring buffer.
+    pub fn store_payloads(&self) -> bool {
+        self.inner.store_payloads
+    }
+
+    /// Number of capture records dropped due to a full channel (R4 overflow
+    /// counter). Surfaced to R5's stats endpoint.
+    pub fn dropped(&self) -> u64 {
+        self.inner.dropped.load(Ordering::Relaxed)
+    }
+
+    /// Shared metadata store handle (R5 query / R6 retention + delete cascade).
+    pub fn store(&self) -> &Arc<Store> {
+        &self.inner.store
+    }
+
+    /// Shared payload buffer handle (R5 drill-through / R6 sweep + cascade).
+    pub fn payloads(&self) -> &Arc<PayloadStore> {
+        &self.inner.payloads
+    }
+
+    /// Build a handle with an explicit channel capacity and **no** consumer
+    /// task, returning the receiver so the caller can keep it alive (an open
+    /// but undrained channel fills deterministically). Used by overflow tests
+    /// to exercise the `try_send` drop-and-count path.
+    #[cfg(test)]
+    fn new_no_consumer(
+        enabled: bool,
+        store_payloads: bool,
+        capacity: usize,
+        store: Arc<Store>,
+        payloads: Arc<PayloadStore>,
+    ) -> (Self, mpsc::Receiver<CaptureRecord>) {
+        let (tx, rx) = mpsc::channel(capacity);
+        let obs = Self {
+            inner: Arc::new(ObservabilityInner {
+                enabled,
+                store_payloads,
+                tx,
+                dropped: AtomicU64::new(0),
+                store,
+                payloads,
+            }),
+        };
+        (obs, rx)
+    }
+}
+
+/// Drain the capture channel until it closes, coalescing metadata writes into
+/// batched transactions (off the async runtime via `spawn_blocking`) and
+/// inserting payloads into the in-memory buffer.
+async fn run_consumer(
+    mut rx: mpsc::Receiver<CaptureRecord>,
+    store: Arc<Store>,
+    payloads: Arc<PayloadStore>,
+) {
+    while let Some(first) = rx.recv().await {
+        let mut records: Vec<CallRecord> = Vec::new();
+        let mut buffered: Vec<(String, CapturedPayloads)> = Vec::new();
+        ingest(first, &mut records, &mut buffered);
+        while records.len() < METADATA_BATCH_MAX {
+            match rx.try_recv() {
+                Ok(next) => ingest(next, &mut records, &mut buffered),
+                Err(_) => break,
+            }
+        }
+
+        let store_for_write = Arc::clone(&store);
+        let to_insert = std::mem::take(&mut records);
+        match tokio::task::spawn_blocking(move || store_for_write.insert_batch(&to_insert)).await {
+            Ok(Ok(_)) => {}
+            Ok(Err(e)) => warn!(error = %e, "observability: failed to persist metadata batch"),
+            Err(e) => warn!(error = %e, "observability: metadata writer task panicked"),
+        }
+
+        for (uid, p) in buffered {
+            payloads.insert(uid, &p.request, &p.response, p.streamed);
+        }
+    }
+    debug!("observability: capture channel closed, consumer task exiting");
+}
+
+/// Split a captured record into its metadata row and (optional) buffered
+/// payloads, keyed by `request_uid`.
+fn ingest(
+    cr: CaptureRecord,
+    records: &mut Vec<CallRecord>,
+    buffered: &mut Vec<(String, CapturedPayloads)>,
+) {
+    if let (Some(uid), Some(p)) = (cr.record.request_uid.clone(), cr.payloads) {
+        buffered.push((uid, p));
+    }
+    records.push(cr.record);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::time::Duration;
+
+    fn config(enabled: bool, store_payloads: bool) -> ObservabilityConfig {
+        ObservabilityConfig {
+            enabled,
+            store_payloads,
+            ..ObservabilityConfig::default()
+        }
+    }
+
+    fn record(uid: &str) -> CaptureRecord {
+        CaptureRecord {
+            record: CallRecord {
+                request_uid: Some(uid.to_string()),
+                server_name: Some("alpha".into()),
+                tool: "alpha__do".into(),
+                ts_start: 1000,
+                ts_end: 1005,
+                duration_ms: 5,
+                success: true,
+                ..Default::default()
+            },
+            payloads: Some(CapturedPayloads {
+                request: json!({"a": 1}),
+                response: json!({"ok": true}),
+                streamed: false,
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn capture_persists_metadata_and_payload() {
+        let store = Arc::new(Store::open_in_memory().unwrap());
+        let payloads = Arc::new(PayloadStore::new(10, 128, 256 * 1024));
+        let obs = Observability::new(
+            &config(true, true),
+            Arc::clone(&store),
+            Arc::clone(&payloads),
+        );
+
+        obs.capture(record("uid-1"));
+
+        // The consumer drains asynchronously; poll until the row lands.
+        let mut found = None;
+        for _ in 0..50 {
+            if let Some(r) = store.get_by_request_uid("uid-1").unwrap() {
+                found = Some(r);
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        let row = found.expect("metadata row persisted");
+        assert_eq!(row.server_name.as_deref(), Some("alpha"));
+        assert!(row.success);
+
+        let buffered = payloads.get("uid-1").expect("payload buffered");
+        assert_eq!(buffered.request, "{\"a\":1}");
+        assert_eq!(buffered.response, "{\"ok\":true}");
+        assert_eq!(obs.dropped(), 0);
+    }
+
+    #[tokio::test]
+    async fn store_payloads_disabled_records_metadata_only() {
+        let store = Arc::new(Store::open_in_memory().unwrap());
+        let payloads = Arc::new(PayloadStore::new(10, 128, 256 * 1024));
+        let obs = Observability::new(
+            &config(true, false),
+            Arc::clone(&store),
+            Arc::clone(&payloads),
+        );
+
+        // Hot path omits payloads when store_payloads is off.
+        let mut cr = record("uid-2");
+        cr.payloads = None;
+        obs.capture(cr);
+
+        for _ in 0..50 {
+            if store.get_by_request_uid("uid-2").unwrap().is_some() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(store.get_by_request_uid("uid-2").unwrap().is_some());
+        assert!(payloads.get("uid-2").is_none());
+    }
+
+    #[tokio::test]
+    async fn overflow_drops_without_blocking_and_counts() {
+        let store = Arc::new(Store::open_in_memory().unwrap());
+        let payloads = Arc::new(PayloadStore::new(10, 128, 256 * 1024));
+        // Capacity 2, no consumer draining: the 3rd+ enqueue overflow-drops.
+        // Keep `_rx` bound so the channel stays open (a dropped receiver would
+        // close it and fail every `try_send`).
+        let (obs, _rx) = Observability::new_no_consumer(true, true, 2, store, payloads);
+
+        for i in 0..5 {
+            obs.capture(record(&format!("uid-{i}")));
+        }
+        assert_eq!(obs.dropped(), 3);
+    }
+
+    #[tokio::test]
+    async fn disabled_capture_is_noop() {
+        let store = Arc::new(Store::open_in_memory().unwrap());
+        let payloads = Arc::new(PayloadStore::new(10, 128, 256 * 1024));
+        let obs = Observability::new(
+            &config(false, true),
+            Arc::clone(&store),
+            Arc::clone(&payloads),
+        );
+
+        obs.capture(record("uid-x"));
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        assert!(store.get_by_request_uid("uid-x").unwrap().is_none());
+        assert!(payloads.is_empty());
+        assert_eq!(obs.dropped(), 0);
+    }
+}

--- a/src/observability/store.rs
+++ b/src/observability/store.rs
@@ -1,0 +1,765 @@
+//! Durable per-`tools/call` metadata store backed by SQLite (`rusqlite`,
+//! bundled). One row per proxied tool call, indexed for the desktop
+//! Observability tab. Payload bodies live elsewhere (in-memory ring buffer,
+//! R3) and are joined back by `request_uid`.
+//!
+//! All methods are synchronous and intended to be driven from a dedicated
+//! blocking writer task (R4). The connection is guarded by a `Mutex` so the
+//! same [`Store`] can be shared (e.g. `Arc<Store>`) between that writer and
+//! read-only API handlers.
+
+use std::path::Path;
+use std::sync::Mutex;
+
+use rusqlite::{params, Connection, OptionalExtension};
+
+/// Columns selected (and mapped) in [`Store::query`] / [`Store::get_by_request_uid`].
+const SELECT_COLUMNS: &str = "id, request_uid, jsonrpc_id, endpoint, server_name, \
+    server_type, transport, profile, client_name, client_version, \
+    client_user_agent, client_origin, tool, ts_start, ts_end, duration_ms, \
+    success, error_message, request_bytes, response_bytes, streamed";
+
+/// A single proxied `tools/call`'s metadata row. Constructed by the capture
+/// pipeline (R4) for insertion and re-hydrated on query. Deliberately holds no
+/// request/response bodies — those stay in the in-memory payload buffer.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CallRecord {
+    /// Auto-increment row id. `None` when constructing for insert; populated on read.
+    pub id: Option<i64>,
+    /// Canonical per-message correlation key from `current_request_context()`.
+    pub request_uid: Option<String>,
+    pub jsonrpc_id: Option<String>,
+    pub endpoint: Option<String>,
+    pub server_name: Option<String>,
+    pub server_type: Option<String>,
+    pub transport: Option<String>,
+    pub profile: Option<String>,
+    pub client_name: Option<String>,
+    pub client_version: Option<String>,
+    pub client_user_agent: Option<String>,
+    pub client_origin: Option<String>,
+    /// Prefixed tool name routed for this call.
+    pub tool: String,
+    /// Call start / end as epoch milliseconds, and the measured duration.
+    pub ts_start: i64,
+    pub ts_end: i64,
+    pub duration_ms: i64,
+    pub success: bool,
+    pub error_message: Option<String>,
+    pub request_bytes: i64,
+    pub response_bytes: i64,
+    /// `true` when the underlying response was streamed/SSE and aggregated.
+    pub streamed: bool,
+}
+
+/// Filter for [`Store::query`]. All fields are ANDed; `None` means unconstrained.
+/// `since`/`until` bound `ts_start` as a half-open `[since, until)` window.
+#[derive(Debug, Clone, Default)]
+pub struct QueryFilter {
+    pub server_name: Option<String>,
+    pub tool: Option<String>,
+    pub success: Option<bool>,
+    pub request_uid: Option<String>,
+    pub since: Option<i64>,
+    pub until: Option<i64>,
+}
+
+/// One time bucket of aggregated metrics for sparklines. `server` is `None`
+/// for the global (all-servers) series.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AggregateBucket {
+    pub server: Option<String>,
+    pub bucket_start: i64,
+    pub count: u64,
+    pub error_count: u64,
+    pub p50_ms: u64,
+    pub p95_ms: u64,
+}
+
+/// Outcome of [`Store::enforce_size_cap`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SizeCapResult {
+    /// Whether any rows were evicted to fit under the cap.
+    pub evicted: bool,
+    pub deleted_rows: usize,
+    /// Oldest `ts_start` still retained after eviction, if any rows remain.
+    pub oldest_retained_ts: Option<i64>,
+}
+
+/// SQLite-backed metadata store.
+pub struct Store {
+    conn: Mutex<Connection>,
+}
+
+impl Store {
+    /// Open (creating if needed) `<dir>/observability.db`, enabling WAL and
+    /// incremental auto-vacuum, and idempotently create the schema.
+    pub fn open(dir: &Path) -> rusqlite::Result<Self> {
+        let path = dir.join("observability.db");
+        let conn = Connection::open(path)?;
+        Self::from_connection(conn)
+    }
+
+    /// Open an in-memory store (used by tests).
+    pub fn open_in_memory() -> rusqlite::Result<Self> {
+        Self::from_connection(Connection::open_in_memory()?)
+    }
+
+    fn from_connection(conn: Connection) -> rusqlite::Result<Self> {
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        conn.pragma_update(None, "auto_vacuum", "INCREMENTAL")?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS calls (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                request_uid TEXT,
+                jsonrpc_id TEXT,
+                endpoint TEXT,
+                server_name TEXT,
+                server_type TEXT,
+                transport TEXT,
+                profile TEXT,
+                client_name TEXT,
+                client_version TEXT,
+                client_user_agent TEXT,
+                client_origin TEXT,
+                tool TEXT NOT NULL,
+                ts_start INTEGER NOT NULL,
+                ts_end INTEGER NOT NULL,
+                duration_ms INTEGER NOT NULL,
+                success INTEGER NOT NULL,
+                error_message TEXT,
+                request_bytes INTEGER NOT NULL DEFAULT 0,
+                response_bytes INTEGER NOT NULL DEFAULT 0,
+                streamed INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE INDEX IF NOT EXISTS idx_calls_request_uid ON calls(request_uid);
+            CREATE INDEX IF NOT EXISTS idx_calls_server_ts ON calls(server_name, ts_start);
+            CREATE INDEX IF NOT EXISTS idx_calls_ts ON calls(ts_start);
+            CREATE INDEX IF NOT EXISTS idx_calls_success ON calls(success);",
+        )?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+}
+
+impl Store {
+    /// Insert a batch of records in a single transaction. Returns the count inserted.
+    pub fn insert_batch(&self, records: &[CallRecord]) -> rusqlite::Result<usize> {
+        if records.is_empty() {
+            return Ok(0);
+        }
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        {
+            let mut stmt = tx.prepare(
+                "INSERT INTO calls (
+                    request_uid, jsonrpc_id, endpoint, server_name, server_type,
+                    transport, profile, client_name, client_version,
+                    client_user_agent, client_origin, tool, ts_start, ts_end,
+                    duration_ms, success, error_message, request_bytes,
+                    response_bytes, streamed
+                ) VALUES (
+                    ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
+                    ?15, ?16, ?17, ?18, ?19, ?20
+                )",
+            )?;
+            for r in records {
+                stmt.execute(params![
+                    r.request_uid,
+                    r.jsonrpc_id,
+                    r.endpoint,
+                    r.server_name,
+                    r.server_type,
+                    r.transport,
+                    r.profile,
+                    r.client_name,
+                    r.client_version,
+                    r.client_user_agent,
+                    r.client_origin,
+                    r.tool,
+                    r.ts_start,
+                    r.ts_end,
+                    r.duration_ms,
+                    r.success as i64,
+                    r.error_message,
+                    r.request_bytes,
+                    r.response_bytes,
+                    r.streamed as i64,
+                ])?;
+            }
+        }
+        tx.commit()?;
+        Ok(records.len())
+    }
+
+    /// Query records (newest first), filtered by `filter`, with `limit`/`offset` paging.
+    pub fn query(
+        &self,
+        filter: &QueryFilter,
+        limit: i64,
+        offset: i64,
+    ) -> rusqlite::Result<Vec<CallRecord>> {
+        let mut sql = format!("SELECT {SELECT_COLUMNS} FROM calls WHERE 1=1");
+        let mut args: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+        if let Some(s) = &filter.server_name {
+            sql.push_str(" AND server_name LIKE ? ESCAPE '\\'");
+            args.push(Box::new(like_contains(s)));
+        }
+        if let Some(t) = &filter.tool {
+            sql.push_str(" AND tool LIKE ? ESCAPE '\\'");
+            args.push(Box::new(like_contains(t)));
+        }
+        if let Some(s) = filter.success {
+            sql.push_str(" AND success = ?");
+            args.push(Box::new(s as i64));
+        }
+        if let Some(u) = &filter.request_uid {
+            sql.push_str(" AND request_uid = ?");
+            args.push(Box::new(u.clone()));
+        }
+        if let Some(since) = filter.since {
+            sql.push_str(" AND ts_start >= ?");
+            args.push(Box::new(since));
+        }
+        if let Some(until) = filter.until {
+            sql.push_str(" AND ts_start < ?");
+            args.push(Box::new(until));
+        }
+        sql.push_str(" ORDER BY ts_start DESC, id DESC LIMIT ? OFFSET ?");
+        args.push(Box::new(limit));
+        args.push(Box::new(offset));
+
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(&sql)?;
+        let params: Vec<&dyn rusqlite::types::ToSql> = args.iter().map(|b| b.as_ref()).collect();
+        let rows = stmt.query_map(params.as_slice(), row_to_record)?;
+        rows.collect()
+    }
+
+    /// Fetch the most recent record for a `request_uid`, if any.
+    pub fn get_by_request_uid(&self, uid: &str) -> rusqlite::Result<Option<CallRecord>> {
+        let conn = self.conn.lock().unwrap();
+        let sql =
+            format!("SELECT {SELECT_COLUMNS} FROM calls WHERE request_uid = ?1 ORDER BY ts_start DESC, id DESC LIMIT 1");
+        conn.query_row(&sql, params![uid], row_to_record).optional()
+    }
+}
+
+fn row_to_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<CallRecord> {
+    Ok(CallRecord {
+        id: row.get(0)?,
+        request_uid: row.get(1)?,
+        jsonrpc_id: row.get(2)?,
+        endpoint: row.get(3)?,
+        server_name: row.get(4)?,
+        server_type: row.get(5)?,
+        transport: row.get(6)?,
+        profile: row.get(7)?,
+        client_name: row.get(8)?,
+        client_version: row.get(9)?,
+        client_user_agent: row.get(10)?,
+        client_origin: row.get(11)?,
+        tool: row.get(12)?,
+        ts_start: row.get(13)?,
+        ts_end: row.get(14)?,
+        duration_ms: row.get(15)?,
+        success: row.get::<_, i64>(16)? != 0,
+        error_message: row.get(17)?,
+        request_bytes: row.get(18)?,
+        response_bytes: row.get(19)?,
+        streamed: row.get::<_, i64>(20)? != 0,
+    })
+}
+
+/// Build a case-insensitive substring `LIKE` pattern (`%value%`) for use with
+/// `ESCAPE '\'`. Backslash-escapes the LIKE metacharacters (`\`, `%`, `_`) in
+/// the user-supplied value so literal occurrences match literally.
+fn like_contains(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len() + 2);
+    escaped.push('%');
+    for ch in value.chars() {
+        if matches!(ch, '\\' | '%' | '_') {
+            escaped.push('\\');
+        }
+        escaped.push(ch);
+    }
+    escaped.push('%');
+    escaped
+}
+
+impl Store {
+    /// Time-bucketed metrics over `[since, until)` for sparklines. Emits one
+    /// [`AggregateBucket`] per (server, bucket) plus a global series
+    /// (`server == None`). `bucket_seconds` is the bucket width; buckets are
+    /// aligned to multiples of the width from the epoch.
+    pub fn aggregate(
+        &self,
+        bucket_seconds: i64,
+        since: i64,
+        until: i64,
+    ) -> rusqlite::Result<Vec<AggregateBucket>> {
+        let bucket_ms = bucket_seconds.max(1) * 1000;
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT server_name, ts_start, duration_ms, success FROM calls \
+             WHERE ts_start >= ?1 AND ts_start < ?2 ORDER BY ts_start ASC",
+        )?;
+        let rows = stmt.query_map(params![since, until], |row| {
+            let server: Option<String> = row.get(0)?;
+            let ts: i64 = row.get(1)?;
+            let dur: i64 = row.get(2)?;
+            let ok: i64 = row.get(3)?;
+            Ok((server, ts, dur.max(0) as u64, ok != 0))
+        })?;
+
+        use std::collections::BTreeMap;
+        // key: (server, bucket_start) -> (durations, error_count)
+        let mut acc: BTreeMap<(Option<String>, i64), (Vec<u64>, u64)> = BTreeMap::new();
+        for row in rows {
+            let (server, ts, dur, ok) = row?;
+            let bucket = (ts / bucket_ms) * bucket_ms;
+            for key in [(server.clone(), bucket), (None, bucket)] {
+                let entry = acc.entry(key).or_default();
+                entry.0.push(dur);
+                if !ok {
+                    entry.1 += 1;
+                }
+            }
+        }
+
+        // Build populated buckets, keeping global (server == None) separate so
+        // we can zero-fill it into a contiguous series spanning the window.
+        let mut global: BTreeMap<i64, AggregateBucket> = BTreeMap::new();
+        let mut per_server = Vec::new();
+        for ((server, bucket_start), (mut durations, error_count)) in acc {
+            durations.sort_unstable();
+            let bucket = AggregateBucket {
+                server: server.clone(),
+                bucket_start,
+                count: durations.len() as u64,
+                error_count,
+                p50_ms: percentile(&durations, 50),
+                p95_ms: percentile(&durations, 95),
+            };
+            if server.is_none() {
+                global.insert(bucket_start, bucket);
+            } else {
+                per_server.push(bucket);
+            }
+        }
+
+        // Emit one global bucket per step across the aligned `[since, until)`
+        // window, filling gaps with zeros so the sparkline draws a real
+        // time-shape instead of collapsing bursts to a single point.
+        let mut out = Vec::new();
+        let start = (since / bucket_ms) * bucket_ms;
+        let mut bucket_start = start;
+        while bucket_start < until {
+            out.push(global.remove(&bucket_start).unwrap_or(AggregateBucket {
+                server: None,
+                bucket_start,
+                count: 0,
+                error_count: 0,
+                p50_ms: 0,
+                p95_ms: 0,
+            }));
+            bucket_start += bucket_ms;
+        }
+        // Any global buckets outside the aligned window (shouldn't normally
+        // occur) are appended to avoid silently dropping data.
+        out.extend(global.into_values());
+        out.extend(per_server);
+        Ok(out)
+    }
+
+    /// Delete all records for a server (cascade on server deletion). Returns rows removed.
+    pub fn delete_for_server(&self, name: &str) -> rusqlite::Result<usize> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute("DELETE FROM calls WHERE server_name = ?1", params![name])
+    }
+
+    /// Remove every record (global purge), then reclaim space.
+    pub fn purge_all(&self) -> rusqlite::Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute("DELETE FROM calls", [])?;
+        conn.execute_batch("PRAGMA incremental_vacuum;")?;
+        Ok(())
+    }
+
+    /// Delete records whose `ts_start` is older than `days` before now. Returns rows removed.
+    pub fn enforce_retention(&self, days: i64) -> rusqlite::Result<usize> {
+        let cutoff = now_ms() - days.max(0) * 86_400_000;
+        let conn = self.conn.lock().unwrap();
+        conn.execute("DELETE FROM calls WHERE ts_start < ?1", params![cutoff])
+    }
+
+    /// Evict oldest rows until the database fits under `max_mb`, then run an
+    /// incremental vacuum. Reports whether eviction occurred and the oldest
+    /// `ts_start` still retained.
+    pub fn enforce_size_cap(&self, max_mb: u64) -> rusqlite::Result<SizeCapResult> {
+        let max_bytes = max_mb.saturating_mul(1024 * 1024) as i64;
+        let conn = self.conn.lock().unwrap();
+        let mut deleted_rows = 0usize;
+        let mut evicted = false;
+        loop {
+            let size = db_size_bytes(&conn)?;
+            if size <= max_bytes {
+                break;
+            }
+            // Delete the oldest chunk, then reclaim pages and re-measure.
+            let n = conn.execute(
+                "DELETE FROM calls WHERE id IN (SELECT id FROM calls ORDER BY ts_start ASC, id ASC LIMIT 256)",
+                [],
+            )?;
+            conn.execute_batch("PRAGMA incremental_vacuum;")?;
+            if n == 0 {
+                break;
+            }
+            deleted_rows += n;
+            evicted = true;
+        }
+        let oldest_retained_ts: Option<i64> = conn
+            .query_row("SELECT MIN(ts_start) FROM calls", [], |r| r.get(0))
+            .optional()?
+            .flatten();
+        Ok(SizeCapResult {
+            evicted,
+            deleted_rows,
+            oldest_retained_ts,
+        })
+    }
+}
+
+/// Nearest-rank percentile (`p` in `0..=100`) over a pre-sorted slice.
+fn percentile(sorted: &[u64], p: u64) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let n = sorted.len();
+    let rank = ((p as f64 / 100.0) * n as f64).ceil() as usize;
+    let idx = rank.saturating_sub(1).min(n - 1);
+    sorted[idx]
+}
+
+/// Current wall-clock time in epoch milliseconds.
+fn now_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+/// Approximate on-disk size = `page_count * page_size`.
+fn db_size_bytes(conn: &Connection) -> rusqlite::Result<i64> {
+    let page_count: i64 = conn.pragma_query_value(None, "page_count", |r| r.get(0))?;
+    let page_size: i64 = conn.pragma_query_value(None, "page_size", |r| r.get(0))?;
+    Ok(page_count * page_size)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rec(server: &str, ts: i64, success: bool, duration: i64) -> CallRecord {
+        CallRecord {
+            request_uid: Some(format!("uid-{server}-{ts}")),
+            server_name: Some(server.to_string()),
+            endpoint: Some(server.to_string()),
+            tool: format!("{server}__do"),
+            ts_start: ts,
+            ts_end: ts + duration,
+            duration_ms: duration,
+            success,
+            request_bytes: 10,
+            response_bytes: 20,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn open_creates_file_and_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let store = Store::open(dir.path()).unwrap();
+            store.insert_batch(&[rec("a", 1000, true, 5)]).unwrap();
+        }
+        assert!(dir.path().join("observability.db").exists());
+        // Re-open: schema creation must be idempotent and data persists.
+        let store = Store::open(dir.path()).unwrap();
+        let rows = store.query(&QueryFilter::default(), 10, 0).unwrap();
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[test]
+    fn insert_query_and_get_by_request_uid() {
+        let store = Store::open_in_memory().unwrap();
+        store
+            .insert_batch(&[
+                rec("alpha", 1000, true, 5),
+                rec("beta", 2000, false, 50),
+                rec("alpha", 3000, true, 15),
+            ])
+            .unwrap();
+
+        // Newest-first ordering.
+        let all = store.query(&QueryFilter::default(), 10, 0).unwrap();
+        assert_eq!(all.len(), 3);
+        assert_eq!(all[0].ts_start, 3000);
+        assert_eq!(all[2].ts_start, 1000);
+
+        // Filter by server (exact name).
+        let alpha = store
+            .query(
+                &QueryFilter {
+                    server_name: Some("alpha".into()),
+                    ..Default::default()
+                },
+                10,
+                0,
+            )
+            .unwrap();
+        assert_eq!(alpha.len(), 2);
+
+        // Substring (LIKE) matching: a leading fragment still matches.
+        let alph = store
+            .query(
+                &QueryFilter {
+                    server_name: Some("alph".into()),
+                    ..Default::default()
+                },
+                10,
+                0,
+            )
+            .unwrap();
+        assert_eq!(alph.len(), 2);
+
+        // Mid-string fragment, case-insensitive.
+        let mid = store
+            .query(
+                &QueryFilter {
+                    server_name: Some("LPH".into()),
+                    ..Default::default()
+                },
+                10,
+                0,
+            )
+            .unwrap();
+        assert_eq!(mid.len(), 2);
+
+        // Tool substring fragment (rec() builds tool = "{server}__do").
+        let by_tool = store
+            .query(
+                &QueryFilter {
+                    tool: Some("ta__".into()),
+                    ..Default::default()
+                },
+                10,
+                0,
+            )
+            .unwrap();
+        assert_eq!(by_tool.len(), 1);
+        assert_eq!(by_tool[0].server_name.as_deref(), Some("beta"));
+
+        // Filter by success + paging.
+        let failed = store
+            .query(
+                &QueryFilter {
+                    success: Some(false),
+                    ..Default::default()
+                },
+                10,
+                0,
+            )
+            .unwrap();
+        assert_eq!(failed.len(), 1);
+        assert_eq!(failed[0].server_name.as_deref(), Some("beta"));
+
+        let page2 = store.query(&QueryFilter::default(), 1, 1).unwrap();
+        assert_eq!(page2.len(), 1);
+        assert_eq!(page2[0].ts_start, 2000);
+
+        // get_by_request_uid round-trip.
+        let got = store.get_by_request_uid("uid-beta-2000").unwrap().unwrap();
+        assert_eq!(got.server_name.as_deref(), Some("beta"));
+        assert!(!got.success);
+        assert!(store.get_by_request_uid("missing").unwrap().is_none());
+    }
+
+    #[test]
+    fn query_escapes_like_wildcards_in_filters() {
+        let store = Store::open_in_memory().unwrap();
+        store
+            .insert_batch(&[
+                rec("a_b", 1000, true, 5),
+                rec("axb", 2000, true, 5),
+                rec("c%d", 3000, true, 5),
+                rec("cXYd", 4000, true, 5),
+            ])
+            .unwrap();
+
+        // `_` in the value is escaped, so it matches a literal underscore only
+        // — not the single-char LIKE wildcard (which would also match "axb").
+        let underscore = store
+            .query(
+                &QueryFilter {
+                    server_name: Some("a_b".into()),
+                    ..Default::default()
+                },
+                10,
+                0,
+            )
+            .unwrap();
+        assert_eq!(underscore.len(), 1);
+        assert_eq!(underscore[0].server_name.as_deref(), Some("a_b"));
+
+        // `%` in the value is escaped, so it matches a literal percent only —
+        // not the multi-char LIKE wildcard (which would also match "cXYd").
+        let percent = store
+            .query(
+                &QueryFilter {
+                    server_name: Some("c%d".into()),
+                    ..Default::default()
+                },
+                10,
+                0,
+            )
+            .unwrap();
+        assert_eq!(percent.len(), 1);
+        assert_eq!(percent[0].server_name.as_deref(), Some("c%d"));
+    }
+
+    #[test]
+    fn aggregate_buckets_with_percentiles_and_global_series() {
+        let store = Store::open_in_memory().unwrap();
+        // All within one 60s bucket starting at 0.
+        store
+            .insert_batch(&[
+                rec("alpha", 1_000, true, 10),
+                rec("alpha", 2_000, false, 100),
+                rec("beta", 3_000, true, 30),
+            ])
+            .unwrap();
+
+        let buckets = store.aggregate(60, 0, 60_000).unwrap();
+        let global: Vec<_> = buckets.iter().filter(|b| b.server.is_none()).collect();
+        assert_eq!(global.len(), 1);
+        assert_eq!(global[0].count, 3);
+        assert_eq!(global[0].error_count, 1);
+        assert_eq!(global[0].bucket_start, 0);
+
+        let alpha: Vec<_> = buckets
+            .iter()
+            .filter(|b| b.server.as_deref() == Some("alpha"))
+            .collect();
+        assert_eq!(alpha.len(), 1);
+        assert_eq!(alpha[0].count, 2);
+        assert_eq!(alpha[0].error_count, 1);
+        assert_eq!(alpha[0].p50_ms, 10);
+        assert_eq!(alpha[0].p95_ms, 100);
+    }
+
+    #[test]
+    fn aggregate_global_series_is_zero_filled_across_window() {
+        let store = Store::open_in_memory().unwrap();
+        // A single burst within one minute, queried over a 1-hour window.
+        store
+            .insert_batch(&[
+                rec("alpha", 1_000, true, 10),
+                rec("alpha", 2_000, false, 100),
+                rec("beta", 3_000, true, 30),
+            ])
+            .unwrap();
+
+        let buckets = store.aggregate(60, 0, 3_600_000).unwrap();
+        let global: Vec<_> = buckets.iter().filter(|b| b.server.is_none()).collect();
+        // 3_600_000 / 60_000 = 60 contiguous global buckets.
+        assert_eq!(global.len(), 60);
+        // Ascending, contiguous bucket starts.
+        for (i, b) in global.iter().enumerate() {
+            assert_eq!(b.bucket_start, i as i64 * 60_000);
+        }
+        // Only the first bucket is populated; the rest are zero-filled.
+        assert_eq!(global[0].count, 3);
+        assert_eq!(global[0].error_count, 1);
+        for b in &global[1..] {
+            assert_eq!(b.count, 0);
+            assert_eq!(b.error_count, 0);
+            assert_eq!(b.p50_ms, 0);
+            assert_eq!(b.p95_ms, 0);
+        }
+
+        // Per-server buckets remain non-empty only.
+        let alpha: Vec<_> = buckets
+            .iter()
+            .filter(|b| b.server.as_deref() == Some("alpha"))
+            .collect();
+        assert_eq!(alpha.len(), 1);
+        assert_eq!(alpha[0].count, 2);
+    }
+
+    #[test]
+    fn retention_deletes_old_rows() {
+        let store = Store::open_in_memory().unwrap();
+        let now = now_ms();
+        let day = 86_400_000;
+        store
+            .insert_batch(&[
+                rec("a", now - 10 * day, true, 5),
+                rec("a", now - day, true, 5),
+            ])
+            .unwrap();
+        let deleted = store.enforce_retention(7).unwrap();
+        assert_eq!(deleted, 1);
+        let rows = store.query(&QueryFilter::default(), 10, 0).unwrap();
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[test]
+    fn size_cap_evicts_oldest_first() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(dir.path()).unwrap();
+        let batch: Vec<CallRecord> = (0..2000)
+            .map(|i| rec("a", 1000 + i as i64, i % 2 == 0, 5))
+            .collect();
+        store.insert_batch(&batch).unwrap();
+
+        // Generous cap: nothing evicted.
+        let big = store.enforce_size_cap(1024).unwrap();
+        assert!(!big.evicted);
+        assert_eq!(big.oldest_retained_ts, Some(1000));
+
+        // Zero cap: evict everything (oldest-first), DB never fits.
+        let zero = store.enforce_size_cap(0).unwrap();
+        assert!(zero.evicted);
+        assert!(zero.deleted_rows > 0);
+        assert_eq!(zero.oldest_retained_ts, None);
+        assert_eq!(store.query(&QueryFilter::default(), 1, 0).unwrap().len(), 0);
+    }
+
+    #[test]
+    fn delete_for_server_and_purge_all() {
+        let store = Store::open_in_memory().unwrap();
+        store
+            .insert_batch(&[
+                rec("alpha", 1000, true, 5),
+                rec("beta", 2000, true, 5),
+                rec("alpha", 3000, true, 5),
+            ])
+            .unwrap();
+
+        let removed = store.delete_for_server("alpha").unwrap();
+        assert_eq!(removed, 2);
+        assert_eq!(
+            store.query(&QueryFilter::default(), 10, 0).unwrap().len(),
+            1
+        );
+
+        store.purge_all().unwrap();
+        assert_eq!(
+            store.query(&QueryFilter::default(), 10, 0).unwrap().len(),
+            0
+        );
+    }
+}

--- a/src/observability/store.rs
+++ b/src/observability/store.rs
@@ -14,7 +14,7 @@ use std::sync::Mutex;
 use rusqlite::{params, Connection, OptionalExtension};
 
 /// Columns selected (and mapped) in [`Store::query`] / [`Store::get_by_request_uid`].
-const SELECT_COLUMNS: &str = "id, request_uid, jsonrpc_id, endpoint, server_name, \
+const SELECT_COLUMNS: &str = "id, request_uid, endpoint, server_name, \
     server_type, transport, profile, client_name, client_version, \
     client_user_agent, client_origin, tool, ts_start, ts_end, duration_ms, \
     success, error_message, request_bytes, response_bytes, streamed";
@@ -28,7 +28,6 @@ pub struct CallRecord {
     pub id: Option<i64>,
     /// Canonical per-message correlation key from `current_request_context()`.
     pub request_uid: Option<String>,
-    pub jsonrpc_id: Option<String>,
     pub endpoint: Option<String>,
     pub server_name: Option<String>,
     pub server_type: Option<String>,
@@ -112,7 +111,6 @@ impl Store {
             "CREATE TABLE IF NOT EXISTS calls (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 request_uid TEXT,
-                jsonrpc_id TEXT,
                 endpoint TEXT,
                 server_name TEXT,
                 server_type TEXT,
@@ -154,20 +152,19 @@ impl Store {
         {
             let mut stmt = tx.prepare(
                 "INSERT INTO calls (
-                    request_uid, jsonrpc_id, endpoint, server_name, server_type,
+                    request_uid, endpoint, server_name, server_type,
                     transport, profile, client_name, client_version,
                     client_user_agent, client_origin, tool, ts_start, ts_end,
                     duration_ms, success, error_message, request_bytes,
                     response_bytes, streamed
                 ) VALUES (
-                    ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
-                    ?15, ?16, ?17, ?18, ?19, ?20
+                    ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13,
+                    ?14, ?15, ?16, ?17, ?18, ?19
                 )",
             )?;
             for r in records {
                 stmt.execute(params![
                     r.request_uid,
-                    r.jsonrpc_id,
                     r.endpoint,
                     r.server_name,
                     r.server_type,
@@ -250,25 +247,24 @@ fn row_to_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<CallRecord> {
     Ok(CallRecord {
         id: row.get(0)?,
         request_uid: row.get(1)?,
-        jsonrpc_id: row.get(2)?,
-        endpoint: row.get(3)?,
-        server_name: row.get(4)?,
-        server_type: row.get(5)?,
-        transport: row.get(6)?,
-        profile: row.get(7)?,
-        client_name: row.get(8)?,
-        client_version: row.get(9)?,
-        client_user_agent: row.get(10)?,
-        client_origin: row.get(11)?,
-        tool: row.get(12)?,
-        ts_start: row.get(13)?,
-        ts_end: row.get(14)?,
-        duration_ms: row.get(15)?,
-        success: row.get::<_, i64>(16)? != 0,
-        error_message: row.get(17)?,
-        request_bytes: row.get(18)?,
-        response_bytes: row.get(19)?,
-        streamed: row.get::<_, i64>(20)? != 0,
+        endpoint: row.get(2)?,
+        server_name: row.get(3)?,
+        server_type: row.get(4)?,
+        transport: row.get(5)?,
+        profile: row.get(6)?,
+        client_name: row.get(7)?,
+        client_version: row.get(8)?,
+        client_user_agent: row.get(9)?,
+        client_origin: row.get(10)?,
+        tool: row.get(11)?,
+        ts_start: row.get(12)?,
+        ts_end: row.get(13)?,
+        duration_ms: row.get(14)?,
+        success: row.get::<_, i64>(15)? != 0,
+        error_message: row.get(16)?,
+        request_bytes: row.get(17)?,
+        response_bytes: row.get(18)?,
+        streamed: row.get::<_, i64>(19)? != 0,
     })
 }
 

--- a/src/observability/store.rs
+++ b/src/observability/store.rs
@@ -369,6 +369,20 @@ impl Store {
         Ok(out)
     }
 
+    /// Collect the `request_uid`s for every row whose `server_name` matches
+    /// `name` exactly (`WHERE server_name = ?1`, no substring `LIKE`). Used by
+    /// the delete cascade to drop only the buffered payloads belonging to the
+    /// removed server — not siblings whose name merely contains `name` as a
+    /// substring (e.g. deleting `foo` must not collect `foo-staging`'s UIDs).
+    pub fn request_uids_for_server(&self, name: &str) -> rusqlite::Result<Vec<String>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT request_uid FROM calls WHERE server_name = ?1 AND request_uid IS NOT NULL",
+        )?;
+        let rows = stmt.query_map(params![name], |row| row.get::<_, String>(0))?;
+        rows.collect()
+    }
+
     /// Delete all records for a server (cascade on server deletion). Returns rows removed.
     pub fn delete_for_server(&self, name: &str) -> rusqlite::Result<usize> {
         let conn = self.conn.lock().unwrap();
@@ -757,5 +771,28 @@ mod tests {
             store.query(&QueryFilter::default(), 10, 0).unwrap().len(),
             0
         );
+    }
+
+    #[test]
+    fn request_uids_for_server_is_exact_not_substring() {
+        let store = Store::open_in_memory().unwrap();
+        // `foo` is a substring of `foo-staging`; a `LIKE %foo%` collection
+        // would over-collect the sibling server's UIDs.
+        store
+            .insert_batch(&[
+                rec("foo", 1000, true, 5),
+                rec("foo", 2000, true, 5),
+                rec("foo-staging", 3000, true, 5),
+            ])
+            .unwrap();
+
+        let mut uids = store.request_uids_for_server("foo").unwrap();
+        uids.sort();
+        assert_eq!(uids, vec!["uid-foo-1000", "uid-foo-2000"]);
+
+        let staging = store.request_uids_for_server("foo-staging").unwrap();
+        assert_eq!(staging, vec!["uid-foo-staging-3000"]);
+
+        assert!(store.request_uids_for_server("missing").unwrap().is_empty());
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -797,7 +797,8 @@ impl AdapterRegistry {
         // the span's inbound `request_uid`. An `execute_tools` JS batch reuses a
         // single inbound `request_uid` across all its inner `tools/call`s, so
         // reusing it here would collapse them into one row and overwrite each
-        // other's payloads. `jsonrpc_id` (recorded below) still groups a batch.
+        // other's payloads. Batched calls stay correlated via the shared inbound
+        // request span and the per-call `request_uid`s minted below.
         if span_ctx.request_uid.is_none() {
             return entry.adapter.call_tool(tool, arguments).await;
         }
@@ -853,7 +854,6 @@ impl AdapterRegistry {
         let record = CallRecord {
             id: None,
             request_uid: Some(request_uid),
-            jsonrpc_id: span_ctx.jsonrpc_id.clone(),
             endpoint: Some(endpoint_name),
             server_name,
             server_type,
@@ -1732,7 +1732,8 @@ mod tests {
     /// capture block must mint a fresh per-call uuid for each captured row so
     /// the inner calls produce distinct rows (and distinct payload entries when
     /// `store_payloads` is on) instead of collapsing into one row that
-    /// overwrites the others, while `jsonrpc_id` still groups the batch.
+    /// overwrites the others. The batch stays correlated via the shared inbound
+    /// request span and the per-call `request_uid`s minted by the capture block.
     #[tokio::test]
     async fn batched_inner_calls_get_distinct_request_uids() {
         use crate::config::ObservabilityConfig;
@@ -1768,7 +1769,6 @@ mod tests {
         // Both inner calls run inside ONE inbound `request` span (same
         // `request_uid`), exactly as `execute_tools` dispatches a JS batch.
         let shared_uid = "inbound-uid-shared";
-        let jsonrpc_id = "42".to_string();
         async {
             registry
                 .route_tool_call("echo", json!({ "n": 1 }))
@@ -1782,7 +1782,6 @@ mod tests {
         .instrument(tracing::info_span!(
             "request",
             method = "tools/call",
-            id = %jsonrpc_id,
             request_uid = %shared_uid,
         ))
         .await;
@@ -1807,9 +1806,6 @@ mod tests {
             uids.iter().all(|u| u != shared_uid),
             "row uids are minted per-call, not the shared inbound request_uid"
         );
-
-        // `jsonrpc_id` is unchanged, so it still groups the batch together.
-        assert!(rows.iter().all(|r| r.jsonrpc_id.as_deref() == Some("42")));
 
         // Each row's payload resolves by its own minted uid and is not
         // overwritten by the sibling call.

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -842,12 +842,12 @@ impl AdapterRegistry {
             }
             Err(e) => {
                 let msg = e.to_string();
-                (
-                    false,
-                    Some(msg.clone()),
-                    serde_json::json!({ "error": msg }),
-                    0,
-                )
+                // The error envelope is a populated `{"error": ...}` JSON that
+                // gets stored/returned, so record its serialized length rather
+                // than 0 to keep size metrics consistent with the success branch.
+                let response_value = serde_json::json!({ "error": msg });
+                let bytes = response_value.to_string().len() as i64;
+                (false, Some(msg), response_value, bytes)
             }
         };
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,6 +1,8 @@
 use crate::adapter::stdio::iso8601_now;
 use crate::adapter::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
 use crate::events::{current_request_context, ToolCallEvent, ToolCallEventBus};
+use crate::observability::pipeline::{CaptureRecord, CapturedPayloads, Observability};
+use crate::observability::store::CallRecord;
 use crate::prefix;
 use async_trait::async_trait;
 use jsonschema::error::{TypeKind, ValidationErrorKind};
@@ -143,6 +145,13 @@ pub struct AdapterRegistry {
     /// [`Self::set_validate_inputs`] on every reload, mirroring the
     /// `js_execution_mode` flag pattern.
     validate_inputs: Arc<AtomicBool>,
+    /// Optional observability ingestion pipeline (R4). When wired via
+    /// [`Self::with_observability`] and enabled, [`Self::route_tool_call`]
+    /// captures each dispatched `tools/call` (args + result + timing +
+    /// `current_request_context()`) and enqueues it without blocking the
+    /// request path. `None` by default so the many test-only call sites that
+    /// construct a bare registry keep compiling.
+    observability: Option<Observability>,
 }
 
 impl Default for AdapterRegistry {
@@ -163,6 +172,7 @@ impl AdapterRegistry {
             event_bus: None,
             schema_cache: Arc::new(RwLock::new(HashMap::new())),
             validate_inputs: Arc::new(AtomicBool::new(true)),
+            observability: None,
         }
     }
 
@@ -198,6 +208,25 @@ impl AdapterRegistry {
     pub fn with_event_bus(mut self, bus: ToolCallEventBus) -> Self {
         self.event_bus = Some(bus);
         self
+    }
+
+    /// Attach the observability ingestion pipeline (R4) so
+    /// [`Self::route_tool_call`] captures each dispatched `tools/call`. Builder
+    /// style so the existing `AdapterRegistry::new()` call sites keep compiling;
+    /// `main.rs` wires the handle constructed from `relay.observability`.
+    pub fn with_observability(mut self, observability: Observability) -> Self {
+        self.observability = Some(observability);
+        self
+    }
+
+    /// Borrow the wired observability handle, if any. Lets management/API
+    /// (R5) and the retention/cascade driver (R6) reach the shared `Store`,
+    /// `PayloadStore`, overflow stats and capture entrypoint through the
+    /// registry the management state already holds. Unused until R5/R6 wire
+    /// their consumers; the allow keeps the binary target warning-clean.
+    #[allow(dead_code)]
+    pub fn observability(&self) -> Option<&Observability> {
+        self.observability.as_ref()
     }
 
     /// Subscribe to the relay-wide tools-changed broadcast. Each `recv()`
@@ -754,7 +783,104 @@ impl AdapterRegistry {
             prefixed = %prefixed_name,
             "Routing tool call"
         );
-        entry.adapter.call_tool(tool, arguments).await
+
+        // Observability capture (R4). Inline on the dispatched `tools/call`
+        // path. Cheap no-op when the pipeline is unwired or disabled, and
+        // skipped for internal callers that have no `request_uid`. Enqueue is
+        // non-blocking (`try_send`); overflow drops are counted in the handle.
+        let Some(obs) = self.observability.as_ref().filter(|o| o.is_enabled()) else {
+            return entry.adapter.call_tool(tool, arguments).await;
+        };
+        let span_ctx = current_request_context();
+        // Gate capture on an inbound request context (skip internal callers),
+        // but key the row/payload on a freshly-minted per-call uuid rather than
+        // the span's inbound `request_uid`. An `execute_tools` JS batch reuses a
+        // single inbound `request_uid` across all its inner `tools/call`s, so
+        // reusing it here would collapse them into one row and overwrite each
+        // other's payloads. `jsonrpc_id` (recorded below) still groups a batch.
+        if span_ctx.request_uid.is_none() {
+            return entry.adapter.call_tool(tool, arguments).await;
+        }
+        let request_uid = uuid::Uuid::new_v4().to_string();
+
+        let store_payloads = obs.store_payloads();
+        let request_value = arguments.clone();
+        let request_bytes = request_value.to_string().len() as i64;
+        let server_type = entry.adapter.server_type();
+        let server_name = entry.adapter.upstream_server_name();
+        let transport = entry.transport.clone();
+        let endpoint_name = endpoint.clone();
+        let tool_name = tool.clone();
+        let (client_name, client_version, client_user_agent, client_origin) = match &span_ctx.client
+        {
+            Some(c) => (
+                c.name.clone(),
+                c.version.clone(),
+                c.user_agent.clone(),
+                c.origin.clone(),
+            ),
+            None => (None, None, None, None),
+        };
+
+        let ts_start = chrono::Utc::now().timestamp_millis();
+        let started = Instant::now();
+        let result = entry.adapter.call_tool(tool, arguments).await;
+        let duration_ms = started.elapsed().as_millis() as i64;
+        let ts_end = ts_start + duration_ms;
+
+        let (success, error_message, response_value, response_bytes) = match &result {
+            Ok(v) => {
+                let bytes = v.to_string().len() as i64;
+                // A transport-level `Ok` can still carry a tool-level error
+                // envelope (`{ content: [...], isError: true }`). Record it as a
+                // failed call while preserving the response payload/bytes.
+                match tool_result_error_message(v) {
+                    Some(msg) => (false, Some(msg), v.clone(), bytes),
+                    None => (true, None, v.clone(), bytes),
+                }
+            }
+            Err(e) => {
+                let msg = e.to_string();
+                (
+                    false,
+                    Some(msg.clone()),
+                    serde_json::json!({ "error": msg }),
+                    0,
+                )
+            }
+        };
+
+        let record = CallRecord {
+            id: None,
+            request_uid: Some(request_uid),
+            jsonrpc_id: span_ctx.jsonrpc_id.clone(),
+            endpoint: Some(endpoint_name),
+            server_name,
+            server_type,
+            transport: Some(transport),
+            profile: span_ctx.profile.clone(),
+            client_name,
+            client_version,
+            client_user_agent,
+            client_origin,
+            tool: tool_name,
+            ts_start,
+            ts_end,
+            duration_ms,
+            success,
+            error_message,
+            request_bytes,
+            response_bytes,
+            streamed: false,
+        };
+        let payloads = store_payloads.then(|| CapturedPayloads {
+            request: request_value,
+            response: response_value,
+            streamed: false,
+        });
+        obs.capture(CaptureRecord { record, payloads });
+
+        result
     }
 
     /// Publish a `Started` + `Failed` pair on the shared
@@ -988,6 +1114,35 @@ fn compile_input_schema(prefixed_name: &str, schema: &serde_json::Value) -> Opti
             None
         }
     }
+}
+
+/// Upper bound on a captured tool-level `error_message`, in characters. Tool
+/// error envelopes are usually short, but a misbehaving server could return a
+/// large blob; cap it so the durable row stays bounded.
+const MAX_CAPTURED_ERROR_MESSAGE_CHARS: usize = 2048;
+
+/// Inspect a transport-level `Ok` `tools/call` result for a tool-level error
+/// envelope (`{ content: [...], isError: true }`). Returns the captured
+/// `error_message` (the first `content[].text` string, truncated) when the tool
+/// reported an error, or `None` for a normal success (`isError` absent/false).
+fn tool_result_error_message(value: &serde_json::Value) -> Option<String> {
+    if value.get("isError").and_then(|e| e.as_bool()) != Some(true) {
+        return None;
+    }
+    let text = value
+        .get("content")
+        .and_then(|c| c.as_array())
+        .and_then(|items| {
+            items
+                .iter()
+                .find_map(|item| item.get("text").and_then(|t| t.as_str()))
+        })
+        .unwrap_or("tool call returned an error result");
+    let truncated: String = text
+        .chars()
+        .take(MAX_CAPTURED_ERROR_MESSAGE_CHARS)
+        .collect();
+    Some(truncated)
 }
 
 /// Format the collected validation errors into the model-friendly MCP error
@@ -1530,6 +1685,145 @@ mod tests {
     use crate::adapter::StartingAdapter;
     use async_trait::async_trait;
     use serde_json::json;
+
+    #[test]
+    fn tool_result_iserror_envelope_is_captured_as_failure() {
+        // A transport-level `Ok` carrying a tool-level error envelope must be
+        // recorded as a failed call with a non-empty error_message taken from
+        // the first text item in `content`.
+        let envelope = json!({
+            "content": [{ "type": "text", "text": "invalid_grant" }],
+            "isError": true,
+        });
+        let msg =
+            tool_result_error_message(&envelope).expect("isError envelope captured as failure");
+        assert_eq!(msg, "invalid_grant");
+    }
+
+    #[test]
+    fn tool_result_success_envelope_is_not_a_failure() {
+        // `isError` absent → success; explicit `isError: false` → success.
+        assert!(tool_result_error_message(&json!({ "content": [] })).is_none());
+        assert!(tool_result_error_message(&json!({
+            "content": [{ "type": "text", "text": "ok" }],
+            "isError": false,
+        }))
+        .is_none());
+    }
+
+    #[test]
+    fn tool_result_iserror_without_text_still_yields_message() {
+        // isError with no usable text content still produces a non-empty
+        // error_message so the durable row reflects the failure.
+        let msg = tool_result_error_message(&json!({ "isError": true, "content": [] }))
+            .expect("isError envelope captured as failure");
+        assert!(!msg.is_empty());
+    }
+
+    #[test]
+    fn tool_result_error_message_is_truncated() {
+        let long = "x".repeat(MAX_CAPTURED_ERROR_MESSAGE_CHARS + 500);
+        let msg = tool_result_error_message(&json!({
+            "isError": true,
+            "content": [{ "type": "text", "text": long }],
+        }))
+        .expect("isError envelope captured as failure");
+        assert_eq!(msg.chars().count(), MAX_CAPTURED_ERROR_MESSAGE_CHARS);
+    }
+
+    /// Regression: an `execute_tools` JS batch reuses one inbound
+    /// `request_uid` across all its inner `tools/call`s. The observability
+    /// capture block must mint a fresh per-call uuid for each captured row so
+    /// the inner calls produce distinct rows (and distinct payload entries when
+    /// `store_payloads` is on) instead of collapsing into one row that
+    /// overwrites the others, while `jsonrpc_id` still groups the batch.
+    #[tokio::test]
+    async fn batched_inner_calls_get_distinct_request_uids() {
+        use crate::config::ObservabilityConfig;
+        use crate::events::SpanFieldCaptureLayer;
+        use crate::observability::payloads::PayloadStore;
+        use crate::observability::store::{QueryFilter, Store};
+        use tracing::Instrument;
+        use tracing_subscriber::prelude::*;
+
+        let subscriber = tracing_subscriber::registry().with(SpanFieldCaptureLayer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let store = Arc::new(Store::open_in_memory().unwrap());
+        let payloads = Arc::new(PayloadStore::new(10, 128, 256 * 1024));
+        let config = ObservabilityConfig {
+            enabled: true,
+            store_payloads: true,
+            ..ObservabilityConfig::default()
+        };
+        let obs = Observability::new(&config, Arc::clone(&store), Arc::clone(&payloads));
+
+        let registry = AdapterRegistry::new().with_observability(obs);
+        registry
+            .register(
+                "ep".into(),
+                Box::new(MockAdapter::healthy(vec![make_tool("echo")])),
+                "stdio".into(),
+                None,
+                Some("ep".into()),
+            )
+            .await;
+
+        // Both inner calls run inside ONE inbound `request` span (same
+        // `request_uid`), exactly as `execute_tools` dispatches a JS batch.
+        let shared_uid = "inbound-uid-shared";
+        let jsonrpc_id = "42".to_string();
+        async {
+            registry
+                .route_tool_call("echo", json!({ "n": 1 }))
+                .await
+                .unwrap();
+            registry
+                .route_tool_call("echo", json!({ "n": 2 }))
+                .await
+                .unwrap();
+        }
+        .instrument(tracing::info_span!(
+            "request",
+            method = "tools/call",
+            id = %jsonrpc_id,
+            request_uid = %shared_uid,
+        ))
+        .await;
+
+        // Drain: poll until both rows land via the background consumer.
+        let mut rows = Vec::new();
+        for _ in 0..50 {
+            rows = store.query(&QueryFilter::default(), 10, 0).unwrap();
+            if rows.len() >= 2 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert_eq!(rows.len(), 2, "both inner calls captured as separate rows");
+
+        let uids: Vec<String> = rows
+            .iter()
+            .map(|r| r.request_uid.clone().expect("request_uid set"))
+            .collect();
+        assert_ne!(uids[0], uids[1], "rows have distinct request_uids");
+        assert!(
+            uids.iter().all(|u| u != shared_uid),
+            "row uids are minted per-call, not the shared inbound request_uid"
+        );
+
+        // `jsonrpc_id` is unchanged, so it still groups the batch together.
+        assert!(rows.iter().all(|r| r.jsonrpc_id.as_deref() == Some("42")));
+
+        // Each row's payload resolves by its own minted uid and is not
+        // overwritten by the sibling call.
+        let p0 = payloads.get(&uids[0]).expect("payload for row 0");
+        let p1 = payloads.get(&uids[1]).expect("payload for row 1");
+        assert_ne!(
+            p0.request, p1.request,
+            "inner-call payloads not overwritten"
+        );
+    }
 
     /// A mock adapter for testing.
     struct MockAdapter {

--- a/tests/hot_reload_integration.rs
+++ b/tests/hot_reload_integration.rs
@@ -65,6 +65,7 @@ async fn test_config_diff_add_endpoint() {
             startup_init_timeout_secs: None,
             session_identity_max_sessions: None,
             validate_inputs: None,
+            observability: config::ObservabilityConfig::default(),
         },
         endpoints: vec![config::EndpointConfig {
             name: "echo-ep".to_string(),
@@ -101,6 +102,7 @@ async fn test_config_diff_add_endpoint() {
             startup_init_timeout_secs: None,
             session_identity_max_sessions: None,
             validate_inputs: None,
+            observability: config::ObservabilityConfig::default(),
         },
         endpoints: vec![
             config::EndpointConfig {
@@ -242,6 +244,7 @@ async fn test_config_diff_remove_endpoint() {
             startup_init_timeout_secs: None,
             session_identity_max_sessions: None,
             validate_inputs: None,
+            observability: config::ObservabilityConfig::default(),
         },
         endpoints: vec![
             config::EndpointConfig {
@@ -302,6 +305,7 @@ async fn test_config_diff_remove_endpoint() {
             startup_init_timeout_secs: None,
             session_identity_max_sessions: None,
             validate_inputs: None,
+            observability: config::ObservabilityConfig::default(),
         },
         endpoints: vec![config::EndpointConfig {
             name: "echo-ep".to_string(),

--- a/tests/management_api_integration.rs
+++ b/tests/management_api_integration.rs
@@ -6,8 +6,11 @@
 
 use async_trait::async_trait;
 use endara_relay::adapter::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
-use endara_relay::config::{Config, EndpointConfig, RelayConfig, Transport};
+use endara_relay::config::{Config, EndpointConfig, ObservabilityConfig, RelayConfig, Transport};
 use endara_relay::management::{management_routes, ManagementState};
+use endara_relay::observability::payloads::PayloadStore;
+use endara_relay::observability::pipeline::Observability;
+use endara_relay::observability::store::{CallRecord, Store};
 use endara_relay::registry::AdapterRegistry;
 use serde_json::{json, Value};
 use std::net::SocketAddr;
@@ -88,6 +91,7 @@ fn test_config() -> Config {
             startup_init_timeout_secs: None,
             session_identity_max_sessions: None,
             validate_inputs: None,
+            observability: ObservabilityConfig::default(),
         },
         endpoints: vec![EndpointConfig {
             name: "echo".to_string(),
@@ -746,4 +750,359 @@ async fn test_management_api_test_connection_happy_path() {
     // The echo server exposes one tool called "echo"
     let tools = body["tools"].as_array().unwrap();
     assert!(tools.iter().any(|t| t.as_str() == Some("echo")));
+}
+
+// ---------------------------------------------------------------------------
+// Observability API (R5)
+// ---------------------------------------------------------------------------
+
+/// Build a seeded `CallRecord` for the observability store fixtures.
+fn obs_record(server: &str, uid: &str, ts: i64, success: bool, dur: i64, tool: &str) -> CallRecord {
+    CallRecord {
+        request_uid: Some(uid.to_string()),
+        server_name: Some(server.to_string()),
+        endpoint: Some(server.to_string()),
+        tool: tool.to_string(),
+        ts_start: ts,
+        ts_end: ts + dur,
+        duration_ms: dur,
+        success,
+        request_bytes: 10,
+        response_bytes: 20,
+        ..Default::default()
+    }
+}
+
+/// Start a management server with observability wired into the registry and the
+/// store/payload buffer pre-seeded with three calls (two `alpha`, one `beta`).
+/// Only `uid-a1` has a buffered payload. Returns the seeded handles so tests can
+/// assert side effects (e.g. purge).
+async fn start_observability_server(
+    config_path: Option<std::path::PathBuf>,
+    store_payloads: bool,
+) -> (
+    SocketAddr,
+    Arc<Store>,
+    Arc<PayloadStore>,
+    tokio::task::JoinHandle<()>,
+) {
+    let store = Arc::new(Store::open_in_memory().unwrap());
+    let payloads = Arc::new(PayloadStore::new(10, 128, 256 * 1024));
+    store
+        .insert_batch(&[
+            obs_record("alpha", "uid-a1", 1000, true, 10, "alpha__do"),
+            obs_record("alpha", "uid-a2", 2000, false, 100, "alpha__do"),
+            obs_record("beta", "uid-b1", 3000, true, 30, "beta__go"),
+        ])
+        .unwrap();
+    payloads.insert("uid-a1", &json!({"a": 1}), &json!({"ok": true}), false);
+
+    let obs_cfg = ObservabilityConfig {
+        enabled: true,
+        store_payloads,
+        ..ObservabilityConfig::default()
+    };
+    let obs = Observability::new(&obs_cfg, Arc::clone(&store), Arc::clone(&payloads));
+    let registry = Arc::new(AdapterRegistry::new().with_observability(obs));
+
+    let state = ManagementState {
+        registry,
+        config: Arc::new(tokio::sync::RwLock::new(test_config())),
+        start_time: Instant::now(),
+        config_path,
+        oauth_flow_manager: None,
+        relay_port: 9400,
+        oauth_adapter_inners: None,
+        token_manager: None,
+        setup_manager: None,
+        profile_registry: None,
+        event_bus: None,
+    };
+
+    let app = management_routes(state);
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.ok();
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    (addr, store, payloads, handle)
+}
+
+#[tokio::test]
+async fn test_observability_calls_list_filter_and_paging() {
+    let (addr, _store, _payloads, _handle) = start_observability_server(None, true).await;
+    let client = reqwest::Client::new();
+
+    // Full list, newest-first.
+    let resp = client
+        .get(format!("http://{}/api/observability/calls", addr))
+        .send()
+        .await
+        .expect("request failed");
+    assert!(resp.status().is_success());
+    let body: Value = resp.json().await.unwrap();
+    let calls = body["calls"].as_array().unwrap();
+    assert_eq!(calls.len(), 3);
+    assert_eq!(calls[0]["tsStart"], 3000);
+    assert_eq!(calls[0]["serverName"], "beta");
+    assert_eq!(body["limit"], 100);
+    assert_eq!(body["offset"], 0);
+
+    // Filter by server.
+    let resp = client
+        .get(format!(
+            "http://{}/api/observability/calls?server_name=alpha",
+            addr
+        ))
+        .send()
+        .await
+        .expect("request failed");
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["calls"].as_array().unwrap().len(), 2);
+
+    // Filter by success.
+    let resp = client
+        .get(format!(
+            "http://{}/api/observability/calls?success=false",
+            addr
+        ))
+        .send()
+        .await
+        .expect("request failed");
+    let body: Value = resp.json().await.unwrap();
+    let calls = body["calls"].as_array().unwrap();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0]["requestUid"], "uid-a2");
+
+    // Paging: second page of size 1 is the middle record (ts 2000).
+    let resp = client
+        .get(format!(
+            "http://{}/api/observability/calls?limit=1&offset=1",
+            addr
+        ))
+        .send()
+        .await
+        .expect("request failed");
+    let body: Value = resp.json().await.unwrap();
+    let calls = body["calls"].as_array().unwrap();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0]["tsStart"], 2000);
+}
+
+#[tokio::test]
+async fn test_observability_call_detail_payload_states() {
+    let (addr, _store, _payloads, _handle) = start_observability_server(None, true).await;
+    let client = reqwest::Client::new();
+
+    // Buffered payload present → status "stored".
+    let resp = client
+        .get(format!("http://{}/api/observability/calls/uid-a1", addr))
+        .send()
+        .await
+        .expect("request failed");
+    assert!(resp.status().is_success());
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["record"]["serverName"], "alpha");
+    assert_eq!(body["payloadStatus"], "stored");
+    assert_eq!(body["payloads"]["request"], "{\"a\":1}");
+
+    // No buffered payload → status "expired", no payloads field.
+    let resp = client
+        .get(format!("http://{}/api/observability/calls/uid-a2", addr))
+        .send()
+        .await
+        .expect("request failed");
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["payloadStatus"], "expired");
+    assert!(body.get("payloads").is_none() || body["payloads"].is_null());
+
+    // Unknown request_uid → 404.
+    let resp = client
+        .get(format!("http://{}/api/observability/calls/missing", addr))
+        .send()
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status().as_u16(), 404);
+}
+
+#[tokio::test]
+async fn test_observability_call_detail_payloads_disabled() {
+    let (addr, _store, _payloads, _handle) = start_observability_server(None, false).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!("http://{}/api/observability/calls/uid-a1", addr))
+        .send()
+        .await
+        .expect("request failed");
+    assert!(resp.status().is_success());
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["payloadStatus"], "disabled");
+    assert!(body.get("payloads").is_none() || body["payloads"].is_null());
+}
+
+#[tokio::test]
+async fn test_observability_aggregates() {
+    let (addr, _store, _payloads, _handle) = start_observability_server(None, true).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!(
+            "http://{}/api/observability/aggregates?since=0&until=10000000&bucket_seconds=60",
+            addr
+        ))
+        .send()
+        .await
+        .expect("request failed");
+    assert!(resp.status().is_success());
+    let body: Value = resp.json().await.unwrap();
+    let buckets = body["buckets"].as_array().unwrap();
+    assert!(!buckets.is_empty());
+    // Global series (server omitted) present with all three calls.
+    let global_total: u64 = buckets
+        .iter()
+        .filter(|b| b.get("server").is_none() || b["server"].is_null())
+        .map(|b| b["count"].as_u64().unwrap())
+        .sum();
+    assert_eq!(global_total, 3);
+
+    let summary = &body["summary"];
+    assert_eq!(summary["enabled"], true);
+    assert_eq!(summary["storePayloads"], true);
+    assert_eq!(summary["dropped"], 0);
+    assert_eq!(summary["payloadBufferLen"], 1);
+}
+
+#[tokio::test]
+async fn test_observability_purge() {
+    let (addr, store, payloads, _handle) = start_observability_server(None, true).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("http://{}/api/observability/purge", addr))
+        .send()
+        .await
+        .expect("request failed");
+    assert!(resp.status().is_success());
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["ok"], true);
+
+    // Both tiers are now empty.
+    assert_eq!(
+        store
+            .query(
+                &endara_relay::observability::store::QueryFilter::default(),
+                10,
+                0
+            )
+            .unwrap()
+            .len(),
+        0
+    );
+    assert!(payloads.is_empty());
+
+    let resp = client
+        .get(format!("http://{}/api/observability/calls", addr))
+        .send()
+        .await
+        .expect("request failed");
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["calls"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn test_observability_config_get_put_persists() {
+    let dir = std::env::temp_dir().join(format!("relay-integ-obs-cfg-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let config_file = dir.join("config.toml");
+    std::fs::write(&config_file, "[relay]\nmachine_name = \"test-machine\"\n").unwrap();
+
+    let (addr, _store, _payloads, _handle) =
+        start_observability_server(Some(config_file.clone()), true).await;
+    let client = reqwest::Client::new();
+
+    // GET returns the in-memory defaults.
+    let resp = client
+        .get(format!("http://{}/api/observability/config", addr))
+        .send()
+        .await
+        .expect("request failed");
+    assert!(resp.status().is_success());
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["enabled"], true);
+    assert_eq!(body["payload_window_minutes"], 10);
+
+    // PUT a modified config.
+    let resp = client
+        .put(format!("http://{}/api/observability/config", addr))
+        .json(&json!({
+            "enabled": false,
+            "store_payloads": false,
+            "payload_window_minutes": 30,
+            "record_retention_days": 3,
+            "max_db_size_mb": 512,
+            "max_payload_bytes": 1024,
+            "payload_buffer_budget_mb": 64
+        }))
+        .send()
+        .await
+        .expect("request failed");
+    assert!(resp.status().is_success());
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["enabled"], false);
+    assert_eq!(body["payload_window_minutes"], 30);
+
+    // The change is persisted to disk under [relay.observability].
+    let written = std::fs::read_to_string(&config_file).unwrap();
+    assert!(written.contains("[relay.observability]"));
+    assert!(written.contains("enabled = false"));
+    assert!(written.contains("payload_window_minutes = 30"));
+    assert!(written.contains("machine_name = \"test-machine\""));
+
+    // GET now reflects the new in-memory baseline.
+    let resp = client
+        .get(format!("http://{}/api/observability/config", addr))
+        .send()
+        .await
+        .expect("request failed");
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["enabled"], false);
+    assert_eq!(body["max_db_size_mb"], 512);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn test_observability_block_in_sanitized_config() {
+    let (addr, _handle) =
+        start_management_server(vec![("echo-ep", MockAdapter::healthy_with_tools(vec![]))]).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!("http://{}/api/config", addr))
+        .send()
+        .await
+        .expect("request failed");
+    assert!(resp.status().is_success());
+    let body: Value = resp.json().await.unwrap();
+    let obs = &body["relay"]["observability"];
+    assert_eq!(obs["enabled"], true);
+    assert_eq!(obs["store_payloads"], true);
+    assert_eq!(obs["payload_window_minutes"], 10);
+}
+
+#[tokio::test]
+async fn test_observability_unavailable_when_unwired() {
+    // The default harness wires no observability handle → 503.
+    let (addr, _handle) =
+        start_management_server(vec![("echo-ep", MockAdapter::healthy_with_tools(vec![]))]).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!("http://{}/api/observability/calls", addr))
+        .send()
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status().as_u16(), 503);
 }

--- a/tests/oauth_setup_integration.rs
+++ b/tests/oauth_setup_integration.rs
@@ -5,7 +5,7 @@
 
 mod common;
 
-use endara_relay::config::{Config, EndpointConfig, RelayConfig, Transport};
+use endara_relay::config::{Config, EndpointConfig, ObservabilityConfig, RelayConfig, Transport};
 use endara_relay::management::{management_routes, ManagementState};
 use endara_relay::oauth::{OAuthFlowManager, OAuthSetupManager};
 use endara_relay::registry::AdapterRegistry;
@@ -29,6 +29,7 @@ fn empty_config() -> Config {
             startup_init_timeout_secs: None,
             session_identity_max_sessions: None,
             validate_inputs: None,
+            observability: ObservabilityConfig::default(),
         },
         endpoints: vec![EndpointConfig {
             name: "echo".to_string(),


### PR DESCRIPTION
## Summary

Adds the **agent-call observability** subsystem to the relay: durable per-`tools/call` metadata plus an in-memory request/response payload buffer, exposed via the management API.

### What's included
- **Two-tier storage keyed by `request_uid`:**
  - Durable per-`tools/call` metadata in SQLite (`observability.db`), retention- and size-capped.
  - In-memory request/response payload ring buffer, time- and memory-capped.
- **Async ingestion pipeline** — overflow-dropping, fed from the `route_tool_call` capture point so proxy latency is unaffected.
- **Management API routes** — calls list (with case-insensitive substring filters on server/tool), drill-through detail, aggregates, purge-all, and config; server-delete cascades to its observability rows.
- **Config** under `[relay.observability]` (enable/disable, payload capture, caps).

### Scope
- Captures `tools/call` only; other JSON-RPC methods are ignored.

## Upstream integration
- Merged latest `main`. Resolved the semantic break from #108 (which removed `jsonrpc_id` from `RequestSpanContext`) by dropping `jsonrpc_id` from the observability feature end-to-end. Batches are correlated via the shared inbound request span + per-call minted `request_uid`s. The overlay/RelayLogs `jsonrpcId` subsystem is unrelated and untouched.

## Verification
- `cargo fmt --check` ✅
- `cargo build` ✅
- `cargo test` ✅ (932 passed; the only failure in the parallel run is the pre-existing flaky `watcher::tests::adapter_init_warns_when_falling_back_to_toml_secret` log-capture race, which passes in isolation)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author