### PR TITLE
fix(oauth): only enforce RFC 9207 iss when AS advertises support

### DIFF
--- a/src/adapter/oauth/jit.rs
+++ b/src/adapter/oauth/jit.rs
@@ -262,6 +262,7 @@ impl JitInterceptor {
                 pkce,
                 &redirect_uri,
                 Some(&disc.issuer),
+                disc.authorization_response_iss_parameter_supported,
             )
             .await;
 

--- a/src/management.rs
+++ b/src/management.rs
@@ -1134,6 +1134,7 @@ async fn oauth_start(
         discovered_scopes,
         auth_server_label,
         issuer,
+        iss_supported,
     ) = if let Some(ref server_url) = oauth_server_url {
         // Prefer RFC 8414 discovery against the configured AS URL. If it
         // succeeds, use the discovered endpoints (explicit token_endpoint
@@ -1152,6 +1153,7 @@ async fn oauth_start(
                     disc.scopes_supported,
                     Some(disc.auth_server_url),
                     Some(disc.issuer),
+                    disc.authorization_response_iss_parameter_supported,
                 )
             }
             Err(e) => {
@@ -1171,6 +1173,7 @@ async fn oauth_start(
                     Vec::<String>::new(),
                     None::<String>,
                     None::<String>,
+                    false,
                 )
             }
         }
@@ -1184,6 +1187,7 @@ async fn oauth_start(
                 disc.scopes_supported,
                 Some(disc.auth_server_url),
                 Some(disc.issuer),
+                disc.authorization_response_iss_parameter_supported,
             ),
             Err(e) => {
                 return error_response(
@@ -1328,6 +1332,7 @@ async fn oauth_start(
             pkce,
             &redirect_uri,
             issuer.as_deref(),
+            iss_supported,
         )
         .await;
 
@@ -2165,6 +2170,7 @@ async fn oauth_setup(
                     pkce,
                     &redirect_uri,
                     Some(issuer.as_str()),
+                    disc.authorization_response_iss_parameter_supported,
                 )
                 .await;
 
@@ -2325,6 +2331,9 @@ async fn oauth_setup_credentials(
             pkce,
             &redirect_uri,
             issuer.as_deref(),
+            // Manual-credential path: no RFC 9207 advertisement was threaded
+            // through the setup session, so tolerate a missing callback `iss`.
+            false,
         )
         .await;
 

--- a/src/oauth/discovery.rs
+++ b/src/oauth/discovery.rs
@@ -47,6 +47,11 @@ pub struct AuthorizationServerMetadata {
     pub token_endpoint_auth_methods_supported: Vec<String>,
     #[serde(default)]
     pub revocation_endpoint: Option<String>,
+    /// Whether the authorization server advertises RFC 9207 authorization-response
+    /// `iss` parameter support. When false/absent, a missing `iss` on the callback
+    /// must not be treated as an error.
+    #[serde(default)]
+    pub authorization_response_iss_parameter_supported: bool,
 }
 
 /// Resolved OAuth server discovery result.
@@ -65,6 +70,9 @@ pub struct DiscoveryResult {
     pub token_endpoint_auth_methods: Vec<String>,
     #[allow(dead_code)]
     pub revocation_endpoint: Option<String>,
+    /// RFC 9207: whether the authorization server advertises support for the
+    /// authorization-response `iss` parameter.
+    pub authorization_response_iss_parameter_supported: bool,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -293,6 +301,8 @@ pub async fn discover_authorization_server(
         code_challenge_methods_supported: as_meta.code_challenge_methods_supported,
         token_endpoint_auth_methods: as_meta.token_endpoint_auth_methods_supported,
         revocation_endpoint: as_meta.revocation_endpoint,
+        authorization_response_iss_parameter_supported: as_meta
+            .authorization_response_iss_parameter_supported,
     })
 }
 

--- a/src/oauth/mod.rs
+++ b/src/oauth/mod.rs
@@ -88,6 +88,10 @@ pub struct PendingFlow {
     /// `None` (e.g. legacy convention-based config without discovery), the
     /// `iss` check is skipped to preserve existing behavior.
     pub issuer: Option<String>,
+    /// RFC 9207: whether the authorization server advertised support for the
+    /// authorization-response `iss` parameter. When `true`, a missing `iss` on
+    /// the callback is rejected; when `false`, a missing `iss` is tolerated.
+    pub iss_parameter_supported: bool,
     pub created_at: Instant,
 }
 
@@ -118,6 +122,7 @@ impl OAuthFlowManager {
         pkce: PkceChallenge,
         redirect_uri: &str,
         issuer: Option<&str>,
+        iss_parameter_supported: bool,
     ) -> String {
         let state = generate_state();
         let flow = PendingFlow {
@@ -128,6 +133,7 @@ impl OAuthFlowManager {
             client_secret: client_secret.map(|s| s.to_string()),
             redirect_uri: redirect_uri.to_string(),
             issuer: issuer.map(|s| s.to_string()),
+            iss_parameter_supported,
             created_at: Instant::now(),
         };
         self.pending.write().await.insert(state.clone(), flow);
@@ -373,6 +379,7 @@ mod tests {
                 pkce,
                 "http://127.0.0.1:9400/oauth/callback",
                 Some("https://auth.example.com"),
+                true,
             )
             .await;
 
@@ -383,6 +390,7 @@ mod tests {
         assert_eq!(flow.client_id, "client123");
         assert_eq!(flow.client_secret.as_deref(), Some("secret"));
         assert_eq!(flow.issuer.as_deref(), Some("https://auth.example.com"));
+        assert!(flow.iss_parameter_supported);
     }
 
     #[tokio::test]
@@ -400,10 +408,12 @@ mod tests {
                 pkce,
                 "http://127.0.0.1:9400/oauth/callback",
                 None,
+                false,
             )
             .await;
         let flow = mgr.consume_flow(&state).await.unwrap();
         assert!(flow.issuer.is_none());
+        assert!(!flow.iss_parameter_supported);
     }
 
     #[tokio::test]
@@ -419,6 +429,7 @@ mod tests {
                 pkce,
                 "http://localhost/cb",
                 None,
+                false,
             )
             .await;
 
@@ -448,6 +459,7 @@ mod tests {
                 pkce,
                 "http://localhost/cb",
                 None,
+                false,
             )
             .await;
 
@@ -478,6 +490,7 @@ mod tests {
                     pkce,
                     "http://localhost/cb",
                     None,
+                    false,
                 )
                 .await;
             let flow = mgr.consume_flow(&state).await.unwrap();

--- a/src/server.rs
+++ b/src/server.rs
@@ -1623,14 +1623,25 @@ struct OAuthCallbackParams {
 /// Validate the RFC 9207 `iss` authorization-response parameter against the
 /// issuer recorded for the pending flow (mix-up defense).
 ///
-/// When `expected` is `Some(_)` (issuer was discovered), the callback `iss`
-/// must be present and an exact match. When `expected` is `None` (e.g. legacy
-/// convention-based config without RFC 8414 discovery), validation is skipped
-/// so existing flows keep working unchanged.
-fn validate_callback_iss(expected: Option<&str>, provided: Option<&str>) -> bool {
+/// Rules:
+/// - `expected == None` (no discovered issuer, e.g. legacy convention-based
+///   config without RFC 8414 discovery): validation is skipped — returns `true`.
+/// - `provided == Some(p)`: always validate `p == exp` when the server actually
+///   sent `iss`, preserving mix-up defense regardless of advertised support.
+/// - `provided == None`: allow the missing `iss` UNLESS the server advertised
+///   `authorization_response_iss_parameter_supported: true` (`iss_supported`),
+///   in which case a missing `iss` is still a failure.
+fn validate_callback_iss(
+    expected: Option<&str>,
+    provided: Option<&str>,
+    iss_supported: bool,
+) -> bool {
     match expected {
-        Some(exp) => provided == Some(exp),
         None => true,
+        Some(exp) => match provided {
+            Some(p) => p == exp,
+            None => !iss_supported,
+        },
     }
 }
 
@@ -1745,7 +1756,11 @@ async fn oauth_callback(
     // defense). When no issuer was recorded (legacy convention-based config),
     // validation is skipped to preserve existing behavior.
     if let Some(ref expected_issuer) = flow.issuer {
-        if !validate_callback_iss(Some(expected_issuer), params.iss.as_deref()) {
+        if !validate_callback_iss(
+            Some(expected_issuer),
+            params.iss.as_deref(),
+            flow.iss_parameter_supported,
+        ) {
             warn!(
                 endpoint = %flow.endpoint_name,
                 expected = %expected_issuer,
@@ -4846,38 +4861,69 @@ mod tests {
 
     #[test]
     fn test_validate_callback_iss_matching_passes() {
-        // (a) Known issuer + matching `iss` → valid.
+        // (a) Known issuer + matching `iss` → valid (regardless of advertised support).
         assert!(validate_callback_iss(
             Some("https://auth.example.com"),
-            Some("https://auth.example.com")
+            Some("https://auth.example.com"),
+            true
+        ));
+        assert!(validate_callback_iss(
+            Some("https://auth.example.com"),
+            Some("https://auth.example.com"),
+            false
         ));
     }
 
     #[test]
     fn test_validate_callback_iss_mismatch_rejected() {
-        // (b) Known issuer + different `iss` → rejected.
+        // (b) Known issuer + different `iss` → rejected regardless of the flag.
         assert!(!validate_callback_iss(
             Some("https://auth.example.com"),
-            Some("https://evil.example.com")
+            Some("https://evil.example.com"),
+            false
+        ));
+        assert!(!validate_callback_iss(
+            Some("https://auth.example.com"),
+            Some("https://evil.example.com"),
+            true
         ));
     }
 
     #[test]
-    fn test_validate_callback_iss_missing_rejected_when_known() {
-        // (c) Known issuer + missing `iss` → rejected.
+    fn test_validate_callback_iss_missing_allowed_when_not_advertised() {
+        // (c) Known issuer + missing `iss` + server did NOT advertise support →
+        // allowed. This is the awardtravelfinder.com regression case.
+        assert!(validate_callback_iss(
+            Some("https://auth.example.com"),
+            None,
+            false
+        ));
+    }
+
+    #[test]
+    fn test_validate_callback_iss_missing_rejected_when_advertised() {
+        // (c') Known issuer + missing `iss` + server advertised support → rejected.
         assert!(!validate_callback_iss(
             Some("https://auth.example.com"),
-            None
+            None,
+            true
         ));
     }
 
     #[test]
     fn test_validate_callback_iss_none_skips_validation() {
-        // (d) No recorded issuer → validation skipped regardless of `iss`.
-        assert!(validate_callback_iss(None, None));
+        // (d) No recorded issuer → validation skipped regardless of `iss`/flag.
+        assert!(validate_callback_iss(None, None, false));
+        assert!(validate_callback_iss(None, None, true));
         assert!(validate_callback_iss(
             None,
-            Some("https://anything.example.com")
+            Some("https://anything.example.com"),
+            false
+        ));
+        assert!(validate_callback_iss(
+            None,
+            Some("https://anything.example.com"),
+            true
         ));
     }
 
@@ -4885,7 +4931,10 @@ mod tests {
     /// flow with the given issuer, returning the state and the flow's `state`
     /// param. Used to exercise the callback's RFC 9207 rejection paths without
     /// reaching the token-exchange HTTP call.
-    async fn state_with_pending_flow(issuer: Option<&str>) -> (AppState, String) {
+    async fn state_with_pending_flow(
+        issuer: Option<&str>,
+        iss_supported: bool,
+    ) -> (AppState, String) {
         let mut app_state = test_app_state();
         let flow_mgr = Arc::new(OAuthFlowManager::new());
         let pkce = crate::oauth::PkceChallenge::generate();
@@ -4898,6 +4947,7 @@ mod tests {
                 pkce,
                 "http://127.0.0.1:9400/oauth/callback",
                 issuer,
+                iss_supported,
             )
             .await;
         app_state.oauth_flow_manager = Some(flow_mgr);
@@ -4907,7 +4957,8 @@ mod tests {
     #[tokio::test]
     async fn test_oauth_callback_rejects_mismatched_iss() {
         use axum::body::to_bytes;
-        let (state, state_param) = state_with_pending_flow(Some("https://auth.example.com")).await;
+        let (state, state_param) =
+            state_with_pending_flow(Some("https://auth.example.com"), false).await;
         let params = OAuthCallbackParams {
             code: Some("authcode".to_string()),
             state: Some(state_param),
@@ -4921,9 +4972,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_oauth_callback_rejects_missing_iss_when_issuer_known() {
+    async fn test_oauth_callback_rejects_missing_iss_when_advertised() {
         use axum::body::to_bytes;
-        let (state, state_param) = state_with_pending_flow(Some("https://auth.example.com")).await;
+        // Server advertised RFC 9207 support → a missing `iss` is still rejected.
+        let (state, state_param) =
+            state_with_pending_flow(Some("https://auth.example.com"), true).await;
         let params = OAuthCallbackParams {
             code: Some("authcode".to_string()),
             state: Some(state_param),
@@ -4935,6 +4988,31 @@ mod tests {
         let body_str = String::from_utf8(body.to_vec()).unwrap();
         assert!(body_str.contains("issuer mismatch"), "body = {body_str}");
         assert!(body_str.contains("&lt;missing&gt;"), "body = {body_str}");
+    }
+
+    #[tokio::test]
+    async fn test_oauth_callback_allows_missing_iss_when_not_advertised() {
+        use axum::body::to_bytes;
+        // awardtravelfinder.com regression case: issuer discovered, server did
+        // NOT advertise `authorization_response_iss_parameter_supported`, and the
+        // callback omits `iss`. The `iss` check must NOT reject; the flow proceeds
+        // to token exchange (which fails against the unreachable test endpoint, so
+        // the response is not the issuer-mismatch page).
+        let (state, state_param) =
+            state_with_pending_flow(Some("https://auth.example.com"), false).await;
+        let params = OAuthCallbackParams {
+            code: Some("authcode".to_string()),
+            state: Some(state_param),
+            error: None,
+            iss: None,
+        };
+        let resp = oauth_callback(State(state), Query(params)).await;
+        let body = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            !body_str.contains("issuer mismatch"),
+            "missing iss must be tolerated when support is not advertised; body = {body_str}"
+        );
     }
 
     // --- /mcp/sse + initialize tools.listChanged capability ---


### PR DESCRIPTION
## Problem

After v0.1.10-rc.2, re-authorizing an MCP server that publishes RFC 8414 metadata but does not implement the optional RFC 9207 authorization-response iss parameter (e.g. mcp.awardtravelfinder.com) fails with:

    OAuth Error: Authorization response issuer mismatch (expected https://auth.awardtravelfinder.com, got <missing>)

Root cause: the Wave 5 (D14) check rejected the callback whenever an issuer was discovered AND the response iss was missing/different. But every RFC 8414 metadata document carries an issuer, so this over-enforced for essentially every modern server. RFC 9207's response iss parameter is a separate, optional feature advertised via the metadata flag authorization_response_iss_parameter_supported, which the relay never parsed.

## Fix

Gate the missing-iss rejection on advertised support, while preserving the mix-up defense:

- no discovered issuer => skip (unchanged legacy behavior)
- iss present => must match the discovered issuer (wrong iss still rejected)
- iss missing => allowed UNLESS the AS advertised authorization_response_iss_parameter_supported: true

The flag is parsed on AuthorizationServerMetadata (serde default => absent means false), carried on DiscoveryResult, threaded through PendingFlow/start_flow, and passed into validate_callback_iss at the callback. All start_flow call sites updated (oauth_start, oauth_setup use the discovered flag; manual/convention/legacy paths pass false).

## Tests

- New matrix coverage: flag-false+missing => allowed (the regression case), flag-true+missing => rejected, wrong iss => rejected, matching iss => allowed.
- Existing callback tests updated for the new signature.
- Gates green: cargo fmt --check, cargo build, cargo clippy --all-targets -D warnings, cargo test (1010+992 unit + all integration, 0 failed).

Ships in v0.1.10-rc.3.