### PR TITLE
test: fix flaky tests (ETXTBSY retry, tracing cache poisoning, timing-based waits)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,6 +736,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2",
  "strsim",
  "tempfile",
@@ -906,6 +907,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -2687,6 +2699,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ hyper = { version = "1", features = ["client", "http1"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 reqwest = { version = "0.13", features = ["json", "stream"] }
 serde_json = "1"
+serial_test = "3.5.0"
 tempfile = "3.27.0"
 tokio = { version = "1", features = ["test-util"] }
 which = "7"

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -2766,7 +2766,9 @@ mod tests {
     /// via `with_default(...)` and drive an inner current-thread runtime so
     /// the dispatcher stays attached across `tokio::spawn`'d tasks.
     #[test]
+    #[serial_test::serial(tracing)]
     fn call_tool_publishes_request_uid_and_profile_from_request_span() {
+        crate::test_tracing::init_permissive_tracing();
         use crate::events::{SpanFieldCaptureLayer, ToolCallEvent, ToolCallEventBus};
         use tracing::Instrument;
         use tracing_subscriber::prelude::*;

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -2089,7 +2089,9 @@ with open(record_path, "w") as rec:
     /// `#[test]` (not `#[tokio::test]`) because we install the capture layer
     /// via `with_default(...)` and drive an inner current-thread runtime.
     #[test]
+    #[serial_test::serial(tracing)]
     fn call_tool_publishes_request_uid_from_request_span() {
+        crate::test_tracing::init_permissive_tracing();
         use crate::events::{SpanFieldCaptureLayer, ToolCallEvent, ToolCallEventBus};
         use tracing::Instrument;
         use tracing_subscriber::prelude::*;

--- a/src/container_runtime.rs
+++ b/src/container_runtime.rs
@@ -202,7 +202,23 @@ fn is_executable(path: &Path) -> bool {
 /// touches the client binary (never the daemon), so it is fast even when the
 /// engine VM is stopped.
 fn cli_version(cli: &Path) -> Option<String> {
-    let output = std::process::Command::new(cli).arg("--version").output();
+    // Spawning a freshly written/copied binary can transiently fail with
+    // ETXTBSY ("text file busy") while another handle still has it open for
+    // writing. Retry a bounded number of times before giving up.
+    const MAX_ATTEMPTS: usize = 10;
+    let mut output = std::process::Command::new(cli).arg("--version").output();
+    for _ in 1..MAX_ATTEMPTS {
+        match &output {
+            Err(e)
+                if e.kind() == std::io::ErrorKind::ExecutableFileBusy
+                    || e.raw_os_error() == Some(26) =>
+            {
+                std::thread::sleep(std::time::Duration::from_millis(5));
+                output = std::process::Command::new(cli).arg("--version").output();
+            }
+            _ => break,
+        }
+    }
     match output {
         Ok(out) if out.status.success() => parse_cli_version(&String::from_utf8_lossy(&out.stdout)),
         Ok(out) => {

--- a/src/events.rs
+++ b/src/events.rs
@@ -815,7 +815,9 @@ mod tests {
     /// both values via [`current_request_context`] — this is the foundation for
     /// per-event `request_uid` plumbing without a `call_tool` trait change.
     #[test]
+    #[serial_test::serial(tracing)]
     fn current_request_context_walks_request_and_mcp_request_spans() {
+        crate::test_tracing::init_permissive_tracing();
         use tracing::Instrument;
         use tracing_subscriber::prelude::*;
 
@@ -849,7 +851,9 @@ mod tests {
     /// running outside an HTTP-routed request (e.g. background init) must
     /// degrade silently.
     #[test]
+    #[serial_test::serial(tracing)]
     fn current_request_context_without_spans_returns_none() {
+        crate::test_tracing::init_permissive_tracing();
         use tracing_subscriber::prelude::*;
         let subscriber = tracing_subscriber::registry().with(SpanFieldCaptureLayer);
         tracing::subscriber::with_default(subscriber, || {
@@ -863,7 +867,9 @@ mod tests {
     /// a typed value so adapter event emitters can populate
     /// [`ToolCallEvent::Started::client`] without re-deriving it.
     #[test]
+    #[serial_test::serial(tracing)]
     fn current_request_context_captures_client_from_request_span() {
+        crate::test_tracing::init_permissive_tracing();
         use tracing::Instrument;
         use tracing_subscriber::prelude::*;
 
@@ -895,7 +901,9 @@ mod tests {
     /// A malformed `client` field on the `request` span must not propagate;
     /// the visitor silently drops the value so dispatch stays resilient.
     #[test]
+    #[serial_test::serial(tracing)]
     fn current_request_context_ignores_malformed_client_field() {
+        crate::test_tracing::init_permissive_tracing();
         use tracing::Instrument;
         use tracing_subscriber::prelude::*;
         let subscriber = tracing_subscriber::registry().with(SpanFieldCaptureLayer);

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -3107,7 +3107,9 @@ mod tests {
     /// resolves the aggregating client rather than `None`. This is the exact
     /// failure the task reproduced live before the fix.
     #[test]
+    #[serial_test::serial(tracing)]
     fn sandbox_tool_call_reestablishes_client_context() {
+        crate::test_tracing::init_permissive_tracing();
         use crate::events::{current_request_context, ClientIdentity, SpanFieldCaptureLayer};
         use std::sync::Mutex;
         use tracing_subscriber::prelude::*;
@@ -3204,7 +3206,9 @@ mod tests {
     /// `ToolCallEvent::Started.request_uid` and the desktop's collision-free
     /// row/overlay key) resolves the outer UID rather than `None`.
     #[test]
+    #[serial_test::serial(tracing)]
     fn sandbox_tool_call_reestablishes_request_uid() {
+        crate::test_tracing::init_permissive_tracing();
         use crate::events::{current_request_context, SpanFieldCaptureLayer};
         use std::sync::Mutex;
         use tracing_subscriber::prelude::*;
@@ -3285,7 +3289,9 @@ mod tests {
     /// `current_request_context().client` as `None` rather than fabricating an
     /// empty identity.
     #[test]
+    #[serial_test::serial(tracing)]
     fn sandbox_tool_call_without_client_leaves_context_none() {
+        crate::test_tracing::init_permissive_tracing();
         use crate::events::{current_request_context, ClientIdentity, SpanFieldCaptureLayer};
         use std::sync::Mutex;
         use tracing_subscriber::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,3 +28,10 @@ use tokio::sync::RwLock;
 /// Per-endpoint shared OAuth adapter inner states, keyed by endpoint name.
 /// Used by the callback handler to apply tokens to the correct adapter.
 pub type OAuthAdapterInners = Arc<RwLock<HashMap<String, Arc<OAuthAdapterInner>>>>;
+
+/// Test-only support for stabilising `tracing` callsite-interest caching.
+/// Declared in both crate roots (`lib.rs` and `main.rs`) because the binary
+/// re-declares the same module files, so `crate::test_tracing` must resolve in
+/// each crate.
+#[cfg(test)]
+pub(crate) mod test_tracing;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,8 @@ mod profile_registry;
 mod registry;
 mod server;
 mod shell_env;
+#[cfg(test)]
+mod test_tracing;
 mod toon_convert;
 
 use adapter::oauth::{OAuthAdapter, OAuthAdapterConfig, OAuthAdapterInner};

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1735,7 +1735,9 @@ mod tests {
     /// overwrites the others. The batch stays correlated via the shared inbound
     /// request span and the per-call `request_uid`s minted by the capture block.
     #[tokio::test]
+    #[serial_test::serial(tracing)]
     async fn batched_inner_calls_get_distinct_request_uids() {
+        crate::test_tracing::init_permissive_tracing();
         use crate::config::ObservabilityConfig;
         use crate::events::SpanFieldCaptureLayer;
         use crate::observability::payloads::PayloadStore;

--- a/src/server.rs
+++ b/src/server.rs
@@ -2462,7 +2462,9 @@ mod tests {
     /// `mcp_initialize_logged` mints a fresh, non-empty UUID `request_uid` onto
     /// its `request` span (the field `current_request_context()` surfaces).
     #[test]
+    #[serial_test::serial(tracing)]
     fn mcp_initialize_logged_mints_request_uid_span_field() {
+        crate::test_tracing::init_permissive_tracing();
         let uids = request_uids_for(async {
             let state = test_app_state();
             let _ = mcp_initialize_logged(
@@ -2483,7 +2485,9 @@ mod tests {
     /// `mcp_tools_list_logged` mints a fresh, non-empty UUID `request_uid` onto
     /// its `request` span.
     #[test]
+    #[serial_test::serial(tracing)]
     fn mcp_tools_list_logged_mints_request_uid_span_field() {
+        crate::test_tracing::init_permissive_tracing();
         let uids = request_uids_for(async {
             let state = test_app_state();
             let _ = mcp_tools_list_logged(
@@ -2505,7 +2509,9 @@ mod tests {
     /// its `request` span — the route whose inner upstream calls feed
     /// `ToolCallEvent::Started.request_uid`.
     #[test]
+    #[serial_test::serial(tracing)]
     fn mcp_tools_call_logged_mints_request_uid_span_field() {
+        crate::test_tracing::init_permissive_tracing();
         let uids = request_uids_for(async {
             let state = test_app_state();
             let _ = mcp_tools_call_logged(
@@ -2529,7 +2535,9 @@ mod tests {
     /// Each direct-route call mints its own UID, so concurrent direct callers
     /// never collide on the desktop's row/overlay key.
     #[test]
+    #[serial_test::serial(tracing)]
     fn direct_route_request_uids_are_unique_per_call() {
+        crate::test_tracing::init_permissive_tracing();
         let uids = request_uids_for(async {
             for _ in 0..2 {
                 let state = test_app_state();
@@ -5119,7 +5127,9 @@ mod tests {
             // child event's formatted output carries the parent's `profile`
             // field.
             #[tokio::test(flavor = "current_thread")]
+            #[serial_test::serial(tracing)]
             async fn field_present_on_profiled_request() {
+                crate::test_tracing::init_permissive_tracing();
                 let buf = BufWriter::default();
                 let subscriber = ::tracing_subscriber::fmt()
                     .with_writer(buf.clone())
@@ -5159,7 +5169,9 @@ mod tests {
             // accidental insertion (e.g. a stray default span) would break
             // the desktop log filter's per-profile dropdown.
             #[tokio::test(flavor = "current_thread")]
+            #[serial_test::serial(tracing)]
             async fn field_absent_on_global_request() {
+                crate::test_tracing::init_permissive_tracing();
                 let buf = BufWriter::default();
                 let subscriber = ::tracing_subscriber::fmt()
                     .with_writer(buf.clone())

--- a/src/test_tracing.rs
+++ b/src/test_tracing.rs
@@ -1,0 +1,57 @@
+//! Test-only support for stabilising `tracing` callsite-interest caching.
+//!
+//! tracing's callsite-interest cache is process-global and is fixed by the
+//! first thread to touch a callsite. Tests that route through production code
+//! without installing a subscriber would otherwise register shared callsites
+//! (e.g. the `request` span in `server::mcp_*_logged`) as `Interest::never()`
+//! under the no-op default, statically disabling them for the capturing tests
+//! that later assert on those spans. Installing a permissive global default —
+//! one that never returns `never` but drops everything via `enabled() == false`
+//! — keeps every callsite dynamically re-evaluated against whatever scoped
+//! subscriber a test installs with `with_default`/`set_default`.
+
+use std::sync::OnceLock;
+use tracing::level_filters::LevelFilter;
+use tracing::span::{Attributes, Id, Record};
+use tracing::subscriber::Interest;
+use tracing::{Event, Metadata, Subscriber};
+
+struct PermissiveSubscriber;
+
+impl Subscriber for PermissiveSubscriber {
+    fn register_callsite(&self, _metadata: &'static Metadata<'static>) -> Interest {
+        Interest::sometimes()
+    }
+
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        Some(LevelFilter::TRACE)
+    }
+
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+        false
+    }
+
+    fn new_span(&self, _span: &Attributes<'_>) -> Id {
+        Id::from_u64(1)
+    }
+
+    fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+    fn event(&self, _event: &Event<'_>) {}
+
+    fn enter(&self, _span: &Id) {}
+
+    fn exit(&self, _span: &Id) {}
+}
+
+static INIT: OnceLock<()> = OnceLock::new();
+
+/// Idempotently install the permissive global default subscriber. Safe to call
+/// from every test; only the first call wins.
+pub(crate) fn init_permissive_tracing() {
+    INIT.get_or_init(|| {
+        let _ = tracing::subscriber::set_global_default(PermissiveSubscriber);
+    });
+}

--- a/src/test_tracing.rs
+++ b/src/test_tracing.rs
@@ -52,6 +52,10 @@ static INIT: OnceLock<()> = OnceLock::new();
 /// from every test; only the first call wins.
 pub(crate) fn init_permissive_tracing() {
     INIT.get_or_init(|| {
-        let _ = tracing::subscriber::set_global_default(PermissiveSubscriber);
+        tracing::subscriber::set_global_default(PermissiveSubscriber).expect(
+            "init_permissive_tracing: a global tracing subscriber was already installed; \
+             the permissive callsite-interest de-poisoning subscriber must be the only \
+             global default during tests",
+        );
     });
 }

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1945,7 +1945,9 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    #[serial_test::serial(tracing)]
     async fn adapter_init_warns_when_falling_back_to_toml_secret() {
+        crate::test_tracing::init_permissive_tracing();
         use std::io;
         use std::sync::{Arc, Mutex};
         use tracing_subscriber::fmt::MakeWriter;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -5,3 +5,4 @@ pub mod mcp_client;
 pub mod mock_mcp_server;
 pub mod mock_oauth_server;
 pub mod toolchain;
+pub mod wait;

--- a/tests/common/wait.rs
+++ b/tests/common/wait.rs
@@ -1,0 +1,56 @@
+//! Poll-until-ready helpers for integration tests.
+//!
+//! Prefer these over fixed `tokio::time::sleep` calls when waiting for a
+//! positive condition (a server to start, a catalog to populate, an API to
+//! report the expected state). They return as soon as the condition holds and
+//! fail fast on timeout instead of hanging.
+
+#![allow(dead_code)]
+
+use std::future::Future;
+use std::time::{Duration, Instant};
+use tokio::net::TcpStream;
+
+/// Interval between predicate checks.
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Poll `predicate` roughly every 50ms until it returns `true` or `deadline`
+/// elapses. The predicate returns a future, so both async checks
+/// (`|| async { thing().await }`) and sync checks (`|| async { thing() }`)
+/// work. Returns `true` if the condition was met, `false` on timeout.
+pub async fn poll_until<F, Fut>(deadline: Duration, mut predicate: F) -> bool
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = bool>,
+{
+    let stop = Instant::now() + deadline;
+    loop {
+        if predicate().await {
+            return true;
+        }
+        if Instant::now() >= stop {
+            return false;
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// Wait until the host/port behind `url` accepts a TCP connection or `deadline`
+/// elapses. A TCP connect is used (rather than an HTTP GET) so it works
+/// uniformly for streaming endpoints (e.g. SSE) that would otherwise hold a GET
+/// open. Returns `true` once the server is reachable, `false` on timeout.
+pub async fn wait_http_ready(url: &str, deadline: Duration) -> bool {
+    let parsed = url::Url::parse(url).expect("wait_http_ready: invalid URL");
+    let host = parsed
+        .host_str()
+        .expect("wait_http_ready: URL has no host")
+        .to_string();
+    let port = parsed
+        .port_or_known_default()
+        .expect("wait_http_ready: URL has no port");
+    poll_until(deadline, || {
+        let host = host.clone();
+        async move { TcpStream::connect((host.as_str(), port)).await.is_ok() }
+    })
+    .await
+}

--- a/tests/hot_reload_integration.rs
+++ b/tests/hot_reload_integration.rs
@@ -3,6 +3,9 @@
 //! Creates a temp config file, starts relay with it,
 //! modifies config to add/remove endpoints, verifies changes are applied.
 
+mod common;
+
+use common::wait::poll_until;
 use endara_relay::adapter::stdio::{StdioAdapter, StdioConfig};
 use endara_relay::adapter::McpAdapter;
 use endara_relay::config;
@@ -176,7 +179,13 @@ async fn test_config_diff_add_endpoint() {
     .await;
 
     // Wait for background initialization to complete
-    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    assert!(
+        poll_until(std::time::Duration::from_secs(10), || async {
+            registry.merged_catalog().await.len() > 1
+        })
+        .await,
+        "background initialization never produced more than 1 tool after adding multi-ep"
+    );
 
     // Verify the new endpoint was added
     let catalog = registry.merged_catalog().await;

--- a/tests/http_adapter_integration.rs
+++ b/tests/http_adapter_integration.rs
@@ -4,6 +4,9 @@
 //! performs initialize/list_tools/call_tool, then shuts down the server
 //! and verifies the adapter detects unhealthy state.
 
+mod common;
+
+use common::wait::wait_http_ready;
 use endara_relay::adapter::http::{HttpAdapter, HttpConfig};
 use endara_relay::adapter::{HealthStatus, McpAdapter};
 use serde_json::json;
@@ -28,7 +31,14 @@ async fn start_http_server() -> (tokio::process::Child, u16) {
         .expect("failed to start fixture-http-server");
 
     // Wait for server to be ready
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    assert!(
+        wait_http_ready(
+            &format!("http://127.0.0.1:{port}/"),
+            Duration::from_secs(10)
+        )
+        .await,
+        "fixture-http-server did not start accepting connections within 10s on port {port}"
+    );
 
     (child, port)
 }

--- a/tests/management_api_integration.rs
+++ b/tests/management_api_integration.rs
@@ -4,7 +4,10 @@
 //! /api/endpoints/:name/tools, /api/endpoints/:name/refresh,
 //! /api/endpoints/:name/logs, /api/config.
 
+mod common;
+
 use async_trait::async_trait;
+use common::wait::{poll_until, wait_http_ready};
 use endara_relay::adapter::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
 use endara_relay::config::{Config, EndpointConfig, ObservabilityConfig, RelayConfig, Transport};
 use endara_relay::management::{management_routes, ManagementState};
@@ -15,7 +18,7 @@ use endara_relay::registry::AdapterRegistry;
 use serde_json::{json, Value};
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tokio::net::TcpListener;
 
 /// Mock adapter for management API tests.
@@ -157,8 +160,11 @@ async fn start_management_server(
         axum::serve(listener, app).await.ok();
     });
 
-    // Give server a moment to start
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    // Wait until the server is accepting connections.
+    assert!(
+        wait_http_ready(&format!("http://{addr}/"), Duration::from_secs(10)).await,
+        "management server did not become ready within 10s"
+    );
 
     (addr, handle)
 }
@@ -347,7 +353,11 @@ async fn start_management_server_with_config(
         axum::serve(listener, app).await.ok();
     });
 
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    // Wait until the server is accepting connections.
+    assert!(
+        wait_http_ready(&format!("http://{addr}/"), Duration::from_secs(10)).await,
+        "management server did not become ready within 10s"
+    );
     (addr, handle)
 }
 
@@ -406,8 +416,31 @@ command = "cat"
     assert_eq!(body["ok"], true);
     assert_eq!(body["message"], "config reloaded");
 
-    // Allow a moment for the adapter to initialize
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    // Wait until the reloaded adapter's endpoint shows up in the API.
+    assert!(
+        poll_until(Duration::from_secs(10), || async {
+            let Ok(resp) = client
+                .get(format!("http://{}/api/endpoints", addr))
+                .send()
+                .await
+            else {
+                return false;
+            };
+            let Ok(endpoints) = resp.json::<Value>().await else {
+                return false;
+            };
+            endpoints
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|e| e["name"].as_str())
+                        .any(|n| n == "new-ep")
+                })
+                .unwrap_or(false)
+        })
+        .await,
+        "config reload: new-ep never appeared in /api/endpoints within 10s"
+    );
 
     // GET /api/endpoints — should now include the new endpoint
     let resp = client
@@ -825,7 +858,11 @@ async fn start_observability_server(
     let handle = tokio::spawn(async move {
         axum::serve(listener, app).await.ok();
     });
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    // Wait until the server is accepting connections.
+    assert!(
+        wait_http_ready(&format!("http://{addr}/"), Duration::from_secs(10)).await,
+        "observability server did not become ready within 10s"
+    );
     (addr, store, payloads, handle)
 }
 

--- a/tests/sse_adapter_integration.rs
+++ b/tests/sse_adapter_integration.rs
@@ -4,6 +4,9 @@
 //! performs initialize/list_tools/call_tool, then shuts down the server
 //! and verifies the adapter detects unhealthy state.
 
+mod common;
+
+use common::wait::wait_http_ready;
 use endara_relay::adapter::sse::{SseAdapter, SseConfig};
 use endara_relay::adapter::{HealthStatus, McpAdapter};
 use serde_json::json;
@@ -29,7 +32,14 @@ async fn start_sse_server() -> (tokio::process::Child, u16) {
         .expect("failed to start fixture-sse-server");
 
     // Wait for server to be ready
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    assert!(
+        wait_http_ready(
+            &format!("http://127.0.0.1:{port}/"),
+            Duration::from_secs(10)
+        )
+        .await,
+        "fixture-sse-server did not start accepting connections within 10s on port {port}"
+    );
 
     (child, port)
 }

--- a/tests/tools_cache_e2e_integration.rs
+++ b/tests/tools_cache_e2e_integration.rs
@@ -12,6 +12,7 @@ mod common;
 use common::api_client::ApiClient;
 use common::config::ConfigBuilder;
 use common::harness::RelayHarness;
+use common::wait::poll_until;
 use serde_json::json;
 use std::path::Path;
 use std::time::{Duration, Instant};
@@ -23,18 +24,6 @@ fn read_count(path: &Path) -> u64 {
         .ok()
         .and_then(|s| s.trim().parse().ok())
         .unwrap_or(0)
-}
-
-/// Poll `predicate` every 20ms until it returns true or `deadline` elapses.
-async fn poll_until<F: FnMut() -> bool>(deadline: Duration, mut predicate: F) -> bool {
-    let stop = Instant::now() + deadline;
-    while Instant::now() < stop {
-        if predicate() {
-            return true;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-    predicate()
 }
 
 /// GET `/api/endpoints/<name>/tools` and return the tool name set.
@@ -85,7 +74,10 @@ async fn test_per_adapter_tools_cache_end_to_end() {
         "extra tool should NOT be present before swap, got {names:?}"
     );
     assert!(
-        poll_until(Duration::from_secs(2), || read_count(&count_path) >= 1).await,
+        poll_until(Duration::from_secs(2), || async {
+            read_count(&count_path) >= 1
+        })
+        .await,
         "fixture never recorded the first tools/list call"
     );
     assert_eq!(
@@ -126,7 +118,10 @@ async fn test_per_adapter_tools_cache_end_to_end() {
 
     let _ = fetch_tool_names(api, tools_url).await;
     assert!(
-        poll_until(Duration::from_secs(2), || read_count(&count_path) >= 2).await,
+        poll_until(Duration::from_secs(2), || async {
+            read_count(&count_path) >= 2
+        })
+        .await,
         "lifecycle invalidation: expected upstream count to reach 2, got {}",
         read_count(&count_path)
     );
@@ -217,7 +212,10 @@ async fn test_refresh_endpoint_invalidates_per_endpoint_cache() {
     // 1. First GET primes the cache → upstream count = 1.
     let _ = fetch_tool_names(api, tools_url).await;
     assert!(
-        poll_until(Duration::from_secs(2), || read_count(&count_path) >= 1).await,
+        poll_until(Duration::from_secs(2), || async {
+            read_count(&count_path) >= 1
+        })
+        .await,
         "fixture never recorded the first tools/list call"
     );
     assert_eq!(
@@ -241,7 +239,10 @@ async fn test_refresh_endpoint_invalidates_per_endpoint_cache() {
     let (status, _) = api.post_empty_status(refresh_url).await;
     assert!(status.is_success(), "refresh failed: {status}");
     assert!(
-        poll_until(Duration::from_secs(2), || read_count(&count_path) >= 2).await,
+        poll_until(Duration::from_secs(2), || async {
+            read_count(&count_path) >= 2
+        })
+        .await,
         "refresh: expected upstream count to reach 2, got {}",
         read_count(&count_path)
     );
@@ -311,7 +312,10 @@ async fn test_per_tool_disable_enable_invalidates_catalog_cache() {
         "expected get_status in initial catalog, got {names:?}"
     );
     assert!(
-        poll_until(Duration::from_secs(2), || read_count(&count_path) >= 1).await,
+        poll_until(Duration::from_secs(2), || async {
+            read_count(&count_path) >= 1
+        })
+        .await,
         "fixture never recorded the first tools/list call"
     );
     assert_eq!(
@@ -347,7 +351,10 @@ async fn test_per_tool_disable_enable_invalidates_catalog_cache() {
         "non-disabled tool swap_tools must remain in catalog: {names_after_disable:?}"
     );
     assert!(
-        poll_until(Duration::from_secs(2), || read_count(&count_path) >= 2).await,
+        poll_until(Duration::from_secs(2), || async {
+            read_count(&count_path) >= 2
+        })
+        .await,
         "per-tool disable: expected upstream count to reach 2, got {}",
         read_count(&count_path)
     );
@@ -378,7 +385,7 @@ async fn test_per_tool_disable_enable_invalidates_catalog_cache() {
         "catalog cache was not invalidated on enable: get_status missing: {names_after_enable:?}"
     );
     assert!(
-        poll_until(Duration::from_secs(2), || {
+        poll_until(Duration::from_secs(2), || async {
             read_count(&count_path) > count_after_disable
         })
         .await,


### PR DESCRIPTION
## Summary

Fixes the flaky `container_runtime::tests::detect_from_socket_resolves_matching_cli` test and two additional flake families surfaced during stress testing, then hardens timing-based integration tests. All changes are test-only except a bounded, narrowly-scoped retry in the CLI version probe.

## Root causes & fixes

### 1. `ETXTBSY` when probing the CLI version
Spawning the bundled CLI to read its version races a concurrent writable fd to the executable (text file busy), failing `execve` with `ETXTBSY` under parallel test runners.

**Fix:** bounded retry on the spawn, only on `ExecutableFileBusy` / `raw_os_error() == 26`. Genuine errors and non-success statuses still return `None` as before.

### 2. Tracing callsite-interest cache poisoning
`tracing` caches per-callsite interest globally based on the current subscriber. Concurrent tests with no/other subscribers could poison that cache to `Interest::never()`, so WARN / request-span events were silently dropped in tests that install a scoped subscriber (watcher WARN capture, server request-span UIDs).

**Fix (two coordinated parts):**
- A permissive no-op global-default subscriber (`src/test_tracing.rs`): `register_callsite -> sometimes`, `enabled -> false`, span/event no-ops, installed once via `OnceLock` + `set_global_default`, called as the first line of each scoped-subscriber test. Declared in both `lib.rs` and `main.rs` because the binary re-declares the module files.
- Serialize the scoped-subscriber tests with `serial_test`'s `#[serial(tracing)]` (new dev-dependency).

### 3. Timing-based integration tests
Several integration tests used fixed sleeps to wait for a server / background work to settle before asserting, which flakes on slow/loaded CI.

**Fix:** shared `tests/common/wait.rs` (`poll_until` + `wait_http_ready`, bounded deadline + TCP connect, asserts on timeout rather than hanging). Converted the fixture server-start sleeps in `sse_adapter` / `http_adapter`, `hot_reload`'s 2s catalog wait, and the four `management_api` settle waits. `tools_cache_e2e` now uses the shared `poll_until`.

**Intentionally left unchanged:** negative-assertion sleeps (tools_cache cache-hit checks), deliberate delays-under-test (`startup_timeout`), and oauth error-path recovery sleeps.

## Verification
- `cargo fmt --check` clean; `cargo clippy --lib --tests --bins` no new warnings.
- `cargo test --lib` → 934 passed / 0 failed.
- Library stress loop: 40/40 iterations clean (was ~10/40 flaking).
- Hardened integration binaries stress loop: 15/15 clean; targeted suite 33 passed / 0 failed.
- No assertion / pass-fail logic changed; only the container_runtime retry is a (narrow) production-path change.

## Commits
1. `fix(container_runtime): retry CLI version probe on ETXTBSY`
2. `test: stabilize tracing-dependent tests`
3. `test: harden timing-based integration tests with poll-until-ready`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author