### PR TITLE
chore: remove noisy "Endpoint unchanged" and "MCP notification" logs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -954,6 +954,9 @@ pub struct ConfigDiff {
     /// Endpoints present in both but with different settings (name, new config).
     pub changed: Vec<(String, EndpointConfig)>,
     /// Names of endpoints that are identical in both configs.
+    /// Retained for tests (e.g. `tests/hot_reload_integration.rs`); no
+    /// production reader remains after the watcher's unchanged-loop removal.
+    #[allow(dead_code)]
     pub unchanged: Vec<String>,
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -963,19 +963,6 @@ async fn handle_single_message(
 
         // Notifications (no `id` field) get 202 Accepted with no body per MCP spec.
         if is_notification {
-            let elapsed_ms = start.elapsed().as_millis() as u64;
-            info!(
-                method = %method,
-                request_uid = %request_uid,
-                elapsed_ms = elapsed_ms,
-                req_bytes = req_bytes,
-                resp_bytes = 0,
-                status = 202,
-                headers = %headers_str,
-                client_name = ?client_name,
-                client_version = ?client_version,
-                "MCP notification"
-            );
             return None;
         }
 
@@ -1109,7 +1096,7 @@ async fn mcp_unified(
 ///
 /// The dispatch is wrapped in an `info_span!("mcp_request", profile = ...)`
 /// so every event emitted while handling the request — including the inner
-/// `request` span's `MCP request` / `MCP notification` lines and any
+/// `request` span's `MCP request` lines and any
 /// adapter-side child spans — inherits the `profile` field. The field key
 /// `profile` is an immutable cross-stack contract with the desktop log
 /// parser (locked decision Cross-stack #1 / engineering-spec §7.1).

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -408,13 +408,6 @@ pub async fn apply_diff(
             .instrument(init_span),
         );
     }
-
-    // Log unchanged
-    for name in &diff.unchanged {
-        let span = tracing::info_span!("endpoint", endpoint = %name);
-        let _g = span.enter();
-        info!("Endpoint unchanged, keeping running");
-    }
 }
 
 /// Like [`apply_diff`] but also handles per-endpoint validation warnings.
@@ -644,13 +637,6 @@ pub async fn apply_diff_graceful(
             }
             .instrument(init_span),
         );
-    }
-
-    // Log unchanged
-    for name in &diff.unchanged {
-        let span = tracing::info_span!("endpoint", endpoint = %name);
-        let _g = span.enter();
-        info!("Endpoint unchanged, keeping running");
     }
 }
 


### PR DESCRIPTION
## Summary

Removes two high-frequency relay log lines that add noise without much value.

- **`Endpoint unchanged, keeping running`** — was emitted once per unchanged endpoint on every config reload, in both the `apply_diff` and `apply_diff_graceful` loops in `src/watcher.rs`. Both loops existed solely to emit this line and were removed.
- **`MCP notification`** — access-log line emitted for every incoming JSON-RPC notification in `src/server.rs`. The `if is_notification { ... return None; }` 202-Accepted / no-body flow is unchanged; only the `info!` line and its now-dead `elapsed_ms` local were removed, and the doc comment that referenced the line was updated.

Removing the watcher loop left `ConfigDiff.unchanged` (in `src/config.rs`) with no production reader, so it now carries `#[allow(dead_code)]` with a comment — the field is still used by tests.

The `MCP request` log lines and the desktop log parser are untouched.

## Verification

- `grep -rn "Endpoint unchanged\|MCP notification" src` → empty.
- `cargo fmt --check` → clean.
- `cargo build` → no new warnings (notably no `field unchanged is never read`).
- `cargo test` → all pass, including `hot_reload_integration`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author