### PR TITLE
feat: MCP 2026-07-28 spec compliance — Waves 1-5 (version core + server + client + features + OAuth)

### DIFF
--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -1168,6 +1168,16 @@ impl McpAdapter for HttpAdapter {
     }
 
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
+        self.call_tool_with_request_params(name, arguments, serde_json::Map::new())
+            .await
+    }
+
+    async fn call_tool_with_request_params(
+        &self,
+        name: &str,
+        arguments: Value,
+        request_params: serde_json::Map<String, Value>,
+    ) -> Result<Value, AdapterError> {
         // Capture caller span context BEFORE `.instrument(self.span)` re-enters
         // the adapter's own `endpoint` span — endpoint is constructed at
         // adapter init time with no parent linkage to per-request spans, so
@@ -1198,10 +1208,11 @@ impl McpAdapter for HttpAdapter {
                     client: span_ctx.client.clone(),
                 });
             }
-            let params = json!({
+            let mut params = json!({
                 "name": name,
                 "arguments": arguments,
             });
+            crate::adapter::merge_request_params(&mut params, request_params);
             let start = Instant::now();
             let result = self.send_request("tools/call", Some(params)).await;
             // JIT 401 interception: swallow a hard 401 + Bearer challenge and
@@ -2449,6 +2460,109 @@ mod tests {
             list_rec.mcp_name.is_none(),
             "Mcp-Name is absent for methods without a tool name"
         );
+
+        drop(seen);
+        server.abort();
+    }
+
+    // --- Multi round-trip (MRT) passthrough (T10) ---
+
+    #[derive(Clone)]
+    struct MrtState {
+        seen: Arc<Mutex<Vec<Value>>>,
+    }
+
+    /// Fixture for the MRT round-trip: the first `tools/call` (no `requestState`)
+    /// returns an `InputRequiredResult`; a follow-up carrying `requestState`
+    /// returns the terminal `CallToolResult`. Every inbound `params` object is
+    /// recorded so the test can assert what the relay forwarded.
+    async fn dispatch_mrt(
+        State(app): State<MrtState>,
+        Json(body): Json<Value>,
+    ) -> axum::response::Response {
+        let id = body.get("id").cloned().unwrap_or(Value::Null);
+        let params = body.get("params").cloned().unwrap_or(json!({}));
+        app.seen.lock().await.push(params.clone());
+        let result = if params.get("requestState").is_some() {
+            json!({"content": [{"type": "text", "text": "done"}]})
+        } else {
+            json!({
+                "inputRequests": [{"name": "city", "schema": {"type": "string"}}],
+                "requestState": "state-xyz"
+            })
+        };
+        Json(json!({"jsonrpc": "2.0", "result": result, "id": id})).into_response()
+    }
+
+    async fn start_mrt_server() -> (String, Arc<Mutex<Vec<Value>>>, JoinHandle<()>) {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let state = MrtState { seen: seen.clone() };
+        let app = Router::new()
+            .route("/mcp", any(dispatch_mrt))
+            .with_state(state);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{}/mcp", addr);
+        let handle = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        (url, seen, handle)
+    }
+
+    /// A full multi round-trip: the relay forwards a terminal-shaped first call
+    /// untouched, returns the upstream `InputRequiredResult` verbatim, and on the
+    /// follow-up forwards `inputResponses`/`requestState` alongside
+    /// `name`/`arguments` so the upstream can complete the call.
+    #[tokio::test]
+    async fn call_tool_round_trips_input_required_and_request_state() {
+        let (url, seen, server) = start_mrt_server().await;
+        let adapter = HttpAdapter::new(HttpConfig::new(url));
+
+        // First call: no MRT siblings. Upstream returns an InputRequiredResult,
+        // which must pass through unchanged (not coerced into a CallToolResult).
+        let first = adapter
+            .call_tool_with_request_params("ask", json!({"q": "?"}), serde_json::Map::new())
+            .await
+            .expect("first call_tool");
+        assert_eq!(first["requestState"], "state-xyz");
+        assert!(
+            first.get("inputRequests").is_some(),
+            "InputRequiredResult passes through unchanged"
+        );
+        assert!(
+            first.get("content").is_none(),
+            "InputRequiredResult must not be mangled into a content result"
+        );
+
+        // Follow-up: client supplies inputResponses + the echoed requestState.
+        let mut request_params = serde_json::Map::new();
+        request_params.insert(
+            "inputResponses".to_string(),
+            json!([{"name": "city", "value": "NYC"}]),
+        );
+        request_params.insert("requestState".to_string(), json!("state-xyz"));
+        let second = adapter
+            .call_tool_with_request_params("ask", json!({"q": "?"}), request_params)
+            .await
+            .expect("follow-up call_tool");
+        assert_eq!(second["content"][0]["text"], "done");
+
+        let seen = seen.lock().await;
+        assert_eq!(seen.len(), 2, "two upstream tools/call requests");
+
+        // First request carries only name/arguments — byte-for-byte legacy shape.
+        let first_params = &seen[0];
+        assert_eq!(first_params["name"], "ask");
+        assert_eq!(first_params["arguments"], json!({"q": "?"}));
+        assert!(first_params.get("requestState").is_none());
+        assert!(first_params.get("inputResponses").is_none());
+
+        // Follow-up request forwards the MRT siblings verbatim.
+        let followup_params = &seen[1];
+        assert_eq!(followup_params["name"], "ask");
+        assert_eq!(followup_params["arguments"], json!({"q": "?"}));
+        assert_eq!(followup_params["requestState"], "state-xyz");
+        assert_eq!(followup_params["inputResponses"][0]["value"], "NYC");
 
         drop(seen);
         server.abort();

--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -7,7 +7,7 @@ use crate::events::{
     annotations_from_value, current_request_context, ToolCallEvent, ToolCallEventBus,
 };
 use crate::jsonrpc::{self, JsonRpcResponse};
-use crate::protocol::ProtocolVersion;
+use crate::protocol::{detect_upstream_dialect, ProtocolVersion};
 use async_trait::async_trait;
 use reqwest::Client;
 use serde_json::{json, Value};
@@ -264,9 +264,9 @@ impl HttpAdapter {
         self.jit_interceptor = Some(interceptor);
     }
 
-    /// Record the upstream server's negotiated [`ProtocolVersion`]. Wired by
-    /// T7 once real negotiation is implemented; unused today.
-    #[allow(dead_code)]
+    /// Record the upstream server's negotiated [`ProtocolVersion`]. Populated
+    /// during the connection-open handshake (T7); consumed by the 2026 outbound
+    /// code paths (T8).
     pub(crate) async fn set_upstream_dialect(&self, dialect: ProtocolVersion) {
         *self.upstream_dialect.write().await = dialect;
     }
@@ -921,6 +921,14 @@ impl McpAdapter for HttpAdapter {
             }
             *self.server_type.write().await = effective;
             *self.upstream_server_name.write().await = Some(upstream_stripped);
+
+            // Detect and record the upstream's negotiated protocol dialect from
+            // the initialize result before any tool calls are proxied (T7). The
+            // live `server/discover` probe (discover-first path) is wired by T8;
+            // here we pass `None` so legacy upstreams behave byte-for-byte as
+            // before.
+            self.set_upstream_dialect(detect_upstream_dialect(None, Some(&result)))
+                .await;
 
             // Per the MCP spec the client MUST send a notifications/initialized
             // notification after a successful initialize exchange.

--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -2587,4 +2587,153 @@ mod tests {
         drop(seen);
         server.abort();
     }
+
+    // --- D13: W3C Trace Context propagation in `_meta` ---
+
+    /// Fixture that records the full inbound `params._meta` of every POST and
+    /// answers a 2026 `server/discover` probe so the adapter takes the stateless
+    /// 2026 path. The `tools/call` result carries its own `_meta` Trace Context
+    /// so the test can assert the response (upstream→client) direction too.
+    #[derive(Clone)]
+    struct TraceServerState {
+        seen_meta: Arc<Mutex<Vec<Value>>>,
+    }
+
+    async fn dispatch_trace_2026(
+        State(app): State<TraceServerState>,
+        Json(body): Json<Value>,
+    ) -> axum::response::Response {
+        let method = body["method"].as_str().unwrap_or("").to_string();
+        let id = body["id"].as_u64();
+        let meta = body
+            .get("params")
+            .and_then(|p| p.get("_meta"))
+            .cloned()
+            .unwrap_or(Value::Null);
+        app.seen_meta.lock().await.push(meta);
+
+        let result = match method.as_str() {
+            "server/discover" => json!({
+                "protocolVersion": "2026-07-28",
+                "capabilities": {"tools": {"listChanged": true}},
+                "serverInfo": {"name": "trace-2026", "version": "1.0.0"},
+                "tools": []
+            }),
+            "tools/list" => json!({
+                "tools": [{
+                    "name": "echo",
+                    "description": "Echoes",
+                    "inputSchema": {"type": "object"}
+                }]
+            }),
+            // Terminal result carries its own W3C Trace Context under `_meta`
+            // so the test can assert the relay surfaces upstream→client trace
+            // fields back to the caller unmodified.
+            "tools/call" => json!({
+                "content": [{"type": "text", "text": "ok"}],
+                "_meta": {
+                    "traceparent": "00-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-cccccccccccccccc-01",
+                    "tracestate": "vendor=resp"
+                }
+            }),
+            _ => {
+                return Json(json!({
+                    "jsonrpc": "2.0",
+                    "error": {"code": -32601, "message": "Method not found"},
+                    "id": id,
+                }))
+                .into_response();
+            }
+        };
+        if id.is_some() {
+            Json(json!({"jsonrpc": "2.0", "result": result, "id": id})).into_response()
+        } else {
+            (StatusCode::ACCEPTED, "").into_response()
+        }
+    }
+
+    async fn start_trace_2026_server() -> (String, Arc<Mutex<Vec<Value>>>, JoinHandle<()>) {
+        let seen_meta = Arc::new(Mutex::new(Vec::new()));
+        let state = TraceServerState {
+            seen_meta: seen_meta.clone(),
+        };
+        let app = Router::new()
+            .route("/mcp", any(dispatch_trace_2026))
+            .with_state(state);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{}/mcp", addr);
+        let handle = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        (url, seen_meta, handle)
+    }
+
+    /// D13 — W3C Trace Context propagation through the relay's `_meta`, BOTH
+    /// directions, on the 2026 HTTP path:
+    /// - forward (client→relay→upstream): inbound `_meta` trace keys
+    ///   (`traceparent`/`tracestate`/`baggage`) are forwarded to the upstream
+    ///   `tools/call` UNMODIFIED, as siblings of the relay's own `_meta`
+    ///   clientInfo — the clientInfo injection must NOT clobber them.
+    /// - response (upstream→relay→client): the upstream result's `_meta` trace
+    ///   keys are surfaced back to the caller verbatim.
+    #[tokio::test]
+    async fn call_tool_propagates_w3c_trace_context_both_directions() {
+        let (url, seen_meta, server) = start_trace_2026_server().await;
+        let mut adapter = HttpAdapter::new(HttpConfig::new(url));
+        adapter
+            .initialize()
+            .await
+            .expect("2026 initialize succeeds");
+        assert!(
+            adapter.upstream_dialect().await.is_2026(),
+            "upstream should be detected as 2026"
+        );
+
+        // Inbound client→relay `_meta` carrying W3C Trace Context.
+        let mut request_params = serde_json::Map::new();
+        request_params.insert(
+            "_meta".to_string(),
+            json!({
+                "traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-dddddddddddddddd-01",
+                "tracestate": "vendor=req",
+                "baggage": "userId=42"
+            }),
+        );
+
+        let result = adapter
+            .call_tool_with_request_params("echo", json!({"message": "hi"}), request_params)
+            .await
+            .expect("call_tool");
+
+        // Response direction: upstream `_meta` trace fields surface to caller.
+        assert_eq!(
+            result["_meta"]["traceparent"],
+            "00-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-cccccccccccccccc-01"
+        );
+        assert_eq!(result["_meta"]["tracestate"], "vendor=resp");
+
+        // Forward direction: the upstream tools/call request carried the inbound
+        // trace keys UNMODIFIED alongside the relay clientInfo (no clobbering).
+        let seen = seen_meta.lock().await;
+        let call_meta = seen
+            .iter()
+            .rev()
+            .find(|m| m.get("traceparent").is_some())
+            .expect("a tools/call _meta carrying trace context was forwarded");
+        assert_eq!(
+            call_meta["traceparent"],
+            "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-dddddddddddddddd-01"
+        );
+        assert_eq!(call_meta["tracestate"], "vendor=req");
+        assert_eq!(call_meta["baggage"], "userId=42");
+        assert_eq!(
+            call_meta[protocol::META_CLIENT_INFO_KEY]["name"],
+            "endara-relay",
+            "relay clientInfo must coexist with forwarded trace context"
+        );
+
+        drop(seen);
+        server.abort();
+    }
 }

--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -126,6 +126,11 @@ pub struct HttpAdapter {
     /// real negotiation populates it via [`Self::set_upstream_dialect`] (T7).
     /// Consumed by the 2026 outbound code paths (T8).
     upstream_dialect: Arc<RwLock<ProtocolVersion>>,
+    /// Upstream `ttlMs` freshness hint (SEP-2549) captured from the most recent
+    /// successful `tools/list` result. `Some(ms)` only for 2026 upstreams that
+    /// sent a top-level `ttlMs`; `None` otherwise. Read by the registry cache to
+    /// honor the upstream's freshness window. See [`Self::list_tools_ttl_ms`].
+    list_ttl_ms: Arc<RwLock<Option<u64>>>,
 }
 
 /// HTTP header name reqwest reads/writes for the MCP session ID. Reqwest's
@@ -209,6 +214,7 @@ impl HttpAdapter {
             jit_interceptor: None,
             last_www_authenticate: Arc::new(RwLock::new(None)),
             upstream_dialect: Arc::new(RwLock::new(ProtocolVersion::V2025_03_26)),
+            list_ttl_ms: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -258,6 +264,7 @@ impl HttpAdapter {
             jit_interceptor: None,
             last_www_authenticate: Arc::new(RwLock::new(None)),
             upstream_dialect: Arc::new(RwLock::new(ProtocolVersion::V2025_03_26)),
+            list_ttl_ms: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -1154,6 +1161,15 @@ impl McpAdapter for HttpAdapter {
                 .get("tools")
                 .ok_or_else(|| AdapterError::ProtocolError("missing 'tools' field".into()))?;
             let tools: Vec<ToolInfo> = serde_json::from_value(tools_value.clone())?;
+            // Capture the upstream `ttlMs` freshness hint (SEP-2549) only for
+            // 2026 upstreams; legacy upstreams never carry it and keep the
+            // existing event-driven cache behavior. Read by the registry cache.
+            let ttl = if self.upstream_dialect.read().await.is_2026() {
+                protocol::ttl_ms_from_result(&result)
+            } else {
+                None
+            };
+            *self.list_ttl_ms.write().await = ttl;
             // Refresh the per-tool annotations cache for overlay events.
             let mut cache = self.tool_annotations_cache.write().await;
             cache.clear();
@@ -1165,6 +1181,10 @@ impl McpAdapter for HttpAdapter {
         }
         .instrument(self.span.clone())
         .await
+    }
+
+    async fn list_tools_ttl_ms(&self) -> Option<u64> {
+        *self.list_ttl_ms.read().await
     }
 
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {

--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -7,7 +7,7 @@ use crate::events::{
     annotations_from_value, current_request_context, ToolCallEvent, ToolCallEventBus,
 };
 use crate::jsonrpc::{self, JsonRpcResponse};
-use crate::protocol::{detect_upstream_dialect, ProtocolVersion};
+use crate::protocol::{self, detect_upstream_dialect, ProtocolVersion};
 use async_trait::async_trait;
 use reqwest::Client;
 use serde_json::{json, Value};
@@ -134,6 +134,18 @@ pub struct HttpAdapter {
 /// per the spec; HTTP header names are case-insensitive on transmit.
 const MCP_SESSION_ID_HEADER: reqwest::header::HeaderName =
     reqwest::header::HeaderName::from_static("mcp-session-id");
+
+/// 2026 Streamable HTTP per-request headers (lowercased for reqwest's
+/// `HeaderMap`). Emitted only to upstreams detected as `2026-07-28`:
+/// `MCP-Protocol-Version` conveys the dialect, `Mcp-Method` mirrors the
+/// JSON-RPC method, and `Mcp-Name` mirrors the `tools/call` tool name —
+/// enabling routing/observability without parsing the body.
+const MCP_PROTOCOL_VERSION_HEADER_NAME: reqwest::header::HeaderName =
+    reqwest::header::HeaderName::from_static(protocol::MCP_PROTOCOL_VERSION_HEADER);
+const MCP_METHOD_HEADER_NAME: reqwest::header::HeaderName =
+    reqwest::header::HeaderName::from_static(protocol::MCP_METHOD_HEADER);
+const MCP_NAME_HEADER_NAME: reqwest::header::HeaderName =
+    reqwest::header::HeaderName::from_static(protocol::MCP_NAME_HEADER);
 
 impl HttpAdapter {
     /// Create a new HttpAdapter with the given configuration.
@@ -335,6 +347,52 @@ impl HttpAdapter {
         self.request_id.fetch_add(1, Ordering::SeqCst)
     }
 
+    /// The relay's own client identity, injected under
+    /// `params._meta["io.modelcontextprotocol/clientInfo"]` on every outbound
+    /// request to a 2026 upstream. The 2026 transport is stateless — there is
+    /// no `initialize` handshake — so identity travels per-request instead.
+    fn relay_client_info() -> Value {
+        json!({
+            "name": "endara-relay",
+            "version": env!("CARGO_PKG_VERSION"),
+        })
+    }
+
+    /// Attach the relay's `clientInfo` under `params._meta` for 2026 upstreams,
+    /// creating an empty params object when the request carried none. Non-object
+    /// params are left untouched (MCP params are always objects or absent).
+    fn inject_client_info(params: Option<Value>) -> Option<Value> {
+        let mut params = params.unwrap_or_else(|| json!({}));
+        if params.is_object() {
+            params["_meta"][protocol::META_CLIENT_INFO_KEY] = Self::relay_client_info();
+        }
+        Some(params)
+    }
+
+    /// Apply the 2026 Streamable HTTP per-request headers to `builder`:
+    /// `MCP-Protocol-Version` (always), `Mcp-Method` (the JSON-RPC method), and
+    /// `Mcp-Name` (the `params.name` tool name, when present). These let a 2026
+    /// upstream route/observe a request without parsing its body.
+    fn apply_2026_headers(
+        builder: reqwest::RequestBuilder,
+        method: &str,
+        params: Option<&Value>,
+    ) -> reqwest::RequestBuilder {
+        let mut builder = builder.header(
+            MCP_PROTOCOL_VERSION_HEADER_NAME.clone(),
+            reqwest::header::HeaderValue::from_static(protocol::VERSION_2026_07_28),
+        );
+        if let Ok(val) = reqwest::header::HeaderValue::from_str(method) {
+            builder = builder.header(MCP_METHOD_HEADER_NAME.clone(), val);
+        }
+        if let Some(name) = params.and_then(|p| p.get("name")).and_then(Value::as_str) {
+            if let Ok(val) = reqwest::header::HeaderValue::from_str(name) {
+                builder = builder.header(MCP_NAME_HEADER_NAME.clone(), val);
+            }
+        }
+        builder
+    }
+
     /// Parse an SSE (text/event-stream) response body and extract the JSON-RPC
     /// response matching the given request `id`.
     ///
@@ -427,18 +485,29 @@ impl HttpAdapter {
         method: &str,
         params: Option<Value>,
     ) -> Result<(), AdapterError> {
+        // 2026 upstreams: attach `_meta` clientInfo + routing headers and omit
+        // `Mcp-Session-Id` (the transport is stateless). Legacy: unchanged.
+        let is_2026 = self.upstream_dialect.read().await.is_2026();
+        let params = if is_2026 {
+            Self::inject_client_info(params)
+        } else {
+            params
+        };
+
         let mut request = json!({
             "jsonrpc": "2.0",
             "method": method,
         });
-        if let Some(p) = params {
-            request["params"] = p;
+        if let Some(ref p) = params {
+            request["params"] = p.clone();
         }
 
         trace!(method = method, url = %self.config.url, "sending HTTP JSON-RPC notification");
 
         let mut builder = self.client.post(&self.config.url).json(&request);
-        if let Some(ref id) = *self.session_id.read().await {
+        if is_2026 {
+            builder = Self::apply_2026_headers(builder, method, params.as_ref());
+        } else if let Some(ref id) = *self.session_id.read().await {
             if let Ok(val) = reqwest::header::HeaderValue::from_str(id) {
                 builder = builder.header(MCP_SESSION_ID_HEADER.clone(), val);
             }
@@ -477,13 +546,25 @@ impl HttpAdapter {
         method: &str,
         params: Option<Value>,
     ) -> Result<Value, AdapterError> {
+        // 2026 upstreams: every request carries the relay's `clientInfo` under
+        // `_meta` (no handshake) plus the 2026 routing headers; the stateless
+        // transport replaces `Mcp-Session-Id` affinity entirely.
+        let is_2026 = self.upstream_dialect.read().await.is_2026();
+        let params = if is_2026 {
+            Self::inject_client_info(params)
+        } else {
+            params
+        };
+
         let id = self.next_id();
         let request = jsonrpc::new_request(method, params, id);
 
         trace!(method = method, id = id, url = %self.config.url, "sending HTTP JSON-RPC request");
 
         let mut builder = self.client.post(&self.config.url).json(&request);
-        if let Some(ref sid) = *self.session_id.read().await {
+        if is_2026 {
+            builder = Self::apply_2026_headers(builder, method, request.params.as_ref());
+        } else if let Some(ref sid) = *self.session_id.read().await {
             if let Ok(val) = reqwest::header::HeaderValue::from_str(sid) {
                 builder = builder.header(MCP_SESSION_ID_HEADER.clone(), val);
             }
@@ -698,6 +779,125 @@ impl HttpAdapter {
             }
         }
     }
+
+    /// Stateless `server/discover` probe used to detect a 2026 upstream before
+    /// the legacy `initialize` handshake. Sent with the 2026 routing headers
+    /// and `_meta` clientInfo and NO `Mcp-Session-Id`. Returns the JSON-RPC
+    /// `result` object on success, or `None` on any failure (transport error,
+    /// non-2xx, JSON-RPC error, missing result) so the caller falls back to the
+    /// legacy handshake. Legacy servers reject `server/discover` (e.g.
+    /// method-not-found) and the relay falls back transparently.
+    async fn try_discover_probe(&self) -> Option<Value> {
+        let id = self.next_id();
+        let params = Self::inject_client_info(None);
+        let request = jsonrpc::new_request("server/discover", params, id);
+        trace!(method = "server/discover", id = id, url = %self.config.url, "probing upstream protocol dialect");
+
+        let builder = self.client.post(&self.config.url).json(&request);
+        let builder = Self::apply_2026_headers(builder, "server/discover", request.params.as_ref());
+        let resp = builder.send().await.ok()?;
+        if !resp.status().is_success() {
+            return None;
+        }
+
+        let content_type = resp
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+
+        let response: JsonRpcResponse = if content_type.contains("text/event-stream") {
+            let body = resp.text().await.ok()?;
+            Self::parse_sse_response(&body, id, Some(&self.tools_changed_tx)).ok()?
+        } else {
+            resp.json().await.ok()?
+        };
+
+        if response.error.is_some() {
+            return None;
+        }
+        response.result
+    }
+
+    /// Extract, validate, and record the upstream `serverInfo.name` from an
+    /// `initialize` or `server/discover` result. Sets the adapter unhealthy and
+    /// returns `Err` when the name is missing or fails sanitization. Shared by
+    /// the legacy handshake and the 2026 stateless paths so both name the
+    /// endpoint identically.
+    async fn apply_server_identity(&self, result: &Value) -> Result<(), AdapterError> {
+        // Extract serverInfo.name — REQUIRED per MCP spec enforcement
+        let raw_name = match result
+            .get("serverInfo")
+            .and_then(|si| si.get("name"))
+            .and_then(|n| n.as_str())
+        {
+            Some(name) => name,
+            None => {
+                let err = ServerNameError::Missing;
+                let msg = err.to_string();
+                error!(url = %self.config.url, error = %msg, "MCP server did not provide serverInfo.name");
+                *self.health.write().await = HealthStatus::Unhealthy(msg.clone());
+                return Err(AdapterError::ProtocolError(msg));
+            }
+        };
+
+        // Validate and sanitize the server name
+        let sanitized = match sanitize_server_name(raw_name) {
+            Ok(s) => s,
+            Err(e) => {
+                let msg = e.to_string();
+                error!(url = %self.config.url, raw_name = %raw_name, error = %msg, "serverInfo.name validation failed");
+                *self.health.write().await = HealthStatus::Unhealthy(msg.clone());
+                return Err(AdapterError::ProtocolError(msg));
+            }
+        };
+
+        if let Some(ref ov) = self.config.server_type_override {
+            if sanitize_server_name(ov).is_err() {
+                warn!(
+                    override = %ov,
+                    "server_type_override failed sanitization; falling back to upstream-derived name"
+                );
+            }
+        }
+        let effective = effective_server_type(
+            self.config.server_type_override.clone(),
+            Some(sanitized.clone()),
+        );
+        let upstream_stripped = strip_mcp_server_suffix(sanitized.clone());
+
+        info!(url = %self.config.url, raw_name = %raw_name, sanitized = %sanitized, effective = ?effective, "MCP server reported serverInfo.name");
+        if let Some(ref name) = effective {
+            self.span
+                .record("server_type", tracing::field::display(name));
+        }
+        *self.server_type.write().await = effective;
+        *self.upstream_server_name.write().await = Some(upstream_stripped);
+        Ok(())
+    }
+
+    /// Spawn the long-lived `GET <url>` SSE listener for server-initiated
+    /// notifications (notably `notifications/tools/list_changed`). Snapshots the
+    /// current session id at spawn time (always `None` for 2026 stateless
+    /// upstreams). Shared by the legacy and 2026 initialize paths.
+    async fn spawn_get_listener(&self) {
+        let url = self.config.url.clone();
+        let headers = self.config.headers.clone();
+        // Snapshot the session ID at spawn time so the listener doesn't
+        // need to re-read adapter state. Matches how `headers` is passed.
+        let session_id = self.session_id.read().await.clone();
+        let tx = self.tools_changed_tx.clone();
+        let shutdown = self.shutdown_notify.clone();
+        let listener_span = self.span.clone();
+        let handle = tokio::spawn(
+            async move {
+                Self::run_get_listener(url, headers, session_id, tx, shutdown).await;
+            }
+            .instrument(listener_span),
+        );
+        *self.listener_handle.lock().await = Some(handle);
+    }
 }
 
 impl Drop for HttpAdapter {
@@ -721,6 +921,28 @@ impl McpAdapter for HttpAdapter {
     async fn initialize(&mut self) -> Result<(), AdapterError> {
         async {
             *self.health.write().await = HealthStatus::Starting;
+
+            // Discover-first dialect detection (T7/T8): probe `server/discover`
+            // before the legacy handshake. A 2026 upstream answers with a
+            // `protocolVersion` of `2026-07-28`, in which case the relay skips
+            // the `initialize`/`notifications/initialized` handshake and the
+            // `Mcp-Session-Id` machinery entirely — the 2026 transport is
+            // stateless, carrying version + identity on every request instead.
+            // Any other outcome (legacy result, JSON-RPC error, transport
+            // failure) falls through to the unchanged legacy handshake below.
+            let discover_result = self.try_discover_probe().await;
+            if detect_upstream_dialect(discover_result.as_ref(), None).is_2026() {
+                let result = discover_result.as_ref().expect(
+                    "detect_upstream_dialect reports 2026 only when a discover result is present",
+                );
+                self.set_upstream_dialect(ProtocolVersion::V2026_07_28).await;
+                self.apply_server_identity(result).await?;
+                // 2026 is stateless: no notifications/initialized, no session id.
+                self.spawn_get_listener().await;
+                *self.health.write().await = HealthStatus::Healthy;
+                info!(url = %self.config.url, "HTTP MCP adapter initialized (2026 stateless path)");
+                return Ok(());
+            }
 
             let params = json!({
                 "protocolVersion": ProtocolVersion::V2025_03_26.as_str(),
@@ -874,61 +1096,18 @@ impl McpAdapter for HttpAdapter {
                 }
             };
 
-            // Extract serverInfo.name — REQUIRED per MCP spec enforcement
-            let raw_name = match result
-                .get("serverInfo")
-                .and_then(|si| si.get("name"))
-                .and_then(|n| n.as_str())
-            {
-                Some(name) => name,
-                None => {
-                    let err = ServerNameError::Missing;
-                    let msg = err.to_string();
-                    error!(url = %self.config.url, error = %msg, "MCP server did not provide serverInfo.name");
-                    *self.health.write().await = HealthStatus::Unhealthy(msg.clone());
-                    return Err(AdapterError::ProtocolError(msg));
-                }
-            };
+            // Validate + record the upstream serverInfo.name (REQUIRED per MCP
+            // spec enforcement). Shared with the 2026 stateless path above.
+            self.apply_server_identity(&result).await?;
 
-            // Validate and sanitize the server name
-            let sanitized = match sanitize_server_name(raw_name) {
-                Ok(s) => s,
-                Err(e) => {
-                    let msg = e.to_string();
-                    error!(url = %self.config.url, raw_name = %raw_name, error = %msg, "serverInfo.name validation failed");
-                    *self.health.write().await = HealthStatus::Unhealthy(msg.clone());
-                    return Err(AdapterError::ProtocolError(msg));
-                }
-            };
-
-            if let Some(ref ov) = self.config.server_type_override {
-                if sanitize_server_name(ov).is_err() {
-                    warn!(
-                        override = %ov,
-                        "server_type_override failed sanitization; falling back to upstream-derived name"
-                    );
-                }
-            }
-            let effective = effective_server_type(
-                self.config.server_type_override.clone(),
-                Some(sanitized.clone()),
-            );
-            let upstream_stripped = strip_mcp_server_suffix(sanitized.clone());
-
-            info!(url = %self.config.url, raw_name = %raw_name, sanitized = %sanitized, effective = ?effective, "MCP server reported serverInfo.name");
-            if let Some(ref name) = effective {
-                self.span.record("server_type", tracing::field::display(name));
-            }
-            *self.server_type.write().await = effective;
-            *self.upstream_server_name.write().await = Some(upstream_stripped);
-
-            // Detect and record the upstream's negotiated protocol dialect from
-            // the initialize result before any tool calls are proxied (T7). The
-            // live `server/discover` probe (discover-first path) is wired by T8;
-            // here we pass `None` so legacy upstreams behave byte-for-byte as
-            // before.
-            self.set_upstream_dialect(detect_upstream_dialect(None, Some(&result)))
-                .await;
+            // Record the upstream's negotiated dialect. The discover probe ran
+            // above (legacy result or none) and the initialize result carries
+            // the negotiated legacy version; neither is 2026 on this path.
+            self.set_upstream_dialect(detect_upstream_dialect(
+                discover_result.as_ref(),
+                Some(&result),
+            ))
+            .await;
 
             // Per the MCP spec the client MUST send a notifications/initialized
             // notification after a successful initialize exchange.
@@ -945,21 +1124,7 @@ impl McpAdapter for HttpAdapter {
             // that don't support it return 404/405 and the task exits
             // quietly — inline POST notifications still reach the broadcast
             // via `parse_sse_response`.
-            let url = self.config.url.clone();
-            let headers = self.config.headers.clone();
-            // Snapshot the session ID at spawn time so the listener doesn't
-            // need to re-read adapter state. Matches how `headers` is passed.
-            let session_id = self.session_id.read().await.clone();
-            let tx = self.tools_changed_tx.clone();
-            let shutdown = self.shutdown_notify.clone();
-            let listener_span = self.span.clone();
-            let handle = tokio::spawn(
-                async move {
-                    Self::run_get_listener(url, headers, session_id, tx, shutdown).await;
-                }
-                .instrument(listener_span),
-            );
-            *self.listener_handle.lock().await = Some(handle);
+            self.spawn_get_listener().await;
 
             *self.health.write().await = HealthStatus::Healthy;
             info!(url = %self.config.url, "HTTP MCP adapter initialized");
@@ -2051,6 +2216,228 @@ mod tests {
             Err(AdapterError::HttpError { status: 401, .. }) => {}
             other => panic!("expected HttpError {{ 401 }}, got {:?}", other),
         }
+        server.abort();
+    }
+
+    // --- 2026 stateless Streamable HTTP path (T8) ---
+
+    #[test]
+    fn test_inject_client_info_creates_and_preserves_params() {
+        // None params → a fresh object carrying only `_meta` clientInfo.
+        let injected = HttpAdapter::inject_client_info(None).unwrap();
+        let ci = &injected["_meta"][protocol::META_CLIENT_INFO_KEY];
+        assert_eq!(ci["name"], "endara-relay");
+        assert!(ci["version"].is_string());
+
+        // Existing fields are preserved; `_meta` clientInfo is added.
+        let injected =
+            HttpAdapter::inject_client_info(Some(json!({"name": "echo", "arguments": {}})))
+                .unwrap();
+        assert_eq!(injected["name"], "echo");
+        assert_eq!(
+            injected["_meta"][protocol::META_CLIENT_INFO_KEY]["name"],
+            "endara-relay"
+        );
+    }
+
+    /// Per-POST capture for the 2026 fixture below.
+    struct Captured2026 {
+        method: String,
+        protocol_version: Option<String>,
+        mcp_method: Option<String>,
+        mcp_name: Option<String>,
+        had_session_id: bool,
+        meta_client_info: Option<Value>,
+    }
+
+    #[derive(Clone)]
+    struct Server2026State {
+        seen: Arc<Mutex<Vec<Captured2026>>>,
+    }
+
+    async fn dispatch_2026(
+        State(app): State<Server2026State>,
+        req: axum::extract::Request,
+    ) -> axum::response::Response {
+        if req.method() != axum::http::Method::POST {
+            // 2026 fixture does not implement the GET server-initiated stream.
+            return (StatusCode::METHOD_NOT_ALLOWED, "").into_response();
+        }
+        let headers = req.headers().clone();
+        let body_bytes = match axum::body::to_bytes(req.into_body(), 1024 * 1024).await {
+            Ok(b) => b,
+            Err(_) => return (StatusCode::BAD_REQUEST, "bad body").into_response(),
+        };
+        let body: Value = match serde_json::from_slice(&body_bytes) {
+            Ok(v) => v,
+            Err(_) => return (StatusCode::BAD_REQUEST, "bad json").into_response(),
+        };
+        let method = body["method"].as_str().unwrap_or("").to_string();
+        let id = body["id"].as_u64();
+        let header_str = |name: &str| {
+            headers
+                .get(name)
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string())
+        };
+        app.seen.lock().await.push(Captured2026 {
+            method: method.clone(),
+            protocol_version: header_str("mcp-protocol-version"),
+            mcp_method: header_str("mcp-method"),
+            mcp_name: header_str("mcp-name"),
+            had_session_id: headers.get("mcp-session-id").is_some(),
+            meta_client_info: body
+                .get("params")
+                .and_then(|p| p.get("_meta"))
+                .and_then(|m| m.get(protocol::META_CLIENT_INFO_KEY))
+                .cloned(),
+        });
+
+        let result = match method.as_str() {
+            "server/discover" => json!({
+                "protocolVersion": "2026-07-28",
+                "capabilities": {"tools": {"listChanged": true}},
+                "serverInfo": {"name": "stateless-2026", "version": "1.0.0"},
+                "tools": []
+            }),
+            "tools/list" => json!({
+                "tools": [{
+                    "name": "echo",
+                    "description": "Echoes",
+                    "inputSchema": {"type": "object"}
+                }]
+            }),
+            "tools/call" => json!({"content": [{"type": "text", "text": "ok"}]}),
+            _ => {
+                return Json(json!({
+                    "jsonrpc": "2.0",
+                    "error": {"code": -32601, "message": "Method not found"},
+                    "id": id,
+                }))
+                .into_response();
+            }
+        };
+        // 2026 is stateless: the server never emits `Mcp-Session-Id`.
+        if id.is_some() {
+            Json(json!({"jsonrpc": "2.0", "result": result, "id": id})).into_response()
+        } else {
+            (StatusCode::ACCEPTED, "").into_response()
+        }
+    }
+
+    async fn start_fake_2026_http_server() -> (
+        String,
+        Arc<Mutex<Vec<Captured2026>>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let state = Server2026State { seen: seen.clone() };
+        let app = Router::new()
+            .route("/mcp", any(dispatch_2026))
+            .with_state(state);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{}/mcp", addr);
+        let handle = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        (url, seen, handle)
+    }
+
+    /// 2026 upstream: the `server/discover` probe detects `2026-07-28`, so the
+    /// adapter skips `initialize`/`notifications/initialized`, captures no
+    /// session id, and every POST carries the 2026 routing headers
+    /// (`MCP-Protocol-Version`, `Mcp-Method`, `Mcp-Name` for tool calls) plus
+    /// `_meta` clientInfo and never an `Mcp-Session-Id`.
+    #[tokio::test]
+    async fn test_2026_upstream_stateless_path_headers_and_no_handshake() {
+        let (url, seen, server) = start_fake_2026_http_server().await;
+        let mut adapter = HttpAdapter::new(HttpConfig::new(url));
+        adapter
+            .initialize()
+            .await
+            .expect("2026 initialize succeeds");
+
+        assert_eq!(adapter.health(), HealthStatus::Healthy);
+        assert!(
+            adapter.upstream_dialect().await.is_2026(),
+            "upstream should be detected as 2026"
+        );
+        assert!(
+            adapter.session_id.read().await.is_none(),
+            "no session id is captured on the 2026 stateless path"
+        );
+
+        let tools = adapter.list_tools().await.expect("list_tools");
+        assert_eq!(tools.len(), 1);
+        let call = adapter
+            .call_tool("echo", json!({"message": "hi"}))
+            .await
+            .expect("call_tool");
+        assert_eq!(call["content"][0]["text"], "ok");
+
+        let seen = seen.lock().await;
+        let methods: Vec<&str> = seen.iter().map(|c| c.method.as_str()).collect();
+        assert!(
+            methods.contains(&"server/discover"),
+            "discover probe must be sent, got {methods:?}"
+        );
+        assert!(
+            !methods.contains(&"initialize"),
+            "2026 path must skip initialize, got {methods:?}"
+        );
+        assert!(
+            !methods.contains(&"notifications/initialized"),
+            "2026 path must skip notifications/initialized, got {methods:?}"
+        );
+
+        for c in seen.iter() {
+            assert_eq!(
+                c.protocol_version.as_deref(),
+                Some("2026-07-28"),
+                "every 2026 POST carries MCP-Protocol-Version ({})",
+                c.method
+            );
+            assert_eq!(
+                c.mcp_method.as_deref(),
+                Some(c.method.as_str()),
+                "Mcp-Method mirrors the JSON-RPC method"
+            );
+            assert!(
+                !c.had_session_id,
+                "2026 POSTs never carry Mcp-Session-Id ({})",
+                c.method
+            );
+            assert_eq!(
+                c.meta_client_info
+                    .as_ref()
+                    .and_then(|v| v.get("name"))
+                    .and_then(|n| n.as_str()),
+                Some("endara-relay"),
+                "every 2026 POST carries _meta clientInfo ({})",
+                c.method
+            );
+        }
+
+        let call_rec = seen
+            .iter()
+            .find(|c| c.method == "tools/call")
+            .expect("tools/call recorded");
+        assert_eq!(
+            call_rec.mcp_name.as_deref(),
+            Some("echo"),
+            "Mcp-Name mirrors the tools/call tool name"
+        );
+        let list_rec = seen
+            .iter()
+            .find(|c| c.method == "tools/list")
+            .expect("tools/list recorded");
+        assert!(
+            list_rec.mcp_name.is_none(),
+            "Mcp-Name is absent for methods without a tool name"
+        );
+
+        drop(seen);
         server.abort();
     }
 }

--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -378,8 +378,8 @@ impl HttpAdapter {
 
     /// Apply the 2026 Streamable HTTP per-request headers to `builder`:
     /// `MCP-Protocol-Version` (always), `Mcp-Method` (the JSON-RPC method), and
-    /// `Mcp-Name` (the `params.name` tool name, when present). These let a 2026
-    /// upstream route/observe a request without parsing its body.
+    /// `Mcp-Name` (the `params.name` tool name, for `tools/call` only). These let
+    /// a 2026 upstream route/observe a request without parsing its body.
     fn apply_2026_headers(
         builder: reqwest::RequestBuilder,
         method: &str,
@@ -392,9 +392,14 @@ impl HttpAdapter {
         if let Ok(val) = reqwest::header::HeaderValue::from_str(method) {
             builder = builder.header(MCP_METHOD_HEADER_NAME.clone(), val);
         }
-        if let Some(name) = params.and_then(|p| p.get("name")).and_then(Value::as_str) {
-            if let Ok(val) = reqwest::header::HeaderValue::from_str(name) {
-                builder = builder.header(MCP_NAME_HEADER_NAME.clone(), val);
+        // `Mcp-Name` is tied to `tools/call` by the 2026-07-28 spec: only emit it
+        // for that method, even if another method happens to carry a string
+        // `params.name`.
+        if method == "tools/call" {
+            if let Some(name) = params.and_then(|p| p.get("name")).and_then(Value::as_str) {
+                if let Ok(val) = reqwest::header::HeaderValue::from_str(name) {
+                    builder = builder.header(MCP_NAME_HEADER_NAME.clone(), val);
+                }
             }
         }
         builder
@@ -2281,6 +2286,45 @@ mod tests {
         assert_eq!(
             injected["_meta"][protocol::META_CLIENT_INFO_KEY]["name"],
             "endara-relay"
+        );
+    }
+
+    /// The 2026-07-28 spec ties `Mcp-Name` to `tools/call`: it must be emitted
+    /// for that method (mirroring `params.name`) and never for another method
+    /// that happens to carry a string `params.name`.
+    #[test]
+    fn test_2026_mcp_name_header_scoped_to_tools_call() {
+        let client = reqwest::Client::new();
+        let url = "http://localhost/mcp";
+
+        // (a) tools/call with a string `name` still emits `Mcp-Name`.
+        let req = HttpAdapter::apply_2026_headers(
+            client.post(url),
+            "tools/call",
+            Some(&json!({"name": "echo", "arguments": {}})),
+        )
+        .build()
+        .unwrap();
+        assert_eq!(
+            req.headers()
+                .get(protocol::MCP_NAME_HEADER)
+                .and_then(|v| v.to_str().ok()),
+            Some("echo"),
+            "tools/call emits Mcp-Name from params.name"
+        );
+
+        // (b) a non-tools/call method carrying a string `name` param does NOT
+        // emit `Mcp-Name`.
+        let req = HttpAdapter::apply_2026_headers(
+            client.post(url),
+            "tools/list",
+            Some(&json!({"name": "echo"})),
+        )
+        .build()
+        .unwrap();
+        assert!(
+            req.headers().get(protocol::MCP_NAME_HEADER).is_none(),
+            "non-tools/call method does not emit Mcp-Name even with a string name param"
         );
     }
 

--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -371,6 +371,16 @@ impl HttpAdapter {
     fn inject_client_info(params: Option<Value>) -> Option<Value> {
         let mut params = params.unwrap_or_else(|| json!({}));
         if params.is_object() {
+            // Normalize `_meta` to a JSON object before the nested assignment:
+            // serde_json's `IndexMut` panics on `value[key] = ...` when the
+            // existing value is a non-object/non-null (e.g. an inbound 2026
+            // request that already carries `params._meta` as a String/Array/
+            // number/bool). Replace only a missing/null or non-object `_meta`;
+            // a pre-existing object `_meta` (W3C Trace Context siblings) is
+            // preserved so the clientInfo key is added alongside them.
+            if !params["_meta"].is_object() {
+                params["_meta"] = json!({});
+            }
             params["_meta"][protocol::META_CLIENT_INFO_KEY] = Self::relay_client_info();
         }
         Some(params)
@@ -2283,6 +2293,32 @@ mod tests {
             HttpAdapter::inject_client_info(Some(json!({"name": "echo", "arguments": {}})))
                 .unwrap();
         assert_eq!(injected["name"], "echo");
+        assert_eq!(
+            injected["_meta"][protocol::META_CLIENT_INFO_KEY]["name"],
+            "endara-relay"
+        );
+
+        // A pre-existing OBJECT `_meta` with sibling keys (e.g. W3C Trace
+        // Context) is preserved; clientInfo is added alongside the siblings.
+        let injected = HttpAdapter::inject_client_info(Some(json!({
+            "name": "echo",
+            "_meta": {"traceparent": "tp", "tracestate": "ts"}
+        })))
+        .unwrap();
+        assert_eq!(injected["_meta"]["traceparent"], "tp");
+        assert_eq!(injected["_meta"]["tracestate"], "ts");
+        assert_eq!(
+            injected["_meta"][protocol::META_CLIENT_INFO_KEY]["name"],
+            "endara-relay"
+        );
+
+        // A pre-existing NON-OBJECT `_meta` (here a String) must NOT panic:
+        // it is normalized to an object and clientInfo is still injected.
+        let injected = HttpAdapter::inject_client_info(Some(
+            json!({"name": "echo", "_meta": "not-an-object"}),
+        ))
+        .unwrap();
+        assert!(injected["_meta"].is_object());
         assert_eq!(
             injected["_meta"][protocol::META_CLIENT_INFO_KEY]["name"],
             "endara-relay"

--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -2,7 +2,7 @@ use super::oauth::jit::{self, JitInterceptor};
 use super::server_name::{sanitize_server_name, ServerNameError};
 use super::server_type_resolution::{effective_server_type, strip_mcp_server_suffix};
 use super::stdio::{iso8601_now, RingBuffer};
-use super::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
+use super::{AdapterError, HealthStatus, McpAdapter, ToolInfo, DISCOVER_PROBE_TIMEOUT};
 use crate::events::{
     annotations_from_value, current_request_context, ToolCallEvent, ToolCallEventBus,
 };
@@ -793,31 +793,44 @@ impl HttpAdapter {
         let request = jsonrpc::new_request("server/discover", params, id);
         trace!(method = "server/discover", id = id, url = %self.config.url, "probing upstream protocol dialect");
 
-        let builder = self.client.post(&self.config.url).json(&request);
-        let builder = Self::apply_2026_headers(builder, "server/discover", request.params.as_ref());
-        let resp = builder.send().await.ok()?;
-        if !resp.status().is_success() {
-            return None;
-        }
+        // Bound the probe with a short dedicated timeout (below the full reqwest
+        // transport timeout) so a legacy/unresponsive upstream that silently
+        // drops the unknown request falls back to the legacy handshake fast. A
+        // timeout maps to `None`, the same clean legacy fallback as any other
+        // failure.
+        let probe = async {
+            let builder = self.client.post(&self.config.url).json(&request);
+            let builder =
+                Self::apply_2026_headers(builder, "server/discover", request.params.as_ref());
+            let resp = builder.send().await.ok()?;
+            if !resp.status().is_success() {
+                return None;
+            }
 
-        let content_type = resp
-            .headers()
-            .get(reqwest::header::CONTENT_TYPE)
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("")
-            .to_string();
+            let content_type = resp
+                .headers()
+                .get(reqwest::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("")
+                .to_string();
 
-        let response: JsonRpcResponse = if content_type.contains("text/event-stream") {
-            let body = resp.text().await.ok()?;
-            Self::parse_sse_response(&body, id, Some(&self.tools_changed_tx)).ok()?
-        } else {
-            resp.json().await.ok()?
+            let response: JsonRpcResponse = if content_type.contains("text/event-stream") {
+                let body = resp.text().await.ok()?;
+                Self::parse_sse_response(&body, id, Some(&self.tools_changed_tx)).ok()?
+            } else {
+                resp.json().await.ok()?
+            };
+
+            if response.error.is_some() {
+                return None;
+            }
+            response.result
         };
 
-        if response.error.is_some() {
-            return None;
-        }
-        response.result
+        tokio::time::timeout(DISCOVER_PROBE_TIMEOUT, probe)
+            .await
+            .ok()
+            .flatten()
     }
 
     /// Extract, validate, and record the upstream `serverInfo.name` from an

--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -7,6 +7,7 @@ use crate::events::{
     annotations_from_value, current_request_context, ToolCallEvent, ToolCallEventBus,
 };
 use crate::jsonrpc::{self, JsonRpcResponse};
+use crate::protocol::ProtocolVersion;
 use async_trait::async_trait;
 use reqwest::Client;
 use serde_json::{json, Value};
@@ -120,6 +121,11 @@ pub struct HttpAdapter {
     /// hand it to the JIT interceptor. Per-host challenges are effectively
     /// constant, so a concurrent overwrite is harmless.
     last_www_authenticate: Arc<RwLock<Option<String>>>,
+    /// Negotiated protocol dialect of the upstream server. Defaults to the
+    /// legacy `2025-03-26` version this adapter advertises in `initialize`;
+    /// real negotiation populates it via [`Self::set_upstream_dialect`] (T7).
+    /// Consumed by the 2026 outbound code paths (T8).
+    upstream_dialect: Arc<RwLock<ProtocolVersion>>,
 }
 
 /// HTTP header name reqwest reads/writes for the MCP session ID. Reqwest's
@@ -190,6 +196,7 @@ impl HttpAdapter {
             session_id: Arc::new(RwLock::new(None)),
             jit_interceptor: None,
             last_www_authenticate: Arc::new(RwLock::new(None)),
+            upstream_dialect: Arc::new(RwLock::new(ProtocolVersion::V2025_03_26)),
         }
     }
 
@@ -238,6 +245,7 @@ impl HttpAdapter {
             session_id: Arc::new(RwLock::new(None)),
             jit_interceptor: None,
             last_www_authenticate: Arc::new(RwLock::new(None)),
+            upstream_dialect: Arc::new(RwLock::new(ProtocolVersion::V2025_03_26)),
         }
     }
 
@@ -254,6 +262,20 @@ impl HttpAdapter {
     #[allow(dead_code)]
     pub(crate) fn set_jit_interceptor(&mut self, interceptor: Arc<JitInterceptor>) {
         self.jit_interceptor = Some(interceptor);
+    }
+
+    /// Record the upstream server's negotiated [`ProtocolVersion`]. Wired by
+    /// T7 once real negotiation is implemented; unused today.
+    #[allow(dead_code)]
+    pub(crate) async fn set_upstream_dialect(&self, dialect: ProtocolVersion) {
+        *self.upstream_dialect.write().await = dialect;
+    }
+
+    /// Read the upstream server's negotiated [`ProtocolVersion`]. Defaults to
+    /// the legacy version this adapter advertises until T7 populates it.
+    #[allow(dead_code)]
+    pub(crate) async fn upstream_dialect(&self) -> ProtocolVersion {
+        *self.upstream_dialect.read().await
     }
 
     /// Apply the JIT 401 interception policy to a tool-call outcome.
@@ -701,7 +723,7 @@ impl McpAdapter for HttpAdapter {
             *self.health.write().await = HealthStatus::Starting;
 
             let params = json!({
-                "protocolVersion": "2025-03-26",
+                "protocolVersion": ProtocolVersion::V2025_03_26.as_str(),
                 "capabilities": {},
                 "clientInfo": {
                     "name": "endara-relay",

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -148,6 +148,23 @@ pub trait McpAdapter: Send + Sync {
     /// List the tools available from the MCP server.
     async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError>;
 
+    /// Upstream-provided `ttlMs` freshness hint (SEP-2549) from the most recent
+    /// successful [`Self::list_tools`] call, in milliseconds.
+    ///
+    /// Returns `Some(ms)` only when the upstream peer negotiated the 2026-07-28
+    /// dialect **and** included a top-level `ttlMs` on its `tools/list` result;
+    /// the relay-as-client honors it as the cache freshness window in
+    /// [`crate::registry::RegisteredAdapter::cached_list_tools`]. Returns `None`
+    /// for legacy upstreams or when no hint was sent, preserving the existing
+    /// purely event-driven cache behavior. Implementors clamp a negative
+    /// upstream `ttlMs` to `0` (immediately stale).
+    ///
+    /// The default impl returns `None` (placeholder / read-only adapters never
+    /// emit a caching hint).
+    async fn list_tools_ttl_ms(&self) -> Option<u64> {
+        None
+    }
+
     /// Call a tool on the MCP server.
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError>;
 

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -21,6 +21,28 @@ use std::time::Duration;
 /// short; normal (non-probe) requests keep their full transport timeout.
 pub(crate) const DISCOVER_PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 
+/// Merge extra top-level `tools/call` params into an outgoing params object,
+/// alongside the `name`/`arguments` the adapter already set. Used by the
+/// transport adapters to transparently forward the MCP 2026-07-28 multi
+/// round-trip fields (`inputResponses`, `requestState`) and any sibling params.
+///
+/// Keys never collide with `name`/`arguments` because the inbound handler
+/// strips those before populating `request_params`. An empty map is a no-op, so
+/// a normal terminal `tools/call` request is forwarded byte-for-byte unchanged.
+pub(crate) fn merge_request_params(
+    params: &mut Value,
+    request_params: serde_json::Map<String, Value>,
+) {
+    if request_params.is_empty() {
+        return;
+    }
+    if let Some(obj) = params.as_object_mut() {
+        for (k, v) in request_params {
+            obj.insert(k, v);
+        }
+    }
+}
+
 /// Health status of an adapter.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum HealthStatus {
@@ -128,6 +150,24 @@ pub trait McpAdapter: Send + Sync {
 
     /// Call a tool on the MCP server.
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError>;
+
+    /// Call a tool, forwarding extra top-level `tools/call` params verbatim to
+    /// the upstream alongside `name`/`arguments`. Used to transparently proxy
+    /// the MCP 2026-07-28 multi round-trip fields (`inputResponses`,
+    /// `requestState`) and any other sibling params (e.g. `_meta`) so the relay
+    /// neither interprets nor strips them.
+    ///
+    /// The default implementation ignores the extra params and delegates to
+    /// [`Self::call_tool`]; transports that proxy raw JSON-RPC override it to
+    /// merge `request_params` into the outgoing params object.
+    async fn call_tool_with_request_params(
+        &self,
+        name: &str,
+        arguments: Value,
+        _request_params: serde_json::Map<String, Value>,
+    ) -> Result<Value, AdapterError> {
+        self.call_tool(name, arguments).await
+    }
 
     /// Get the current health status.
     fn health(&self) -> HealthStatus;

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -463,4 +463,42 @@ mod tests {
         };
         assert_eq!(err.to_string(), "HTTP error 404: not found");
     }
+
+    /// D13 — forward direction: an inbound `_meta` carrying W3C Trace Context
+    /// (`traceparent`/`tracestate`/`baggage`) is merged onto the outgoing
+    /// `tools/call` params verbatim, so the relay forwards it to the upstream
+    /// unmodified. The relay is intentionally key-agnostic for `_meta` siblings
+    /// — it copies the whole inbound `_meta` rather than enumerating trace keys.
+    #[test]
+    fn merge_request_params_forwards_meta_trace_context() {
+        let mut params = serde_json::json!({ "name": "echo", "arguments": {} });
+        let mut request_params = serde_json::Map::new();
+        request_params.insert(
+            "_meta".to_string(),
+            serde_json::json!({
+                "traceparent": "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+                "tracestate": "vendor=abc",
+                "baggage": "userId=42"
+            }),
+        );
+        merge_request_params(&mut params, request_params);
+        assert_eq!(
+            params["_meta"]["traceparent"],
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+        );
+        assert_eq!(params["_meta"]["tracestate"], "vendor=abc");
+        assert_eq!(params["_meta"]["baggage"], "userId=42");
+        // name/arguments are untouched.
+        assert_eq!(params["name"], "echo");
+    }
+
+    /// D13 — with no inbound siblings, `merge_request_params` is a no-op, so a
+    /// legacy frame that carried no `_meta` stays byte-for-byte unchanged and
+    /// the relay never injects an empty `_meta` of its own.
+    #[test]
+    fn merge_request_params_no_meta_leaves_params_unchanged() {
+        let mut params = serde_json::json!({ "name": "echo", "arguments": {} });
+        merge_request_params(&mut params, serde_json::Map::new());
+        assert!(params.get("_meta").is_none());
+    }
 }

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -9,6 +9,17 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::fmt;
+use std::time::Duration;
+
+/// Short, dedicated timeout for the upstream `server/discover` dialect probe.
+///
+/// The probe must fail fast to the legacy `initialize` fallback when an upstream
+/// silently drops the unknown request (per the MCP `2026-07-28` stdio
+/// Backward-Compatibility rule: "any other error, or no response within a
+/// reasonable timeout → legacy"). Without this bound the probe would inherit the
+/// 30s per-request timeout and stall startup. Only the probe is bounded this
+/// short; normal (non-probe) requests keep their full transport timeout.
+pub(crate) const DISCOVER_PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// Health status of an adapter.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/adapter/oauth/jit.rs
+++ b/src/adapter/oauth/jit.rs
@@ -28,7 +28,7 @@ use crate::adapter::AdapterError;
 use crate::oauth::dcr::{self, ClientRegistrationResponse};
 use crate::oauth::discovery::{self, DiscoveryError, DiscoveryResult};
 use crate::oauth::{OAuthFlowManager, PkceChallenge};
-use crate::token_manager::{DcrCredentials, TokenManager};
+use crate::token_manager::{dcr_issuer_allows_reuse, merge_scopes, DcrCredentials, TokenManager};
 use serde_json::{json, Value};
 
 /// A parsed `WWW-Authenticate: Bearer ...` challenge.
@@ -261,6 +261,7 @@ impl JitInterceptor {
                 client_secret.as_deref(),
                 pkce,
                 &redirect_uri,
+                Some(&disc.issuer),
             )
             .await;
 
@@ -283,11 +284,23 @@ impl JitInterceptor {
             urlencoding(&state_param),
             urlencoding(&code_challenge),
         );
-        if !disc.scopes_supported.is_empty() {
-            authorize_url.push_str(&format!(
-                "&scope={}",
-                urlencoding(&disc.scopes_supported.join(" "))
-            ));
+        // Scope accumulation for step-up authorization: when this endpoint
+        // already has a persisted token with a granted scope, request the
+        // UNION of previously-granted scopes and the scopes we'd request today
+        // so the user never silently loses access they already granted.
+        let prior_scope = if let Some(ref tm) = self.token_manager {
+            tm.load(endpoint_name)
+                .await
+                .ok()
+                .flatten()
+                .and_then(|t| t.scope)
+        } else {
+            None
+        };
+        let requested_scope = disc.scopes_supported.join(" ");
+        let merged_scope = merge_scopes(prior_scope.as_deref(), &requested_scope);
+        if !merged_scope.is_empty() {
+            authorize_url.push_str(&format!("&scope={}", urlencoding(&merged_scope)));
         }
 
         info!(
@@ -312,7 +325,19 @@ impl JitInterceptor {
     ) -> Result<(String, Option<String>), JitError> {
         if let Some(ref tm) = self.token_manager {
             if let Ok(Some(creds)) = tm.load_dcr(endpoint_name).await {
-                return Ok((creds.client_id, creds.client_secret));
+                // Credential-to-issuer binding: only reuse a stored client_id
+                // with the SAME authorization server that issued it. If the AS
+                // issuer changed, discard and re-register (RFC 7591). Legacy
+                // creds with no stored issuer are reused as-is.
+                if dcr_issuer_allows_reuse(creds.issuer.as_deref(), Some(disc.issuer.as_str())) {
+                    return Ok((creds.client_id, creds.client_secret));
+                }
+                info!(
+                    endpoint = %endpoint_name,
+                    stored_issuer = ?creds.issuer,
+                    current_issuer = %disc.issuer,
+                    "DCR credential issuer changed; discarding stored credentials and re-registering"
+                );
             }
         }
 
@@ -334,6 +359,7 @@ impl JitInterceptor {
                 client_secret: resp.client_secret.clone(),
                 client_secret_expires_at: resp.client_secret_expires_at,
                 registered_at: now_secs(),
+                issuer: Some(disc.issuer.clone()),
             };
             if let Err(e) = tm.save_dcr(endpoint_name, &creds).await {
                 warn!(error = %e, "failed to persist JIT-registered DCR credentials");

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -999,6 +999,16 @@ impl McpAdapter for OAuthAdapter {
         .await
     }
 
+    async fn list_tools_ttl_ms(&self) -> Option<u64> {
+        // Delegate to the inner transport adapter, which captured the upstream
+        // `ttlMs` (gated on its own negotiated dialect) during `list_tools`.
+        let guard = self.inner.inner_adapter.read().await;
+        match guard.as_ref() {
+            Some(adapter) => adapter.list_tools_ttl_ms().await,
+            None => None,
+        }
+    }
+
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
         self.call_tool_with_request_params(name, arguments, serde_json::Map::new())
             .await

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -1000,6 +1000,16 @@ impl McpAdapter for OAuthAdapter {
     }
 
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
+        self.call_tool_with_request_params(name, arguments, serde_json::Map::new())
+            .await
+    }
+
+    async fn call_tool_with_request_params(
+        &self,
+        name: &str,
+        arguments: Value,
+        request_params: serde_json::Map<String, Value>,
+    ) -> Result<Value, AdapterError> {
         // NB: do NOT wrap the inner adapter's `call_tool` invocations in
         // `.instrument(self.inner.span)`. The inner `HttpAdapter::call_tool`
         // captures the caller's per-request span context (`request{request_uid}`,
@@ -1023,7 +1033,10 @@ impl McpAdapter for OAuthAdapter {
             }
         };
 
-        match adapter.call_tool(name, arguments.clone()).await {
+        match adapter
+            .call_tool_with_request_params(name, arguments.clone(), request_params.clone())
+            .await
+        {
             Ok(result) => Ok(result),
             Err(AdapterError::HttpError { status: 401, .. }) => {
                 // Drop the read lock before refreshing
@@ -1047,7 +1060,9 @@ impl McpAdapter for OAuthAdapter {
                                 "Adapter lost during refresh".to_string(),
                             )
                         })?;
-                        adapter.call_tool(name, arguments).await
+                        adapter
+                            .call_tool_with_request_params(name, arguments, request_params)
+                            .await
                     }
                     Err(e) => {
                         async {

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -6,7 +6,7 @@ use crate::events::{
     annotations_from_value, current_request_context, ToolCallEvent, ToolCallEventBus,
 };
 use crate::jsonrpc::{self, JsonRpcResponse};
-use crate::protocol::{detect_upstream_dialect, ProtocolVersion};
+use crate::protocol::{self, detect_upstream_dialect, ProtocolVersion};
 use async_trait::async_trait;
 use reqwest::Client;
 use serde_json::{json, Value};
@@ -249,6 +249,29 @@ impl SseAdapter {
         *self.upstream_dialect.read().await
     }
 
+    /// The relay's own client identity, injected under
+    /// `params._meta["io.modelcontextprotocol/clientInfo"]` on every outbound
+    /// request to a 2026 upstream. The 2026 transport is stateless — there is
+    /// no `initialize` handshake — and the SSE transport carries no per-request
+    /// HTTP headers for identity, so it travels per-request inside `_meta`.
+    fn relay_client_info() -> Value {
+        json!({
+            "name": "endara-relay",
+            "version": env!("CARGO_PKG_VERSION"),
+        })
+    }
+
+    /// Attach the relay's `clientInfo` under `params._meta` for 2026 upstreams,
+    /// creating an empty params object when the request carried none. Non-object
+    /// params are left untouched (MCP params are always objects or absent).
+    fn inject_client_info(params: Option<Value>) -> Option<Value> {
+        let mut params = params.unwrap_or_else(|| json!({}));
+        if params.is_object() {
+            params["_meta"][protocol::META_CLIENT_INFO_KEY] = Self::relay_client_info();
+        }
+        Some(params)
+    }
+
     /// Resolve a relative endpoint URL against the SSE base URL.
     #[allow(dead_code)]
     fn resolve_endpoint(&self, endpoint: &str) -> String {
@@ -481,6 +504,14 @@ impl SseAdapter {
         method: &str,
         params: Option<Value>,
     ) -> Result<(), AdapterError> {
+        // 2026 upstreams: attach `_meta` clientInfo on notifications too, so the
+        // upstream sees the relay's identity per-message. Legacy: unchanged.
+        let params = if self.upstream_dialect.read().await.is_2026() {
+            Self::inject_client_info(params)
+        } else {
+            params
+        };
+
         let endpoint = {
             let guard = self.post_endpoint.read().await;
             guard.clone().ok_or(AdapterError::NotInitialized)?
@@ -534,6 +565,16 @@ impl SseAdapter {
         method: &str,
         params: Option<Value>,
     ) -> Result<Value, AdapterError> {
+        // 2026 upstreams: every request carries the relay's `clientInfo` under
+        // `params._meta` (there is no handshake). SSE carries no per-request
+        // HTTP headers, so version/identity travel entirely in `_meta`.
+        // Legacy: unchanged.
+        let params = if self.upstream_dialect.read().await.is_2026() {
+            Self::inject_client_info(params)
+        } else {
+            params
+        };
+
         let endpoint = {
             let guard = self.post_endpoint.read().await;
             guard.clone().ok_or(AdapterError::NotInitialized)?
@@ -593,59 +634,37 @@ impl SseAdapter {
             .ok_or_else(|| AdapterError::ProtocolError("response has no result".into()))
     }
 
-    /// Connect to the SSE endpoint and perform the MCP initialize handshake.
-    ///
-    /// Used by `initialize()` for the first connection and by the reconnect
-    /// supervisor task to re-establish a healthy connection. On success, sets
-    /// `health = Healthy` and resets the crash tracker. On failure, sets
-    /// `health = Unhealthy(...)` with the underlying error.
-    async fn connect_and_handshake(&self) -> Result<(), AdapterError> {
-        if let Err(e) = self.connect().await {
-            let msg = e.to_string();
-            *self.health.write().await = HealthStatus::Unhealthy(msg);
-            return Err(e);
-        }
+    /// Stateless `server/discover` probe used to detect a 2026 upstream before
+    /// the legacy `initialize` handshake. The request carries the relay's
+    /// `_meta` clientInfo (SSE has no per-request HTTP headers for identity, so
+    /// version/identity travel entirely in `params._meta`). Returns the
+    /// JSON-RPC `result` object on success, or `None` on any failure (JSON-RPC
+    /// error, transport failure, missing result) so the caller falls back to the
+    /// legacy handshake. Legacy servers reject `server/discover` and the relay
+    /// falls back transparently.
+    async fn try_discover_probe(&self) -> Option<Value> {
+        // Build params with `_meta` clientInfo explicitly: the upstream dialect
+        // is still the legacy default here, so `send_request` would not inject
+        // it for us, and a 2026 server expects identity on every request.
+        let params = Self::inject_client_info(None);
+        self.send_request("server/discover", params).await.ok()
+    }
 
-        let params = json!({
-            "protocolVersion": ProtocolVersion::V2024_11_05.as_str(),
-            "capabilities": {},
-            "clientInfo": {
-                "name": "endara-relay",
-                "version": env!("CARGO_PKG_VERSION")
-            }
-        });
-
-        let result = match self.send_request("initialize", Some(params)).await {
-            Ok(r) => r,
-            Err(e) => {
-                let msg = e.to_string();
-                *self.health.write().await = HealthStatus::Unhealthy(msg);
-                return Err(e);
-            }
-        };
-
+    /// Extract, validate, and record the upstream `serverInfo.name` from an
+    /// `initialize` or `server/discover` result. Returns `Err` when the name is
+    /// missing or fails sanitization. Shared by the legacy handshake and the
+    /// 2026 stateless path so both name the endpoint identically. Does not touch
+    /// `health`; the caller maps any error onto `HealthStatus::Unhealthy`.
+    async fn apply_server_identity(&self, result: &Value) -> Result<(), AdapterError> {
         // Extract serverInfo.name — REQUIRED per MCP spec enforcement
-        let raw_name = match result
+        let raw_name = result
             .get("serverInfo")
             .and_then(|si| si.get("name"))
             .and_then(|n| n.as_str())
-        {
-            Some(n) => n.to_string(),
-            None => {
-                let msg = ServerNameError::Missing.to_string();
-                *self.health.write().await = HealthStatus::Unhealthy(msg.clone());
-                return Err(AdapterError::ProtocolError(msg));
-            }
-        };
+            .ok_or_else(|| AdapterError::ProtocolError(ServerNameError::Missing.to_string()))?;
 
-        let sanitized = match sanitize_server_name(&raw_name) {
-            Ok(s) => s,
-            Err(e) => {
-                let msg = e.to_string();
-                *self.health.write().await = HealthStatus::Unhealthy(msg.clone());
-                return Err(AdapterError::ProtocolError(msg));
-            }
-        };
+        let sanitized = sanitize_server_name(raw_name)
+            .map_err(|e| AdapterError::ProtocolError(e.to_string()))?;
 
         if let Some(ref ov) = self.config.server_type_override {
             if sanitize_server_name(ov).is_err() {
@@ -668,13 +687,84 @@ impl SseAdapter {
         }
         *self.server_type.write().await = effective;
         *self.upstream_server_name.write().await = Some(upstream_stripped);
+        Ok(())
+    }
 
-        // Detect and record the upstream's negotiated protocol dialect from the
-        // initialize result before any tool calls are proxied (T7). The live
-        // `server/discover` probe (discover-first path) is wired by T9; here we
-        // pass `None` so legacy upstreams behave byte-for-byte as before.
-        self.set_upstream_dialect(detect_upstream_dialect(None, Some(&result)))
-            .await;
+    /// Connect to the SSE endpoint and perform the MCP initialize handshake.
+    ///
+    /// Used by `initialize()` for the first connection and by the reconnect
+    /// supervisor task to re-establish a healthy connection. On success, sets
+    /// `health = Healthy` and resets the crash tracker. On failure, sets
+    /// `health = Unhealthy(...)` with the underlying error.
+    async fn connect_and_handshake(&self) -> Result<(), AdapterError> {
+        if let Err(e) = self.connect().await {
+            let msg = e.to_string();
+            *self.health.write().await = HealthStatus::Unhealthy(msg);
+            return Err(e);
+        }
+
+        // Discover-first dialect detection (T9): probe `server/discover` before
+        // the legacy handshake. A 2026 upstream answers with a `protocolVersion`
+        // of `2026-07-28`, in which case the relay skips the `initialize`/
+        // `notifications/initialized` handshake entirely — the 2026 transport is
+        // stateless, carrying version + identity in `params._meta` on every
+        // request instead. Any other outcome (legacy result, JSON-RPC error,
+        // transport failure) falls through to the unchanged legacy handshake.
+        let discover_result = self.try_discover_probe().await;
+        if detect_upstream_dialect(discover_result.as_ref(), None).is_2026() {
+            let result = discover_result.as_ref().expect(
+                "detect_upstream_dialect reports 2026 only when a discover result is present",
+            );
+            self.set_upstream_dialect(ProtocolVersion::V2026_07_28)
+                .await;
+            if let Err(e) = self.apply_server_identity(result).await {
+                let msg = e.to_string();
+                *self.health.write().await = HealthStatus::Unhealthy(msg);
+                return Err(e);
+            }
+            // 2026 is stateless: no notifications/initialized handshake.
+            *self.health.write().await = HealthStatus::Healthy;
+            self.crash_tracker.lock().await.reset();
+            let _ = self.tools_changed_tx.send(());
+            info!(url = %self.config.url, "MCP initialize skipped (2026 stateless path)");
+            return Ok(());
+        }
+
+        let params = json!({
+            "protocolVersion": ProtocolVersion::V2024_11_05.as_str(),
+            "capabilities": {},
+            "clientInfo": {
+                "name": "endara-relay",
+                "version": env!("CARGO_PKG_VERSION")
+            }
+        });
+
+        let result = match self.send_request("initialize", Some(params)).await {
+            Ok(r) => r,
+            Err(e) => {
+                let msg = e.to_string();
+                *self.health.write().await = HealthStatus::Unhealthy(msg);
+                return Err(e);
+            }
+        };
+
+        // Validate + record the upstream serverInfo.name (REQUIRED per MCP spec
+        // enforcement). Shared with the 2026 stateless path above; map any error
+        // onto the adapter's health before returning.
+        if let Err(e) = self.apply_server_identity(&result).await {
+            let msg = e.to_string();
+            *self.health.write().await = HealthStatus::Unhealthy(msg);
+            return Err(e);
+        }
+
+        // Detect and record the upstream's negotiated protocol dialect. The
+        // discover probe ran above (legacy result or none) and the initialize
+        // result carries the negotiated legacy version; neither is 2026 here.
+        self.set_upstream_dialect(detect_upstream_dialect(
+            discover_result.as_ref(),
+            Some(&result),
+        ))
+        .await;
 
         // Per the MCP spec the client MUST send a notifications/initialized
         // notification after a successful initialize exchange. Failure is
@@ -1092,6 +1182,9 @@ mod tests {
             /// When true, /message does NOT broadcast `tools/call` responses
             /// (used to test pending-request error propagation).
             silent_on_tools_call: AtomicBool,
+            /// When true, /message answers `server/discover` with a `2026-07-28`
+            /// result (used to test the 2026 stateless version-gating path).
+            discover_returns_2026: AtomicBool,
             /// Bodies of every POST /message received, in arrival order.
             posts: std::sync::Mutex<Vec<Value>>,
         }
@@ -1186,6 +1279,17 @@ mod tests {
 
             let id = body["id"].as_u64().unwrap_or(0);
             let response = match method.as_str() {
+                "server/discover" if app.fake.discover_returns_2026.load(Ordering::SeqCst) => {
+                    json!({
+                        "jsonrpc": "2.0",
+                        "result": {
+                            "protocolVersion": "2026-07-28",
+                            "capabilities": {"tools": {}},
+                            "serverInfo": {"name": "fake-sse-2026", "version": "1.0.0"}
+                        },
+                        "id": id,
+                    })
+                }
                 "initialize" => json!({
                     "jsonrpc": "2.0",
                     "result": {
@@ -1193,6 +1297,11 @@ mod tests {
                         "capabilities": {"tools": {}},
                         "serverInfo": {"name": "fake-sse", "version": "0.0.0"}
                     },
+                    "id": id,
+                }),
+                "tools/list" => json!({
+                    "jsonrpc": "2.0",
+                    "result": {"tools": []},
                     "id": id,
                 }),
                 _ => json!({
@@ -1642,6 +1751,117 @@ mod tests {
                 elapsed
             );
             assert_eq!(adapter.health(), HealthStatus::Stopped);
+        }
+
+        #[test]
+        fn test_inject_client_info_creates_and_preserves_params() {
+            // None params → a fresh object carrying only `_meta` clientInfo.
+            let injected = SseAdapter::inject_client_info(None).unwrap();
+            let ci = &injected["_meta"][protocol::META_CLIENT_INFO_KEY];
+            assert_eq!(ci["name"], "endara-relay");
+            assert!(ci["version"].is_string());
+
+            // Existing fields are preserved; `_meta` clientInfo is added.
+            let injected =
+                SseAdapter::inject_client_info(Some(json!({"name": "echo", "arguments": {}})))
+                    .unwrap();
+            assert_eq!(injected["name"], "echo");
+            assert_eq!(
+                injected["_meta"][protocol::META_CLIENT_INFO_KEY]["name"],
+                "endara-relay"
+            );
+        }
+
+        /// 2026 upstream over SSE: the `server/discover` probe detects
+        /// `2026-07-28`, so the adapter skips `initialize`/
+        /// `notifications/initialized` entirely, and every subsequent POST
+        /// carries `_meta` clientInfo (SSE has no per-request identity headers).
+        #[tokio::test]
+        async fn test_sse_2026_path_skips_handshake_and_injects_meta() {
+            let server = start_test_server().await;
+            server
+                .state
+                .discover_returns_2026
+                .store(true, Ordering::SeqCst);
+
+            let mut adapter = build_adapter(&server.url, 3).await;
+            adapter
+                .initialize()
+                .await
+                .expect("2026 initialize succeeds");
+            assert!(
+                adapter.upstream_dialect().await.is_2026(),
+                "upstream should be detected as 2026"
+            );
+            let _ = adapter.list_tools().await.expect("list_tools");
+            adapter.shutdown().await.unwrap();
+
+            let posts = server.state.posts.lock().unwrap().clone();
+            let methods: Vec<&str> = posts.iter().filter_map(|p| p["method"].as_str()).collect();
+            assert!(
+                methods.contains(&"server/discover"),
+                "discover probe must be sent, got {methods:?}"
+            );
+            assert!(
+                !methods.contains(&"initialize"),
+                "2026 path must skip initialize, got {methods:?}"
+            );
+            assert!(
+                !methods.contains(&"notifications/initialized"),
+                "2026 path must skip notifications/initialized, got {methods:?}"
+            );
+            for p in &posts {
+                assert_eq!(
+                    p["params"]["_meta"][protocol::META_CLIENT_INFO_KEY]["name"].as_str(),
+                    Some("endara-relay"),
+                    "every 2026 POST must carry _meta clientInfo, got: {p:?}"
+                );
+            }
+        }
+
+        /// Legacy upstream over SSE: the `server/discover` probe returns a
+        /// non-2026 result, so the full `initialize`/`notifications/initialized`
+        /// handshake runs and the relay injects no `_meta` clientInfo on the
+        /// handshake frames.
+        #[tokio::test]
+        async fn test_sse_legacy_path_runs_handshake_without_meta() {
+            let server = start_test_server().await;
+            let mut adapter = build_adapter(&server.url, 3).await;
+            adapter
+                .initialize()
+                .await
+                .expect("legacy initialize succeeds");
+            assert!(
+                !adapter.upstream_dialect().await.is_2026(),
+                "upstream should be detected as legacy"
+            );
+            adapter.shutdown().await.unwrap();
+
+            let posts = server.state.posts.lock().unwrap().clone();
+            let methods: Vec<&str> = posts.iter().filter_map(|p| p["method"].as_str()).collect();
+            assert!(
+                methods.contains(&"server/discover"),
+                "discover probe must precede the legacy handshake, got {methods:?}"
+            );
+            assert!(
+                methods.contains(&"initialize"),
+                "legacy path must run initialize, got {methods:?}"
+            );
+            assert!(
+                methods.contains(&"notifications/initialized"),
+                "legacy path must send notifications/initialized, got {methods:?}"
+            );
+            // Only the discover probe carries `_meta` (it is sent before the
+            // dialect is known); the legacy handshake frames must not.
+            for p in &posts {
+                if p["method"].as_str() == Some("server/discover") {
+                    continue;
+                }
+                assert!(
+                    p["params"].get("_meta").is_none(),
+                    "legacy frame must not carry _meta, got: {p:?}"
+                );
+            }
         }
     }
 }

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -6,6 +6,7 @@ use crate::events::{
     annotations_from_value, current_request_context, ToolCallEvent, ToolCallEventBus,
 };
 use crate::jsonrpc::{self, JsonRpcResponse};
+use crate::protocol::ProtocolVersion;
 use async_trait::async_trait;
 use reqwest::Client;
 use serde_json::{json, Value};
@@ -163,6 +164,11 @@ pub struct SseAdapter {
     /// `call_tool` can attach hint metadata to the overlay's `started`
     /// event without a second round-trip.
     tool_annotations_cache: Arc<RwLock<HashMap<String, Option<Value>>>>,
+    /// Negotiated protocol dialect of the upstream server. Defaults to the
+    /// legacy `2024-11-05` version this adapter advertises in `initialize`;
+    /// real negotiation populates it via [`Self::set_upstream_dialect`] (T7).
+    /// Consumed by the 2026 outbound code paths (T9).
+    upstream_dialect: Arc<RwLock<ProtocolVersion>>,
 }
 
 impl SseAdapter {
@@ -221,11 +227,26 @@ impl SseAdapter {
             span,
             event_bus: Arc::new(OnceLock::new()),
             tool_annotations_cache: Arc::new(RwLock::new(HashMap::new())),
+            upstream_dialect: Arc::new(RwLock::new(ProtocolVersion::V2024_11_05)),
         }
     }
 
     fn next_id(&self) -> u64 {
         self.request_id.fetch_add(1, Ordering::SeqCst)
+    }
+
+    /// Record the upstream server's negotiated [`ProtocolVersion`]. Wired by
+    /// T7/T9 once real negotiation is implemented; unused today.
+    #[allow(dead_code)]
+    pub(crate) async fn set_upstream_dialect(&self, dialect: ProtocolVersion) {
+        *self.upstream_dialect.write().await = dialect;
+    }
+
+    /// Read the upstream server's negotiated [`ProtocolVersion`]. Defaults to
+    /// the legacy version this adapter advertises until T7/T9 populates it.
+    #[allow(dead_code)]
+    pub(crate) async fn upstream_dialect(&self) -> ProtocolVersion {
+        *self.upstream_dialect.read().await
     }
 
     /// Resolve a relative endpoint URL against the SSE base URL.
@@ -586,7 +607,7 @@ impl SseAdapter {
         }
 
         let params = json!({
-            "protocolVersion": "2024-11-05",
+            "protocolVersion": ProtocolVersion::V2024_11_05.as_str(),
             "capabilities": {},
             "clientInfo": {
                 "name": "endara-relay",

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -6,7 +6,7 @@ use crate::events::{
     annotations_from_value, current_request_context, ToolCallEvent, ToolCallEventBus,
 };
 use crate::jsonrpc::{self, JsonRpcResponse};
-use crate::protocol::ProtocolVersion;
+use crate::protocol::{detect_upstream_dialect, ProtocolVersion};
 use async_trait::async_trait;
 use reqwest::Client;
 use serde_json::{json, Value};
@@ -235,9 +235,9 @@ impl SseAdapter {
         self.request_id.fetch_add(1, Ordering::SeqCst)
     }
 
-    /// Record the upstream server's negotiated [`ProtocolVersion`]. Wired by
-    /// T7/T9 once real negotiation is implemented; unused today.
-    #[allow(dead_code)]
+    /// Record the upstream server's negotiated [`ProtocolVersion`]. Populated
+    /// during the connect/handshake path (T7); consumed by the 2026 outbound
+    /// code paths (T9).
     pub(crate) async fn set_upstream_dialect(&self, dialect: ProtocolVersion) {
         *self.upstream_dialect.write().await = dialect;
     }
@@ -668,6 +668,13 @@ impl SseAdapter {
         }
         *self.server_type.write().await = effective;
         *self.upstream_server_name.write().await = Some(upstream_stripped);
+
+        // Detect and record the upstream's negotiated protocol dialect from the
+        // initialize result before any tool calls are proxied (T7). The live
+        // `server/discover` probe (discover-first path) is wired by T9; here we
+        // pass `None` so legacy upstreams behave byte-for-byte as before.
+        self.set_upstream_dialect(detect_upstream_dialect(None, Some(&result)))
+            .await;
 
         // Per the MCP spec the client MUST send a notifications/initialized
         // notification after a successful initialize exchange. Failure is

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -169,6 +169,11 @@ pub struct SseAdapter {
     /// real negotiation populates it via [`Self::set_upstream_dialect`] (T7).
     /// Consumed by the 2026 outbound code paths (T9).
     upstream_dialect: Arc<RwLock<ProtocolVersion>>,
+    /// Upstream `ttlMs` freshness hint (SEP-2549) captured from the most recent
+    /// successful `tools/list` result. `Some(ms)` only for 2026 upstreams that
+    /// sent a top-level `ttlMs`; `None` otherwise. Read by the registry cache to
+    /// honor the upstream's freshness window. See [`Self::list_tools_ttl_ms`].
+    list_ttl_ms: Arc<RwLock<Option<u64>>>,
 }
 
 impl SseAdapter {
@@ -228,6 +233,7 @@ impl SseAdapter {
             event_bus: Arc::new(OnceLock::new()),
             tool_annotations_cache: Arc::new(RwLock::new(HashMap::new())),
             upstream_dialect: Arc::new(RwLock::new(ProtocolVersion::V2024_11_05)),
+            list_ttl_ms: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -886,6 +892,15 @@ impl McpAdapter for SseAdapter {
                 .get("tools")
                 .ok_or_else(|| AdapterError::ProtocolError("missing 'tools' field".into()))?;
             let tools: Vec<ToolInfo> = serde_json::from_value(tools_value.clone())?;
+            // Capture the upstream `ttlMs` freshness hint (SEP-2549) only for
+            // 2026 upstreams; legacy upstreams never carry it and keep the
+            // existing event-driven cache behavior. Read by the registry cache.
+            let ttl = if self.upstream_dialect.read().await.is_2026() {
+                protocol::ttl_ms_from_result(&result)
+            } else {
+                None
+            };
+            *self.list_ttl_ms.write().await = ttl;
             // Refresh the per-tool annotations cache for overlay events.
             let mut cache = self.tool_annotations_cache.write().await;
             cache.clear();
@@ -897,6 +912,10 @@ impl McpAdapter for SseAdapter {
         }
         .instrument(self.span.clone())
         .await
+    }
+
+    async fn list_tools_ttl_ms(&self) -> Option<u64> {
+        *self.list_ttl_ms.read().await
     }
 
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -900,6 +900,16 @@ impl McpAdapter for SseAdapter {
     }
 
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
+        self.call_tool_with_request_params(name, arguments, serde_json::Map::new())
+            .await
+    }
+
+    async fn call_tool_with_request_params(
+        &self,
+        name: &str,
+        arguments: Value,
+        request_params: serde_json::Map<String, Value>,
+    ) -> Result<Value, AdapterError> {
         // Capture caller span context BEFORE `.instrument(self.span)` re-enters
         // the adapter's own `endpoint` span — endpoint is constructed at
         // adapter init time with no parent linkage to per-request spans, so
@@ -930,10 +940,11 @@ impl McpAdapter for SseAdapter {
                     client: span_ctx.client.clone(),
                 });
             }
-            let params = json!({
+            let mut params = json!({
                 "name": name,
                 "arguments": arguments,
             });
+            crate::adapter::merge_request_params(&mut params, request_params);
             let start = Instant::now();
             let result = self.send_request("tools/call", Some(params)).await;
             let duration_ms = start.elapsed().as_millis();

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -1,7 +1,7 @@
 use super::server_name::{sanitize_server_name, ServerNameError};
 use super::server_type_resolution::{effective_server_type, strip_mcp_server_suffix};
 use super::stdio::{iso8601_now, RingBuffer};
-use super::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
+use super::{AdapterError, HealthStatus, McpAdapter, ToolInfo, DISCOVER_PROBE_TIMEOUT};
 use crate::events::{
     annotations_from_value, current_request_context, ToolCallEvent, ToolCallEventBus,
 };
@@ -647,7 +647,20 @@ impl SseAdapter {
         // is still the legacy default here, so `send_request` would not inject
         // it for us, and a 2026 server expects identity on every request.
         let params = Self::inject_client_info(None);
-        self.send_request("server/discover", params).await.ok()
+        // Bound the probe with a short dedicated timeout (below the full
+        // `timeout_secs` transport timeout) so an unresponsive/legacy upstream
+        // that silently drops the unknown request falls back to the legacy
+        // handshake fast. A timeout maps to `None`, the same clean legacy
+        // fallback as any other failure.
+        match tokio::time::timeout(
+            DISCOVER_PROBE_TIMEOUT,
+            self.send_request("server/discover", params),
+        )
+        .await
+        {
+            Ok(res) => res.ok(),
+            Err(_) => None,
+        }
     }
 
     /// Extract, validate, and record the upstream `serverInfo.name` from an

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -273,6 +273,16 @@ impl SseAdapter {
     fn inject_client_info(params: Option<Value>) -> Option<Value> {
         let mut params = params.unwrap_or_else(|| json!({}));
         if params.is_object() {
+            // Normalize `_meta` to a JSON object before the nested assignment:
+            // serde_json's `IndexMut` panics on `value[key] = ...` when the
+            // existing value is a non-object/non-null (e.g. an inbound 2026
+            // request that already carries `params._meta` as a String/Array/
+            // number/bool). Replace only a missing/null or non-object `_meta`;
+            // a pre-existing object `_meta` (W3C Trace Context siblings) is
+            // preserved so the clientInfo key is added alongside them.
+            if !params["_meta"].is_object() {
+                params["_meta"] = json!({});
+            }
             params["_meta"][protocol::META_CLIENT_INFO_KEY] = Self::relay_client_info();
         }
         Some(params)
@@ -1809,6 +1819,32 @@ mod tests {
                 SseAdapter::inject_client_info(Some(json!({"name": "echo", "arguments": {}})))
                     .unwrap();
             assert_eq!(injected["name"], "echo");
+            assert_eq!(
+                injected["_meta"][protocol::META_CLIENT_INFO_KEY]["name"],
+                "endara-relay"
+            );
+
+            // A pre-existing OBJECT `_meta` with sibling keys (e.g. W3C Trace
+            // Context) is preserved; clientInfo is added alongside the siblings.
+            let injected = SseAdapter::inject_client_info(Some(json!({
+                "name": "echo",
+                "_meta": {"traceparent": "tp", "tracestate": "ts"}
+            })))
+            .unwrap();
+            assert_eq!(injected["_meta"]["traceparent"], "tp");
+            assert_eq!(injected["_meta"]["tracestate"], "ts");
+            assert_eq!(
+                injected["_meta"][protocol::META_CLIENT_INFO_KEY]["name"],
+                "endara-relay"
+            );
+
+            // A pre-existing NON-OBJECT `_meta` (here a String) must NOT panic:
+            // it is normalized to an object and clientInfo is still injected.
+            let injected = SseAdapter::inject_client_info(Some(
+                json!({"name": "echo", "_meta": "not-an-object"}),
+            ))
+            .unwrap();
+            assert!(injected["_meta"].is_object());
             assert_eq!(
                 injected["_meta"][protocol::META_CLIENT_INFO_KEY]["name"],
                 "endara-relay"

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -6,6 +6,7 @@ use crate::events::{
     annotations_from_value, current_request_context, ToolCallEvent, ToolCallEventBus,
 };
 use crate::jsonrpc::{self, JsonRpcResponse};
+use crate::protocol::ProtocolVersion;
 use crate::shell_env;
 use async_trait::async_trait;
 use serde::Serialize;
@@ -383,6 +384,11 @@ pub struct StdioAdapter {
     /// [`McpAdapter::isolation_state`]. `None` until the first spawn. Uses a
     /// `std::sync::RwLock` so the sync accessor can read it without await.
     isolation_state: Arc<std::sync::RwLock<Option<IsolationState>>>,
+    /// Negotiated protocol dialect of the upstream server. Defaults to the
+    /// legacy `2024-11-05` version this adapter advertises in `initialize`;
+    /// real negotiation populates it via [`Self::set_upstream_dialect`] (T7).
+    /// Consumed by the 2026 outbound code paths (T9).
+    upstream_dialect: Arc<RwLock<ProtocolVersion>>,
     // Background task handles
     _stderr_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
     _stdout_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
@@ -417,6 +423,7 @@ impl StdioAdapter {
             container_stats: Arc::new(std::sync::RwLock::new(None)),
             stats_poller_handle: Arc::new(Mutex::new(None)),
             isolation_state: Arc::new(std::sync::RwLock::new(None)),
+            upstream_dialect: Arc::new(RwLock::new(ProtocolVersion::V2024_11_05)),
             _stderr_handle: Arc::new(Mutex::new(None)),
             _stdout_handle: Arc::new(Mutex::new(None)),
         }
@@ -424,6 +431,20 @@ impl StdioAdapter {
 
     fn next_id(&self) -> u64 {
         self.request_id.fetch_add(1, Ordering::SeqCst)
+    }
+
+    /// Record the upstream server's negotiated [`ProtocolVersion`]. Wired by
+    /// T7/T9 once real negotiation is implemented; unused today.
+    #[allow(dead_code)]
+    pub(crate) async fn set_upstream_dialect(&self, dialect: ProtocolVersion) {
+        *self.upstream_dialect.write().await = dialect;
+    }
+
+    /// Read the upstream server's negotiated [`ProtocolVersion`]. Defaults to
+    /// the legacy version this adapter advertises until T7/T9 populates it.
+    #[allow(dead_code)]
+    pub(crate) async fn upstream_dialect(&self) -> ProtocolVersion {
+        *self.upstream_dialect.read().await
     }
 
     /// Spawn the child process and set up I/O pipes.
@@ -766,7 +787,7 @@ impl StdioAdapter {
     /// notification is logged at `warn!` level but does not fail the handshake.
     async fn mcp_initialize(&self) -> Result<(), AdapterError> {
         let params = json!({
-            "protocolVersion": "2024-11-05",
+            "protocolVersion": ProtocolVersion::V2024_11_05.as_str(),
             "capabilities": {},
             "clientInfo": {
                 "name": "endara-relay",

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -389,6 +389,11 @@ pub struct StdioAdapter {
     /// real negotiation populates it via [`Self::set_upstream_dialect`] (T7).
     /// Consumed by the 2026 outbound code paths (T9).
     upstream_dialect: Arc<RwLock<ProtocolVersion>>,
+    /// Upstream `ttlMs` freshness hint (SEP-2549) captured from the most recent
+    /// successful `tools/list` result. `Some(ms)` only for 2026 upstreams that
+    /// sent a top-level `ttlMs`; `None` otherwise. Read by the registry cache to
+    /// honor the upstream's freshness window. See [`Self::list_tools_ttl_ms`].
+    list_ttl_ms: Arc<RwLock<Option<u64>>>,
     // Background task handles
     _stderr_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
     _stdout_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
@@ -424,6 +429,7 @@ impl StdioAdapter {
             stats_poller_handle: Arc::new(Mutex::new(None)),
             isolation_state: Arc::new(std::sync::RwLock::new(None)),
             upstream_dialect: Arc::new(RwLock::new(ProtocolVersion::V2024_11_05)),
+            list_ttl_ms: Arc::new(RwLock::new(None)),
             _stderr_handle: Arc::new(Mutex::new(None)),
             _stdout_handle: Arc::new(Mutex::new(None)),
         }
@@ -984,6 +990,15 @@ impl McpAdapter for StdioAdapter {
                 .get("tools")
                 .ok_or_else(|| AdapterError::ProtocolError("missing 'tools' field".into()))?;
             let tools: Vec<ToolInfo> = serde_json::from_value(tools_value.clone())?;
+            // Capture the upstream `ttlMs` freshness hint (SEP-2549) only for
+            // 2026 upstreams; legacy upstreams never carry it and keep the
+            // existing event-driven cache behavior. Read by the registry cache.
+            let ttl = if self.upstream_dialect.read().await.is_2026() {
+                protocol::ttl_ms_from_result(&result)
+            } else {
+                None
+            };
+            *self.list_ttl_ms.write().await = ttl;
             // Refresh the per-tool annotations cache used by `call_tool` to
             // join hint metadata onto the overlay's `started` event. Mirrors
             // the registry's tool cache lifecycle: rewritten on every
@@ -1000,6 +1015,10 @@ impl McpAdapter for StdioAdapter {
         }
         .instrument(self.span.clone())
         .await
+    }
+
+    async fn list_tools_ttl_ms(&self) -> Option<u64> {
+        *self.list_ttl_ms.read().await
     }
 
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -6,7 +6,7 @@ use crate::events::{
     annotations_from_value, current_request_context, ToolCallEvent, ToolCallEventBus,
 };
 use crate::jsonrpc::{self, JsonRpcResponse};
-use crate::protocol::ProtocolVersion;
+use crate::protocol::{detect_upstream_dialect, ProtocolVersion};
 use crate::shell_env;
 use async_trait::async_trait;
 use serde::Serialize;
@@ -433,9 +433,9 @@ impl StdioAdapter {
         self.request_id.fetch_add(1, Ordering::SeqCst)
     }
 
-    /// Record the upstream server's negotiated [`ProtocolVersion`]. Wired by
-    /// T7/T9 once real negotiation is implemented; unused today.
-    #[allow(dead_code)]
+    /// Record the upstream server's negotiated [`ProtocolVersion`]. Populated
+    /// during the `initialize` handshake (T7); consumed by the 2026 outbound
+    /// code paths (T9).
     pub(crate) async fn set_upstream_dialect(&self, dialect: ProtocolVersion) {
         *self.upstream_dialect.write().await = dialect;
     }
@@ -839,6 +839,13 @@ impl StdioAdapter {
         }
         *self.server_type.write().await = effective;
         *self.upstream_server_name.write().await = Some(upstream_stripped);
+
+        // Detect and record the upstream's negotiated protocol dialect from the
+        // initialize result before any tool calls are proxied (T7). The live
+        // `server/discover` probe (discover-first path) is wired by T9; here we
+        // pass `None` so legacy upstreams behave byte-for-byte as before.
+        self.set_upstream_dialect(detect_upstream_dialect(None, Some(&result)))
+            .await;
 
         // Per the MCP spec the client MUST send a notifications/initialized
         // notification after a successful initialize exchange. Strict servers

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -1003,6 +1003,16 @@ impl McpAdapter for StdioAdapter {
     }
 
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
+        self.call_tool_with_request_params(name, arguments, serde_json::Map::new())
+            .await
+    }
+
+    async fn call_tool_with_request_params(
+        &self,
+        name: &str,
+        arguments: Value,
+        request_params: serde_json::Map<String, Value>,
+    ) -> Result<Value, AdapterError> {
         // Pull JSON-RPC id and profile from the surrounding tracing spans
         // (`request{id=...}` / `mcp_request{profile=...}`) BEFORE re-entering
         // the adapter's own `endpoint` span — the endpoint span was created
@@ -1036,10 +1046,11 @@ impl McpAdapter for StdioAdapter {
                     client: span_ctx.client.clone(),
                 });
             }
-            let params = json!({
+            let mut params = json!({
                 "name": name,
                 "arguments": arguments,
             });
+            crate::adapter::merge_request_params(&mut params, request_params);
             let start = Instant::now();
             let result = self.send_request("tools/call", Some(params)).await;
             let duration_ms = start.elapsed().as_millis();

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -1,6 +1,6 @@
 use super::server_name::{sanitize_server_name, ServerNameError};
 use super::server_type_resolution::{effective_server_type, strip_mcp_server_suffix};
-use super::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
+use super::{AdapterError, HealthStatus, McpAdapter, ToolInfo, DISCOVER_PROBE_TIMEOUT};
 use crate::container_stats::{self, ContainerStats, StatsSlot};
 use crate::events::{
     annotations_from_value, current_request_context, ToolCallEvent, ToolCallEventBus,
@@ -829,7 +829,19 @@ impl StdioAdapter {
         // is still the legacy default here, so `send_request` would not inject
         // it for us, and a 2026 server expects identity on every request.
         let params = Self::inject_client_info(None);
-        self.send_request("server/discover", params).await.ok()
+        // Bound the probe with a short dedicated timeout (instead of inheriting
+        // `send_request`'s 30s default) so a legacy upstream that silently drops
+        // the unknown request falls back to the legacy handshake fast. A timeout
+        // maps to `None`, the same clean legacy fallback as any other failure.
+        match tokio::time::timeout(
+            DISCOVER_PROBE_TIMEOUT,
+            self.send_request("server/discover", params),
+        )
+        .await
+        {
+            Ok(res) => res.ok(),
+            Err(_) => None,
+        }
     }
 
     /// Extract, validate, and record the upstream `serverInfo.name` from an
@@ -2217,6 +2229,121 @@ with open(record_path, "w") as rec:
             frames[3]["params"].get("_meta").is_none(),
             "legacy tools/list frame must not carry _meta, got: {:?}",
             frames[3]
+        );
+    }
+
+    /// Silent-drop upstream over stdio: the legacy server never answers the
+    /// `server/discover` probe (T9) but responds normally to `initialize`. The
+    /// probe must fail fast via [`DISCOVER_PROBE_TIMEOUT`] and the relay must
+    /// fall back to the legacy handshake well within the bound — NOT stall on the
+    /// 30s per-request default. This is the MCP `2026-07-28` "no response within
+    /// a reasonable timeout → legacy" rule.
+    #[tokio::test]
+    async fn test_stdio_silent_discover_falls_back_to_initialize_fast() {
+        // Python mock: record every received line, answer `initialize` and
+        // `tools/list`, but SILENTLY DROP `server/discover` (no response).
+        let script = r#"
+import sys, json, os
+record_path = os.environ["RECORD_PATH"]
+with open(record_path, "w") as rec:
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        rec.write(line + "\n")
+        rec.flush()
+        try:
+            req = json.loads(line)
+        except Exception:
+            continue
+        method = req.get("method")
+        req_id = req.get("id")
+        if req_id is None:
+            continue
+        if method == "server/discover":
+            # Silently drop the unknown probe — emit no response at all.
+            continue
+        if method == "initialize":
+            resp = {
+                "jsonrpc": "2.0",
+                "result": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "serverInfo": {"name": "test", "version": "0.1"},
+                },
+                "id": req_id,
+            }
+        elif method == "tools/list":
+            resp = {"jsonrpc": "2.0", "result": {"tools": []}, "id": req_id}
+        else:
+            resp = {"jsonrpc": "2.0", "result": {}, "id": req_id}
+        sys.stdout.write(json.dumps(resp) + "\n")
+        sys.stdout.flush()
+"#;
+        let record_path = std::env::temp_dir().join(format!(
+            "endara-stdio-silent-discover-{}-{}.log",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let mut env = HashMap::new();
+        env.insert(
+            "RECORD_PATH".to_string(),
+            record_path.to_string_lossy().into_owned(),
+        );
+        let mut adapter = StdioAdapter::new(StdioConfig {
+            command: "python3".to_string(),
+            args: vec!["-u".to_string(), "-c".to_string(), script.to_string()],
+            env,
+            ..Default::default()
+        });
+
+        let start = Instant::now();
+        (&mut adapter as &mut dyn McpAdapter)
+            .initialize()
+            .await
+            .unwrap();
+        let elapsed = start.elapsed();
+
+        // The probe is bounded by DISCOVER_PROBE_TIMEOUT, then the legacy
+        // handshake runs. The whole thing must complete far below the 30s
+        // per-request default — well under 10s leaves generous CI headroom while
+        // still proving we did not stall on the 30s path.
+        assert!(
+            elapsed < Duration::from_secs(10),
+            "initialize must fall back fast after a silent discover probe, took {:?}",
+            elapsed
+        );
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        adapter.shutdown().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let recorded = std::fs::read_to_string(&record_path)
+            .expect("record file should exist after handshake");
+        let _ = std::fs::remove_file(&record_path);
+        let frames: Vec<Value> = recorded
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str(l).expect("each recorded line is valid JSON"))
+            .collect();
+
+        let methods: Vec<&str> = frames.iter().filter_map(|f| f["method"].as_str()).collect();
+        // The probe was still sent (then dropped), and the relay fell back to the
+        // legacy handshake.
+        assert!(
+            methods.contains(&"server/discover"),
+            "discover probe must be sent, got {methods:?}"
+        );
+        assert!(
+            methods.contains(&"initialize"),
+            "must fall back to legacy initialize, got {methods:?}"
+        );
+        assert!(
+            methods.contains(&"notifications/initialized"),
+            "legacy fallback must send notifications/initialized, got {methods:?}"
         );
     }
 

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -471,6 +471,16 @@ impl StdioAdapter {
     fn inject_client_info(params: Option<Value>) -> Option<Value> {
         let mut params = params.unwrap_or_else(|| json!({}));
         if params.is_object() {
+            // Normalize `_meta` to a JSON object before the nested assignment:
+            // serde_json's `IndexMut` panics on `value[key] = ...` when the
+            // existing value is a non-object/non-null (e.g. an inbound 2026
+            // request that already carries `params._meta` as a String/Array/
+            // number/bool). Replace only a missing/null or non-object `_meta`;
+            // a pre-existing object `_meta` (W3C Trace Context siblings) is
+            // preserved so the clientInfo key is added alongside them.
+            if !params["_meta"].is_object() {
+                params["_meta"] = json!({});
+            }
             params["_meta"][protocol::META_CLIENT_INFO_KEY] = Self::relay_client_info();
         }
         Some(params)
@@ -2390,6 +2400,32 @@ with open(record_path, "w") as rec:
             StdioAdapter::inject_client_info(Some(json!({"name": "echo", "arguments": {}})))
                 .unwrap();
         assert_eq!(injected["name"], "echo");
+        assert_eq!(
+            injected["_meta"][crate::protocol::META_CLIENT_INFO_KEY]["name"],
+            "endara-relay"
+        );
+
+        // A pre-existing OBJECT `_meta` with sibling keys (e.g. W3C Trace
+        // Context) is preserved; clientInfo is added alongside the siblings.
+        let injected = StdioAdapter::inject_client_info(Some(json!({
+            "name": "echo",
+            "_meta": {"traceparent": "tp", "tracestate": "ts"}
+        })))
+        .unwrap();
+        assert_eq!(injected["_meta"]["traceparent"], "tp");
+        assert_eq!(injected["_meta"]["tracestate"], "ts");
+        assert_eq!(
+            injected["_meta"][crate::protocol::META_CLIENT_INFO_KEY]["name"],
+            "endara-relay"
+        );
+
+        // A pre-existing NON-OBJECT `_meta` (here a String) must NOT panic:
+        // it is normalized to an object and clientInfo is still injected.
+        let injected = StdioAdapter::inject_client_info(Some(
+            json!({"name": "echo", "_meta": "not-an-object"}),
+        ))
+        .unwrap();
+        assert!(injected["_meta"].is_object());
         assert_eq!(
             injected["_meta"][crate::protocol::META_CLIENT_INFO_KEY]["name"],
             "endara-relay"

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -6,7 +6,7 @@ use crate::events::{
     annotations_from_value, current_request_context, ToolCallEvent, ToolCallEventBus,
 };
 use crate::jsonrpc::{self, JsonRpcResponse};
-use crate::protocol::{detect_upstream_dialect, ProtocolVersion};
+use crate::protocol::{self, detect_upstream_dialect, ProtocolVersion};
 use crate::shell_env;
 use async_trait::async_trait;
 use serde::Serialize;
@@ -447,6 +447,29 @@ impl StdioAdapter {
         *self.upstream_dialect.read().await
     }
 
+    /// The relay's own client identity, injected under
+    /// `params._meta["io.modelcontextprotocol/clientInfo"]` on every outbound
+    /// request to a 2026 upstream. The 2026 transport is stateless — there is
+    /// no `initialize` handshake — and stdio carries no HTTP headers, so
+    /// identity travels per-request inside `_meta`.
+    fn relay_client_info() -> Value {
+        json!({
+            "name": "endara-relay",
+            "version": env!("CARGO_PKG_VERSION"),
+        })
+    }
+
+    /// Attach the relay's `clientInfo` under `params._meta` for 2026 upstreams,
+    /// creating an empty params object when the request carried none. Non-object
+    /// params are left untouched (MCP params are always objects or absent).
+    fn inject_client_info(params: Option<Value>) -> Option<Value> {
+        let mut params = params.unwrap_or_else(|| json!({}));
+        if params.is_object() {
+            params["_meta"][protocol::META_CLIENT_INFO_KEY] = Self::relay_client_info();
+        }
+        Some(params)
+    }
+
     /// Spawn the child process and set up I/O pipes.
     async fn spawn_process(&self) -> Result<(), AdapterError> {
         *self.health.write().await = HealthStatus::Starting;
@@ -673,6 +696,15 @@ impl StdioAdapter {
         method: &str,
         params: Option<Value>,
     ) -> Result<Value, AdapterError> {
+        // 2026 upstreams: every request carries the relay's `clientInfo` under
+        // `params._meta` (there is no handshake). stdio has no HTTP headers, so
+        // version/identity travel entirely in `_meta`. Legacy: unchanged.
+        let params = if self.upstream_dialect.read().await.is_2026() {
+            Self::inject_client_info(params)
+        } else {
+            params
+        };
+
         let id = self.next_id();
         let request = jsonrpc::new_request(method, params, id);
         let mut line = serde_json::to_string(&request)?;
@@ -757,6 +789,14 @@ impl StdioAdapter {
         method: &str,
         params: Option<Value>,
     ) -> Result<(), AdapterError> {
+        // 2026 upstreams: attach `_meta` clientInfo on notifications too, so the
+        // upstream sees the relay's identity per-message. Legacy: unchanged.
+        let params = if self.upstream_dialect.read().await.is_2026() {
+            Self::inject_client_info(params)
+        } else {
+            params
+        };
+
         let notification = jsonrpc::new_notification(method, params);
         let mut line = serde_json::to_string(&notification)?;
         line.push('\n');
@@ -776,27 +816,27 @@ impl StdioAdapter {
         Ok(())
     }
 
-    /// Perform the MCP initialize handshake.
-    ///
-    /// This method enforces that the server MUST provide a valid `serverInfo.name`
-    /// in the initialize response. If the name is missing, empty, or reduces to
-    /// empty after sanitization, the handshake fails with a ProtocolError.
-    ///
-    /// On success, a `notifications/initialized` notification is sent to the
-    /// server (per the MCP spec) before returning. A failure to send that
-    /// notification is logged at `warn!` level but does not fail the handshake.
-    async fn mcp_initialize(&self) -> Result<(), AdapterError> {
-        let params = json!({
-            "protocolVersion": ProtocolVersion::V2024_11_05.as_str(),
-            "capabilities": {},
-            "clientInfo": {
-                "name": "endara-relay",
-                "version": env!("CARGO_PKG_VERSION")
-            }
-        });
+    /// Stateless `server/discover` probe used to detect a 2026 upstream before
+    /// the legacy `initialize` handshake. The request carries the relay's
+    /// `_meta` clientInfo (stdio has no HTTP headers, so version/identity travel
+    /// entirely in `params._meta`). Returns the JSON-RPC `result` object on
+    /// success, or `None` on any failure (JSON-RPC error, transport failure,
+    /// missing result) so the caller falls back to the legacy handshake. Legacy
+    /// servers reject `server/discover` (e.g. method-not-found / request before
+    /// initialize) and the relay falls back transparently.
+    async fn try_discover_probe(&self) -> Option<Value> {
+        // Build params with `_meta` clientInfo explicitly: the upstream dialect
+        // is still the legacy default here, so `send_request` would not inject
+        // it for us, and a 2026 server expects identity on every request.
+        let params = Self::inject_client_info(None);
+        self.send_request("server/discover", params).await.ok()
+    }
 
-        let result = self.send_request("initialize", Some(params)).await?;
-
+    /// Extract, validate, and record the upstream `serverInfo.name` from an
+    /// `initialize` or `server/discover` result. Returns `Err` when the name is
+    /// missing or fails sanitization. Shared by the legacy handshake and the
+    /// 2026 stateless path so both name the endpoint identically.
+    async fn apply_server_identity(&self, result: &Value) -> Result<(), AdapterError> {
         // Extract serverInfo.name — REQUIRED per MCP spec enforcement
         let raw_name = result
             .get("serverInfo")
@@ -839,13 +879,62 @@ impl StdioAdapter {
         }
         *self.server_type.write().await = effective;
         *self.upstream_server_name.write().await = Some(upstream_stripped);
+        Ok(())
+    }
 
-        // Detect and record the upstream's negotiated protocol dialect from the
-        // initialize result before any tool calls are proxied (T7). The live
-        // `server/discover` probe (discover-first path) is wired by T9; here we
-        // pass `None` so legacy upstreams behave byte-for-byte as before.
-        self.set_upstream_dialect(detect_upstream_dialect(None, Some(&result)))
-            .await;
+    /// Perform the MCP initialize handshake.
+    ///
+    /// This method enforces that the server MUST provide a valid `serverInfo.name`
+    /// in the initialize response. If the name is missing, empty, or reduces to
+    /// empty after sanitization, the handshake fails with a ProtocolError.
+    ///
+    /// On success, a `notifications/initialized` notification is sent to the
+    /// server (per the MCP spec) before returning. A failure to send that
+    /// notification is logged at `warn!` level but does not fail the handshake.
+    async fn mcp_initialize(&self) -> Result<(), AdapterError> {
+        // Discover-first dialect detection (T9): probe `server/discover` before
+        // the legacy handshake. A 2026 upstream answers with a `protocolVersion`
+        // of `2026-07-28`, in which case the relay skips the `initialize`/
+        // `notifications/initialized` handshake entirely — the 2026 transport is
+        // stateless, carrying version + identity in `params._meta` on every
+        // request instead. Any other outcome (legacy result, JSON-RPC error,
+        // transport failure) falls through to the unchanged legacy handshake.
+        let discover_result = self.try_discover_probe().await;
+        if detect_upstream_dialect(discover_result.as_ref(), None).is_2026() {
+            let result = discover_result.as_ref().expect(
+                "detect_upstream_dialect reports 2026 only when a discover result is present",
+            );
+            self.set_upstream_dialect(ProtocolVersion::V2026_07_28)
+                .await;
+            self.apply_server_identity(result).await?;
+            // 2026 is stateless: no notifications/initialized handshake.
+            info!("MCP initialize skipped (2026 stateless path)");
+            return Ok(());
+        }
+
+        let params = json!({
+            "protocolVersion": ProtocolVersion::V2024_11_05.as_str(),
+            "capabilities": {},
+            "clientInfo": {
+                "name": "endara-relay",
+                "version": env!("CARGO_PKG_VERSION")
+            }
+        });
+
+        let result = self.send_request("initialize", Some(params)).await?;
+
+        // Validate + record the upstream serverInfo.name (REQUIRED per MCP spec
+        // enforcement). Shared with the 2026 stateless path above.
+        self.apply_server_identity(&result).await?;
+
+        // Detect and record the upstream's negotiated protocol dialect. The
+        // discover probe ran above (legacy result or none) and the initialize
+        // result carries the negotiated legacy version; neither is 2026 here.
+        self.set_upstream_dialect(detect_upstream_dialect(
+            discover_result.as_ref(),
+            Some(&result),
+        ))
+        .await;
 
         // Per the MCP spec the client MUST send a notifications/initialized
         // notification after a successful initialize exchange. Strict servers
@@ -2007,7 +2096,9 @@ for line in sys.stdin:
     async fn test_stdio_sends_initialized_notification_after_handshake() {
         // Python script that records every received stdin line to a file
         // (path passed via the RECORD_PATH env var) and responds to the
-        // initialize and tools/list requests with minimal valid results.
+        // initialize and tools/list requests with minimal valid results. The
+        // `server/discover` probe (T9) is answered with an empty result, so the
+        // adapter detects a legacy upstream and runs the full handshake.
         let script = r#"
 import sys, json, os
 record_path = os.environ["RECORD_PATH"]
@@ -2085,26 +2176,177 @@ with open(record_path, "w") as rec:
             .collect();
 
         assert!(
-            frames.len() >= 3,
-            "expected at least 3 frames, got {}: {:?}",
+            frames.len() >= 4,
+            "expected at least 4 frames, got {}: {:?}",
             frames.len(),
             frames
         );
-        assert_eq!(frames[0]["method"].as_str(), Some("initialize"));
+        // The discover-first probe (T9) precedes the legacy handshake. It is the
+        // only legacy-path frame that carries `_meta` clientInfo (it is sent
+        // before the dialect is known, so identity is attached explicitly).
+        assert_eq!(frames[0]["method"].as_str(), Some("server/discover"));
+        assert_eq!(
+            frames[0]["params"]["_meta"][crate::protocol::META_CLIENT_INFO_KEY]["name"].as_str(),
+            Some("endara-relay"),
+            "discover probe must carry _meta clientInfo, got: {:?}",
+            frames[0]
+        );
+        assert_eq!(frames[1]["method"].as_str(), Some("initialize"));
         assert!(
-            frames[0].get("id").and_then(|v| v.as_u64()).is_some(),
+            frames[1].get("id").and_then(|v| v.as_u64()).is_some(),
             "initialize frame must carry a numeric id"
         );
+        // Legacy upstream: the relay must NOT inject `_meta` clientInfo on the
+        // handshake/tool frames — only the 2026 stateless path does.
+        assert!(
+            frames[1]["params"].get("_meta").is_none(),
+            "legacy initialize frame must not carry _meta, got: {:?}",
+            frames[1]
+        );
         assert_eq!(
-            frames[1]["method"].as_str(),
+            frames[2]["method"].as_str(),
             Some("notifications/initialized")
         );
         assert!(
-            frames[1].get("id").is_none(),
+            frames[2].get("id").is_none(),
             "notifications/initialized frame must not have an id field, got: {:?}",
-            frames[1]
+            frames[2]
         );
-        assert_eq!(frames[2]["method"].as_str(), Some("tools/list"));
+        assert_eq!(frames[3]["method"].as_str(), Some("tools/list"));
+        assert!(
+            frames[3]["params"].get("_meta").is_none(),
+            "legacy tools/list frame must not carry _meta, got: {:?}",
+            frames[3]
+        );
+    }
+
+    #[test]
+    fn test_inject_client_info_creates_and_preserves_params() {
+        // None params → a fresh object carrying only `_meta` clientInfo.
+        let injected = StdioAdapter::inject_client_info(None).unwrap();
+        let ci = &injected["_meta"][crate::protocol::META_CLIENT_INFO_KEY];
+        assert_eq!(ci["name"], "endara-relay");
+        assert!(ci["version"].is_string());
+
+        // Existing fields are preserved; `_meta` clientInfo is added.
+        let injected =
+            StdioAdapter::inject_client_info(Some(json!({"name": "echo", "arguments": {}})))
+                .unwrap();
+        assert_eq!(injected["name"], "echo");
+        assert_eq!(
+            injected["_meta"][crate::protocol::META_CLIENT_INFO_KEY]["name"],
+            "endara-relay"
+        );
+    }
+
+    /// 2026 upstream over stdio: the `server/discover` probe detects
+    /// `2026-07-28`, so the adapter skips `initialize`/
+    /// `notifications/initialized` entirely, and every subsequent request
+    /// carries `_meta` clientInfo (stdio has no HTTP headers, so identity travels
+    /// in `params._meta`).
+    #[tokio::test]
+    async fn test_stdio_2026_path_skips_handshake_and_injects_meta() {
+        // Python mock: answer `server/discover` with a 2026 result + serverInfo;
+        // respond to `tools/list`; record every received line.
+        let script = r#"
+import sys, json, os
+record_path = os.environ["RECORD_PATH"]
+with open(record_path, "w") as rec:
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        rec.write(line + "\n")
+        rec.flush()
+        try:
+            req = json.loads(line)
+        except Exception:
+            continue
+        method = req.get("method")
+        req_id = req.get("id")
+        if req_id is None:
+            continue
+        if method == "server/discover":
+            resp = {
+                "jsonrpc": "2.0",
+                "result": {
+                    "protocolVersion": "2026-07-28",
+                    "capabilities": {},
+                    "serverInfo": {"name": "test-2026", "version": "1.0"},
+                },
+                "id": req_id,
+            }
+        elif method == "tools/list":
+            resp = {"jsonrpc": "2.0", "result": {"tools": []}, "id": req_id}
+        else:
+            resp = {"jsonrpc": "2.0", "result": {}, "id": req_id}
+        sys.stdout.write(json.dumps(resp) + "\n")
+        sys.stdout.flush()
+"#;
+        let record_path = std::env::temp_dir().join(format!(
+            "endara-stdio-2026-{}-{}.log",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let mut env = HashMap::new();
+        env.insert(
+            "RECORD_PATH".to_string(),
+            record_path.to_string_lossy().into_owned(),
+        );
+        let mut adapter = StdioAdapter::new(StdioConfig {
+            command: "python3".to_string(),
+            args: vec!["-u".to_string(), "-c".to_string(), script.to_string()],
+            env,
+            ..Default::default()
+        });
+
+        (&mut adapter as &mut dyn McpAdapter)
+            .initialize()
+            .await
+            .unwrap();
+        assert!(
+            adapter.upstream_dialect().await.is_2026(),
+            "upstream should be detected as 2026"
+        );
+        let _ = adapter.list_tools().await.unwrap();
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        adapter.shutdown().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let recorded = std::fs::read_to_string(&record_path)
+            .expect("record file should exist after 2026 discover + list_tools");
+        let _ = std::fs::remove_file(&record_path);
+        let frames: Vec<Value> = recorded
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str(l).expect("each recorded line is valid JSON"))
+            .collect();
+
+        let methods: Vec<&str> = frames.iter().filter_map(|f| f["method"].as_str()).collect();
+        assert!(
+            methods.contains(&"server/discover"),
+            "discover probe must be sent, got {methods:?}"
+        );
+        assert!(
+            !methods.contains(&"initialize"),
+            "2026 path must skip initialize, got {methods:?}"
+        );
+        assert!(
+            !methods.contains(&"notifications/initialized"),
+            "2026 path must skip notifications/initialized, got {methods:?}"
+        );
+        // Every recorded frame on the 2026 path carries `_meta` clientInfo.
+        for f in &frames {
+            assert_eq!(
+                f["params"]["_meta"][crate::protocol::META_CLIENT_INFO_KEY]["name"].as_str(),
+                Some("endara-relay"),
+                "every 2026 frame must carry _meta clientInfo, got: {f:?}"
+            );
+        }
     }
 
     /// End-to-end sanity check that `request_uid` flows from the surrounding

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -68,7 +68,7 @@ mod tests {
     fn test_request_serialization_roundtrip() {
         let req = new_request(
             "initialize",
-            Some(json!({"protocolVersion": "2025-03-26"})),
+            Some(json!({"protocolVersion": crate::protocol::VERSION_2025_03_26})),
             1,
         );
         let serialized = serde_json::to_string(&req).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod oauth;
 pub mod observability;
 pub mod prefix;
 pub mod profile_registry;
+pub mod protocol;
 pub mod registry;
 pub mod server;
 pub mod shell_env;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod container_stats;
 mod jsonrpc;
 mod prefix;
 mod profile_registry;
+mod protocol;
 mod registry;
 mod server;
 mod shell_env;

--- a/src/management.rs
+++ b/src/management.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, OnceLock};
 use std::time::Instant;
 use tokio::sync::RwLock;
 
-use tracing::warn;
+use tracing::{info, warn};
 
 use crate::adapter::http::{HttpAdapter, HttpConfig};
 use crate::adapter::oauth::OAuthState;
@@ -27,7 +27,7 @@ use crate::observability::payloads::StoredPayloads;
 use crate::observability::store::{AggregateBucket, CallRecord, QueryFilter};
 use crate::profile_registry::ProfileRegistry;
 use crate::registry::AdapterRegistry;
-use crate::token_manager::{DcrCredentials, TokenManager};
+use crate::token_manager::{dcr_issuer_allows_reuse, merge_scopes, DcrCredentials, TokenManager};
 use crate::OAuthAdapterInners;
 
 // ---------------------------------------------------------------------------
@@ -1133,6 +1133,7 @@ async fn oauth_start(
         registration_endpoint,
         discovered_scopes,
         auth_server_label,
+        issuer,
     ) = if let Some(ref server_url) = oauth_server_url {
         // Prefer RFC 8414 discovery against the configured AS URL. If it
         // succeeds, use the discovered endpoints (explicit token_endpoint
@@ -1150,6 +1151,7 @@ async fn oauth_start(
                     disc.registration_endpoint,
                     disc.scopes_supported,
                     Some(disc.auth_server_url),
+                    Some(disc.issuer),
                 )
             }
             Err(e) => {
@@ -1168,6 +1170,7 @@ async fn oauth_start(
                     None::<String>,
                     Vec::<String>::new(),
                     None::<String>,
+                    None::<String>,
                 )
             }
         }
@@ -1180,6 +1183,7 @@ async fn oauth_start(
                 disc.registration_endpoint,
                 disc.scopes_supported,
                 Some(disc.auth_server_url),
+                Some(disc.issuer),
             ),
             Err(e) => {
                 return error_response(
@@ -1213,6 +1217,24 @@ async fn oauth_start(
         }
     } else {
         None
+    };
+
+    // Credential-to-issuer binding: if the stored DCR credentials were
+    // registered against a DIFFERENT authorization server issuer than the one
+    // we just discovered, discard them so resolution falls through to dynamic
+    // re-registration (RFC 7591), exactly as if no creds existed. Legacy creds
+    // with no stored issuer are reused as-is (backward compatibility).
+    let persisted_dcr = match persisted_dcr {
+        Some(creds) if !dcr_issuer_allows_reuse(creds.issuer.as_deref(), issuer.as_deref()) => {
+            info!(
+                endpoint = %name,
+                stored_issuer = ?creds.issuer,
+                current_issuer = ?issuer,
+                "DCR credential issuer changed; discarding stored credentials and re-registering"
+            );
+            None
+        }
+        other => other,
     };
 
     let (client_id, client_secret, dcr_used) = if let Some(cid) = config_client_id {
@@ -1249,6 +1271,7 @@ async fn oauth_start(
                             .duration_since(std::time::UNIX_EPOCH)
                             .unwrap_or_default()
                             .as_secs(),
+                        issuer: issuer.clone(),
                     };
                     if let Err(e) = tm.save_dcr(&name, &creds).await {
                         warn!(endpoint = %name, error = %e, "Failed to persist DCR credentials");
@@ -1304,6 +1327,7 @@ async fn oauth_start(
             client_secret.as_deref(),
             pkce,
             &redirect_uri,
+            issuer.as_deref(),
         )
         .await;
 
@@ -1317,11 +1341,20 @@ async fn oauth_start(
         urlencoding(&code_challenge),
     );
 
-    // Prefer config scopes; fall back to discovered scopes
+    // Scope accumulation for step-up authorization: union the scopes we'd
+    // request today (config scopes) with any previously-granted scopes from a
+    // persisted TokenSet, so re-authorizing for more access never drops scopes
+    // the user already granted. First login (no prior token) is unchanged.
     let effective_scopes = scopes.unwrap_or_default();
-    if !effective_scopes.is_empty() {
-        let scope_str = effective_scopes.join(" ");
-        authorize_url.push_str(&format!("&scope={}", urlencoding(&scope_str)));
+    let requested_scope = effective_scopes.join(" ");
+    let prior_scope = if let Some(ref tm) = state.token_manager {
+        tm.load(&name).await.ok().flatten().and_then(|t| t.scope)
+    } else {
+        None
+    };
+    let merged_scope = merge_scopes(prior_scope.as_deref(), &requested_scope);
+    if !merged_scope.is_empty() {
+        authorize_url.push_str(&format!("&scope={}", urlencoding(&merged_scope)));
     }
 
     let discovery_info = auth_server_label.map(|auth_server| OAuthDiscoveryInfo {
@@ -1377,6 +1410,9 @@ async fn oauth_credentials(
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs(),
+        // Manually-supplied credentials are user-managed, not bound to a
+        // discovered issuer; leave None so they are always reused as-is.
+        issuer: None,
     };
 
     if let Err(e) = tm.save_dcr(&name, &creds).await {
@@ -1441,6 +1477,9 @@ async fn set_endpoint_credentials(
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs(),
+        // Manually-supplied credentials are user-managed, not bound to a
+        // discovered issuer; leave None so they are always reused as-is.
+        issuer: None,
     };
 
     if let Err(e) = tm.save_dcr(&name, &creds).await {
@@ -2019,6 +2058,7 @@ async fn oauth_setup(
     let registration_endpoint = disc.registration_endpoint.clone();
     let discovered_scopes = disc.scopes_supported.clone();
     let auth_server_url = disc.auth_server_url.clone();
+    let issuer = disc.issuer.clone();
 
     setup_mgr
         .get_session_mut(&session_id, |s| {
@@ -2026,6 +2066,7 @@ async fn oauth_setup(
             s.token_endpoint = Some(disc.token_endpoint.clone());
             s.registration_endpoint = disc.registration_endpoint.clone();
             s.oauth_server_url = Some(disc.auth_server_url.clone());
+            s.issuer = Some(disc.issuer.clone());
         })
         .await;
 
@@ -2058,6 +2099,8 @@ async fn oauth_setup(
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap_or_default()
                     .as_secs(),
+                // Manually-supplied credentials are user-managed; not issuer-bound.
+                issuer: None,
             };
             if let Err(e) = tm.save_dcr(&body.name, &creds).await {
                 warn!(endpoint = %body.name, error = %e, "Failed to persist manual credentials");
@@ -2084,6 +2127,7 @@ async fn oauth_setup(
                             .duration_since(std::time::UNIX_EPOCH)
                             .unwrap_or_default()
                             .as_secs(),
+                        issuer: Some(issuer.clone()),
                     };
                     if let Err(e) = tm.save_dcr(&body.name, &creds).await {
                         warn!(endpoint = %body.name, error = %e, "Failed to persist DCR credentials");
@@ -2120,6 +2164,7 @@ async fn oauth_setup(
                     client_secret.as_deref(),
                     pkce,
                     &redirect_uri,
+                    Some(issuer.as_str()),
                 )
                 .await;
 
@@ -2132,10 +2177,21 @@ async fn oauth_setup(
                 urlencoding(&code_challenge),
             );
 
-            if let Some(ref scope_str) = scopes_str {
-                if !scope_str.is_empty() {
-                    authorize_url.push_str(&format!("&scope={}", urlencoding(scope_str)));
-                }
+            // Scope accumulation: union any previously-granted scopes (from a
+            // persisted TokenSet for this name) with the requested scopes.
+            let requested_scope = scopes_str.clone().unwrap_or_default();
+            let prior_scope = if let Some(ref tm) = state.token_manager {
+                tm.load(&body.name)
+                    .await
+                    .ok()
+                    .flatten()
+                    .and_then(|t| t.scope)
+            } else {
+                None
+            };
+            let merged_scope = merge_scopes(prior_scope.as_deref(), &requested_scope);
+            if !merged_scope.is_empty() {
+                authorize_url.push_str(&format!("&scope={}", urlencoding(&merged_scope)));
             }
 
             let discovery_info = OAuthDiscoveryInfo {
@@ -2227,11 +2283,13 @@ async fn oauth_setup_credentials(
                 s.token_endpoint.clone(),
                 s.scopes.clone(),
                 s.name.clone(),
+                s.issuer.clone(),
             )
         })
         .await;
 
-    let Some((Some(auth_endpoint), Some(token_endpoint), scopes, name)) = session_data else {
+    let Some((Some(auth_endpoint), Some(token_endpoint), scopes, name, issuer)) = session_data
+    else {
         return error_response(StatusCode::NOT_FOUND, "session not found or expired", None)
             .into_response();
     };
@@ -2246,6 +2304,8 @@ async fn oauth_setup_credentials(
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs(),
+            // Manually-supplied credentials are user-managed; not issuer-bound.
+            issuer: None,
         };
         if let Err(e) = tm.save_dcr(&name, &creds).await {
             warn!(endpoint = %name, error = %e, "Failed to persist manual credentials");
@@ -2264,6 +2324,7 @@ async fn oauth_setup_credentials(
             body.client_secret.as_deref(),
             pkce,
             &redirect_uri,
+            issuer.as_deref(),
         )
         .await;
 
@@ -2276,10 +2337,17 @@ async fn oauth_setup_credentials(
         urlencoding(&code_challenge),
     );
 
-    if let Some(ref scope_str) = scopes {
-        if !scope_str.is_empty() {
-            authorize_url.push_str(&format!("&scope={}", urlencoding(scope_str)));
-        }
+    // Scope accumulation: union previously-granted scopes (from a persisted
+    // TokenSet for this endpoint) with the requested scopes for step-up.
+    let requested_scope = scopes.clone().unwrap_or_default();
+    let prior_scope = if let Some(ref tm) = state.token_manager {
+        tm.load(&name).await.ok().flatten().and_then(|t| t.scope)
+    } else {
+        None
+    };
+    let merged_scope = merge_scopes(prior_scope.as_deref(), &requested_scope);
+    if !merged_scope.is_empty() {
+        authorize_url.push_str(&format!("&scope={}", urlencoding(&merged_scope)));
     }
 
     Json(serde_json::json!({
@@ -7035,6 +7103,7 @@ command = "echo"
                 client_secret: Some("dcr-secret".to_string()),
                 client_secret_expires_at: 0,
                 registered_at: 1_700_000_000,
+                issuer: None,
             },
         )
         .await
@@ -7499,6 +7568,7 @@ command = "echo"
             client_secret: Some("from-dcr".to_string()),
             client_secret_expires_at: 0,
             registered_at: 0,
+            issuer: None,
         };
         token_manager.save_dcr("ep1", &creds).await.unwrap();
 
@@ -7560,6 +7630,7 @@ command = "echo"
             client_secret: Some("stale-dcr-secret".to_string()),
             client_secret_expires_at: 0,
             registered_at: 0,
+            issuer: None,
         };
         token_manager.save_dcr("ep1", &creds).await.unwrap();
 

--- a/src/oauth/dcr.rs
+++ b/src/oauth/dcr.rs
@@ -15,6 +15,9 @@ pub struct ClientRegistrationRequest {
     pub response_types: Vec<String>,
     /// How we authenticate at the token endpoint
     pub token_endpoint_auth_method: String,
+    /// Application type per RFC 7591 / OIDC DCR. The relay uses a loopback
+    /// `127.0.0.1` redirect_uri, which is a native/installed application.
+    pub application_type: String,
     /// Scopes we're requesting (informational for DCR)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scope: Option<String>,
@@ -72,6 +75,7 @@ pub async fn register_client(
         ],
         response_types: vec!["code".to_string()],
         token_endpoint_auth_method: "none".to_string(),
+        application_type: "native".to_string(),
         scope: None,
     };
 
@@ -107,6 +111,7 @@ mod tests {
             ],
             response_types: vec!["code".to_string()],
             token_endpoint_auth_method: "none".to_string(),
+            application_type: "native".to_string(),
             scope: None,
         };
         let json = serde_json::to_value(&req).unwrap();
@@ -119,6 +124,8 @@ mod tests {
         assert_eq!(json["grant_types"][1], "refresh_token");
         assert_eq!(json["response_types"][0], "code");
         assert_eq!(json["token_endpoint_auth_method"], "none");
+        // loopback redirect_uri → native application per RFC 7591 / OIDC DCR
+        assert_eq!(json["application_type"], "native");
         // scope should be absent when None (skip_serializing_if)
         assert!(json.get("scope").is_none());
     }
@@ -131,6 +138,7 @@ mod tests {
             grant_types: vec!["authorization_code".to_string()],
             response_types: vec!["code".to_string()],
             token_endpoint_auth_method: "none".to_string(),
+            application_type: "native".to_string(),
             scope: Some("read write".to_string()),
         };
         let json = serde_json::to_value(&req).unwrap();

--- a/src/oauth/discovery.rs
+++ b/src/oauth/discovery.rs
@@ -27,7 +27,6 @@ pub struct ProtectedResourceMetadata {
 /// Returned by `{auth_server_url}/.well-known/oauth-authorization-server`.
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct AuthorizationServerMetadata {
-    #[allow(dead_code)]
     pub issuer: String,
     pub authorization_endpoint: String,
     pub token_endpoint: String,
@@ -53,6 +52,9 @@ pub struct AuthorizationServerMetadata {
 /// Resolved OAuth server discovery result.
 pub struct DiscoveryResult {
     pub auth_server_url: String,
+    /// The authorization server's issuer identifier (RFC 8414 `issuer`).
+    /// Used for RFC 9207 `iss` validation on the authorization response.
+    pub issuer: String,
     pub authorization_endpoint: String,
     pub token_endpoint: String,
     pub registration_endpoint: Option<String>,
@@ -97,6 +99,11 @@ pub enum DiscoveryError {
 ///   → `https://auth.example.com/.well-known/oauth-authorization-server`
 /// - `https://github.com/login/oauth` + `oauth-authorization-server`
 ///   → `https://github.com/.well-known/oauth-authorization-server/login/oauth`
+///
+/// This path-aware suffix placement matches the 2026-07-28 spec clarification
+/// for BOTH `oauth-protected-resource` (RFC 9728) and `oauth-authorization-server`
+/// (RFC 8414): the suffix is inserted directly after the origin, ahead of the
+/// resource/issuer path, with a root-only fallback handled by the callers.
 fn build_well_known_url(base_url: &str, well_known_suffix: &str) -> Result<String, DiscoveryError> {
     let parsed = Url::parse(base_url).map_err(|_| DiscoveryError::MetadataNotFound {
         url: base_url.to_string(),
@@ -278,6 +285,7 @@ pub async fn discover_authorization_server(
 
     Ok(DiscoveryResult {
         auth_server_url: auth_server_url.to_string(),
+        issuer: as_meta.issuer,
         authorization_endpoint: as_meta.authorization_endpoint,
         token_endpoint: as_meta.token_endpoint,
         registration_endpoint: as_meta.registration_endpoint,

--- a/src/oauth/mod.rs
+++ b/src/oauth/mod.rs
@@ -83,6 +83,11 @@ pub struct PendingFlow {
     pub client_id: String,
     pub client_secret: Option<String>,
     pub redirect_uri: String,
+    /// Expected authorization server issuer (RFC 8414 `issuer`), when known.
+    /// When `Some(_)`, the callback enforces RFC 9207 `iss` validation; when
+    /// `None` (e.g. legacy convention-based config without discovery), the
+    /// `iss` check is skipped to preserve existing behavior.
+    pub issuer: Option<String>,
     pub created_at: Instant,
 }
 
@@ -103,6 +108,7 @@ impl OAuthFlowManager {
     ///
     /// `token_endpoint` should be the fully resolved token endpoint URL
     /// (from discovery or built from config convention).
+    #[allow(clippy::too_many_arguments)]
     pub async fn start_flow(
         &self,
         endpoint_name: &str,
@@ -111,6 +117,7 @@ impl OAuthFlowManager {
         client_secret: Option<&str>,
         pkce: PkceChallenge,
         redirect_uri: &str,
+        issuer: Option<&str>,
     ) -> String {
         let state = generate_state();
         let flow = PendingFlow {
@@ -120,6 +127,7 @@ impl OAuthFlowManager {
             client_id: client_id.to_string(),
             client_secret: client_secret.map(|s| s.to_string()),
             redirect_uri: redirect_uri.to_string(),
+            issuer: issuer.map(|s| s.to_string()),
             created_at: Instant::now(),
         };
         self.pending.write().await.insert(state.clone(), flow);
@@ -189,6 +197,9 @@ pub struct OAuthSetupSession {
     pub registration_endpoint: Option<String>,
     /// OAuth server base URL (if configured or discovered).
     pub oauth_server_url: Option<String>,
+    /// Discovered authorization server issuer (RFC 8414 `issuer`), used for
+    /// RFC 9207 `iss` validation on the callback. `None` when not discovered.
+    pub issuer: Option<String>,
     /// Client ID (from DCR or manual input).
     pub client_id: Option<String>,
     /// Client secret (optional).
@@ -237,6 +248,7 @@ impl OAuthSetupManager {
             token_endpoint: None,
             registration_endpoint: None,
             oauth_server_url: None,
+            issuer: None,
             client_id: None,
             client_secret: None,
             tokens: None,
@@ -360,6 +372,7 @@ mod tests {
                 Some("secret"),
                 pkce,
                 "http://127.0.0.1:9400/oauth/callback",
+                Some("https://auth.example.com"),
             )
             .await;
 
@@ -369,6 +382,28 @@ mod tests {
         assert_eq!(flow.token_endpoint, "https://auth.example.com/token");
         assert_eq!(flow.client_id, "client123");
         assert_eq!(flow.client_secret.as_deref(), Some("secret"));
+        assert_eq!(flow.issuer.as_deref(), Some("https://auth.example.com"));
+    }
+
+    #[tokio::test]
+    async fn flow_manager_stores_none_issuer() {
+        // Legacy/convention-based flows pass `None` for issuer; the stored flow
+        // must reflect that so the callback skips RFC 9207 `iss` validation.
+        let mgr = OAuthFlowManager::new();
+        let pkce = PkceChallenge::generate();
+        let state = mgr
+            .start_flow(
+                "legacy-ep",
+                "https://auth.example.com/token",
+                "cid",
+                None,
+                pkce,
+                "http://127.0.0.1:9400/oauth/callback",
+                None,
+            )
+            .await;
+        let flow = mgr.consume_flow(&state).await.unwrap();
+        assert!(flow.issuer.is_none());
     }
 
     #[tokio::test]
@@ -383,6 +418,7 @@ mod tests {
                 None,
                 pkce,
                 "http://localhost/cb",
+                None,
             )
             .await;
 
@@ -411,6 +447,7 @@ mod tests {
                 None,
                 pkce,
                 "http://localhost/cb",
+                None,
             )
             .await;
 
@@ -440,6 +477,7 @@ mod tests {
                     None,
                     pkce,
                     "http://localhost/cb",
+                    None,
                 )
                 .await;
             let flow = mgr.consume_flow(&state).await.unwrap();

--- a/src/profile_registry.rs
+++ b/src/profile_registry.rs
@@ -136,6 +136,32 @@ impl ProfileRegistryView {
         }
         self.inner.route_tool_call(prefixed_name, arguments).await
     }
+
+    /// Profile-scoped variant of
+    /// [`AdapterRegistry::route_tool_call_with_request_params`]. Applies the
+    /// same allowed-endpoint guard as [`Self::route_tool_call`], then forwards
+    /// the extra top-level `tools/call` params (MCP 2026-07-28 multi round-trip
+    /// `inputResponses`/`requestState`) verbatim to the underlying registry.
+    pub async fn route_tool_call_with_request_params(
+        &self,
+        prefixed_name: &str,
+        arguments: Value,
+        request_params: serde_json::Map<String, Value>,
+    ) -> Result<Value, AdapterError> {
+        let (_, lookup) = self.inner.merged_catalog_with_lookup().await;
+        let (endpoint, _) = lookup.get(prefixed_name).ok_or_else(|| {
+            AdapterError::ProtocolError(format!("no tool '{}' in profile", prefixed_name))
+        })?;
+        if !self.allowed_endpoints.contains(endpoint) {
+            return Err(AdapterError::ProtocolError(format!(
+                "tool '{}' is not available in this profile",
+                prefixed_name
+            )));
+        }
+        self.inner
+            .route_tool_call_with_request_params(prefixed_name, arguments, request_params)
+            .await
+    }
 }
 
 #[async_trait]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -23,6 +23,15 @@ pub const VERSION_2026_07_28: &str = "2026-07-28";
 /// per-request protocol version for Streamable HTTP peers.
 pub const MCP_PROTOCOL_VERSION_HEADER: &str = "mcp-protocol-version";
 
+/// HTTP header (lowercased) that mirrors the JSON-RPC `method` of a 2026
+/// Streamable HTTP request, enabling routing/observability without parsing the
+/// body. Required for 2026 clients.
+pub const MCP_METHOD_HEADER: &str = "mcp-method";
+
+/// HTTP header (lowercased) that mirrors the tool name (`params.name`) of a
+/// 2026 `tools/call` request. Absent for methods without a tool name.
+pub const MCP_NAME_HEADER: &str = "mcp-name";
+
 /// Reverse-DNS key under `params._meta` that 2026 clients use to attach their
 /// identity on every request (there is no `initialize` handshake in 2026).
 pub const META_CLIENT_INFO_KEY: &str = "io.modelcontextprotocol/clientInfo";

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -65,7 +65,6 @@ impl ProtocolVersion {
 
     /// `true` for the `2026-07-28` dialect — the gate every additive 2026
     /// behavior branches on. Consumed by T3–T13.
-    #[allow(dead_code)]
     pub fn is_2026(&self) -> bool {
         matches!(self, ProtocolVersion::V2026_07_28)
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,0 +1,208 @@
+//! Shared MCP protocol-version primitive.
+//!
+//! The relay must distinguish three dialects per peer — legacy `2024-11-05`,
+//! legacy `2025-03-26`, and the new `2026-07-28` — because every 2026 behavior
+//! branches on the negotiated version of *that specific peer*. This module is
+//! the single source of truth for parsing, classifying, and detecting that
+//! version so later behavioral tasks reference one type instead of scattered
+//! string literals.
+//!
+//! This is plumbing only: no handshake or dispatch behavior changes here.
+
+use serde_json::Value;
+
+/// Wire string for the legacy `2024-11-05` dialect.
+pub const VERSION_2024_11_05: &str = "2024-11-05";
+/// Wire string for the legacy `2025-03-26` dialect (the relay's advertised
+/// server baseline today).
+pub const VERSION_2025_03_26: &str = "2025-03-26";
+/// Wire string for the new `2026-07-28` dialect.
+pub const VERSION_2026_07_28: &str = "2026-07-28";
+
+/// HTTP header (lowercased, per `reqwest`/`http` storage) that conveys the
+/// per-request protocol version for Streamable HTTP peers.
+pub const MCP_PROTOCOL_VERSION_HEADER: &str = "mcp-protocol-version";
+
+/// Reverse-DNS key under `params._meta` that 2026 clients use to attach their
+/// identity on every request (there is no `initialize` handshake in 2026).
+pub const META_CLIENT_INFO_KEY: &str = "io.modelcontextprotocol/clientInfo";
+
+/// A negotiated MCP protocol dialect for a single peer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ProtocolVersion {
+    /// Legacy `2024-11-05`.
+    V2024_11_05,
+    /// Legacy `2025-03-26`.
+    V2025_03_26,
+    /// New `2026-07-28`.
+    V2026_07_28,
+}
+
+impl ProtocolVersion {
+    /// Fallback dialect when no explicit signal distinguishes a legacy peer.
+    /// Matches the relay's advertised server baseline (`2025-03-26`).
+    pub const LEGACY_DEFAULT: ProtocolVersion = ProtocolVersion::V2025_03_26;
+
+    /// Parse a wire version string into a known dialect. Returns `None` for
+    /// any string the relay does not model (e.g. `2025-06-18`, garbage).
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            VERSION_2024_11_05 => Some(ProtocolVersion::V2024_11_05),
+            VERSION_2025_03_26 => Some(ProtocolVersion::V2025_03_26),
+            VERSION_2026_07_28 => Some(ProtocolVersion::V2026_07_28),
+            _ => None,
+        }
+    }
+
+    /// The canonical wire string for this dialect.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ProtocolVersion::V2024_11_05 => VERSION_2024_11_05,
+            ProtocolVersion::V2025_03_26 => VERSION_2025_03_26,
+            ProtocolVersion::V2026_07_28 => VERSION_2026_07_28,
+        }
+    }
+
+    /// `true` for the `2026-07-28` dialect — the gate every additive 2026
+    /// behavior branches on. Consumed by T3–T13.
+    #[allow(dead_code)]
+    pub fn is_2026(&self) -> bool {
+        matches!(self, ProtocolVersion::V2026_07_28)
+    }
+
+    /// `true` for any pre-2026 (legacy) dialect. Consumed by T3–T13.
+    #[allow(dead_code)]
+    pub fn is_legacy(&self) -> bool {
+        !self.is_2026()
+    }
+}
+
+impl Default for ProtocolVersion {
+    fn default() -> Self {
+        ProtocolVersion::LEGACY_DEFAULT
+    }
+}
+
+impl std::fmt::Display for ProtocolVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for ProtocolVersion {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        ProtocolVersion::parse(s).ok_or(())
+    }
+}
+
+/// Borrow the `params._meta["io.modelcontextprotocol/clientInfo"]` value, if
+/// present. 2026 clients attach this on every request in lieu of a handshake.
+pub fn meta_client_info(params: Option<&Value>) -> Option<&Value> {
+    params?.get("_meta")?.get(META_CLIENT_INFO_KEY)
+}
+
+/// Detect the dialect of an inbound (relay-as-server) request from the three
+/// signals defined by the spec, in priority order:
+///
+/// 1. An explicit, recognized `MCP-Protocol-Version` header wins outright.
+/// 2. Otherwise, the absence of an `initialize` handshake combined with a
+///    `_meta` `clientInfo` payload identifies a stateless 2026 client.
+/// 3. Otherwise fall back to the legacy baseline.
+///
+/// This is pure detection — it records nothing and changes no behavior.
+pub fn detect_inbound_dialect(
+    has_initialize: bool,
+    protocol_header: Option<&str>,
+    params: Option<&Value>,
+) -> ProtocolVersion {
+    if let Some(version) = protocol_header.and_then(ProtocolVersion::parse) {
+        return version;
+    }
+    if !has_initialize && meta_client_info(params).is_some() {
+        return ProtocolVersion::V2026_07_28;
+    }
+    ProtocolVersion::LEGACY_DEFAULT
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_as_str_round_trip() {
+        for v in [
+            ProtocolVersion::V2024_11_05,
+            ProtocolVersion::V2025_03_26,
+            ProtocolVersion::V2026_07_28,
+        ] {
+            assert_eq!(ProtocolVersion::parse(v.as_str()), Some(v));
+            assert_eq!(v.to_string(), v.as_str());
+            assert_eq!(v.as_str().parse::<ProtocolVersion>(), Ok(v));
+        }
+    }
+
+    #[test]
+    fn parse_rejects_unknown_strings() {
+        for s in ["", "2025-06-18", "2026-07-28 ", "garbage", "2024"] {
+            assert_eq!(ProtocolVersion::parse(s), None);
+            assert_eq!(s.parse::<ProtocolVersion>(), Err(()));
+        }
+    }
+
+    #[test]
+    fn classification_gates() {
+        assert!(ProtocolVersion::V2026_07_28.is_2026());
+        assert!(!ProtocolVersion::V2026_07_28.is_legacy());
+        for v in [ProtocolVersion::V2024_11_05, ProtocolVersion::V2025_03_26] {
+            assert!(!v.is_2026());
+            assert!(v.is_legacy());
+        }
+        assert_eq!(ProtocolVersion::default(), ProtocolVersion::V2025_03_26);
+    }
+
+    #[test]
+    fn detect_from_header_wins() {
+        assert_eq!(
+            detect_inbound_dialect(true, Some("2026-07-28"), None),
+            ProtocolVersion::V2026_07_28
+        );
+        assert_eq!(
+            detect_inbound_dialect(false, Some("2024-11-05"), None),
+            ProtocolVersion::V2024_11_05
+        );
+    }
+
+    #[test]
+    fn detect_from_meta_client_info_without_initialize() {
+        let params = json!({
+            "_meta": { META_CLIENT_INFO_KEY: { "name": "demo", "version": "1.0" } }
+        });
+        assert_eq!(
+            detect_inbound_dialect(false, None, Some(&params)),
+            ProtocolVersion::V2026_07_28
+        );
+        assert!(meta_client_info(Some(&params)).is_some());
+    }
+
+    #[test]
+    fn detect_falls_back_to_legacy_baseline() {
+        assert_eq!(
+            detect_inbound_dialect(true, None, None),
+            ProtocolVersion::V2025_03_26
+        );
+        let params = json!({
+            "_meta": { META_CLIENT_INFO_KEY: { "name": "demo" } }
+        });
+        assert_eq!(
+            detect_inbound_dialect(true, None, Some(&params)),
+            ProtocolVersion::V2025_03_26
+        );
+        assert_eq!(
+            detect_inbound_dialect(false, Some("garbage"), None),
+            ProtocolVersion::V2025_03_26
+        );
+    }
+}

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -145,6 +145,28 @@ pub fn protocol_version_from_result(result: &Value) -> Option<ProtocolVersion> {
         .and_then(ProtocolVersion::parse)
 }
 
+/// Extract the SEP-2549 `ttlMs` caching hint from a list/read result object
+/// (the top-level `result` of `tools/list`, `prompts/list`, `resources/list`,
+/// `resources/templates/list`, `resources/read`, or `server/discover`).
+///
+/// Returns the freshness window in milliseconds, clamped to `>= 0` — a
+/// negative `ttlMs` means "immediately stale" per spec and is represented as
+/// `0`. Returns `None` when the field is absent or not a JSON number, in which
+/// case the relay falls back to its existing event-driven cache behavior.
+pub fn ttl_ms_from_result(result: &Value) -> Option<u64> {
+    let v = result.get("ttlMs")?;
+    if let Some(n) = v.as_i64() {
+        return Some(n.max(0) as u64);
+    }
+    if let Some(n) = v.as_u64() {
+        return Some(n);
+    }
+    if let Some(f) = v.as_f64() {
+        return Some(if f < 0.0 { 0 } else { f as u64 });
+    }
+    None
+}
+
 /// Detect an upstream server's dialect (relay-as-client) using the spec's
 /// discover-first, initialize-fallback strategy:
 ///
@@ -209,6 +231,21 @@ mod tests {
             assert!(v.is_legacy());
         }
         assert_eq!(ProtocolVersion::default(), ProtocolVersion::V2025_03_26);
+    }
+
+    #[test]
+    fn ttl_ms_parsing() {
+        assert_eq!(ttl_ms_from_result(&json!({ "ttlMs": 60000 })), Some(60000));
+        assert_eq!(ttl_ms_from_result(&json!({ "ttlMs": 0 })), Some(0));
+        // Negative ttlMs means "immediately stale" → clamp to 0.
+        assert_eq!(ttl_ms_from_result(&json!({ "ttlMs": -5 })), Some(0));
+        // Float values are floored after clamping.
+        assert_eq!(ttl_ms_from_result(&json!({ "ttlMs": 1500.9 })), Some(1500));
+        assert_eq!(ttl_ms_from_result(&json!({ "ttlMs": -2.0 })), Some(0));
+        // Absent or non-numeric → None (fall back to event-driven cache).
+        assert_eq!(ttl_ms_from_result(&json!({})), None);
+        assert_eq!(ttl_ms_from_result(&json!({ "ttlMs": "60000" })), None);
+        assert_eq!(ttl_ms_from_result(&json!({ "ttlMs": null })), None);
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -134,6 +134,46 @@ pub fn detect_inbound_dialect(
     ProtocolVersion::LEGACY_DEFAULT
 }
 
+/// Extract and classify the `protocolVersion` field of a handshake or
+/// discovery result (the `result` object of an `initialize` or
+/// `server/discover` response). Returns `None` when the field is absent or
+/// names a dialect the relay does not model.
+pub fn protocol_version_from_result(result: &Value) -> Option<ProtocolVersion> {
+    result
+        .get("protocolVersion")
+        .and_then(Value::as_str)
+        .and_then(ProtocolVersion::parse)
+}
+
+/// Detect an upstream server's dialect (relay-as-client) using the spec's
+/// discover-first, initialize-fallback strategy:
+///
+/// 1. If a stateless `server/discover` probe returned a result whose
+///    `protocolVersion` is the new `2026-07-28` dialect, the upstream is 2026.
+/// 2. Otherwise fall back to the legacy `initialize` handshake result and use
+///    its negotiated `protocolVersion`.
+/// 3. If neither yields a recognized version, assume the legacy baseline.
+///
+/// Callers pass `discover_result = None` when they did not (or cannot) probe
+/// `server/discover`. The live, transport-specific `server/discover` probe is
+/// wired by T8/T9; today the adapters run their existing legacy handshake and
+/// pass only the `initialize` result, so legacy upstreams behave byte-for-byte
+/// as before.
+pub fn detect_upstream_dialect(
+    discover_result: Option<&Value>,
+    initialize_result: Option<&Value>,
+) -> ProtocolVersion {
+    if let Some(version) = discover_result.and_then(protocol_version_from_result) {
+        if version.is_2026() {
+            return version;
+        }
+    }
+    if let Some(version) = initialize_result.and_then(protocol_version_from_result) {
+        return version;
+    }
+    ProtocolVersion::LEGACY_DEFAULT
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -211,6 +251,83 @@ mod tests {
         assert_eq!(
             detect_inbound_dialect(false, Some("garbage"), None),
             ProtocolVersion::V2025_03_26
+        );
+    }
+
+    #[test]
+    fn protocol_version_from_result_parses_known_and_rejects_unknown() {
+        assert_eq!(
+            protocol_version_from_result(&json!({ "protocolVersion": "2026-07-28" })),
+            Some(ProtocolVersion::V2026_07_28)
+        );
+        assert_eq!(
+            protocol_version_from_result(&json!({ "protocolVersion": "2024-11-05" })),
+            Some(ProtocolVersion::V2024_11_05)
+        );
+        assert_eq!(
+            protocol_version_from_result(&json!({ "protocolVersion": "2025-06-18" })),
+            None
+        );
+        assert_eq!(protocol_version_from_result(&json!({})), None);
+    }
+
+    #[test]
+    fn detect_upstream_2026_when_discover_succeeds() {
+        // 2026 upstream: server/discover returns a 2026 result → dialect=2026,
+        // regardless of any initialize result.
+        let discover = json!({
+            "protocolVersion": "2026-07-28",
+            "capabilities": {}
+        });
+        assert_eq!(
+            detect_upstream_dialect(Some(&discover), None),
+            ProtocolVersion::V2026_07_28
+        );
+        let init = json!({ "protocolVersion": "2025-03-26" });
+        assert_eq!(
+            detect_upstream_dialect(Some(&discover), Some(&init)),
+            ProtocolVersion::V2026_07_28
+        );
+    }
+
+    #[test]
+    fn detect_upstream_falls_back_to_initialize_when_discover_fails() {
+        // Legacy upstream: server/discover not attempted/rejected (None) → fall
+        // back to the initialize result's negotiated version.
+        let init_2024 = json!({ "protocolVersion": "2024-11-05" });
+        assert_eq!(
+            detect_upstream_dialect(None, Some(&init_2024)),
+            ProtocolVersion::V2024_11_05
+        );
+        let init_2025 = json!({ "protocolVersion": "2025-03-26" });
+        assert_eq!(
+            detect_upstream_dialect(None, Some(&init_2025)),
+            ProtocolVersion::V2025_03_26
+        );
+    }
+
+    #[test]
+    fn detect_upstream_initialize_only_server_not_broken() {
+        // An initialize-only upstream (no server/discover support) that omits or
+        // sends an unmodeled protocolVersion still resolves to a usable legacy
+        // dialect rather than erroring.
+        let init_no_version = json!({ "serverInfo": { "name": "legacy" } });
+        assert_eq!(
+            detect_upstream_dialect(None, Some(&init_no_version)),
+            ProtocolVersion::LEGACY_DEFAULT
+        );
+        // A discover result that is present but not a recognized 2026 version
+        // does not win; we still fall back to initialize.
+        let discover_legacy = json!({ "protocolVersion": "2024-11-05" });
+        let init = json!({ "protocolVersion": "2025-03-26" });
+        assert_eq!(
+            detect_upstream_dialect(Some(&discover_legacy), Some(&init)),
+            ProtocolVersion::V2025_03_26
+        );
+        // Nothing at all → legacy baseline.
+        assert_eq!(
+            detect_upstream_dialect(None, None),
+            ProtocolVersion::LEGACY_DEFAULT
         );
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -672,6 +672,21 @@ impl AdapterRegistry {
         prefixed_name: &str,
         arguments: serde_json::Value,
     ) -> Result<serde_json::Value, AdapterError> {
+        self.route_tool_call_with_request_params(prefixed_name, arguments, serde_json::Map::new())
+            .await
+    }
+
+    /// Variant of [`Self::route_tool_call`] that forwards extra top-level
+    /// `tools/call` params (the MCP 2026-07-28 multi round-trip
+    /// `inputResponses`/`requestState`, plus any sibling params) verbatim to the
+    /// dispatched adapter. An empty `request_params` map dispatches identically
+    /// to the legacy path, so terminal tool calls are unaffected.
+    pub async fn route_tool_call_with_request_params(
+        &self,
+        prefixed_name: &str,
+        arguments: serde_json::Value,
+        request_params: serde_json::Map<String, serde_json::Value>,
+    ) -> Result<serde_json::Value, AdapterError> {
         let (catalog, lookup) = self.merged_catalog_with_lookup().await;
 
         let (endpoint, tool) = match lookup.get(prefixed_name) {
@@ -789,7 +804,10 @@ impl AdapterRegistry {
         // skipped for internal callers that have no `request_uid`. Enqueue is
         // non-blocking (`try_send`); overflow drops are counted in the handle.
         let Some(obs) = self.observability.as_ref().filter(|o| o.is_enabled()) else {
-            return entry.adapter.call_tool(tool, arguments).await;
+            return entry
+                .adapter
+                .call_tool_with_request_params(tool, arguments, request_params)
+                .await;
         };
         let span_ctx = current_request_context();
         // Gate capture on an inbound request context (skip internal callers),
@@ -800,7 +818,10 @@ impl AdapterRegistry {
         // other's payloads. Batched calls stay correlated via the shared inbound
         // request span and the per-call `request_uid`s minted below.
         if span_ctx.request_uid.is_none() {
-            return entry.adapter.call_tool(tool, arguments).await;
+            return entry
+                .adapter
+                .call_tool_with_request_params(tool, arguments, request_params)
+                .await;
         }
         let request_uid = uuid::Uuid::new_v4().to_string();
 
@@ -825,7 +846,10 @@ impl AdapterRegistry {
 
         let ts_start = chrono::Utc::now().timestamp_millis();
         let started = Instant::now();
-        let result = entry.adapter.call_tool(tool, arguments).await;
+        let result = entry
+            .adapter
+            .call_tool_with_request_params(tool, arguments, request_params)
+            .await;
         let duration_ms = started.elapsed().as_millis() as i64;
         let ts_end = ts_start + duration_ms;
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -136,10 +136,16 @@ impl RegisteredAdapter {
     /// recent `list_tools()` into an absolute cache deadline. `None` (no hint /
     /// legacy upstream) keeps the entry event-driven with no time expiry.
     async fn ttl_expiry(&self) -> Option<Instant> {
+        // `ms` comes from untrusted upstream `ttlMs` (already clamped >= 0 by
+        // `ttl_ms_from_result`). A huge value would overflow
+        // `Instant::now() + Duration::from_millis(ms)` and panic, so use
+        // `checked_add` and fall back to `None` on overflow — treated as no
+        // time expiry / event-driven, consistent with the `None` semantics
+        // documented above.
         self.adapter
             .list_tools_ttl_ms()
             .await
-            .map(|ms| Instant::now() + Duration::from_millis(ms))
+            .and_then(|ms| Instant::now().checked_add(Duration::from_millis(ms)))
     }
 }
 
@@ -2095,6 +2101,33 @@ mod tests {
             calls.load(Ordering::SeqCst),
             1,
             "without a ttlMs hint the cache must remain event-driven"
+        );
+    }
+
+    #[tokio::test]
+    async fn ttl_expiry_handles_overflow_without_panic() {
+        // `Instant::now() + Duration::from_millis(u64::MAX)` panics on overflow
+        // (platform-dependent: it overflows where `Instant`'s representation is
+        // narrow, e.g. Linux). `ttl_expiry` uses `checked_add`, so a huge
+        // upstream `ttlMs` must be handled gracefully — completing the call here
+        // without unwinding proves the panic is gone. When the add overflows it
+        // falls back to `None` (no time expiry / event-driven) per the doc
+        // comment; on platforms where it does not overflow it yields `Some`.
+        let (registry, _calls) = register_ttl_adapter(Some(u64::MAX)).await;
+        {
+            let entries = registry.entries().read().await;
+            let entry = entries.get("ep").unwrap();
+            // The call returning at all is the assertion: the old `+` panicked.
+            let _expiry = entry.ttl_expiry().await;
+        }
+
+        // A normal ttlMs still yields a concrete deadline.
+        let (registry, _calls) = register_ttl_adapter(Some(60_000)).await;
+        let entries = registry.entries().read().await;
+        let entry = entries.get("ep").unwrap();
+        assert!(
+            entry.ttl_expiry().await.is_some(),
+            "a normal ttlMs must yield a concrete deadline"
         );
     }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -12,10 +12,34 @@ use serde_json::Value;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio::task::AbortHandle;
 use tracing::{debug, info, warn};
+
+/// A cached `list_tools()` result with an optional freshness deadline.
+///
+/// `expires_at == None` ⇒ no upstream `ttlMs` hint was provided (legacy
+/// upstream, or a 2026 upstream that sent none); the entry is purely
+/// event-driven and never expires by time, preserving the relay's pre-2026
+/// caching behavior byte-for-byte. `Some(deadline)` ⇒ a 2026 upstream supplied
+/// a `ttlMs` freshness window (SEP-2549); the entry is considered stale once
+/// `Instant::now() >= deadline`, at which point `cached_list_tools` refetches.
+pub(crate) struct CachedTools {
+    pub(crate) tools: Vec<ToolInfo>,
+    pub(crate) expires_at: Option<Instant>,
+}
+
+impl CachedTools {
+    /// `true` while the entry may still be served from cache. Entries with no
+    /// upstream TTL hint are always fresh (event-driven invalidation only).
+    fn is_fresh(&self) -> bool {
+        match self.expires_at {
+            None => true,
+            Some(deadline) => Instant::now() < deadline,
+        }
+    }
+}
 
 /// A registered adapter with its metadata.
 pub struct RegisteredAdapter {
@@ -27,9 +51,10 @@ pub struct RegisteredAdapter {
     pub disabled: bool,
     pub disabled_tools: HashSet<String>,
     /// Per-adapter cache of the most recent successful `list_tools()` result.
-    /// Purely event-driven (no TTL); cleared by registry invalidation methods
-    /// or when the adapter is swapped/restarted.
-    pub(crate) tool_cache: RwLock<Option<Vec<ToolInfo>>>,
+    /// Event-driven invalidation (cleared by registry invalidation methods or
+    /// when the adapter is swapped/restarted) plus an optional upstream-provided
+    /// `ttlMs` freshness window honored for 2026 upstreams (see [`CachedTools`]).
+    pub(crate) tool_cache: RwLock<Option<CachedTools>>,
     /// Coalesces concurrent cache misses so only one `list_tools()` call is
     /// in-flight per adapter at a time.
     pub(crate) tool_cache_populate_lock: Mutex<()>,
@@ -59,11 +84,14 @@ impl RegisteredAdapter {
     /// without writing the cache, preserving the invariant that an
     /// unhealthy adapter never poisons the cache.
     pub async fn cached_list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
-        // Fast path: healthy adapter with a populated cache returns
-        // without taking the populate lock or calling the adapter.
+        // Fast path: healthy adapter with a populated, still-fresh cache
+        // returns without taking the populate lock or calling the adapter.
+        // An entry past its upstream `ttlMs` deadline is treated as a miss.
         if matches!(self.adapter.health(), HealthStatus::Healthy) {
             if let Some(cached) = self.tool_cache.read().await.as_ref() {
-                return Ok(cached.clone());
+                if cached.is_fresh() {
+                    return Ok(cached.tools.clone());
+                }
             }
         }
         // Slow path: serialize concurrent callers behind the populate lock
@@ -74,10 +102,16 @@ impl RegisteredAdapter {
         // and populated the cache while we were parked.
         if matches!(self.adapter.health(), HealthStatus::Healthy) {
             if let Some(cached) = self.tool_cache.read().await.as_ref() {
-                return Ok(cached.clone());
+                if cached.is_fresh() {
+                    return Ok(cached.tools.clone());
+                }
             }
             let tools = self.adapter.list_tools().await?;
-            *self.tool_cache.write().await = Some(tools.clone());
+            let expires_at = self.ttl_expiry().await;
+            *self.tool_cache.write().await = Some(CachedTools {
+                tools: tools.clone(),
+                expires_at,
+            });
             return Ok(tools);
         }
         // Still not `Healthy` under the lock: delegate straight to the
@@ -89,9 +123,23 @@ impl RegisteredAdapter {
         // adapter never poisons the cache.
         let tools = self.adapter.list_tools().await?;
         if matches!(self.adapter.health(), HealthStatus::Healthy) {
-            *self.tool_cache.write().await = Some(tools.clone());
+            let expires_at = self.ttl_expiry().await;
+            *self.tool_cache.write().await = Some(CachedTools {
+                tools: tools.clone(),
+                expires_at,
+            });
         }
         Ok(tools)
+    }
+
+    /// Translate the upstream `ttlMs` hint captured by the adapter's most
+    /// recent `list_tools()` into an absolute cache deadline. `None` (no hint /
+    /// legacy upstream) keeps the entry event-driven with no time expiry.
+    async fn ttl_expiry(&self) -> Option<Instant> {
+        self.adapter
+            .list_tools_ttl_ms()
+            .await
+            .map(|ms| Instant::now() + Duration::from_millis(ms))
     }
 }
 
@@ -1911,6 +1959,113 @@ mod tests {
         }
     }
 
+    /// Healthy mock that counts `list_tools()` calls and reports a fixed
+    /// upstream `ttlMs` hint, used to exercise the registry's freshness-window
+    /// honoring in [`RegisteredAdapter::cached_list_tools`].
+    struct TtlCountingAdapter {
+        tools: Vec<ToolInfo>,
+        calls: Arc<AtomicU64>,
+        ttl_ms: Option<u64>,
+    }
+
+    #[async_trait]
+    impl McpAdapter for TtlCountingAdapter {
+        async fn initialize(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+        async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self.tools.clone())
+        }
+        async fn list_tools_ttl_ms(&self) -> Option<u64> {
+            self.ttl_ms
+        }
+        async fn call_tool(
+            &self,
+            name: &str,
+            arguments: serde_json::Value,
+        ) -> Result<serde_json::Value, AdapterError> {
+            Ok(json!({ "called": name, "args": arguments }))
+        }
+        fn health(&self) -> HealthStatus {
+            HealthStatus::Healthy
+        }
+        async fn shutdown(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+    }
+
+    async fn register_ttl_adapter(ttl_ms: Option<u64>) -> (AdapterRegistry, Arc<AtomicU64>) {
+        let registry = AdapterRegistry::new();
+        let calls = Arc::new(AtomicU64::new(0));
+        let adapter = TtlCountingAdapter {
+            tools: vec![make_tool("a")],
+            calls: calls.clone(),
+            ttl_ms,
+        };
+        registry
+            .register(
+                "ep".into(),
+                Box::new(adapter),
+                "stdio".into(),
+                None,
+                Some("ep".into()),
+            )
+            .await;
+        (registry, calls)
+    }
+
+    #[tokio::test]
+    async fn cached_list_tools_honors_upstream_ttl_while_fresh() {
+        // A generous upstream ttlMs keeps the cached entry fresh: a second
+        // call within the window is served from cache (no extra list_tools).
+        let (registry, calls) = register_ttl_adapter(Some(60_000)).await;
+        let entries = registry.entries().read().await;
+        let entry = entries.get("ep").unwrap();
+        entry.cached_list_tools().await.unwrap();
+        entry.cached_list_tools().await.unwrap();
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "fresh entry within ttlMs must be served from cache"
+        );
+    }
+
+    #[tokio::test]
+    async fn cached_list_tools_refetches_after_ttl_expiry() {
+        // A short upstream ttlMs expires between calls: the second call sees a
+        // stale entry and refetches from the upstream.
+        let (registry, calls) = register_ttl_adapter(Some(15)).await;
+        let entries = registry.entries().read().await;
+        let entry = entries.get("ep").unwrap();
+        entry.cached_list_tools().await.unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        entry.cached_list_tools().await.unwrap();
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "entry past its ttlMs deadline must be refetched"
+        );
+    }
+
+    #[tokio::test]
+    async fn cached_list_tools_without_ttl_caches_indefinitely() {
+        // Absent upstream ttlMs (legacy upstream / no hint) preserves the
+        // existing event-driven behavior: the entry never expires by time.
+        let (registry, calls) = register_ttl_adapter(None).await;
+        let entries = registry.entries().read().await;
+        let entry = entries.get("ep").unwrap();
+        entry.cached_list_tools().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        entry.cached_list_tools().await.unwrap();
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "without a ttlMs hint the cache must remain event-driven"
+        );
+    }
+
     fn make_tool(name: &str) -> ToolInfo {
         ToolInfo {
             name: name.to_string(),
@@ -3580,11 +3735,13 @@ mod tests {
         // still contains the previously-primed entry. (If a future change
         // populates the cache from the bypass branch, the asserted name
         // would flip and force a deliberate review here.)
-        let cached_after = entry.tool_cache.read().await.clone();
-        let cached_after = cached_after.expect("cache must remain populated after bypass");
-        assert_eq!(cached_after.len(), 1);
+        let cache_guard = entry.tool_cache.read().await;
+        let cached_after = cache_guard
+            .as_ref()
+            .expect("cache must remain populated after bypass");
+        assert_eq!(cached_after.tools.len(), 1);
         assert_eq!(
-            cached_after[0].name, "cached_tool",
+            cached_after.tools[0].name, "cached_tool",
             "bypass must not write through to the cache"
         );
     }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -7,7 +7,7 @@ use crate::prefix;
 use async_trait::async_trait;
 use jsonschema::error::{TypeKind, ValidationErrorKind};
 use jsonschema::paths::{Location, LocationSegment};
-use jsonschema::{ValidationError, Validator};
+use jsonschema::{Retrieve, Uri, ValidationError, Validator};
 use serde_json::Value;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -1155,18 +1155,50 @@ fn schema_keyword_constrains(key: &str, value: &serde_json::Value) -> bool {
     }
 }
 
+/// A [`Retrieve`] that refuses to dereference any external schema resource.
+///
+/// `jsonschema` ships with the `resolve-http` feature on by default, so its
+/// built-in retriever would issue a **blocking network request** for any
+/// external `$ref` URI (e.g. `https://example.com/schema.json`) encountered
+/// while compiling a validator. The relay must never fetch or auto-dereference
+/// external references in an upstream tool's `inputSchema`, so this retriever
+/// is installed on every validator build: external `$ref`s make the build fail
+/// (and the tool falls back to pass-through, validation skipped), while
+/// internal `$ref`/`$defs` (e.g. `#/$defs/Foo`) resolve against the document
+/// itself and never reach the retriever.
+#[derive(Debug)]
+struct NonFetchingRetriever;
+
+impl Retrieve for NonFetchingRetriever {
+    fn retrieve(
+        &self,
+        uri: &Uri<String>,
+    ) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
+        Err(format!(
+            "external schema reference '{}' is not dereferenced by the relay",
+            uri.as_str()
+        )
+        .into())
+    }
+}
+
 /// Compile a tool's `inputSchema` into a reusable [`Validator`], or return
 /// `None` to signal pass-through. Degenerate schemas (see
 /// [`schema_is_validatable`]) and schemas the upstream server shipped
 /// malformed both yield `None` — the relay never blocks a call because of a
 /// bad upstream schema; it lets the upstream handle it. `format` is enforced
 /// as an assertion (spec §11.1).
+///
+/// External `$ref` URIs are never fetched: a [`NonFetchingRetriever`] is
+/// installed so any external reference fails compilation (yielding `None` /
+/// pass-through) rather than triggering a blocking network request.
 fn compile_input_schema(prefixed_name: &str, schema: &serde_json::Value) -> Option<Arc<Validator>> {
     if !schema_is_validatable(schema) {
         return None;
     }
     match jsonschema::options()
         .should_validate_formats(true)
+        .with_retriever(NonFetchingRetriever)
         .build(schema)
     {
         Ok(validator) => {
@@ -4172,6 +4204,158 @@ mod tests {
             text
         );
         text
+    }
+
+    /// A representative JSON Schema 2020-12 document exercising the
+    /// combinators (`oneOf`/`anyOf`/`allOf`), internal `$ref`/`$defs`, nested
+    /// combinators, and an **external** `$ref` URI. Used to prove the relay
+    /// passes such schemas through aggregation intact and never dereferences
+    /// the external reference.
+    fn complex_2020_12_schema() -> serde_json::Value {
+        json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "kind": {
+                    "oneOf": [
+                        { "type": "string", "const": "circle" },
+                        { "type": "string", "const": "square" }
+                    ]
+                },
+                "shape": { "$ref": "#/$defs/Shape" },
+                "either": {
+                    "anyOf": [
+                        { "$ref": "#/$defs/Shape" },
+                        { "type": "null" }
+                    ]
+                },
+                "combined": {
+                    "allOf": [
+                        { "type": "object" },
+                        { "$ref": "#/$defs/Shape" }
+                    ]
+                },
+                "remote": { "$ref": "https://example.com/schemas/widget.json#/$defs/Widget" }
+            },
+            "$defs": {
+                "Shape": {
+                    "type": "object",
+                    "properties": {
+                        "sides": { "type": "integer", "minimum": 3 },
+                        "nested": {
+                            "oneOf": [
+                                { "$ref": "#/$defs/Shape" },
+                                { "type": "null" }
+                            ]
+                        }
+                    },
+                    "required": ["sides"]
+                }
+            }
+        })
+    }
+
+    // Complex 2020-12 schemas (oneOf/anyOf/allOf, internal $ref/$defs, nested
+    // combinators, and an external $ref) survive the merged catalog
+    // byte-for-byte, modulo the intentional tool-name prefixing/description
+    // enrichment which never touch `inputSchema`.
+    #[tokio::test]
+    async fn merged_catalog_preserves_complex_2020_12_schema_verbatim() {
+        let schema = complex_2020_12_schema();
+        let registry = registry_with_schema("draw", schema.clone()).await;
+        let catalog = registry.merged_catalog().await;
+        assert_eq!(catalog.len(), 1);
+        // Single-server no-prefix mode keeps the raw tool name…
+        assert_eq!(catalog[0].name, "draw");
+        // …and the schema is passed through completely unchanged.
+        assert_eq!(catalog[0].input_schema, schema);
+        // The external `$ref` URI is preserved verbatim, not resolved/inlined.
+        assert_eq!(
+            catalog[0].input_schema["properties"]["remote"]["$ref"],
+            json!("https://example.com/schemas/widget.json#/$defs/Widget")
+        );
+    }
+
+    // A two-server registry forces prefixing: the tool name gains its
+    // `{prefix}__` segment, but the complex 2020-12 `inputSchema` is still
+    // carried through byte-for-byte.
+    #[tokio::test]
+    async fn merged_catalog_prefixes_name_but_preserves_complex_schema() {
+        let schema = complex_2020_12_schema();
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "a".into(),
+                Box::new(MockAdapter::healthy(vec![make_tool_with_schema(
+                    "draw",
+                    schema.clone(),
+                )])),
+                "stdio".into(),
+                None,
+                Some("a".into()),
+            )
+            .await;
+        registry
+            .register(
+                "b".into(),
+                Box::new(MockAdapter::healthy(vec![make_tool("ping")])),
+                "stdio".into(),
+                None,
+                Some("b".into()),
+            )
+            .await;
+
+        let catalog = registry.merged_catalog().await;
+        let drawn = catalog
+            .iter()
+            .find(|t| t.name == "a__draw")
+            .expect("prefixed tool present");
+        assert_eq!(drawn.input_schema, schema);
+    }
+
+    // Internal `$ref`/`$defs` (e.g. `#/$defs/Foo`) resolve against the
+    // document itself, so a schema constrained solely via internal references
+    // compiles into an enforced validator (no pass-through, no fetch).
+    #[test]
+    fn compile_input_schema_resolves_internal_defs() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "shape": { "$ref": "#/$defs/Shape" } },
+            "required": ["shape"],
+            "$defs": {
+                "Shape": {
+                    "type": "object",
+                    "properties": { "sides": { "type": "integer", "minimum": 3 } },
+                    "required": ["sides"]
+                }
+            }
+        });
+        let validator = compile_input_schema("t__draw", &schema)
+            .expect("internal $ref/$defs schema should compile");
+        // Valid instance passes…
+        assert!(validator.is_valid(&json!({ "shape": { "sides": 4 } })));
+        // …and the internal constraint is actually enforced.
+        assert!(!validator.is_valid(&json!({ "shape": { "sides": 2 } })));
+    }
+
+    // External `$ref` URIs are NEVER fetched: the [`NonFetchingRetriever`]
+    // makes compilation fail rather than issue a network request, so the tool
+    // falls back to pass-through (`None`). The fake host below would hang or
+    // error on a real fetch; the test returns instantly because nothing is
+    // retrieved.
+    #[test]
+    fn compile_input_schema_does_not_fetch_external_ref() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "remote": { "$ref": "https://example.invalid/schemas/widget.json" }
+            },
+            "required": ["remote"]
+        });
+        assert!(
+            compile_input_schema("t__draw", &schema).is_none(),
+            "external $ref must yield pass-through (None), never a fetched validator"
+        );
     }
 
     #[tokio::test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -4595,6 +4595,106 @@ mod tests {
 
     // --- Alphabetical sorting tests ---
 
+    // A full JSON Schema 2020-12 `inputSchema` (oneOf/anyOf/allOf, internal
+    // `$ref`/`$defs`, nested combinators, and an external `$ref` URI) must
+    // survive `tools/list` aggregation byte-for-byte, modulo the intentional
+    // tool-name prefix. The external `$ref` is passed through verbatim and is
+    // never fetched/dereferenced.
+    #[tokio::test]
+    async fn tools_list_passes_through_complex_2020_12_schema_modulo_prefix() {
+        let schema = json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "kind": {
+                    "oneOf": [
+                        { "type": "string", "const": "circle" },
+                        { "type": "string", "const": "square" }
+                    ]
+                },
+                "shape": { "$ref": "#/$defs/Shape" },
+                "either": {
+                    "anyOf": [
+                        { "$ref": "#/$defs/Shape" },
+                        { "type": "null" }
+                    ]
+                },
+                "combined": {
+                    "allOf": [
+                        { "type": "object" },
+                        { "$ref": "#/$defs/Shape" }
+                    ]
+                },
+                "remote": { "$ref": "https://example.com/schemas/widget.json#/$defs/Widget" }
+            },
+            "$defs": {
+                "Shape": {
+                    "type": "object",
+                    "properties": {
+                        "sides": { "type": "integer", "minimum": 3 },
+                        "nested": {
+                            "oneOf": [
+                                { "$ref": "#/$defs/Shape" },
+                                { "type": "null" }
+                            ]
+                        }
+                    },
+                    "required": ["sides"]
+                }
+            }
+        });
+        let state = test_app_state();
+        // Two endpoints force prefixing so the tool name gains its `{prefix}__`
+        // segment while the schema body must remain untouched.
+        state
+            .registry
+            .register(
+                "a".into(),
+                Box::new(MockAdapter {
+                    tools: vec![ToolInfo {
+                        name: "draw".into(),
+                        description: Some("draw tool".into()),
+                        input_schema: schema.clone(),
+                        annotations: None,
+                    }],
+                }),
+                "stdio".into(),
+                None,
+                Some("a".into()),
+            )
+            .await;
+        state
+            .registry
+            .register(
+                "b".into(),
+                Box::new(MockAdapter::with_tools(&["ping"])),
+                "stdio".into(),
+                None,
+                Some("b".into()),
+            )
+            .await;
+
+        let body = JsonRpcBody {
+            jsonrpc: Some("2.0".to_string()),
+            method: Some("tools/list".to_string()),
+            params: None,
+            id: Some(json!(1)),
+        };
+        let Json(resp) = mcp_tools_list(State(state), Json(body), None).await;
+        let tools = resp["result"]["tools"].as_array().unwrap();
+        let drawn = tools
+            .iter()
+            .find(|t| t["name"] == "a__draw")
+            .expect("prefixed complex tool present in tools/list");
+        // inputSchema passes through completely unchanged.
+        assert_eq!(drawn["inputSchema"], schema);
+        // The external `$ref` URI is preserved verbatim, never resolved.
+        assert_eq!(
+            drawn["inputSchema"]["properties"]["remote"]["$ref"],
+            json!("https://example.com/schemas/widget.json#/$defs/Widget")
+        );
+    }
+
     #[tokio::test]
     async fn test_tools_list_returns_sorted_tools() {
         let state = test_app_state();

--- a/src/server.rs
+++ b/src/server.rs
@@ -4499,6 +4499,79 @@ mod tests {
         );
     }
 
+    /// D6 (2026-07-28): the relay must never *originate* the retired `-32002`
+    /// error code. Param-level not-found/invalid conditions map to the standard
+    /// JSON-RPC `-32602` (Invalid Params); method-not-found stays `-32601` and
+    /// malformed requests stay `-32600`. This guard fires the representative
+    /// error-producing requests on both the legacy and 2026 inbound paths and
+    /// asserts none of them come back as `-32002`, and that the param-level
+    /// missing-`name` case maps to `-32602` under the 2026 dialect too.
+    #[tokio::test]
+    async fn relay_never_originates_minus_32002() {
+        // Legacy: missing 'name' (param-level) → -32602, never -32002.
+        let resp = post_mcp(
+            test_app_state(),
+            &json!({
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"arguments": {}},
+                "id": 1
+            }),
+        )
+        .await;
+        let body = body_json(resp).await;
+        assert_eq!(body["error"]["code"], -32602);
+        assert_ne!(body["error"]["code"], json!(-32002));
+
+        // Legacy: unknown tool → JSON-RPC error, never -32002.
+        let resp = post_mcp(
+            test_app_state(),
+            &json!({
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "does_not_exist", "arguments": {}},
+                "id": 2
+            }),
+        )
+        .await;
+        let body = body_json(resp).await;
+        assert!(body["error"].is_object());
+        assert_ne!(body["error"]["code"], json!(-32002));
+
+        // Legacy: unknown method → -32601, never -32002.
+        let resp = post_mcp(
+            test_app_state(),
+            &json!({"jsonrpc": "2.0", "method": "no/such/method", "id": 3}),
+        )
+        .await;
+        let body = body_json(resp).await;
+        assert_ne!(body["error"]["code"], json!(-32002));
+
+        // 2026 path (dialect detected via `_meta` clientInfo): missing 'name'
+        // (param-level) → -32602, never -32002.
+        let resp = post_mcp(
+            test_app_state(),
+            &json!({
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "id": 4,
+                "params": {
+                    "arguments": {},
+                    "_meta": {
+                        protocol::META_CLIENT_INFO_KEY: { "name": "stateless-client", "version": "3.1" },
+                    },
+                },
+            }),
+        )
+        .await;
+        let body = body_json(resp).await;
+        assert_eq!(
+            body["error"]["code"], -32602,
+            "2026 param-level missing-name must map to -32602"
+        );
+        assert_ne!(body["error"]["code"], json!(-32002));
+    }
+
     // --- Alphabetical sorting tests ---
 
     #[tokio::test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -858,13 +858,34 @@ async fn mcp_tools_call(
         ));
     }
 
+    // Transparent MCP 2026-07-28 multi round-trip passthrough: forward every
+    // top-level `tools/call` param other than `name`/`arguments` (e.g.
+    // `inputResponses`, `requestState`, `_meta`) verbatim to the upstream so an
+    // `InputRequiredResult` round-trip survives the relay hop. A normal terminal
+    // call carries no such siblings, so this map is empty and dispatch is
+    // identical to the legacy path.
+    let request_params: serde_json::Map<String, Value> = params
+        .as_object()
+        .map(|obj| {
+            obj.iter()
+                .filter(|(k, _)| k.as_str() != "name" && k.as_str() != "arguments")
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect()
+        })
+        .unwrap_or_default();
+
     let route_result = match profile_ctx {
         Some(ctx) => {
             ctx.registry_view
-                .route_tool_call(tool_name, arguments)
+                .route_tool_call_with_request_params(tool_name, arguments, request_params)
                 .await
         }
-        None => state.registry.route_tool_call(tool_name, arguments).await,
+        None => {
+            state
+                .registry
+                .route_tool_call_with_request_params(tool_name, arguments, request_params)
+                .await
+        }
     };
     match route_result {
         Ok(result) => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,6 +3,7 @@ use crate::events::ClientIdentity;
 use crate::js_sandbox::MetaToolHandler;
 use crate::oauth::{OAuthFlowManager, OAuthSetupManager};
 use crate::profile_registry::{ProfileContext, ProfileRegistry};
+use crate::protocol::{self, ProtocolVersion};
 use crate::registry::AdapterRegistry;
 use crate::token_manager::TokenManager;
 use crate::OAuthAdapterInners;
@@ -161,9 +162,12 @@ impl MetaToolSchemas {
 pub struct SessionIdentityStore {
     capacity: usize,
     next_seq: u64,
-    /// `session_id → (identity, recency seq)`. The seq is duplicated in
-    /// [`recency`] so the LRU pop is `O(log n)` rather than `O(n)`.
-    entries: HashMap<String, (ClientIdentity, u64)>,
+    /// `session_id → (identity, detected dialect, recency seq)`. The seq is
+    /// duplicated in [`recency`] so the LRU pop is `O(log n)` rather than
+    /// `O(n)`. The dialect is the inbound peer's negotiated
+    /// [`ProtocolVersion`], recorded at `initialize` time and consumed by
+    /// later version-gated dispatch (T3).
+    entries: HashMap<String, (ClientIdentity, ProtocolVersion, u64)>,
     /// `recency seq → session_id`. The smallest key is the least-
     /// recently-used entry; `pop_first` evicts it in `O(log n)`.
     recency: BTreeMap<u64, String>,
@@ -195,18 +199,32 @@ impl SessionIdentityStore {
     /// previously-stored identity for the same session id (typically
     /// `None`; a `Some` value indicates a session-id collision between
     /// two `initialize` calls and is overwritten).
+    #[allow(dead_code)]
     pub fn insert(
         &mut self,
         session_id: String,
         identity: ClientIdentity,
     ) -> Option<ClientIdentity> {
+        self.insert_with_dialect(session_id, identity, ProtocolVersion::default())
+    }
+
+    /// Insert or refresh an entry while recording the inbound peer's detected
+    /// [`ProtocolVersion`]. Eviction semantics match [`insert`]; the returned
+    /// `Option` is the previously-stored identity for the same session id.
+    pub fn insert_with_dialect(
+        &mut self,
+        session_id: String,
+        identity: ClientIdentity,
+        dialect: ProtocolVersion,
+    ) -> Option<ClientIdentity> {
         let new_seq = self.next_seq();
-        let previous = if let Some((prev_id, prev_seq)) = self.entries.remove(&session_id) {
-            self.recency.remove(&prev_seq);
-            Some(prev_id)
-        } else {
-            None
-        };
+        let previous =
+            if let Some((prev_id, _prev_dialect, prev_seq)) = self.entries.remove(&session_id) {
+                self.recency.remove(&prev_seq);
+                Some(prev_id)
+            } else {
+                None
+            };
         while self.entries.len() >= self.capacity {
             let Some((evict_seq, evict_key)) = self.recency.pop_first() else {
                 break;
@@ -217,20 +235,29 @@ impl SessionIdentityStore {
             let _ = evict_seq;
         }
         self.recency.insert(new_seq, session_id.clone());
-        self.entries.insert(session_id, (identity, new_seq));
+        self.entries
+            .insert(session_id, (identity, dialect, new_seq));
         previous
     }
 
     /// Resolve the [`ClientIdentity`] for a session id and mark the entry
     /// as most-recently-used.
     pub fn get(&mut self, session_id: &str) -> Option<ClientIdentity> {
-        let (identity, prev_seq) = self.entries.get(session_id).cloned()?;
+        let (identity, dialect, prev_seq) = self.entries.get(session_id).cloned()?;
         self.recency.remove(&prev_seq);
         let new_seq = self.next_seq();
         self.recency.insert(new_seq, session_id.to_string());
         self.entries
-            .insert(session_id.to_string(), (identity.clone(), new_seq));
+            .insert(session_id.to_string(), (identity.clone(), dialect, new_seq));
         Some(identity)
+    }
+
+    /// Read the inbound dialect recorded for a session id without disturbing
+    /// recency. Returns `None` for an unknown session. Consumed by T3 to gate
+    /// dispatch on the inbound peer's negotiated protocol version.
+    #[allow(dead_code)]
+    pub fn dialect(&self, session_id: &str) -> Option<ProtocolVersion> {
+        self.entries.get(session_id).map(|(_, dialect, _)| *dialect)
     }
 
     /// Number of live entries. Exposed for unit tests that exercise the
@@ -418,7 +445,7 @@ async fn mcp_initialize(
     profile_ctx: Option<&ProfileContext>,
 ) -> Json<Value> {
     let mut result = json!({
-        "protocolVersion": "2025-03-26",
+        "protocolVersion": protocol::VERSION_2025_03_26,
         "capabilities": {
             "tools": { "listChanged": true }
         },
@@ -1110,9 +1137,17 @@ fn resolve_identity_for_message(
     let init_identity = identity_from_initialize_params(msg.get("params"));
     let header_identity = identity_from_headers(headers);
     let session_id = uuid::Uuid::new_v4().to_string();
+    // Detect and record the inbound peer's dialect alongside its identity so
+    // version-gated dispatch (T3) can branch on it. Pure plumbing: storing the
+    // value changes no response or handshake behavior.
+    let dialect = protocol::detect_inbound_dialect(
+        true,
+        header_str(headers, protocol::MCP_PROTOCOL_VERSION_HEADER),
+        msg.get("params"),
+    );
     if !init_identity.is_empty() {
         if let Ok(mut guard) = state.session_identities.lock() {
-            guard.insert(session_id.clone(), init_identity.clone());
+            guard.insert_with_dialect(session_id.clone(), init_identity.clone(), dialect);
         }
     }
     let merged = merge_identity(init_identity, header_identity);

--- a/src/server.rs
+++ b/src/server.rs
@@ -1147,6 +1147,12 @@ async fn mcp_unified_impl(
 
             let mut responses: Vec<Value> = Vec::new();
             for msg in messages {
+                // 2026 HTTP routing headers (Mcp-Method/Mcp-Name) must agree
+                // with each message body; a mismatch is rejected before dispatch.
+                if let Some(err) = validate_2026_routing_headers(&headers, &msg) {
+                    responses.push(err);
+                    continue;
+                }
                 let (identity, new_session) = resolve_identity_for_message(&state, &headers, &msg);
                 if emitted_session_id.is_none() {
                     emitted_session_id = new_session;
@@ -1172,6 +1178,11 @@ async fn mcp_unified_impl(
             }
         }
         Value::Object(_) => {
+            // 2026 HTTP routing headers (Mcp-Method/Mcp-Name) must agree with
+            // the request body; a mismatch is rejected before dispatch.
+            if let Some(err) = validate_2026_routing_headers(&headers, &body) {
+                return json_response(err);
+            }
             let (identity, new_session) = resolve_identity_for_message(&state, &headers, &body);
             emitted_session_id = new_session;
             match handle_single_message(
@@ -1247,35 +1258,97 @@ fn resolve_identity_for_message(
             None,
         );
     }
-    // `initialize`: issue a fresh session id unconditionally so the
-    // client can echo it on follow-ups, even when it sent no
-    // `clientInfo`. Only cache the structured `clientInfo` (name /
-    // version) — the per-request `User-Agent`/`Origin` fallback covers
-    // the empty case on later requests without polluting the LRU with
-    // zero-signal entries.
     let init_identity = identity_from_initialize_params(msg.get("params"));
     let header_identity = identity_from_headers(headers);
-    let session_id = uuid::Uuid::new_v4().to_string();
-    // Detect and record the inbound peer's dialect alongside its identity so
-    // version-gated dispatch (T3) can branch on it. Pure plumbing: storing the
-    // value changes no response or handshake behavior.
+    // Detect the inbound peer's dialect so the session path can branch on it.
     let dialect = protocol::detect_inbound_dialect(
         true,
         header_str(headers, protocol::MCP_PROTOCOL_VERSION_HEADER),
         msg.get("params"),
     );
-    if !init_identity.is_empty() {
-        if let Ok(mut guard) = state.session_identities.lock() {
-            guard.insert_with_dialect(session_id.clone(), init_identity.clone(), dialect);
-        }
-    }
-    let merged = merge_identity(init_identity, header_identity);
+    let merged = merge_identity(init_identity.clone(), header_identity);
     let identity = if merged.is_empty() {
         None
     } else {
         Some(merged)
     };
+    // 2026 clients are stateless: they are not required to send `initialize`
+    // and, when they do, the relay mints/stores/echoes no `Mcp-Session-Id`
+    // (statelessness replaces session affinity — identity travels in `_meta`).
+    if dialect.is_2026() {
+        return (identity, None);
+    }
+    // Legacy `initialize`: issue a fresh session id unconditionally so the
+    // client can echo it on follow-ups, even when it sent no `clientInfo`.
+    // Only cache the structured `clientInfo` (name / version) — the per-request
+    // `User-Agent`/`Origin` fallback covers the empty case on later requests
+    // without polluting the LRU with zero-signal entries.
+    let session_id = uuid::Uuid::new_v4().to_string();
+    if !init_identity.is_empty() {
+        if let Ok(mut guard) = state.session_identities.lock() {
+            guard.insert_with_dialect(session_id.clone(), init_identity, dialect);
+        }
+    }
     (identity, Some(session_id))
+}
+
+/// Validate the 2026 Streamable-HTTP routing headers against a single
+/// JSON-RPC message body. 2026 clients mirror the JSON-RPC `method` in
+/// `Mcp-Method` and (for `tools/call`) the tool name in `Mcp-Name` so proxies
+/// can route/observe without parsing the body. When a header is *present* and
+/// disagrees with the body the request is rejected with `-32600 Invalid
+/// Request` — the relay's existing code for header/body-level malformed
+/// requests (header/body disagreement is fundamentally an Invalid Request, not
+/// a params-validation failure, so `-32600` is used for both headers).
+///
+/// Returns `Some(error envelope)` to reject, or `None` to accept. Absent
+/// headers are accepted: the 2026 stateless path also identifies clients via
+/// `_meta`, and `Mcp-Name` is not applicable to methods without a tool name.
+/// Legacy dialects are never validated (this is a 2026-only, HTTP-only check).
+fn validate_2026_routing_headers(headers: &HeaderMap, msg: &Value) -> Option<Value> {
+    let method = msg.get("method").and_then(|v| v.as_str()).unwrap_or("");
+    let dialect = protocol::detect_inbound_dialect(
+        method == "initialize",
+        header_str(headers, protocol::MCP_PROTOCOL_VERSION_HEADER),
+        msg.get("params"),
+    );
+    if !dialect.is_2026() {
+        return None;
+    }
+    let id = msg.get("id").cloned().unwrap_or(Value::Null);
+    let invalid_request = |message: String| {
+        Some(json!({
+            "jsonrpc": "2.0",
+            "error": { "code": -32600, "message": message },
+            "id": id,
+        }))
+    };
+    if let Some(hdr_method) = header_str(headers, protocol::MCP_METHOD_HEADER) {
+        if hdr_method != method {
+            return invalid_request(format!(
+                "Invalid Request: Mcp-Method header '{}' does not match body method '{}'",
+                hdr_method, method
+            ));
+        }
+    }
+    if let Some(hdr_name) = header_str(headers, protocol::MCP_NAME_HEADER) {
+        // `Mcp-Name` mirrors the tool name for `tools/call`; methods without a
+        // tool name have nothing to compare against.
+        if method == "tools/call" {
+            let body_name = msg
+                .get("params")
+                .and_then(|p| p.get("name"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if hdr_name != body_name {
+                return invalid_request(format!(
+                    "Invalid Request: Mcp-Name header '{}' does not match tool name '{}'",
+                    hdr_name, body_name
+                ));
+            }
+        }
+    }
+    None
 }
 
 /// JSON 404 body returned by profile-scoped routes when the URL `{profile}`
@@ -3358,6 +3431,29 @@ mod tests {
         router.oneshot(request).await.unwrap()
     }
 
+    /// Helper: send a JSON-RPC POST to `/mcp` with extra request headers.
+    async fn post_mcp_with_headers(
+        state: AppState,
+        body: &Value,
+        extra_headers: &[(&str, &str)],
+    ) -> axum::response::Response {
+        use axum::body::Body;
+        use tower::ServiceExt;
+
+        let router = build_router(state);
+        let mut builder = axum::http::Request::builder()
+            .method("POST")
+            .uri("/mcp")
+            .header("content-type", "application/json");
+        for (k, v) in extra_headers {
+            builder = builder.header(*k, *v);
+        }
+        let request = builder
+            .body(Body::from(serde_json::to_vec(body).unwrap()))
+            .unwrap();
+        router.oneshot(request).await.unwrap()
+    }
+
     /// Helper: collect the response body bytes into a `Value`.
     async fn body_json(resp: axum::response::Response) -> Value {
         let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
@@ -3452,6 +3548,203 @@ mod tests {
         // handshake/method-not-found rejection of the bare request.
         assert!(body.get("result").is_some() || body.get("error").is_some());
         assert_ne!(body["error"]["code"], json!(-32601));
+    }
+
+    // --- T5: 2026 routing-header validation + session-id gating ---------------
+
+    #[tokio::test]
+    async fn validate_2026_routing_headers_accepts_matching_method_and_name() {
+        // 2026 request (explicit header) with Mcp-Method/Mcp-Name that agree
+        // with the body passes validation.
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            protocol::MCP_PROTOCOL_VERSION_HEADER,
+            HeaderValue::from_static("2026-07-28"),
+        );
+        headers.insert(
+            protocol::MCP_METHOD_HEADER,
+            HeaderValue::from_static("tools/call"),
+        );
+        headers.insert(
+            protocol::MCP_NAME_HEADER,
+            HeaderValue::from_static("search_tools"),
+        );
+        let msg = json!({
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 1,
+            "params": { "name": "search_tools", "arguments": {} },
+        });
+        assert!(validate_2026_routing_headers(&headers, &msg).is_none());
+    }
+
+    #[tokio::test]
+    async fn validate_2026_routing_headers_rejects_method_mismatch() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            protocol::MCP_PROTOCOL_VERSION_HEADER,
+            HeaderValue::from_static("2026-07-28"),
+        );
+        headers.insert(
+            protocol::MCP_METHOD_HEADER,
+            HeaderValue::from_static("tools/list"),
+        );
+        let msg =
+            json!({ "jsonrpc": "2.0", "method": "tools/call", "id": 2, "params": { "name": "x" } });
+        let err = validate_2026_routing_headers(&headers, &msg)
+            .expect("Mcp-Method/body mismatch must be rejected");
+        assert_eq!(err["error"]["code"], json!(-32600));
+        assert_eq!(err["id"], json!(2));
+    }
+
+    #[tokio::test]
+    async fn validate_2026_routing_headers_rejects_name_mismatch() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            protocol::MCP_PROTOCOL_VERSION_HEADER,
+            HeaderValue::from_static("2026-07-28"),
+        );
+        headers.insert(
+            protocol::MCP_METHOD_HEADER,
+            HeaderValue::from_static("tools/call"),
+        );
+        headers.insert(
+            protocol::MCP_NAME_HEADER,
+            HeaderValue::from_static("wrong_tool"),
+        );
+        let msg = json!({
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 3,
+            "params": { "name": "right_tool", "arguments": {} },
+        });
+        let err = validate_2026_routing_headers(&headers, &msg)
+            .expect("Mcp-Name/body mismatch must be rejected");
+        assert_eq!(err["error"]["code"], json!(-32600));
+        assert_eq!(err["id"], json!(3));
+    }
+
+    #[tokio::test]
+    async fn validate_2026_routing_headers_ignores_legacy_dialect() {
+        // A legacy request (no 2026 signal) with a contradictory Mcp-Method is
+        // NOT validated — legacy clients are unaffected by 2026 routing headers.
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            protocol::MCP_METHOD_HEADER,
+            HeaderValue::from_static("tools/list"),
+        );
+        let msg =
+            json!({ "jsonrpc": "2.0", "method": "tools/call", "id": 4, "params": { "name": "x" } });
+        assert!(validate_2026_routing_headers(&headers, &msg).is_none());
+    }
+
+    #[tokio::test]
+    async fn mcp_unified_rejects_2026_method_header_mismatch() {
+        // End-to-end: a 2026 request whose Mcp-Method disagrees with the body
+        // is rejected with -32600 before dispatch.
+        let state = test_app_state();
+        let resp = post_mcp_with_headers(
+            state,
+            &json!({"jsonrpc":"2.0","method":"tools/list","id":41}),
+            &[
+                (protocol::MCP_PROTOCOL_VERSION_HEADER, "2026-07-28"),
+                (protocol::MCP_METHOD_HEADER, "tools/call"),
+            ],
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["error"]["code"], json!(-32600));
+        assert_eq!(body["id"], json!(41));
+    }
+
+    #[tokio::test]
+    async fn mcp_unified_accepts_2026_matching_headers() {
+        // A 2026 request with agreeing Mcp-Method dispatches normally.
+        let state = test_app_state();
+        let resp = post_mcp_with_headers(
+            state,
+            &json!({"jsonrpc":"2.0","method":"tools/list","id":42}),
+            &[
+                (protocol::MCP_PROTOCOL_VERSION_HEADER, "2026-07-28"),
+                (protocol::MCP_METHOD_HEADER, "tools/list"),
+            ],
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert!(body["result"]["tools"].is_array());
+        assert_eq!(body["id"], json!(42));
+    }
+
+    #[tokio::test]
+    async fn mcp_unified_2026_initialize_emits_no_session_id() {
+        // A 2026 `initialize` (explicit header) is stateless: the response
+        // carries no Mcp-Session-Id.
+        let state = test_app_state();
+        let resp = post_mcp_with_headers(
+            state,
+            &json!({
+                "jsonrpc": "2.0",
+                "method": "initialize",
+                "id": 51,
+                "params": { "clientInfo": { "name": "stateless-ai", "version": "1.0" } },
+            }),
+            &[(protocol::MCP_PROTOCOL_VERSION_HEADER, "2026-07-28")],
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(
+            resp.headers().get(MCP_SESSION_ID_HEADER).is_none(),
+            "2026 responses must not emit Mcp-Session-Id"
+        );
+    }
+
+    #[tokio::test]
+    async fn mcp_unified_legacy_initialize_still_emits_session_id() {
+        // Legacy `initialize` keeps the session path: the response echoes a
+        // freshly-minted Mcp-Session-Id.
+        let state = test_app_state();
+        let resp = post_mcp(
+            state,
+            &json!({
+                "jsonrpc": "2.0",
+                "method": "initialize",
+                "id": 52,
+                "params": { "clientInfo": { "name": "legacy-ai", "version": "1.0" } },
+            }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(
+            resp.headers().get(MCP_SESSION_ID_HEADER).is_some(),
+            "legacy responses must emit Mcp-Session-Id"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_identity_for_message_2026_initialize_mints_no_session() {
+        // A 2026 `initialize` mints no session id and stores nothing keyed by
+        // session, even though it carries structured clientInfo.
+        let state = test_app_state();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            protocol::MCP_PROTOCOL_VERSION_HEADER,
+            HeaderValue::from_static("2026-07-28"),
+        );
+        let msg = json!({
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "id": 53,
+            "params": { "clientInfo": { "name": "stateless-ai", "version": "2.0" } },
+        });
+        let (identity, session_id) = resolve_identity_for_message(&state, &headers, &msg);
+        assert!(
+            session_id.is_none(),
+            "2026 initialize must mint no session id"
+        );
+        let identity = identity.expect("2026 initialize still resolves identity from clientInfo");
+        assert_eq!(identity.name.as_deref(), Some("stateless-ai"));
     }
 
     #[tokio::test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -508,6 +508,14 @@ async fn mcp_initialize(
     Json(body): Json<JsonRpcBody>,
     profile_ctx: Option<&ProfileContext>,
 ) -> Json<Value> {
+    let result = build_initialize_result(&state, profile_ctx).await;
+    jsonrpc_response(body.id, result)
+}
+
+/// Build the `InitializeResult` body (`protocolVersion`/`capabilities`/
+/// `serverInfo`/optional `instructions`) shared by `initialize` and
+/// `server/discover`, so both advertise the relay identically.
+async fn build_initialize_result(state: &AppState, profile_ctx: Option<&ProfileContext>) -> Value {
     let mut result = json!({
         "protocolVersion": protocol::VERSION_2025_03_26,
         "capabilities": {
@@ -524,6 +532,44 @@ async fn mcp_initialize(
     };
     if let Some(instructions) = instructions {
         result["instructions"] = Value::String(instructions);
+    }
+    result
+}
+
+/// POST /mcp `server/discover`
+///
+/// 2026-07-28 clients are stateless — they may fetch the relay's server
+/// identity and primitive catalog in a single call without the legacy
+/// `initialize` handshake. The result reuses [`build_initialize_result`] so
+/// `serverInfo`/`capabilities`/`protocolVersion` stay byte-for-byte consistent
+/// with `initialize`, then appends the aggregated primitive summary the relay
+/// exposes — `tools` (mirroring `tools/list`). The relay advertises no prompts
+/// or resources, so only `tools` appears.
+///
+/// Per the coordinator decision (T11 — relay is local/single-user), the result
+/// carries NO `ttlMs` and NO `cacheScope`: 2026 clients treat the absent hint
+/// as immediately stale and rely on `listChanged`, which the relay supports.
+async fn mcp_server_discover(
+    State(state): State<AppState>,
+    Json(body): Json<JsonRpcBody>,
+    profile_ctx: Option<&ProfileContext>,
+) -> Json<Value> {
+    let mut result = build_initialize_result(&state, profile_ctx).await;
+    // Reuse the `tools/list` aggregation verbatim for the primitive summary.
+    let tools_body = JsonRpcBody {
+        jsonrpc: None,
+        method: None,
+        params: None,
+        id: None,
+    };
+    let Json(mut tools_resp) =
+        mcp_tools_list(State(state.clone()), Json(tools_body), profile_ctx).await;
+    if let Some(tools) = tools_resp
+        .get_mut("result")
+        .and_then(|r| r.get_mut("tools"))
+        .map(Value::take)
+    {
+        result["tools"] = tools;
     }
     jsonrpc_response(body.id, result)
 }
@@ -926,6 +972,9 @@ async fn handle_single_message(
 
         let result: Result<Json<Value>, (StatusCode, Json<Value>)> = match method.as_str() {
             "initialize" => Ok(mcp_initialize(State(state.clone()), Json(body), profile_ctx).await),
+            "server/discover" => {
+                Ok(mcp_server_discover(State(state.clone()), Json(body), profile_ctx).await)
+            }
             "tools/list" => Ok(mcp_tools_list(State(state.clone()), Json(body), profile_ctx).await),
             "tools/call" => mcp_tools_call(State(state.clone()), Json(body), profile_ctx).await,
             _ => Err(jsonrpc_error(
@@ -3403,6 +3452,94 @@ mod tests {
         // handshake/method-not-found rejection of the bare request.
         assert!(body.get("result").is_some() || body.get("error").is_some());
         assert_ne!(body["error"]["code"], json!(-32601));
+    }
+
+    #[tokio::test]
+    async fn mcp_unified_server_discover_returns_discovery_result() {
+        // `server/discover` returns the InitializeResult-equivalent identity
+        // (serverInfo/capabilities/protocolVersion) plus the aggregated `tools`
+        // primitive summary, and carries NO caching hints (T11).
+        let state = test_app_state();
+        let resp = post_mcp(
+            state,
+            &json!({"jsonrpc":"2.0","method":"server/discover","id":31}),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["jsonrpc"], "2.0");
+        assert_eq!(body["id"], 31);
+        let result = &body["result"];
+        // serverInfo/capabilities/protocolVersion match what `initialize` emits.
+        assert_eq!(result["protocolVersion"], "2025-03-26");
+        assert_eq!(result["serverInfo"]["name"], "Endara Relay");
+        assert!(!result["serverInfo"]["version"].as_str().unwrap().is_empty());
+        assert_eq!(result["capabilities"]["tools"]["listChanged"], true);
+        // Primitive summary: aggregated tools array (relay exposes tools only).
+        assert!(result["tools"].is_array());
+        // Coordinator decision T11: relay-as-server emits no caching hints.
+        assert!(result.get("ttlMs").is_none());
+        assert!(result.get("cacheScope").is_none());
+    }
+
+    #[tokio::test]
+    async fn mcp_unified_server_discover_stateless_without_handshake() {
+        // A 2026 client calls server/discover with no prior initialize and a
+        // `_meta` clientInfo payload — it must be dispatched normally.
+        let state = test_app_state();
+        let resp = post_mcp(
+            state,
+            &json!({
+                "jsonrpc": "2.0",
+                "method": "server/discover",
+                "id": 32,
+                "params": {
+                    "_meta": {
+                        protocol::META_CLIENT_INFO_KEY: { "name": "stateless-client", "version": "3.1" },
+                    },
+                },
+            }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["id"], 32);
+        assert_eq!(body["result"]["serverInfo"]["name"], "Endara Relay");
+        assert!(body["result"]["tools"].is_array());
+        // Not rejected as method-not-found.
+        assert_ne!(body["error"]["code"], json!(-32601));
+    }
+
+    #[tokio::test]
+    async fn mcp_unified_server_discover_matches_initialize_identity() {
+        // The serverInfo/capabilities/protocolVersion served by server/discover
+        // are byte-for-byte the same fields `initialize` returns (shared
+        // builder), so legacy initialize stays unaffected.
+        let state = test_app_state();
+        let init = body_json(
+            post_mcp(
+                state.clone(),
+                &json!({"jsonrpc":"2.0","method":"initialize","id":1}),
+            )
+            .await,
+        )
+        .await;
+        let discover = body_json(
+            post_mcp(
+                state,
+                &json!({"jsonrpc":"2.0","method":"server/discover","id":2}),
+            )
+            .await,
+        )
+        .await;
+        for field in ["protocolVersion", "capabilities", "serverInfo"] {
+            assert_eq!(
+                init["result"][field], discover["result"][field],
+                "server/discover {field} must match initialize"
+            );
+        }
+        // initialize remains a handshake result with no tools summary.
+        assert!(init["result"].get("tools").is_none());
     }
 
     #[tokio::test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -332,6 +332,32 @@ fn identity_from_initialize_params(params: Option<&Value>) -> ClientIdentity {
     }
 }
 
+/// Extract a [`ClientIdentity`] from a 2026 request's
+/// `params._meta["io.modelcontextprotocol/clientInfo"]` object. Because the
+/// 2026 dialect removes the `initialize` handshake, a stateless client attaches
+/// its identity on every request under this reverse-DNS `_meta` key instead of
+/// in an `initialize` body. Mirrors [`identity_from_initialize_params`]: every
+/// field is optional, so a malformed payload degrades to an empty identity
+/// rather than rejecting the request. (`title`, when present, is not stored —
+/// [`ClientIdentity`] carries only `name`/`version`.)
+fn identity_from_meta_client_info(params: Option<&Value>) -> ClientIdentity {
+    let Some(info) = protocol::meta_client_info(params) else {
+        return ClientIdentity::default();
+    };
+    ClientIdentity {
+        name: info
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        version: info
+            .get("version")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        user_agent: None,
+        origin: None,
+    }
+}
+
 /// Fold `fallback`'s non-empty fields into `primary` so structured
 /// `clientInfo` (name/version from `initialize`) wins over the per-request
 /// `User-Agent`/`Origin` headers when both are present.
@@ -361,6 +387,44 @@ fn resolve_inbound_identity(state: &AppState, headers: &HeaderMap) -> Option<Cli
         Some(s) => merge_identity(s, header_identity),
         None => header_identity,
     };
+    if merged.is_empty() {
+        None
+    } else {
+        Some(merged)
+    }
+}
+
+/// Resolve the caller's [`ClientIdentity`] for a non-`initialize` inbound
+/// message, branching on the per-request detected dialect (D2/D3).
+///
+/// 2026 clients are stateless — they send no `initialize` handshake and no
+/// `Mcp-Session-Id`, attaching their identity on every request under
+/// `params._meta["io.modelcontextprotocol/clientInfo"]` instead. When the
+/// request is detected as 2026 (an explicit `MCP-Protocol-Version: 2026-07-28`
+/// header, or `_meta` clientInfo present with no handshake), identity is read
+/// from that per-request `_meta` payload — merged with the `User-Agent`/`Origin`
+/// header fallback — rather than from the session cache.
+///
+/// Legacy clients (`2024-11-05` / `2025-03-26`) fall through to
+/// [`resolve_inbound_identity`] unchanged, preserving the session-cache lookup
+/// byte-for-byte.
+fn resolve_inbound_identity_versioned(
+    state: &AppState,
+    headers: &HeaderMap,
+    params: Option<&Value>,
+) -> Option<ClientIdentity> {
+    let dialect = protocol::detect_inbound_dialect(
+        false,
+        header_str(headers, protocol::MCP_PROTOCOL_VERSION_HEADER),
+        params,
+    );
+    if !dialect.is_2026() {
+        return resolve_inbound_identity(state, headers);
+    }
+    let merged = merge_identity(
+        identity_from_meta_client_info(params),
+        identity_from_headers(headers),
+    );
     if merged.is_empty() {
         None
     } else {
@@ -1126,7 +1190,13 @@ fn resolve_identity_for_message(
 ) -> (Option<ClientIdentity>, Option<String>) {
     let is_initialize = msg.get("method").and_then(|v| v.as_str()) == Some("initialize");
     if !is_initialize {
-        return (resolve_inbound_identity(state, headers), None);
+        // Non-`initialize` messages branch on the detected dialect: 2026 clients
+        // are stateless and carry identity in `params._meta` (no session), while
+        // legacy clients keep the session-cache lookup unchanged.
+        return (
+            resolve_inbound_identity_versioned(state, headers, msg.get("params")),
+            None,
+        );
     }
     // `initialize`: issue a fresh session id unconditionally so the
     // client can echo it on follow-ups, even when it sent no
@@ -1719,7 +1789,7 @@ async fn mcp_tools_list_logged(
     headers: HeaderMap,
     body: Json<JsonRpcBody>,
 ) -> Json<Value> {
-    let identity = resolve_inbound_identity(&state.0, &headers);
+    let identity = resolve_inbound_identity_versioned(&state.0, &headers, body.params.as_ref());
     let client_json = identity
         .as_ref()
         .filter(|c| !c.is_empty())
@@ -1773,7 +1843,7 @@ async fn mcp_tools_call_logged(
     headers: HeaderMap,
     body: Json<JsonRpcBody>,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
-    let identity = resolve_inbound_identity(&state.0, &headers);
+    let identity = resolve_inbound_identity_versioned(&state.0, &headers, body.params.as_ref());
     let client_json = identity
         .as_ref()
         .filter(|c| !c.is_empty())
@@ -2276,6 +2346,127 @@ mod tests {
         assert!(session_id.is_some());
         // Empty identities are not cached.
         assert!(state.session_identities.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn identity_from_meta_client_info_extracts_name_and_version() {
+        let params = json!({
+            "_meta": {
+                protocol::META_CLIENT_INFO_KEY: { "name": "claude-ai", "version": "2.0.0" },
+            },
+        });
+        let id = identity_from_meta_client_info(Some(&params));
+        assert_eq!(id.name.as_deref(), Some("claude-ai"));
+        assert_eq!(id.version.as_deref(), Some("2.0.0"));
+        assert!(id.user_agent.is_none());
+        assert!(id.origin.is_none());
+    }
+
+    #[test]
+    fn identity_from_meta_client_info_missing_is_empty() {
+        // No `_meta` at all, and a `_meta` without the clientInfo key, both
+        // degrade to an empty identity rather than panicking.
+        assert!(identity_from_meta_client_info(None).is_empty());
+        assert!(identity_from_meta_client_info(Some(&json!({}))).is_empty());
+        assert!(identity_from_meta_client_info(Some(&json!({ "_meta": {} }))).is_empty());
+    }
+
+    #[tokio::test]
+    async fn resolve_inbound_identity_versioned_2026_reads_meta_client_info() {
+        // A 2026 client sends no `initialize` and no `Mcp-Session-Id`; identity
+        // comes from per-request `_meta` clientInfo. Seed the session store to
+        // prove the 2026 path does NOT consult it.
+        let state = test_app_state();
+        state
+            .session_identities
+            .lock()
+            .unwrap()
+            .insert("stale".into(), identity("should-not-be-used", "9.9"));
+
+        let params = json!({
+            "_meta": {
+                protocol::META_CLIENT_INFO_KEY: { "name": "stateless-client", "version": "3.1" },
+            },
+        });
+
+        // Detected via the explicit protocol header.
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            protocol::MCP_PROTOCOL_VERSION_HEADER,
+            HeaderValue::from_static("2026-07-28"),
+        );
+        let resolved = resolve_inbound_identity_versioned(&state, &headers, Some(&params))
+            .expect("2026 identity must resolve from _meta");
+        assert_eq!(resolved.name.as_deref(), Some("stateless-client"));
+        assert_eq!(resolved.version.as_deref(), Some("3.1"));
+
+        // Detected via `_meta` clientInfo presence alone (no header).
+        let resolved = resolve_inbound_identity_versioned(&state, &HeaderMap::new(), Some(&params))
+            .expect("2026 identity must resolve from _meta without a header");
+        assert_eq!(resolved.name.as_deref(), Some("stateless-client"));
+        assert_eq!(resolved.version.as_deref(), Some("3.1"));
+    }
+
+    #[tokio::test]
+    async fn resolve_inbound_identity_versioned_2026_merges_header_fallback() {
+        // `_meta` clientInfo wins on name/version; `User-Agent`/`Origin`
+        // headers still fill the fields it leaves empty.
+        let state = test_app_state();
+        let params = json!({
+            "_meta": { protocol::META_CLIENT_INFO_KEY: { "name": "stateless-client" } },
+        });
+        let mut headers = HeaderMap::new();
+        headers.insert("user-agent", HeaderValue::from_static("relay-test/0.1"));
+        headers.insert("origin", HeaderValue::from_static("https://example.test"));
+        let resolved = resolve_inbound_identity_versioned(&state, &headers, Some(&params))
+            .expect("identity must resolve");
+        assert_eq!(resolved.name.as_deref(), Some("stateless-client"));
+        assert_eq!(resolved.user_agent.as_deref(), Some("relay-test/0.1"));
+        assert_eq!(resolved.origin.as_deref(), Some("https://example.test"));
+    }
+
+    #[tokio::test]
+    async fn resolve_inbound_identity_versioned_legacy_uses_session_cache() {
+        // A legacy client (no 2026 header, no `_meta` clientInfo) keeps the
+        // existing session-cache lookup byte-for-byte.
+        let state = test_app_state();
+        let sid = "legacy-session";
+        state
+            .session_identities
+            .lock()
+            .unwrap()
+            .insert(sid.into(), identity("legacy-ai", "1.0.0"));
+        let mut headers = HeaderMap::new();
+        headers.insert(MCP_SESSION_ID_HEADER, HeaderValue::from_static(sid));
+        let resolved = resolve_inbound_identity_versioned(&state, &headers, None)
+            .expect("legacy identity must resolve from the session cache");
+        assert_eq!(resolved.name.as_deref(), Some("legacy-ai"));
+        assert_eq!(resolved.version.as_deref(), Some("1.0.0"));
+    }
+
+    #[tokio::test]
+    async fn resolve_identity_for_message_2026_stateless_uses_meta() {
+        // A `tools/call` with `_meta` clientInfo and no handshake resolves its
+        // identity from `_meta` (not the session cache) and mints no session id.
+        let state = test_app_state();
+        let msg = json!({
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 7,
+            "params": {
+                "name": "demo",
+                "arguments": {},
+                "_meta": {
+                    protocol::META_CLIENT_INFO_KEY: { "name": "stateless-client", "version": "3.1" },
+                },
+            },
+        });
+        let (identity, session_id) = resolve_identity_for_message(&state, &HeaderMap::new(), &msg);
+        let identity = identity.expect("2026 stateless message should resolve identity");
+        assert_eq!(identity.name.as_deref(), Some("stateless-client"));
+        assert_eq!(identity.version.as_deref(), Some("3.1"));
+        // No session id is minted for non-`initialize` messages.
+        assert!(session_id.is_none());
     }
 
     #[tokio::test]
@@ -3153,6 +3344,65 @@ mod tests {
         let body = body_json(resp).await;
         assert_eq!(body["id"], 2);
         assert!(body["result"]["tools"].is_array());
+    }
+
+    #[tokio::test]
+    async fn mcp_unified_2026_stateless_tools_list_without_handshake() {
+        // A 2026 client calls tools/list with no prior initialize/initialized
+        // handshake, conveying its identity via `_meta` clientInfo. The relay
+        // must dispatch it normally.
+        let state = test_app_state();
+        let resp = post_mcp(
+            state,
+            &json!({
+                "jsonrpc": "2.0",
+                "method": "tools/list",
+                "id": 21,
+                "params": {
+                    "_meta": {
+                        protocol::META_CLIENT_INFO_KEY: { "name": "stateless-client", "version": "3.1" },
+                    },
+                },
+            }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["id"], 21);
+        assert!(body["result"]["tools"].is_array());
+    }
+
+    #[tokio::test]
+    async fn mcp_unified_2026_stateless_tools_call_without_handshake() {
+        // A 2026 client calls tools/call with no handshake. With no upstream
+        // tool registered the call resolves to a JSON-RPC-level result rather
+        // than a transport/handshake error — proving the stateless request was
+        // dispatched without requiring `initialize`.
+        let state = test_app_state();
+        let resp = post_mcp(
+            state,
+            &json!({
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "id": 22,
+                "params": {
+                    "name": "list_tools",
+                    "arguments": {},
+                    "_meta": {
+                        protocol::META_CLIENT_INFO_KEY: { "name": "stateless-client", "version": "3.1" },
+                    },
+                },
+            }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["jsonrpc"], "2.0");
+        assert_eq!(body["id"], 22);
+        // The dispatcher produced a JSON-RPC envelope (result or error), not a
+        // handshake/method-not-found rejection of the bare request.
+        assert!(body.get("result").is_some() || body.get("error").is_some());
+        assert_ne!(body["error"]["code"], json!(-32601));
     }
 
     #[tokio::test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1615,6 +1615,23 @@ struct OAuthCallbackParams {
     code: Option<String>,
     state: Option<String>,
     error: Option<String>,
+    /// RFC 9207 issuer identifier of the authorization server that produced
+    /// this response. Validated against the discovered issuer when known.
+    iss: Option<String>,
+}
+
+/// Validate the RFC 9207 `iss` authorization-response parameter against the
+/// issuer recorded for the pending flow (mix-up defense).
+///
+/// When `expected` is `Some(_)` (issuer was discovered), the callback `iss`
+/// must be present and an exact match. When `expected` is `None` (e.g. legacy
+/// convention-based config without RFC 8414 discovery), validation is skipped
+/// so existing flows keep working unchanged.
+fn validate_callback_iss(expected: Option<&str>, provided: Option<&str>) -> bool {
+    match expected {
+        Some(exp) => provided == Some(exp),
+        None => true,
+    }
 }
 
 /// Escape a string for safe interpolation into an HTML text node or quoted attribute.
@@ -1722,6 +1739,26 @@ async fn oauth_callback(
             );
         }
     };
+
+    // RFC 9207 issuer (`iss`) validation: when we discovered the authorization
+    // server's issuer, the callback MUST carry a matching `iss` (mix-up
+    // defense). When no issuer was recorded (legacy convention-based config),
+    // validation is skipped to preserve existing behavior.
+    if let Some(ref expected_issuer) = flow.issuer {
+        if !validate_callback_iss(Some(expected_issuer), params.iss.as_deref()) {
+            warn!(
+                endpoint = %flow.endpoint_name,
+                expected = %expected_issuer,
+                received = %params.iss.as_deref().unwrap_or("<missing>"),
+                "OAuth callback `iss` missing or does not match discovered issuer; rejecting"
+            );
+            return oauth_html_response(format!(
+                "<html><body><h1>OAuth Error</h1><p>Authorization response issuer mismatch (expected {}, got {}).</p><p>You can close this window.</p></body></html>",
+                html_escape(expected_issuer),
+                html_escape(params.iss.as_deref().unwrap_or("<missing>"))
+            ));
+        }
+    }
 
     // Exchange authorization code for tokens
     let client = reqwest::Client::new();
@@ -4788,6 +4825,7 @@ mod tests {
             error: Some(
                 "<script>fetch('/api/test-connection',{method:'POST'})</script>".to_string(),
             ),
+            iss: None,
         };
         let resp = oauth_callback(State(state), Query(params)).await;
         let csp = resp
@@ -4802,6 +4840,101 @@ mod tests {
         let body_str = String::from_utf8(body.to_vec()).unwrap();
         assert!(body_str.contains("&lt;script&gt;"), "body = {body_str}");
         assert!(!body_str.contains("<script>"));
+    }
+
+    // --- RFC 9207 `iss` validation -----------------------------------------
+
+    #[test]
+    fn test_validate_callback_iss_matching_passes() {
+        // (a) Known issuer + matching `iss` → valid.
+        assert!(validate_callback_iss(
+            Some("https://auth.example.com"),
+            Some("https://auth.example.com")
+        ));
+    }
+
+    #[test]
+    fn test_validate_callback_iss_mismatch_rejected() {
+        // (b) Known issuer + different `iss` → rejected.
+        assert!(!validate_callback_iss(
+            Some("https://auth.example.com"),
+            Some("https://evil.example.com")
+        ));
+    }
+
+    #[test]
+    fn test_validate_callback_iss_missing_rejected_when_known() {
+        // (c) Known issuer + missing `iss` → rejected.
+        assert!(!validate_callback_iss(
+            Some("https://auth.example.com"),
+            None
+        ));
+    }
+
+    #[test]
+    fn test_validate_callback_iss_none_skips_validation() {
+        // (d) No recorded issuer → validation skipped regardless of `iss`.
+        assert!(validate_callback_iss(None, None));
+        assert!(validate_callback_iss(
+            None,
+            Some("https://anything.example.com")
+        ));
+    }
+
+    /// Helper: build an `AppState` whose flow manager already holds a pending
+    /// flow with the given issuer, returning the state and the flow's `state`
+    /// param. Used to exercise the callback's RFC 9207 rejection paths without
+    /// reaching the token-exchange HTTP call.
+    async fn state_with_pending_flow(issuer: Option<&str>) -> (AppState, String) {
+        let mut app_state = test_app_state();
+        let flow_mgr = Arc::new(OAuthFlowManager::new());
+        let pkce = crate::oauth::PkceChallenge::generate();
+        let state_param = flow_mgr
+            .start_flow(
+                "iss-test",
+                "https://auth.example.com/token",
+                "client123",
+                None,
+                pkce,
+                "http://127.0.0.1:9400/oauth/callback",
+                issuer,
+            )
+            .await;
+        app_state.oauth_flow_manager = Some(flow_mgr);
+        (app_state, state_param)
+    }
+
+    #[tokio::test]
+    async fn test_oauth_callback_rejects_mismatched_iss() {
+        use axum::body::to_bytes;
+        let (state, state_param) = state_with_pending_flow(Some("https://auth.example.com")).await;
+        let params = OAuthCallbackParams {
+            code: Some("authcode".to_string()),
+            state: Some(state_param),
+            error: None,
+            iss: Some("https://evil.example.com".to_string()),
+        };
+        let resp = oauth_callback(State(state), Query(params)).await;
+        let body = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+        assert!(body_str.contains("issuer mismatch"), "body = {body_str}");
+    }
+
+    #[tokio::test]
+    async fn test_oauth_callback_rejects_missing_iss_when_issuer_known() {
+        use axum::body::to_bytes;
+        let (state, state_param) = state_with_pending_flow(Some("https://auth.example.com")).await;
+        let params = OAuthCallbackParams {
+            code: Some("authcode".to_string()),
+            state: Some(state_param),
+            error: None,
+            iss: None,
+        };
+        let resp = oauth_callback(State(state), Query(params)).await;
+        let body = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+        assert!(body_str.contains("issuer mismatch"), "body = {body_str}");
+        assert!(body_str.contains("&lt;missing&gt;"), "body = {body_str}");
     }
 
     // --- /mcp/sse + initialize tools.listChanged capability ---

--- a/src/token_manager.rs
+++ b/src/token_manager.rs
@@ -51,6 +51,47 @@ pub struct DcrCredentials {
     pub client_secret_expires_at: u64,
     /// Unix timestamp (seconds) when the client was registered.
     pub registered_at: u64,
+    /// Authorization server `issuer` (RFC 8414) these credentials were
+    /// registered against. Bound so a stored DCR `client_id` is only reused
+    /// with the SAME issuing AS; an issuer change triggers re-registration
+    /// (RFC 7591). `None` for legacy credential files saved before this field
+    /// existed (treated as "reuse as-is" for backward compatibility).
+    #[serde(default)]
+    pub issuer: Option<String>,
+}
+
+/// Decide whether persisted DCR credentials may be reused with the current
+/// authorization server, or must be discarded and re-registered (RFC 7591).
+///
+/// Returns `true` to reuse, `false` to re-register. The decision is pure so it
+/// can be unit-tested directly:
+/// - stored issuer `None` (legacy creds) → reuse (backward compatibility)
+/// - current issuer `None` (issuer unknown) → reuse (cannot detect a migration)
+/// - both `Some` and equal → reuse
+/// - both `Some` and differ → re-register (issuer migration)
+pub fn dcr_issuer_allows_reuse(stored: Option<&str>, current: Option<&str>) -> bool {
+    match (stored, current) {
+        (Some(s), Some(c)) => s == c,
+        _ => true,
+    }
+}
+
+/// Compute the set-union of previously-granted scopes and the scopes that would
+/// be requested today, for step-up authorization. Prior scopes are emitted
+/// first (stable order), then any newly-requested scopes not already present;
+/// duplicates are removed. Whitespace-delimited, per the OAuth `scope` syntax.
+pub fn merge_scopes(prior: Option<&str>, requested: &str) -> String {
+    let mut out: Vec<&str> = Vec::new();
+    for s in prior
+        .unwrap_or("")
+        .split_whitespace()
+        .chain(requested.split_whitespace())
+    {
+        if !out.contains(&s) {
+            out.push(s);
+        }
+    }
+    out.join(" ")
 }
 
 /// Owns token persistence. One instance shared across all OAuth adapters via `Arc<TokenManager>`.
@@ -310,6 +351,7 @@ mod tests {
             client_secret: Some("dcr-client-secret".to_string()),
             client_secret_expires_at: 0,
             registered_at: 1700000000,
+            issuer: Some("https://auth.example.com".to_string()),
         }
     }
 
@@ -415,12 +457,100 @@ mod tests {
             client_secret: None,
             client_secret_expires_at: 0,
             registered_at: 1700000000,
+            issuer: None,
         };
 
         mgr.save_dcr("public-ep", &creds).await.unwrap();
         let loaded = mgr.load_dcr("public-ep").await.unwrap().unwrap();
         assert_eq!(loaded, creds);
         assert!(loaded.client_secret.is_none());
+    }
+
+    #[tokio::test]
+    async fn dcr_round_trip_preserves_issuer() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        let creds = make_dcr_creds();
+        assert_eq!(creds.issuer.as_deref(), Some("https://auth.example.com"));
+
+        mgr.save_dcr("issuer-ep", &creds).await.unwrap();
+        let loaded = mgr.load_dcr("issuer-ep").await.unwrap().unwrap();
+        assert_eq!(loaded.issuer.as_deref(), Some("https://auth.example.com"));
+        assert_eq!(loaded, creds);
+    }
+
+    #[test]
+    fn dcr_legacy_file_without_issuer_loads_as_none() {
+        // Credential files written before the `issuer` field existed must still
+        // deserialize, with issuer = None (no spurious re-registration).
+        let json = r#"{"client_id":"legacy-id","client_secret":"legacy-secret","client_secret_expires_at":0,"registered_at":1700000000}"#;
+        let creds: DcrCredentials = serde_json::from_str(json).unwrap();
+        assert_eq!(creds.client_id, "legacy-id");
+        assert_eq!(creds.issuer, None);
+    }
+
+    // --- dcr_issuer_allows_reuse() decision tests ---
+
+    #[test]
+    fn issuer_reuse_legacy_none_is_reused() {
+        // Stored issuer None (legacy) → reuse regardless of current issuer.
+        assert!(dcr_issuer_allows_reuse(None, Some("https://a.example")));
+        assert!(dcr_issuer_allows_reuse(None, None));
+    }
+
+    #[test]
+    fn issuer_reuse_matching_is_reused() {
+        assert!(dcr_issuer_allows_reuse(
+            Some("https://a.example"),
+            Some("https://a.example")
+        ));
+    }
+
+    #[test]
+    fn issuer_reuse_differing_triggers_reregister() {
+        assert!(!dcr_issuer_allows_reuse(
+            Some("https://a.example"),
+            Some("https://b.example")
+        ));
+    }
+
+    #[test]
+    fn issuer_reuse_unknown_current_is_reused() {
+        // Current issuer unknown (discovery fallback) → cannot detect a
+        // migration, so reuse to avoid spurious re-registration.
+        assert!(dcr_issuer_allows_reuse(Some("https://a.example"), None));
+    }
+
+    // --- merge_scopes() tests ---
+
+    #[test]
+    fn merge_scopes_empty_prior_returns_requested() {
+        assert_eq!(merge_scopes(None, "read write"), "read write");
+        assert_eq!(merge_scopes(Some(""), "read write"), "read write");
+    }
+
+    #[test]
+    fn merge_scopes_overlapping_dedups() {
+        assert_eq!(
+            merge_scopes(Some("read write"), "write delete"),
+            "read write delete"
+        );
+    }
+
+    #[test]
+    fn merge_scopes_disjoint_unions() {
+        assert_eq!(merge_scopes(Some("read"), "write"), "read write");
+    }
+
+    #[test]
+    fn merge_scopes_preserves_prior_first_order() {
+        // Prior scopes are emitted first, then new ones; dedup keeps first seen.
+        assert_eq!(merge_scopes(Some("b a"), "a c b"), "b a c");
+    }
+
+    #[test]
+    fn merge_scopes_empty_requested_keeps_prior() {
+        assert_eq!(merge_scopes(Some("read write"), ""), "read write");
     }
 
     #[cfg(unix)]

--- a/src/toon_convert.rs
+++ b/src/toon_convert.rs
@@ -230,6 +230,28 @@ mod tests {
         assert_eq!(out3, weird);
     }
 
+    // D13 — response direction: toonifying a `CallToolResult` must preserve a
+    // sibling `_meta` carrying W3C Trace Context so upstream→client trace
+    // fields survive the TOON pass and reach the inbound client unmodified.
+    #[test]
+    fn toonify_call_result_preserves_meta_trace_context() {
+        let input = json!({
+            "content": [{ "type": "text", "text": "{\"k\":1}" }],
+            "_meta": {
+                "traceparent": "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+                "tracestate": "vendor=abc"
+            }
+        });
+        let out = toonify_call_result(input);
+        assert_eq!(
+            out["_meta"]["traceparent"],
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+        );
+        assert_eq!(out["_meta"]["tracestate"], "vendor=abc");
+        // The text content was still toonified (no longer raw JSON).
+        assert_ne!(out["content"][0]["text"], "{\"k\":1}");
+    }
+
     // §5 row 9: toonify_value converts JSON object to TOON string.
     #[test]
     fn toonify_value_converts_object_to_toon() {

--- a/src/toon_convert.rs
+++ b/src/toon_convert.rs
@@ -90,6 +90,19 @@ mod tests {
         assert_eq!(decoded, json!({"name": "Alice", "age": 30}));
     }
 
+    // T10: an MCP 2026-07-28 `InputRequiredResult` has no `content` array, so
+    // toonification leaves it byte-for-byte unchanged — the multi round-trip
+    // shape (`inputRequests`/`requestState`) survives the TOON pass intact.
+    #[test]
+    fn leaves_input_required_result_unchanged() {
+        let input = json!({
+            "inputRequests": [{"name": "city", "schema": {"type": "string"}}],
+            "requestState": "state-xyz"
+        });
+        let out = toonify_call_result(input.clone());
+        assert_eq!(out, input);
+    }
+
     // §5 row 2: toonify_call_result converts JSON array in TextContent.text
     // to TOON.
     #[test]

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1911,6 +1911,7 @@ mod tests {
                 client_secret: Some("dcr-secret".to_string()),
                 client_secret_expires_at: 0,
                 registered_at: 1_700_000_000,
+                issuer: None,
             },
         )
         .await

--- a/tests/oauth_integration.rs
+++ b/tests/oauth_integration.rs
@@ -141,13 +141,19 @@ async fn mock_auth_server_metadata(
 }
 
 async fn mock_authorize(
+    State(state): axum::extract::State<Arc<MockOAuthState>>,
     axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
 ) -> impl axum::response::IntoResponse {
     // In a real flow the browser would redirect. For tests, we return the
-    // redirect_uri + code so the test can simulate the callback.
+    // redirect_uri + code so the test can simulate the callback. Include the
+    // RFC 9207 `iss` parameter so the relay's issuer validation passes.
     let redirect_uri = params.get("redirect_uri").cloned().unwrap_or_default();
     let state_param = params.get("state").cloned().unwrap_or_default();
-    let location = format!("{}?code=mock-auth-code&state={}", redirect_uri, state_param);
+    let issuer = format!("http://127.0.0.1:{}", state.port);
+    let location = format!(
+        "{}?code=mock-auth-code&state={}&iss={}",
+        redirect_uri, state_param, issuer
+    );
     (
         axum::http::StatusCode::FOUND,
         [(axum::http::header::LOCATION, location)],
@@ -521,8 +527,14 @@ async fn simulate_oauth_login(api: &ApiClient, endpoint_name: &str) -> Value {
     let redirect_uri = query_pairs.get("redirect_uri").expect("no redirect_uri");
     let state_param = query_pairs.get("state").expect("no state param");
 
-    // Step 3: Simulate the callback (as if the browser redirected)
-    let callback_url = format!("{}?code=mock-auth-code&state={}", redirect_uri, state_param);
+    // Step 3: Simulate the callback (as if the browser redirected). Include the
+    // RFC 9207 `iss` parameter matching the mock AS issuer so the relay's
+    // issuer validation passes.
+    let issuer = parsed.origin().ascii_serialization();
+    let callback_url = format!(
+        "{}?code=mock-auth-code&state={}&iss={}",
+        redirect_uri, state_param, issuer
+    );
 
     // Use a client that doesn't follow redirects so we can see the response
     let no_redirect_client = reqwest::Client::builder()
@@ -606,6 +618,66 @@ async fn test_oauth_fresh_login_flow() {
     assert!(
         !auth_requests.is_empty(),
         "Expected upstream MCP requests with Bearer token"
+    );
+}
+
+/// Scope accumulation: after a successful login persists a granted scope,
+/// a subsequent re-authorization (step-up) must request the UNION of the
+/// previously-granted scopes and the scopes requested today, so the user never
+/// silently loses access they already granted.
+#[tokio::test]
+async fn test_oauth_reauth_accumulates_prior_scope() {
+    let (oauth_addr, _oauth_state) = start_mock_oauth(3600, true).await;
+    let (mcp_addr, _mcp_state) = start_mock_mcp("access-token-1").await;
+
+    let oauth_url = format!("http://127.0.0.1:{}", oauth_addr.port());
+    let mcp_url = format!("http://127.0.0.1:{}/mcp", mcp_addr.port());
+
+    let config = ConfigBuilder::new()
+        .add_oauth_with_client("test-oauth", &mcp_url, Some(&oauth_url), "test-client")
+        .build();
+
+    let harness = RelayHarness::start(&config).await;
+
+    poll_oauth_status(
+        harness.api(),
+        "test-oauth",
+        "needs_login",
+        Duration::from_secs(10),
+    )
+    .await;
+
+    // First login — the mock token endpoint grants scope "read write", which
+    // the relay persists in the TokenSet.
+    simulate_oauth_login(harness.api(), "test-oauth").await;
+    poll_oauth_status(
+        harness.api(),
+        "test-oauth",
+        "authenticated",
+        Duration::from_secs(15),
+    )
+    .await;
+
+    // Re-authorize: the new authorize URL must carry the previously-granted
+    // scopes in its `scope` parameter.
+    let start_resp = harness
+        .api()
+        .post_empty("/api/endpoints/test-oauth/oauth/start")
+        .await;
+    let authorize_url = start_resp["authorize_url"]
+        .as_str()
+        .expect("no authorize_url on re-auth");
+    let parsed = url::Url::parse(authorize_url).expect("invalid authorize_url");
+    let scope = parsed
+        .query_pairs()
+        .find(|(k, _)| k == "scope")
+        .map(|(_, v)| v.to_string())
+        .expect("re-auth authorize_url must include a scope param");
+    let granted: Vec<&str> = scope.split_whitespace().collect();
+    assert!(
+        granted.contains(&"read") && granted.contains(&"write"),
+        "re-auth scope must accumulate previously-granted scopes, got {:?}",
+        scope
     );
 }
 
@@ -1210,8 +1282,13 @@ async fn test_oauth_server_info_name_enforcement() {
 
     // Step 4c: Simulate the callback (as if the browser redirected)
     // Use a client that doesn't follow redirects, with long timeout since
-    // the relay does work during the callback
-    let callback_url = format!("{}?code=mock-auth-code&state={}", redirect_uri, state_param);
+    // the relay does work during the callback. Include the RFC 9207 `iss`
+    // parameter matching the mock AS issuer so issuer validation passes.
+    let issuer = parsed.origin().ascii_serialization();
+    let callback_url = format!(
+        "{}?code=mock-auth-code&state={}&iss={}",
+        redirect_uri, state_param, issuer
+    );
     let callback_client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
         .timeout(Duration::from_secs(30))


### PR DESCRIPTION
## END-6: MCP 2026-07-28 spec compliance (backward-compatible) — Waves 1-5 (COMPLETE)

This PR ships **all five waves** of [END-6](https://linear.app/furinkazan/issue/END-6), implementing both the server-side and client-side paths for the [2026-07-28 MCP spec](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/). The relay both **accepts stateless 2026-07-28 requests** (server) and **speaks 2026-07-28 to upstreams** (client), while preserving byte-identical legacy behavior for 2024-11-05 and 2025-03-26 peers.

### What changed

#### Wave 1 — Foundation (commit `3677170`)
- **D1 (T2):** New `ProtocolVersion` primitive (`src/protocol.rs`) with per-peer dialect detection (`detect_inbound_dialect`) and classification (`is_2026()`, `is_legacy()`). Wired into server session identity and all three adapters' upstream state. **No advertised baseline bump** — relay continues to send `2025-03-26` (server/http) and `2024-11-05` (stdio/sse).

#### Wave 2 — Server (commits `b89124b..13411d2`)
- **D2/D3 (T3):** 2026 clients can call `tools/list`, `tools/call`, etc. **with no `initialize` handshake**. Identity is resolved from per-request `params._meta["io.modelcontextprotocol/clientInfo"]`. Legacy handshake path byte-for-byte unchanged.
- **D4 (T4):** New `server/discover` method returns `serverInfo`/`capabilities`/`protocolVersion` + aggregated tools summary, callable statelessly. **Emits no `ttlMs`/`cacheScope`** (local single-user app).
- **D5 (T5):** 2026 inbound `/mcp` validates `Mcp-Method`/`Mcp-Name` headers against the body (`-32600` on mismatch). 2026 clients **neither require nor receive `Mcp-Session-Id`**.
- **D6 (T6):** Relay originates **zero `-32002`** errors (param-level missing-name maps to `-32602`). Regression guard added.

#### Wave 3 — Client (commits `c6cbfb6..21da4e3`)
- **D7 (T7):** Upstream dialect detection (`detect_upstream_dialect`) via discover-first / `initialize`-fallback.
- **D8 (T8):** HTTP adapter 2026 outbound: `server/discover` probe, skip `initialize`, emit `Mcp-Method`/`Mcp-Name`/`MCP-Protocol-Version` headers, drop `Mcp-Session-Id`, inject `_meta` clientInfo. Legacy unchanged.
- **D9 (T9):** stdio + SSE adapters mirror the version-gating (transport-specific). Legacy unchanged.
- **Hardening (`21da4e3`):** `server/discover` probe bounded by a short `DISCOVER_PROBE_TIMEOUT` (3s) so a silent-drop legacy upstream falls back to `initialize` fast instead of stalling on the 30s default. Normal requests keep their full timeout.

#### Wave 4 — Features (commits `f3442ed..8267bbe`)
- **D10 (T10):** Transparent multi round-trip passthrough — upstream `InputRequiredResult` and the client's `requestState` follow-up route unmodified. Terminal calls byte-for-byte unaffected.
- **D11 (T11):** Relay-as-client honors upstream `ttlMs` (top-level result field; negatives clamped to 0) as the tools-cache freshness window, gated on the 2026 dialect. Relay-as-server emits no `ttlMs`/`cacheScope`.
- **D12 (T12):** Full JSON Schema 2020-12 `inputSchema` (`oneOf`/`anyOf`/`allOf`, `$ref`/`$defs`) passes through verbatim. A `NonFetchingRetriever` guarantees external `$ref` URIs are never dereferenced.
- **D13 (T13):** Bidirectional W3C Trace Context — bare `traceparent`/`tracestate`/`baggage` under `params._meta` propagate both directions unmodified, coexisting with Wave 3's `clientInfo` injection (no clobber).

#### Wave 5 — OAuth hardening (commit `fd70158`)
- **D14 (T14):** **RFC 9207 `iss` validation** — the authorization-server `issuer` is surfaced from RFC 8414 discovery, threaded through `PendingFlow`/`start_flow`, and enforced in `oauth_callback` **before** the code exchange. Validation is **conditional** on a known issuer, so legacy/convention-based AS flows with no issuer are byte-for-byte unchanged. **DCR `application_type=native`** added to the RFC 7591 registration request (loopback redirect). **`.well-known` discovery suffix** confirmed to match the 2026-07-28 path-aware rule (comment added, no logic change).
- **D15 (T15):** **DCR credential-to-issuer binding** — `DcrCredentials.issuer` (`#[serde(default)]` for legacy files) is persisted at registration; on reuse, a pure `dcr_issuer_allows_reuse` helper decides: matching issuer reuses, a mismatched issuer triggers re-registration (migration), and legacy `None` reuses without forced re-registration. **Scope accumulation** — `TokenSet` captures the granted `scope`, and a `merge_scopes` union (dedup, stable order) of previously-granted ∪ newly-requested scopes is applied at all four authorize-URL sites, so step-up authorization never silently drops prior grants. First login is unchanged.

### Compliance
- **Grounded:** [Delta catalog workspace note](intent://local/note/1c0e631c-4013-4ad7-9fb8-d5a8a7572740) (D1–D15) cites every file:line.
- **Verified:** Wave 1–5 verifiers all high-confidence approved. Legacy byte-for-byte preserved across all waves; OAuth backward-compat confirmed via serde defaults (old on-disk credentials/tokens load without re-registration or scope loss). `cargo fmt --check`, `clippy --all-targets -- -D warnings`, `cargo test` all green (lib 1006 + main 988 + integration incl. oauth_integration 13/13, 0 failures).

### Conventional commits
```
3677170 feat(relay): add ProtocolVersion negotiation core (END-6 T2)
b89124b feat(server): accept stateless 2026 requests with _meta clientInfo
949afa2 feat(server): implement server/discover for 2026 clients
76a06b8 feat(server): require Mcp-Method/Mcp-Name headers and drop Mcp-Session-Id for 2026 clients
13411d2 test(server): audit -32002 retirement, ensure param errors use -32602
c6cbfb6 feat(adapter): detect upstream protocol version via server/discover + initialize fallback
90694c2 feat(adapter/http): send 2026 requests with headers, no handshake/session-id for 2026 upstreams
70a71ce feat(adapter/stdio,sse): version-gate handshake + _meta clientInfo for 2026 upstreams
21da4e3 fix(adapter): bound server/discover probe with a short timeout
f3442ed feat(relay): transparently proxy MCP 2026-07-28 multi round-trip tool calls
f6853db feat(relay): honor upstream ttlMs freshness window for tool cache
6440df5 feat(relay): preserve complex JSON Schema 2020-12 inputSchema and never fetch external $ref
8267bbe feat: propagate W3C Trace Context through _meta bidirectionally
fd70158 feat(oauth): harden OAuth for MCP 2026-07-28 (END-6 T14-T15)
```

cc @panghy

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author