### PR TITLE
chore: bump version to 0.1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "endara-relay"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endara-relay"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 description = "Local MCP tool aggregator — aggregate multiple MCP servers behind a single endpoint"
 license = "Apache-2.0"


### PR DESCRIPTION
Scenario 3 base-version bump after the v0.1.9 stable release. Bumps the committed base version to 0.1.10 for the next rc cycle.

- `Cargo.toml` package version → 0.1.10
- `Cargo.lock` regenerated via `cargo update --workspace` (one-line relay crate bump)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author