### PR TITLE
feat(oauth): RFC 9728 openid-configuration fallback + Client ID Metadata Document (CIMD)

### DIFF
--- a/src/adapter/oauth/jit.rs
+++ b/src/adapter/oauth/jit.rs
@@ -25,6 +25,7 @@ use url::Url;
 
 use super::state::OAuthState;
 use crate::adapter::AdapterError;
+use crate::oauth::client::{self, ClientRegistration, ResolvedClient};
 use crate::oauth::dcr::{self, ClientRegistrationResponse};
 use crate::oauth::discovery::{self, DiscoveryError, DiscoveryResult};
 use crate::oauth::{OAuthFlowManager, PkceChallenge};
@@ -246,9 +247,12 @@ impl JitInterceptor {
 
         let redirect_uri = format!("http://127.0.0.1:{}/oauth/callback", self.relay_port);
 
-        let (client_id, client_secret) = self
+        let resolved = self
             .resolve_client(&disc, &redirect_uri, endpoint_name)
             .await?;
+        let client_id = resolved.client_id;
+        let client_secret = resolved.client_secret;
+        let client_registration = resolved.registration;
 
         let pkce = PkceChallenge::generate();
         let code_challenge = pkce.code_challenge.clone();
@@ -306,6 +310,7 @@ impl JitInterceptor {
 
         info!(
             endpoint = %endpoint_name,
+            client_registration = client_registration.as_str(),
             "JIT OAuth self-initiated on upstream 401; authorize URL composed"
         );
         *self.state.write().await = OAuthState::NeedsLogin;
@@ -313,61 +318,97 @@ impl JitInterceptor {
         Ok(authorize_url)
     }
 
-    /// Resolve `(client_id, client_secret)` for the flow: reuse persisted DCR
-    /// credentials when present, otherwise dynamically register. The RETURNED
-    /// auth method/secret is honored (some servers issue a `client_secret`
-    /// even when `none` was requested), and freshly registered credentials are
-    /// persisted when a token manager is available.
+    /// Resolve client credentials for the flow following the shared fallback
+    /// chain **pre-registered → CIMD → DCR** (JIT never supplies a manual
+    /// client_id). Pre-registered creds are reused only when issuer-bound to the
+    /// current AS; when the AS advertises a Client ID Metadata Document, the
+    /// relay authenticates as a zero-config public client (no secret, no DCR).
+    /// Freshly resolved DCR/CIMD credentials are persisted when a token manager
+    /// is available so future refresh / re-auth can find them.
     async fn resolve_client(
         &self,
         disc: &DiscoveryResult,
         redirect_uri: &str,
         endpoint_name: &str,
-    ) -> Result<(String, Option<String>), JitError> {
-        if let Some(ref tm) = self.token_manager {
-            if let Ok(Some(creds)) = tm.load_dcr(endpoint_name).await {
-                // Credential-to-issuer binding: only reuse a stored client_id
-                // with the SAME authorization server that issued it. If the AS
-                // issuer changed, discard and re-register (RFC 7591). Legacy
-                // creds with no stored issuer are reused as-is.
-                if dcr_issuer_allows_reuse(creds.issuer.as_deref(), Some(disc.issuer.as_str())) {
-                    return Ok((creds.client_id, creds.client_secret));
+    ) -> Result<ResolvedClient, JitError> {
+        // Pre-registered (issuer-bound) stored credentials, validated for reuse.
+        let preregistered = if let Some(ref tm) = self.token_manager {
+            match tm.load_dcr(endpoint_name).await {
+                Ok(Some(creds)) => {
+                    // Credential-to-issuer binding: only reuse a stored client_id
+                    // with the SAME authorization server that issued it. If the
+                    // AS issuer changed, discard and fall through (CIMD/DCR).
+                    // Legacy creds with no stored issuer are reused as-is.
+                    if dcr_issuer_allows_reuse(creds.issuer.as_deref(), Some(disc.issuer.as_str()))
+                    {
+                        Some((creds.client_id, creds.client_secret))
+                    } else {
+                        info!(
+                            endpoint = %endpoint_name,
+                            stored_issuer = ?creds.issuer,
+                            current_issuer = %disc.issuer,
+                            "DCR credential issuer changed; discarding stored credentials and re-registering"
+                        );
+                        None
+                    }
                 }
-                info!(
-                    endpoint = %endpoint_name,
-                    stored_issuer = ?creds.issuer,
-                    current_issuer = %disc.issuer,
-                    "DCR credential issuer changed; discarding stored credentials and re-registering"
-                );
+                _ => None,
             }
-        }
-
-        let Some(ref reg_endpoint) = disc.registration_endpoint else {
-            return Err(JitError::NoClientCredentials);
+        } else {
+            None
         };
 
-        let resp: ClientRegistrationResponse = dcr::register_client(
-            reg_endpoint,
-            redirect_uri,
-            endpoint_name,
-            self.allow_insecure_oauth,
+        let allow_insecure = self.allow_insecure_oauth;
+        let resolved = client::resolve_client(
+            client::ClientInputs {
+                explicit_manual: None,
+                preregistered,
+                cimd_supported: disc.client_id_metadata_document_supported,
+                registration_endpoint: disc.registration_endpoint.clone(),
+            },
+            |reg_endpoint| async move {
+                let resp: ClientRegistrationResponse = dcr::register_client(
+                    &reg_endpoint,
+                    redirect_uri,
+                    endpoint_name,
+                    allow_insecure,
+                )
+                .await?;
+                Ok::<_, dcr::DcrError>(client::DcrOutcome {
+                    client_id: resp.client_id,
+                    client_secret: resp.client_secret,
+                    client_secret_expires_at: resp.client_secret_expires_at,
+                })
+            },
         )
-        .await?;
+        .await
+        .map_err(|e| match e {
+            client::ClientResolveError::Dcr(e) => JitError::Dcr(e),
+            client::ClientResolveError::NoCredentials => JitError::NoClientCredentials,
+        })?;
 
-        if let Some(ref tm) = self.token_manager {
-            let creds = DcrCredentials {
-                client_id: resp.client_id.clone(),
-                client_secret: resp.client_secret.clone(),
-                client_secret_expires_at: resp.client_secret_expires_at,
-                registered_at: now_secs(),
-                issuer: Some(disc.issuer.clone()),
-            };
-            if let Err(e) = tm.save_dcr(endpoint_name, &creds).await {
-                warn!(error = %e, "failed to persist JIT-registered DCR credentials");
+        // Persist freshly-resolved credentials (DCR or CIMD) so future refresh /
+        // re-auth can find the client_id. Pre-registered creds are already
+        // stored; CIMD persists the constant client_id as a public client.
+        if matches!(
+            resolved.registration,
+            ClientRegistration::Dcr | ClientRegistration::Cimd
+        ) {
+            if let Some(ref tm) = self.token_manager {
+                let creds = DcrCredentials {
+                    client_id: resolved.client_id.clone(),
+                    client_secret: resolved.client_secret.clone(),
+                    client_secret_expires_at: resolved.client_secret_expires_at,
+                    registered_at: now_secs(),
+                    issuer: Some(disc.issuer.clone()),
+                };
+                if let Err(e) = tm.save_dcr(endpoint_name, &creds).await {
+                    warn!(error = %e, "failed to persist JIT client credentials");
+                }
             }
         }
 
-        Ok((resp.client_id, resp.client_secret))
+        Ok(resolved)
     }
 }
 
@@ -752,6 +793,98 @@ mod tests {
         );
         assert!(q.contains_key("code_challenge"));
         assert!(q.contains_key("scope"));
+
+        server.abort();
+    }
+
+    /// Spawn an OAuth fixture whose AS advertises a Client ID Metadata Document
+    /// (`client_id_metadata_document_supported: true`) and serves NO
+    /// registration endpoint — so any DCR attempt would 404. This makes the
+    /// CIMD path the only way to succeed.
+    async fn spawn_oauth_fixture_cimd() -> (String, tokio::task::JoinHandle<()>) {
+        use axum::extract::State;
+        use axum::routing::get;
+        use axum::{Json, Router};
+
+        async fn protected_resource(State(base): State<String>) -> Json<Value> {
+            Json(json!({
+                "resource": base,
+                "authorization_servers": [base],
+                "bearer_methods_supported": ["header"],
+            }))
+        }
+        async fn auth_server(State(base): State<String>) -> Json<Value> {
+            Json(json!({
+                "issuer": base,
+                "authorization_endpoint": format!("{}/authorize", base),
+                "token_endpoint": format!("{}/token", base),
+                "code_challenge_methods_supported": ["S256"],
+                "scopes_supported": ["read", "write"],
+                "client_id_metadata_document_supported": true,
+            }))
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let base = format!("http://127.0.0.1:{}", addr.port());
+        let router = Router::new()
+            .route(
+                "/.well-known/oauth-protected-resource",
+                get(protected_resource),
+            )
+            .route("/.well-known/oauth-authorization-server", get(auth_server))
+            .with_state(base.clone());
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        (base, handle)
+    }
+
+    /// When the AS advertises CIMD and there is no pre-registered client, the
+    /// authorize URL's `client_id` is the Endara CIMD URL — no DCR is attempted
+    /// (the fixture serves no `/register`), and the pending flow carries no
+    /// client_secret (public client).
+    #[tokio::test]
+    async fn intercept_uses_cimd_client_id_when_advertised() {
+        let (base, server) = spawn_oauth_fixture_cimd().await;
+        let flow_mgr = Arc::new(OAuthFlowManager::new());
+        let interceptor = JitInterceptor::new(9400, flow_mgr.clone(), None, true);
+
+        let www_authenticate = format!(
+            "Bearer resource_metadata=\"{}/.well-known/oauth-protected-resource\"",
+            base
+        );
+        let resource_url = format!("{}/mcp", base);
+
+        let authorize_url = interceptor
+            .intercept(&resource_url, &www_authenticate, "cimd-ep")
+            .await
+            .expect("intercept should self-initiate via CIMD");
+
+        assert_eq!(interceptor.state().await, OAuthState::NeedsLogin);
+
+        let url = Url::parse(&authorize_url).unwrap();
+        let q: std::collections::HashMap<_, _> = url.query_pairs().into_owned().collect();
+        assert_eq!(
+            q.get("client_id").map(String::as_str),
+            Some(client::ENDARA_CLIENT_METADATA_URL)
+        );
+        // The URL-encoded CIMD URL must appear verbatim in the raw query string.
+        assert!(
+            authorize_url
+                .contains("client_id=https%3A%2F%2Fendara.ai%2Foauth%2Fclient-metadata.json"),
+            "got: {}",
+            authorize_url
+        );
+
+        let state_param = q.get("state").expect("state param present").clone();
+        let flow = flow_mgr
+            .consume_flow(&state_param)
+            .await
+            .expect("pending flow registered");
+        assert_eq!(flow.client_id, client::ENDARA_CLIENT_METADATA_URL);
+        assert!(flow.client_secret.is_none(), "CIMD is a public client");
 
         server.abort();
     }

--- a/src/management.rs
+++ b/src/management.rs
@@ -22,6 +22,7 @@ use crate::adapter::stdio::{StdioAdapter, StdioConfig};
 use crate::adapter::{FailedAdapter, HealthStatus, McpAdapter, StartingAdapter};
 use crate::config::{Config, ObservabilityConfig};
 use crate::events::ToolCallEventBus;
+use crate::oauth::client::{self, ClientRegistration};
 use crate::oauth::{OAuthFlowManager, OAuthSetupManager, PkceChallenge};
 use crate::observability::payloads::StoredPayloads;
 use crate::observability::store::{AggregateBucket, CallRecord, QueryFilter};
@@ -2089,65 +2090,77 @@ async fn oauth_setup(
         .as_ref()
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty());
-    let used_dcr = manual_client_id.is_none();
-
-    let dcr_result: Result<(String, Option<String>), String> = if let Some(client_id) =
-        manual_client_id
-    {
-        // Persist manual credentials so future re-auth can find them
-        if let Some(ref tm) = state.token_manager {
-            let creds = DcrCredentials {
-                client_id: client_id.clone(),
-                client_secret: manual_client_secret.clone(),
-                client_secret_expires_at: 0,
-                registered_at: std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs(),
-                // Manually-supplied credentials are user-managed; not issuer-bound.
-                issuer: None,
-            };
-            if let Err(e) = tm.save_dcr(&body.name, &creds).await {
-                warn!(endpoint = %body.name, error = %e, "Failed to persist manual credentials");
-            }
+    // Resolve client credentials through the shared fallback chain:
+    // explicit manual → pre-registered → CIMD → DCR. The Add Server flow does
+    // not consult stored credentials (always a fresh setup), so `preregistered`
+    // is `None`; an explicit pasted client_id wins, otherwise a CIMD-advertising
+    // AS yields a zero-config public client and DCR is the final fallback.
+    let manual = manual_client_id
+        .clone()
+        .map(|id| (id, manual_client_secret.clone()));
+    let dcr_redirect_uri = redirect_uri.clone();
+    let dcr_endpoint_name = body.name.clone();
+    let resolve_result = client::resolve_client(
+        client::ClientInputs {
+            explicit_manual: manual,
+            preregistered: None,
+            cimd_supported: disc.client_id_metadata_document_supported,
+            registration_endpoint: registration_endpoint.clone(),
+        },
+        |reg_endpoint| async move {
+            let resp = dcr::register_client(
+                &reg_endpoint,
+                &dcr_redirect_uri,
+                &dcr_endpoint_name,
+                allow_insecure_oauth,
+            )
+            .await?;
+            Ok::<_, dcr::DcrError>(client::DcrOutcome {
+                client_id: resp.client_id,
+                client_secret: resp.client_secret,
+                client_secret_expires_at: resp.client_secret_expires_at,
+            })
+        },
+    )
+    .await
+    .map_err(|e| match e {
+        client::ClientResolveError::Dcr(e) => format!("{e}"),
+        client::ClientResolveError::NoCredentials => {
+            "No registration endpoint available".to_string()
         }
-        Ok((client_id, manual_client_secret))
-    } else if let Some(ref reg_endpoint) = registration_endpoint {
-        match dcr::register_client(
-            reg_endpoint,
-            &redirect_uri,
-            &body.name,
-            allow_insecure_oauth,
-        )
-        .await
-        {
-            Ok(resp) => {
-                // Persist DCR credentials for future re-auth
-                if let Some(ref tm) = state.token_manager {
-                    let creds = DcrCredentials {
-                        client_id: resp.client_id.clone(),
-                        client_secret: resp.client_secret.clone(),
-                        client_secret_expires_at: resp.client_secret_expires_at,
-                        registered_at: std::time::SystemTime::now()
-                            .duration_since(std::time::UNIX_EPOCH)
-                            .unwrap_or_default()
-                            .as_secs(),
-                        issuer: Some(issuer.clone()),
-                    };
-                    if let Err(e) = tm.save_dcr(&body.name, &creds).await {
-                        warn!(endpoint = %body.name, error = %e, "Failed to persist DCR credentials");
-                    }
+    });
+
+    match resolve_result {
+        Ok(resolved) => {
+            let client_id = resolved.client_id;
+            let client_secret = resolved.client_secret;
+            let client_registration = resolved.registration;
+            // Only true DCR registration counts as DCR for the response flag;
+            // CIMD and manual paths do not.
+            let used_dcr = matches!(client_registration, ClientRegistration::Dcr);
+
+            // Persist resolved credentials so future re-auth can find them.
+            // Manual creds are user-managed (not issuer-bound); DCR/CIMD creds
+            // are bound to the discovered issuer.
+            if let Some(ref tm) = state.token_manager {
+                let creds = DcrCredentials {
+                    client_id: client_id.clone(),
+                    client_secret: client_secret.clone(),
+                    client_secret_expires_at: resolved.client_secret_expires_at,
+                    registered_at: std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs(),
+                    issuer: match client_registration {
+                        ClientRegistration::Manual => None,
+                        _ => Some(issuer.clone()),
+                    },
+                };
+                if let Err(e) = tm.save_dcr(&body.name, &creds).await {
+                    warn!(endpoint = %body.name, error = %e, "Failed to persist client credentials");
                 }
-                Ok((resp.client_id, resp.client_secret))
             }
-            Err(e) => Err(format!("{e}")),
-        }
-    } else {
-        Err("No registration endpoint available".to_string())
-    };
 
-    match dcr_result {
-        Ok((client_id, client_secret)) => {
             // Store credentials in session
             setup_mgr
                 .get_session_mut(&session_id, |s| {
@@ -2199,6 +2212,12 @@ async fn oauth_setup(
             if !merged_scope.is_empty() {
                 authorize_url.push_str(&format!("&scope={}", urlencoding(&merged_scope)));
             }
+
+            info!(
+                endpoint = %body.name,
+                client_registration = client_registration.as_str(),
+                "OAuth setup: authorize URL composed"
+            );
 
             let discovery_info = OAuthDiscoveryInfo {
                 auth_server: auth_server_url,

--- a/src/management.rs
+++ b/src/management.rs
@@ -7194,6 +7194,18 @@ command = "echo"
         (format!("http://127.0.0.1:{}", addr.port()), handle)
     }
 
+    /// Build the AS metadata `issuer` from the request `Host` header so a mock
+    /// AS advertises an issuer matching its own origin, exactly like a real AS
+    /// (RFC 8414 §2/§3.3). Discovery validates the advertised issuer against the
+    /// probe origin, so hardcoding a foreign issuer would be (correctly) rejected.
+    fn mock_issuer(headers: &axum::http::HeaderMap) -> String {
+        let host = headers
+            .get(axum::http::header::HOST)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("127.0.0.1");
+        format!("http://{host}")
+    }
+
     /// Build a ManagementState wired for `oauth_start` against a mock AS.
     fn test_state_oauth_start(
         name: &str,
@@ -7362,9 +7374,9 @@ command = "echo"
         // Mock AS: serve real-looking endpoints at /.well-known/oauth-authorization-server.
         // Discovered URLs intentionally differ from the convention `{base}/authorize`
         // and `{base}/token`.
-        async fn well_known() -> Json<Value> {
+        async fn well_known(headers: axum::http::HeaderMap) -> Json<Value> {
             Json(serde_json::json!({
-                "issuer": "http://example.test",
+                "issuer": mock_issuer(&headers),
                 "authorization_endpoint": "http://example.test/discovered-auth",
                 "token_endpoint": "http://example.test/discovered-token",
                 "code_challenge_methods_supported": ["S256"],
@@ -7435,9 +7447,9 @@ command = "echo"
         // Mock AS: discovery succeeds but advertises a token_endpoint that
         // differs from the operator-configured explicit override. The
         // override must win.
-        async fn well_known() -> Json<Value> {
+        async fn well_known(headers: axum::http::HeaderMap) -> Json<Value> {
             Json(serde_json::json!({
-                "issuer": "http://example.test",
+                "issuer": mock_issuer(&headers),
                 "authorization_endpoint": "http://example.test/discovered-auth",
                 "token_endpoint": "http://example.test/discovered-token",
                 "code_challenge_methods_supported": ["S256"],
@@ -7493,12 +7505,12 @@ command = "echo"
         let wk = well_known_hits.clone();
         let bad = bad_double_slash_hits.clone();
 
-        let well_known_handler = move || {
+        let well_known_handler = move |headers: axum::http::HeaderMap| {
             let wk = wk.clone();
             async move {
                 wk.fetch_add(1, Ordering::SeqCst);
                 Json(serde_json::json!({
-                    "issuer": "http://example.test",
+                    "issuer": mock_issuer(&headers),
                     "authorization_endpoint": "http://example.test/discovered-auth",
                     "token_endpoint": "http://example.test/discovered-token",
                     "code_challenge_methods_supported": ["S256"],
@@ -7572,9 +7584,9 @@ command = "echo"
 
     #[tokio::test]
     async fn oauth_start_prefers_dcr_client_secret_when_toml_only_has_client_id() {
-        async fn well_known() -> Json<Value> {
+        async fn well_known(headers: axum::http::HeaderMap) -> Json<Value> {
             Json(serde_json::json!({
-                "issuer": "http://example.test",
+                "issuer": mock_issuer(&headers),
                 "authorization_endpoint": "http://example.test/authorize",
                 "token_endpoint": "http://example.test/token",
                 "code_challenge_methods_supported": ["S256"],
@@ -7636,9 +7648,9 @@ command = "echo"
 
     #[tokio::test]
     async fn oauth_start_falls_back_to_config_when_dcr_client_id_mismatches() {
-        async fn well_known() -> Json<Value> {
+        async fn well_known(headers: axum::http::HeaderMap) -> Json<Value> {
             Json(serde_json::json!({
-                "issuer": "http://example.test",
+                "issuer": mock_issuer(&headers),
                 "authorization_endpoint": "http://example.test/authorize",
                 "token_endpoint": "http://example.test/token",
                 "code_challenge_methods_supported": ["S256"],

--- a/src/oauth/client.rs
+++ b/src/oauth/client.rs
@@ -1,0 +1,276 @@
+//! Centralized OAuth client-credential resolution.
+//!
+//! A single fallback chain — **pre-registered → CIMD → DCR → manual** — shared
+//! by the JIT 401 interceptor (`adapter/oauth/jit.rs`) and the Add Server setup
+//! flow (`management.rs`). When the authorization server advertises a Client ID
+//! Metadata Document (CIMD) and there is no pre-registered client, the relay
+//! authenticates as a zero-config public client using
+//! [`ENDARA_CLIENT_METADATA_URL`] as the `client_id` (no secret, no DCR).
+//!
+//! An *explicit* user-supplied client_id (e.g. pasted into Add Server) wins for
+//! that flow; the chain's "manual = last" ordering applies to the automatic/JIT
+//! path, which never supplies a manual client_id.
+
+use std::future::Future;
+
+/// Endara's hosted Client ID Metadata Document (CIMD). Used as the `client_id`
+/// for zero-config public-client authentication when the authorization server
+/// advertises `client_id_metadata_document_supported`.
+pub const ENDARA_CLIENT_METADATA_URL: &str = "https://endara.ai/oauth/client-metadata.json";
+
+/// Which path produced the resolved client credentials. Surfaced in structured
+/// logs as `client_registration=<as_str>`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClientRegistration {
+    Preregistered,
+    Cimd,
+    Dcr,
+    Manual,
+}
+
+impl ClientRegistration {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ClientRegistration::Preregistered => "preregistered",
+            ClientRegistration::Cimd => "cimd",
+            ClientRegistration::Dcr => "dcr",
+            ClientRegistration::Manual => "manual",
+        }
+    }
+}
+
+/// Result of a successful Dynamic Client Registration, returned by the DCR
+/// closure passed to [`resolve_client`].
+#[derive(Debug)]
+pub struct DcrOutcome {
+    pub client_id: String,
+    pub client_secret: Option<String>,
+    pub client_secret_expires_at: u64,
+}
+
+/// Inputs gathered by the call site before resolution.
+pub struct ClientInputs {
+    /// Explicit user-supplied client_id (+ optional secret), e.g. pasted into
+    /// Add Server. When present it wins over every automatic path for this flow.
+    pub explicit_manual: Option<(String, Option<String>)>,
+    /// Pre-registered / stored credentials already validated as reusable
+    /// (issuer-bound) by the caller.
+    pub preregistered: Option<(String, Option<String>)>,
+    /// Whether the AS advertises Client ID Metadata Document (CIMD) support.
+    pub cimd_supported: bool,
+    /// The AS registration endpoint, when DCR is available.
+    pub registration_endpoint: Option<String>,
+}
+
+/// Resolved client credentials plus the path taken.
+#[derive(Debug)]
+pub struct ResolvedClient {
+    pub client_id: String,
+    pub client_secret: Option<String>,
+    /// Seconds-since-epoch expiry of `client_secret` from DCR (0 = never / N/A).
+    pub client_secret_expires_at: u64,
+    pub registration: ClientRegistration,
+}
+
+/// Error from [`resolve_client`].
+#[derive(Debug, thiserror::Error)]
+pub enum ClientResolveError<E> {
+    #[error("dynamic client registration failed: {0}")]
+    Dcr(E),
+    #[error("no client credentials: server does not support DCR/CIMD and none are stored")]
+    NoCredentials,
+}
+
+/// Resolve client credentials following **pre-registered → CIMD → DCR →
+/// manual**, with one exception: an *explicit* user-supplied client_id
+/// (`explicit_manual`) wins for that flow.
+///
+/// `dcr` is awaited ONLY when the DCR path is selected — i.e. no explicit,
+/// pre-registered, or CIMD credentials are available but a registration
+/// endpoint exists. CIMD and pre-registered paths therefore never trigger a
+/// network registration.
+pub async fn resolve_client<F, Fut, E>(
+    inputs: ClientInputs,
+    dcr: F,
+) -> Result<ResolvedClient, ClientResolveError<E>>
+where
+    F: FnOnce(String) -> Fut,
+    Fut: Future<Output = Result<DcrOutcome, E>>,
+{
+    if let Some((client_id, client_secret)) = inputs.explicit_manual {
+        return Ok(ResolvedClient {
+            client_id,
+            client_secret,
+            client_secret_expires_at: 0,
+            registration: ClientRegistration::Manual,
+        });
+    }
+    if let Some((client_id, client_secret)) = inputs.preregistered {
+        return Ok(ResolvedClient {
+            client_id,
+            client_secret,
+            client_secret_expires_at: 0,
+            registration: ClientRegistration::Preregistered,
+        });
+    }
+    if inputs.cimd_supported {
+        return Ok(ResolvedClient {
+            client_id: ENDARA_CLIENT_METADATA_URL.to_string(),
+            client_secret: None,
+            client_secret_expires_at: 0,
+            registration: ClientRegistration::Cimd,
+        });
+    }
+    if let Some(reg_endpoint) = inputs.registration_endpoint {
+        let outcome = dcr(reg_endpoint).await.map_err(ClientResolveError::Dcr)?;
+        return Ok(ResolvedClient {
+            client_id: outcome.client_id,
+            client_secret: outcome.client_secret,
+            client_secret_expires_at: outcome.client_secret_expires_at,
+            registration: ClientRegistration::Dcr,
+        });
+    }
+    Err(ClientResolveError::NoCredentials)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    fn ok_dcr() -> DcrOutcome {
+        DcrOutcome {
+            client_id: "dcr-client".to_string(),
+            client_secret: Some("dcr-secret".to_string()),
+            client_secret_expires_at: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn explicit_manual_wins_over_everything() {
+        let called = AtomicBool::new(false);
+        let resolved = resolve_client(
+            ClientInputs {
+                explicit_manual: Some(("manual-id".into(), Some("manual-secret".into()))),
+                preregistered: Some(("pre".into(), None)),
+                cimd_supported: true,
+                registration_endpoint: Some("https://as/register".into()),
+            },
+            |_ep| {
+                called.store(true, Ordering::SeqCst);
+                async { Ok::<_, ()>(ok_dcr()) }
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(resolved.registration, ClientRegistration::Manual);
+        assert_eq!(resolved.client_id, "manual-id");
+        assert_eq!(resolved.client_secret.as_deref(), Some("manual-secret"));
+        assert!(!called.load(Ordering::SeqCst), "DCR must not be invoked");
+    }
+
+    #[tokio::test]
+    async fn preregistered_wins_over_cimd_and_dcr() {
+        let called = AtomicBool::new(false);
+        let resolved = resolve_client(
+            ClientInputs {
+                explicit_manual: None,
+                preregistered: Some(("pre-id".into(), Some("pre-secret".into()))),
+                cimd_supported: true,
+                registration_endpoint: Some("https://as/register".into()),
+            },
+            |_ep| {
+                called.store(true, Ordering::SeqCst);
+                async { Ok::<_, ()>(ok_dcr()) }
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(resolved.registration, ClientRegistration::Preregistered);
+        assert_eq!(resolved.client_id, "pre-id");
+        assert!(!called.load(Ordering::SeqCst), "DCR must not be invoked");
+    }
+
+    #[tokio::test]
+    async fn cimd_chosen_without_pre_registered_and_skips_dcr() {
+        let called = AtomicBool::new(false);
+        let resolved = resolve_client(
+            ClientInputs {
+                explicit_manual: None,
+                preregistered: None,
+                cimd_supported: true,
+                registration_endpoint: Some("https://as/register".into()),
+            },
+            |_ep| {
+                called.store(true, Ordering::SeqCst);
+                async { Ok::<_, ()>(ok_dcr()) }
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(resolved.registration, ClientRegistration::Cimd);
+        assert_eq!(resolved.client_id, ENDARA_CLIENT_METADATA_URL);
+        assert!(resolved.client_secret.is_none());
+        assert!(
+            !called.load(Ordering::SeqCst),
+            "DCR must not be invoked when CIMD is advertised"
+        );
+    }
+
+    #[tokio::test]
+    async fn dcr_chosen_when_cimd_absent() {
+        let called = AtomicBool::new(false);
+        let resolved = resolve_client(
+            ClientInputs {
+                explicit_manual: None,
+                preregistered: None,
+                cimd_supported: false,
+                registration_endpoint: Some("https://as/register".into()),
+            },
+            |ep| {
+                assert_eq!(ep, "https://as/register");
+                called.store(true, Ordering::SeqCst);
+                async { Ok::<_, ()>(ok_dcr()) }
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(resolved.registration, ClientRegistration::Dcr);
+        assert_eq!(resolved.client_id, "dcr-client");
+        assert_eq!(resolved.client_secret.as_deref(), Some("dcr-secret"));
+        assert!(called.load(Ordering::SeqCst), "DCR must be invoked");
+    }
+
+    #[tokio::test]
+    async fn no_credentials_when_nothing_available() {
+        let result = resolve_client(
+            ClientInputs {
+                explicit_manual: None,
+                preregistered: None,
+                cimd_supported: false,
+                registration_endpoint: None,
+            },
+            |_ep| async { Ok::<_, ()>(ok_dcr()) },
+        )
+        .await;
+        assert!(matches!(result, Err(ClientResolveError::NoCredentials)));
+    }
+
+    #[tokio::test]
+    async fn dcr_error_propagates() {
+        let result = resolve_client(
+            ClientInputs {
+                explicit_manual: None,
+                preregistered: None,
+                cimd_supported: false,
+                registration_endpoint: Some("https://as/register".into()),
+            },
+            |_ep| async { Err::<DcrOutcome, _>("boom") },
+        )
+        .await;
+        match result {
+            Err(ClientResolveError::Dcr(e)) => assert_eq!(e, "boom"),
+            other => panic!("expected Dcr error, got {other:?}"),
+        }
+    }
+}

--- a/src/oauth/discovery.rs
+++ b/src/oauth/discovery.rs
@@ -52,6 +52,11 @@ pub struct AuthorizationServerMetadata {
     /// must not be treated as an error.
     #[serde(default)]
     pub authorization_response_iss_parameter_supported: bool,
+    /// Whether the authorization server advertises support for Client ID Metadata
+    /// Documents (CIMD). When false/absent, CIMD-based client identification is
+    /// unavailable.
+    #[serde(default)]
+    pub client_id_metadata_document_supported: bool,
 }
 
 /// Resolved OAuth server discovery result.
@@ -73,6 +78,10 @@ pub struct DiscoveryResult {
     /// RFC 9207: whether the authorization server advertises support for the
     /// authorization-response `iss` parameter.
     pub authorization_response_iss_parameter_supported: bool,
+    /// Whether the authorization server advertises support for Client ID
+    /// Metadata Documents (CIMD).
+    #[allow(dead_code)]
+    pub client_id_metadata_document_supported: bool,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -139,6 +148,31 @@ fn build_well_known_url_root(
     })?;
     let origin = parsed.origin().ascii_serialization();
     Ok(format!("{origin}/.well-known/{well_known_suffix}"))
+}
+
+/// Build an OpenID Connect Discovery 1.0 URL (§4).
+///
+/// Unlike RFC 8414 / RFC 5785 (which insert `.well-known` directly after the
+/// origin — see [`build_well_known_url`]), OIDC Discovery appends
+/// `/.well-known/openid-configuration` to the END of the issuer's full path:
+/// - `https://issuer.example.com/oauth2/default`
+///   → `https://issuer.example.com/oauth2/default/.well-known/openid-configuration`
+/// - `https://issuer.example.com` (or with a trailing slash)
+///   → `https://issuer.example.com/.well-known/openid-configuration`
+fn build_openid_configuration_url(base_url: &str) -> Result<String, DiscoveryError> {
+    let parsed = Url::parse(base_url).map_err(|_| DiscoveryError::MetadataNotFound {
+        url: base_url.to_string(),
+    })?;
+    let original_path = parsed.path().trim_matches('/');
+    let origin = parsed.origin().ascii_serialization();
+
+    if original_path.is_empty() {
+        Ok(format!("{origin}/.well-known/openid-configuration"))
+    } else {
+        Ok(format!(
+            "{origin}/{original_path}/.well-known/openid-configuration"
+        ))
+    }
 }
 
 /// Returns true if the base URL has a non-empty path component.
@@ -233,19 +267,26 @@ pub async fn discover_oauth_server_from_metadata(
     discover_authorization_server(&auth_server_url, allow_insecure).await
 }
 
-/// Discover OAuth authorization server metadata directly (RFC 8414 only).
+/// Discover OAuth authorization server metadata directly (RFC 8414 + OIDC).
 ///
 /// Unlike [`discover_oauth_server`], this skips the RFC 9728 protected
 /// resource step and fetches the AS metadata against `auth_server_url`
-/// itself:
+/// itself, probing the following locations in order and falling through ONLY
+/// on a 404 / [`DiscoveryError::MetadataNotFound`]:
 ///
-/// 1. `{origin}/.well-known/oauth-authorization-server{path}`
-///    - Falls back to `{origin}/.well-known/oauth-authorization-server`
-///      if 404 and `auth_server_url` has a path component.
-/// 2. Validates S256 PKCE support.
+/// 1. `{origin}/.well-known/oauth-authorization-server{path}` (RFC 8414 path-insert)
+/// 2. `{origin}/.well-known/oauth-authorization-server` (RFC 8414 root)
+/// 3. `{origin}{path}/.well-known/openid-configuration` (OIDC Discovery end-append)
+/// 4. `{origin}/.well-known/openid-configuration` (OIDC Discovery root)
 ///
-/// The input URL is validated through [`url_guard`] before any HTTP
-/// request is sent, and the request uses a per-host pinned client.
+/// Candidates that collapse to an already-probed URL (e.g. when
+/// `auth_server_url` has no path) are skipped. S256 PKCE support is then
+/// validated.
+///
+/// All candidates share the same origin, so a single per-host pinned client —
+/// validated through [`url_guard`] against the first URL before any HTTP
+/// request is sent — is reused, preserving the SSRF guard and DNS-rebinding
+/// protections.
 ///
 /// The returned `DiscoveryResult.auth_server_url` is set to the input
 /// `auth_server_url` so callers can label discovery output consistently.
@@ -253,33 +294,59 @@ pub async fn discover_authorization_server(
     auth_server_url: &str,
     allow_insecure: bool,
 ) -> Result<DiscoveryResult, DiscoveryError> {
-    let as_well_known = build_well_known_url(auth_server_url, "oauth-authorization-server")
-        .map_err(|_| DiscoveryError::AuthServerMetadataNotFound {
-            url: auth_server_url.to_string(),
-        })?;
-    let as_client = url_guard::validated_client(&as_well_known, allow_insecure).await?;
+    let map_err = || DiscoveryError::AuthServerMetadataNotFound {
+        url: auth_server_url.to_string(),
+    };
 
-    let as_meta: AuthorizationServerMetadata = match fetch_well_known(&as_client, &as_well_known)
-        .await
-    {
-        Ok(resp) => resp.json().await?,
-        Err(DiscoveryError::MetadataNotFound { .. }) if has_path(auth_server_url) => {
-            let root_url = build_well_known_url_root(auth_server_url, "oauth-authorization-server")
-                .map_err(|_| DiscoveryError::AuthServerMetadataNotFound {
-                    url: auth_server_url.to_string(),
-                })?;
-            fetch_well_known(&as_client, &root_url)
-                .await
-                .map_err(|_| DiscoveryError::AuthServerMetadataNotFound {
-                    url: as_well_known.clone(),
-                })?
-                .json()
-                .await?
+    // Build the ordered probe list. All candidates share the same origin.
+    let mut candidates: Vec<String> = Vec::new();
+    let as_path_insert = build_well_known_url(auth_server_url, "oauth-authorization-server")
+        .map_err(|_| map_err())?;
+    candidates.push(as_path_insert.clone());
+
+    let as_root = build_well_known_url_root(auth_server_url, "oauth-authorization-server")
+        .map_err(|_| map_err())?;
+    if !candidates.contains(&as_root) {
+        candidates.push(as_root);
+    }
+
+    let oidc_append = build_openid_configuration_url(auth_server_url).map_err(|_| map_err())?;
+    if !candidates.contains(&oidc_append) {
+        candidates.push(oidc_append);
+    }
+
+    let oidc_root = build_well_known_url_root(auth_server_url, "openid-configuration")
+        .map_err(|_| map_err())?;
+    if !candidates.contains(&oidc_root) {
+        candidates.push(oidc_root);
+    }
+
+    let as_client = url_guard::validated_client(&as_path_insert, allow_insecure).await?;
+
+    // Probe each candidate, falling through only on MetadataNotFound (404).
+    let mut as_meta: Option<AuthorizationServerMetadata> = None;
+    let mut last_not_found: Option<String> = None;
+    for candidate in &candidates {
+        match fetch_well_known(&as_client, candidate).await {
+            Ok(resp) => {
+                as_meta = Some(resp.json().await?);
+                break;
+            }
+            Err(DiscoveryError::MetadataNotFound { url }) => {
+                last_not_found = Some(url);
+                continue;
+            }
+            Err(e) => return Err(e),
         }
-        Err(DiscoveryError::MetadataNotFound { url }) => {
-            return Err(DiscoveryError::AuthServerMetadataNotFound { url });
+    }
+
+    let as_meta = match as_meta {
+        Some(meta) => meta,
+        None => {
+            return Err(DiscoveryError::AuthServerMetadataNotFound {
+                url: last_not_found.unwrap_or(as_path_insert),
+            });
         }
-        Err(e) => return Err(e),
     };
 
     // Validate S256 is supported (required for PKCE)
@@ -303,6 +370,7 @@ pub async fn discover_authorization_server(
         revocation_endpoint: as_meta.revocation_endpoint,
         authorization_response_iss_parameter_supported: as_meta
             .authorization_response_iss_parameter_supported,
+        client_id_metadata_document_supported: as_meta.client_id_metadata_document_supported,
     })
 }
 
@@ -742,15 +810,22 @@ mod tests {
 
     /// Spawn an axum server on `127.0.0.1:0` that serves AS metadata. Returns
     /// `(base_url, handle)`. The `path_status` controls what the path-shaped
-    /// well-known URL returns; the root well-known URL always serves
-    /// `root_body` when provided.
+    /// `oauth-authorization-server` well-known URL returns; the root
+    /// `oauth-authorization-server` URL serves `root_body` when provided.
+    ///
+    /// `oidc_root_body` is served at `/.well-known/openid-configuration`, and
+    /// `oidc_append_body` is served at any URL ending in
+    /// `/.well-known/openid-configuration` (the OIDC end-append form). Each
+    /// serves 404 when `None`.
     async fn spawn_as_fixture(
         path_status: axum::http::StatusCode,
         root_body: Option<serde_json::Value>,
         path_body: Option<serde_json::Value>,
+        oidc_root_body: Option<serde_json::Value>,
+        oidc_append_body: Option<serde_json::Value>,
     ) -> (String, tokio::task::JoinHandle<()>) {
         use axum::extract::{Path as AxPath, State};
-        use axum::http::StatusCode;
+        use axum::http::{StatusCode, Uri};
         use axum::{response::IntoResponse, routing::get, Json, Router};
 
         #[derive(Clone)]
@@ -758,6 +833,8 @@ mod tests {
             path_status: StatusCode,
             root_body: std::sync::Arc<Option<serde_json::Value>>,
             path_body: std::sync::Arc<Option<serde_json::Value>>,
+            oidc_root_body: std::sync::Arc<Option<serde_json::Value>>,
+            oidc_append_body: std::sync::Arc<Option<serde_json::Value>>,
         }
 
         async fn root(State(fx): State<Fx>) -> axum::response::Response {
@@ -779,11 +856,31 @@ mod tests {
                 (fx.path_status, "not found").into_response()
             }
         }
+        async fn oidc_root(State(fx): State<Fx>) -> axum::response::Response {
+            match fx.oidc_root_body.as_ref() {
+                Some(v) => (StatusCode::OK, Json(v.clone())).into_response(),
+                None => (StatusCode::NOT_FOUND, "not found").into_response(),
+            }
+        }
+        // Catch-all: serves the OIDC end-append body for any URL ending in
+        // `/.well-known/openid-configuration`; 404 otherwise.
+        async fn oidc_append_fallback(State(fx): State<Fx>, uri: Uri) -> axum::response::Response {
+            if uri.path().ends_with("/.well-known/openid-configuration") {
+                match fx.oidc_append_body.as_ref() {
+                    Some(v) => (StatusCode::OK, Json(v.clone())).into_response(),
+                    None => (StatusCode::NOT_FOUND, "not found").into_response(),
+                }
+            } else {
+                (StatusCode::NOT_FOUND, "not found").into_response()
+            }
+        }
 
         let fx = Fx {
             path_status,
             root_body: std::sync::Arc::new(root_body),
             path_body: std::sync::Arc::new(path_body),
+            oidc_root_body: std::sync::Arc::new(oidc_root_body),
+            oidc_append_body: std::sync::Arc::new(oidc_append_body),
         };
 
         let router = Router::new()
@@ -792,6 +889,8 @@ mod tests {
                 "/.well-known/oauth-authorization-server/{*tail}",
                 get(path_handler),
             )
+            .route("/.well-known/openid-configuration", get(oidc_root))
+            .fallback(oidc_append_fallback)
             .with_state(fx);
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -818,6 +917,8 @@ mod tests {
         let (base, server) = spawn_as_fixture(
             axum::http::StatusCode::NOT_FOUND,
             Some(root_meta.clone()),
+            None,
+            None,
             None,
         )
         .await;
@@ -850,8 +951,14 @@ mod tests {
         });
         // URL has no path so the first fetch hits the root well-known route;
         // serve the metadata there.
-        let (base, server) =
-            spawn_as_fixture(axum::http::StatusCode::OK, Some(root_meta), None).await;
+        let (base, server) = spawn_as_fixture(
+            axum::http::StatusCode::OK,
+            Some(root_meta),
+            None,
+            None,
+            None,
+        )
+        .await;
 
         let result = discover_authorization_server(&base, true).await;
         assert!(
@@ -874,5 +981,183 @@ mod tests {
             Err(other) => panic!("expected DiscoveryError::UrlGuard, got {:?}", other),
             Ok(_) => panic!("expected DiscoveryError::UrlGuard, got Ok(_)"),
         }
+    }
+
+    // --- build_openid_configuration_url tests --------------------------------
+
+    #[test]
+    fn test_build_openid_configuration_url_no_path() {
+        let url = build_openid_configuration_url("https://issuer.example.com").unwrap();
+        assert_eq!(
+            url,
+            "https://issuer.example.com/.well-known/openid-configuration"
+        );
+    }
+
+    #[test]
+    fn test_build_openid_configuration_url_with_path() {
+        let url =
+            build_openid_configuration_url("https://issuer.example.com/oauth2/default").unwrap();
+        assert_eq!(
+            url,
+            "https://issuer.example.com/oauth2/default/.well-known/openid-configuration"
+        );
+    }
+
+    #[test]
+    fn test_build_openid_configuration_url_trailing_slash() {
+        // Root + trailing slash collapses to the root form.
+        let url = build_openid_configuration_url("https://issuer.example.com/").unwrap();
+        assert_eq!(
+            url,
+            "https://issuer.example.com/.well-known/openid-configuration"
+        );
+        // Path + trailing slash collapses the trailing slash too.
+        let url =
+            build_openid_configuration_url("https://issuer.example.com/oauth2/default/").unwrap();
+        assert_eq!(
+            url,
+            "https://issuer.example.com/oauth2/default/.well-known/openid-configuration"
+        );
+    }
+
+    #[test]
+    fn test_build_openid_configuration_url_with_port() {
+        let url = build_openid_configuration_url("https://localhost:8080/api/auth").unwrap();
+        assert_eq!(
+            url,
+            "https://localhost:8080/api/auth/.well-known/openid-configuration"
+        );
+    }
+
+    // --- openid-configuration fallback discovery tests -----------------------
+
+    /// oauth-as path 404 + oauth-as root 404 → openid-configuration end-append
+    /// succeeds.
+    #[tokio::test]
+    async fn discover_authorization_server_falls_back_to_openid_configuration() {
+        use serde_json::json;
+        let oidc_meta = json!({
+            "issuer": "https://issuer.example.com",
+            "authorization_endpoint": "https://issuer.example.com/authorize",
+            "token_endpoint": "https://issuer.example.com/token",
+            "code_challenge_methods_supported": ["S256"],
+        });
+        // oauth-as path 404 (path_status), oauth-as root 404 (root_body None),
+        // openid-configuration end-append served.
+        let (base, server) = spawn_as_fixture(
+            axum::http::StatusCode::NOT_FOUND,
+            None,
+            None,
+            None,
+            Some(oidc_meta),
+        )
+        .await;
+
+        let url = format!("{}/oauth2/default", base);
+        let result = discover_authorization_server(&url, true)
+            .await
+            .expect("openid-configuration end-append must succeed");
+        assert_eq!(
+            result.authorization_endpoint,
+            "https://issuer.example.com/authorize"
+        );
+        assert_eq!(result.token_endpoint, "https://issuer.example.com/token");
+        assert_eq!(result.auth_server_url, url);
+
+        server.abort();
+    }
+
+    /// oauth-as path 404 + oauth-as root 404 + openid-configuration end-append
+    /// 404 → openid-configuration root fallback succeeds.
+    #[tokio::test]
+    async fn discover_authorization_server_falls_back_to_openid_configuration_root() {
+        use serde_json::json;
+        let oidc_meta = json!({
+            "issuer": "https://issuer.example.com",
+            "authorization_endpoint": "https://issuer.example.com/authorize",
+            "token_endpoint": "https://issuer.example.com/token",
+            "code_challenge_methods_supported": ["S256"],
+        });
+        // Only the openid-configuration root URL serves metadata.
+        let (base, server) = spawn_as_fixture(
+            axum::http::StatusCode::NOT_FOUND,
+            None,
+            None,
+            Some(oidc_meta),
+            None,
+        )
+        .await;
+
+        let url = format!("{}/oauth2/default", base);
+        let result = discover_authorization_server(&url, true)
+            .await
+            .expect("openid-configuration root fallback must succeed");
+        assert_eq!(
+            result.authorization_endpoint,
+            "https://issuer.example.com/authorize"
+        );
+        assert_eq!(result.token_endpoint, "https://issuer.example.com/token");
+
+        server.abort();
+    }
+
+    // --- client_id_metadata_document_supported parsing + threading -----------
+
+    #[test]
+    fn test_cimd_parses_true_false_absent() {
+        let with_true = r#"{
+            "issuer": "https://auth.example.com",
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+            "client_id_metadata_document_supported": true
+        }"#;
+        let meta: AuthorizationServerMetadata = serde_json::from_str(with_true).unwrap();
+        assert!(meta.client_id_metadata_document_supported);
+
+        let with_false = r#"{
+            "issuer": "https://auth.example.com",
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+            "client_id_metadata_document_supported": false
+        }"#;
+        let meta: AuthorizationServerMetadata = serde_json::from_str(with_false).unwrap();
+        assert!(!meta.client_id_metadata_document_supported);
+
+        let absent = r#"{
+            "issuer": "https://auth.example.com",
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token"
+        }"#;
+        let meta: AuthorizationServerMetadata = serde_json::from_str(absent).unwrap();
+        assert!(!meta.client_id_metadata_document_supported);
+    }
+
+    /// `client_id_metadata_document_supported` is threaded onto `DiscoveryResult`.
+    #[tokio::test]
+    async fn discover_authorization_server_surfaces_cimd_flag() {
+        use serde_json::json;
+        let root_meta = json!({
+            "issuer": "https://example.com",
+            "authorization_endpoint": "https://example.com/authorize",
+            "token_endpoint": "https://example.com/token",
+            "code_challenge_methods_supported": ["S256"],
+            "client_id_metadata_document_supported": true,
+        });
+        let (base, server) = spawn_as_fixture(
+            axum::http::StatusCode::OK,
+            Some(root_meta),
+            None,
+            None,
+            None,
+        )
+        .await;
+
+        let result = discover_authorization_server(&base, true)
+            .await
+            .expect("discovery must succeed");
+        assert!(result.client_id_metadata_document_supported);
+
+        server.abort();
     }
 }

--- a/src/oauth/discovery.rs
+++ b/src/oauth/discovery.rs
@@ -182,6 +182,13 @@ fn has_path(base_url: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Normalize an issuer/URL for comparison per RFC 8414 §3.3: tolerate a single
+/// trailing-slash difference. Comparison is otherwise exact on scheme, host,
+/// port, and path.
+fn normalize_issuer(issuer: &str) -> &str {
+    issuer.strip_suffix('/').unwrap_or(issuer)
+}
+
 /// Discover OAuth server metadata for a protected resource using RFC 9728.
 ///
 /// 1. Fetches `{origin}/.well-known/oauth-protected-resource{path}`
@@ -280,8 +287,13 @@ pub async fn discover_oauth_server_from_metadata(
 /// 4. `{origin}/.well-known/openid-configuration` (OIDC Discovery root)
 ///
 /// Candidates that collapse to an already-probed URL (e.g. when
-/// `auth_server_url` has no path) are skipped. S256 PKCE support is then
-/// validated.
+/// `auth_server_url` has no path) are skipped. Each candidate's metadata
+/// `issuer` is validated against the expected issuer identifier for that
+/// candidate form (the origin for the root well-known forms, the full input
+/// URL for the path-insert / end-append forms) per RFC 8414 §3.3; metadata
+/// advertising a mismatching issuer is rejected and probing continues, so we
+/// never accept metadata for a different AS sharing the same origin. S256 PKCE
+/// support is then validated.
 ///
 /// All candidates share the same origin, so a single per-host pinned client —
 /// validated through [`url_guard`] against the first URL before any HTTP
@@ -298,38 +310,60 @@ pub async fn discover_authorization_server(
         url: auth_server_url.to_string(),
     };
 
-    // Build the ordered probe list. All candidates share the same origin.
-    let mut candidates: Vec<String> = Vec::new();
+    // Expected issuer identifiers per RFC 8414 §3.3 / OIDC Discovery: the
+    // origin for the root well-known forms, and the full (normalized) input
+    // URL for the path-insert / end-append forms.
+    let parsed = Url::parse(auth_server_url).map_err(|_| map_err())?;
+    let origin = parsed.origin().ascii_serialization();
+    let input_path = parsed.path().trim_end_matches('/');
+    let input_issuer = if input_path.is_empty() {
+        origin.clone()
+    } else {
+        format!("{origin}{input_path}")
+    };
+
+    // Build the ordered probe list. All candidates share the same origin. Each
+    // entry pairs a candidate URL with the issuer we expect its metadata to
+    // advertise, so we never accept metadata for a different AS on the origin.
+    let mut candidates: Vec<(String, String)> = Vec::new();
     let as_path_insert = build_well_known_url(auth_server_url, "oauth-authorization-server")
         .map_err(|_| map_err())?;
-    candidates.push(as_path_insert.clone());
+    candidates.push((as_path_insert.clone(), input_issuer.clone()));
 
     let as_root = build_well_known_url_root(auth_server_url, "oauth-authorization-server")
         .map_err(|_| map_err())?;
-    if !candidates.contains(&as_root) {
-        candidates.push(as_root);
+    if !candidates.iter().any(|(url, _)| url == &as_root) {
+        candidates.push((as_root, origin.clone()));
     }
 
     let oidc_append = build_openid_configuration_url(auth_server_url).map_err(|_| map_err())?;
-    if !candidates.contains(&oidc_append) {
-        candidates.push(oidc_append);
+    if !candidates.iter().any(|(url, _)| url == &oidc_append) {
+        candidates.push((oidc_append, input_issuer.clone()));
     }
 
     let oidc_root = build_well_known_url_root(auth_server_url, "openid-configuration")
         .map_err(|_| map_err())?;
-    if !candidates.contains(&oidc_root) {
-        candidates.push(oidc_root);
+    if !candidates.iter().any(|(url, _)| url == &oidc_root) {
+        candidates.push((oidc_root, origin.clone()));
     }
 
     let as_client = url_guard::validated_client(&as_path_insert, allow_insecure).await?;
 
-    // Probe each candidate, falling through only on MetadataNotFound (404).
+    // Probe each candidate, falling through on MetadataNotFound (404) or on an
+    // issuer mismatch (RFC 8414 §3.3): metadata whose `issuer` does not match
+    // the expected identifier for that candidate form is rejected and treated
+    // like a miss so we keep probing the remaining candidates.
     let mut as_meta: Option<AuthorizationServerMetadata> = None;
     let mut last_not_found: Option<String> = None;
-    for candidate in &candidates {
+    for (candidate, expected_issuer) in &candidates {
         match fetch_well_known(&as_client, candidate).await {
             Ok(resp) => {
-                as_meta = Some(resp.json().await?);
+                let meta: AuthorizationServerMetadata = resp.json().await?;
+                if normalize_issuer(&meta.issuer) != normalize_issuer(expected_issuer) {
+                    last_not_found = Some(candidate.clone());
+                    continue;
+                }
+                as_meta = Some(meta);
                 break;
             }
             Err(DiscoveryError::MetadataNotFound { url }) => {
@@ -810,19 +844,28 @@ mod tests {
 
     /// Spawn an axum server on `127.0.0.1:0` that serves AS metadata. Returns
     /// `(base_url, handle)`. The `path_status` controls what the path-shaped
-    /// `oauth-authorization-server` well-known URL returns; the root
-    /// `oauth-authorization-server` URL serves `root_body` when provided.
+    /// `oauth-authorization-server` well-known URL returns.
     ///
-    /// `oidc_root_body` is served at `/.well-known/openid-configuration`, and
-    /// `oidc_append_body` is served at any URL ending in
-    /// `/.well-known/openid-configuration` (the OIDC end-append form). Each
-    /// serves 404 when `None`.
+    /// `build_bodies` is invoked with the bound base URL (so fixtures can embed
+    /// the dynamic origin/port in their `issuer` fields) and returns
+    /// `(root_body, path_body, oidc_root_body, oidc_append_body)`:
+    /// - `root_body` is served at `/.well-known/oauth-authorization-server`,
+    /// - `path_body` at the path-shaped `oauth-authorization-server` URL,
+    /// - `oidc_root_body` at `/.well-known/openid-configuration`, and
+    /// - `oidc_append_body` at any URL ending in
+    ///   `/.well-known/openid-configuration` (the OIDC end-append form).
+    ///
+    /// Each serves 404 when its `Option` is `None`.
     async fn spawn_as_fixture(
         path_status: axum::http::StatusCode,
-        root_body: Option<serde_json::Value>,
-        path_body: Option<serde_json::Value>,
-        oidc_root_body: Option<serde_json::Value>,
-        oidc_append_body: Option<serde_json::Value>,
+        build_bodies: impl FnOnce(
+            &str,
+        ) -> (
+            Option<serde_json::Value>,
+            Option<serde_json::Value>,
+            Option<serde_json::Value>,
+            Option<serde_json::Value>,
+        ),
     ) -> (String, tokio::task::JoinHandle<()>) {
         use axum::extract::{Path as AxPath, State};
         use axum::http::{StatusCode, Uri};
@@ -875,6 +918,11 @@ mod tests {
             }
         }
 
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let base = format!("http://127.0.0.1:{}", addr.port());
+        let (root_body, path_body, oidc_root_body, oidc_append_body) = build_bodies(&base);
+
         let fx = Fx {
             path_status,
             root_body: std::sync::Arc::new(root_body),
@@ -893,34 +941,29 @@ mod tests {
             .fallback(oidc_append_fallback)
             .with_state(fx);
 
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
         let handle = tokio::spawn(async move {
             axum::serve(listener, router).await.ok();
         });
         // Tiny delay so the server is accepting connections.
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-        (format!("http://127.0.0.1:{}", addr.port()), handle)
+        (base, handle)
     }
 
     /// 3a. URL has a path → path-shaped well-known 404 → root-only fallback
-    /// returns the parsed metadata.
+    /// returns the parsed metadata. The root form's issuer must match the
+    /// origin per RFC 8414 §3.3.
     #[tokio::test]
     async fn discover_authorization_server_path_404_falls_back_to_root() {
         use serde_json::json;
-        let root_meta = json!({
-            "issuer": "https://example.com",
-            "authorization_endpoint": "https://example.com/authorize",
-            "token_endpoint": "https://example.com/token",
-            "code_challenge_methods_supported": ["S256"],
-        });
-        let (base, server) = spawn_as_fixture(
-            axum::http::StatusCode::NOT_FOUND,
-            Some(root_meta.clone()),
-            None,
-            None,
-            None,
-        )
+        let (base, server) = spawn_as_fixture(axum::http::StatusCode::NOT_FOUND, |base| {
+            let root_meta = json!({
+                "issuer": base,
+                "authorization_endpoint": format!("{base}/authorize"),
+                "token_endpoint": format!("{base}/token"),
+                "code_challenge_methods_supported": ["S256"],
+            });
+            (Some(root_meta), None, None, None)
+        })
         .await;
 
         // Input URL has a path so build_well_known_url emits the path variant
@@ -929,11 +972,8 @@ mod tests {
         let result = discover_authorization_server(&url, true)
             .await
             .expect("root fallback must succeed");
-        assert_eq!(
-            result.authorization_endpoint,
-            "https://example.com/authorize"
-        );
-        assert_eq!(result.token_endpoint, "https://example.com/token");
+        assert_eq!(result.authorization_endpoint, format!("{base}/authorize"));
+        assert_eq!(result.token_endpoint, format!("{base}/token"));
         assert_eq!(result.auth_server_url, url);
 
         server.abort();
@@ -943,21 +983,17 @@ mod tests {
     #[tokio::test]
     async fn discover_authorization_server_rejects_when_s256_missing() {
         use serde_json::json;
-        let root_meta = json!({
-            "issuer": "https://example.com",
-            "authorization_endpoint": "https://example.com/authorize",
-            "token_endpoint": "https://example.com/token",
-            "code_challenge_methods_supported": ["plain"],
-        });
         // URL has no path so the first fetch hits the root well-known route;
-        // serve the metadata there.
-        let (base, server) = spawn_as_fixture(
-            axum::http::StatusCode::OK,
-            Some(root_meta),
-            None,
-            None,
-            None,
-        )
+        // serve the metadata there with an origin-matching issuer.
+        let (base, server) = spawn_as_fixture(axum::http::StatusCode::OK, |base| {
+            let root_meta = json!({
+                "issuer": base,
+                "authorization_endpoint": format!("{base}/authorize"),
+                "token_endpoint": format!("{base}/token"),
+                "code_challenge_methods_supported": ["plain"],
+            });
+            (Some(root_meta), None, None, None)
+        })
         .await;
 
         let result = discover_authorization_server(&base, true).await;
@@ -1033,25 +1069,21 @@ mod tests {
     // --- openid-configuration fallback discovery tests -----------------------
 
     /// oauth-as path 404 + oauth-as root 404 → openid-configuration end-append
-    /// succeeds.
+    /// succeeds. The end-append form's issuer must match the full input URL.
     #[tokio::test]
     async fn discover_authorization_server_falls_back_to_openid_configuration() {
         use serde_json::json;
-        let oidc_meta = json!({
-            "issuer": "https://issuer.example.com",
-            "authorization_endpoint": "https://issuer.example.com/authorize",
-            "token_endpoint": "https://issuer.example.com/token",
-            "code_challenge_methods_supported": ["S256"],
-        });
         // oauth-as path 404 (path_status), oauth-as root 404 (root_body None),
-        // openid-configuration end-append served.
-        let (base, server) = spawn_as_fixture(
-            axum::http::StatusCode::NOT_FOUND,
-            None,
-            None,
-            None,
-            Some(oidc_meta),
-        )
+        // openid-configuration end-append served with an input-matching issuer.
+        let (base, server) = spawn_as_fixture(axum::http::StatusCode::NOT_FOUND, |base| {
+            let oidc_meta = json!({
+                "issuer": format!("{base}/oauth2/default"),
+                "authorization_endpoint": format!("{base}/oauth2/default/authorize"),
+                "token_endpoint": format!("{base}/oauth2/default/token"),
+                "code_challenge_methods_supported": ["S256"],
+            });
+            (None, None, None, Some(oidc_meta))
+        })
         .await;
 
         let url = format!("{}/oauth2/default", base);
@@ -1060,44 +1092,41 @@ mod tests {
             .expect("openid-configuration end-append must succeed");
         assert_eq!(
             result.authorization_endpoint,
-            "https://issuer.example.com/authorize"
+            format!("{base}/oauth2/default/authorize")
         );
-        assert_eq!(result.token_endpoint, "https://issuer.example.com/token");
+        assert_eq!(
+            result.token_endpoint,
+            format!("{base}/oauth2/default/token")
+        );
         assert_eq!(result.auth_server_url, url);
 
         server.abort();
     }
 
     /// oauth-as path 404 + oauth-as root 404 + openid-configuration end-append
-    /// 404 → openid-configuration root fallback succeeds.
+    /// 404 → openid-configuration root fallback succeeds. The root form's
+    /// issuer must match the origin.
     #[tokio::test]
     async fn discover_authorization_server_falls_back_to_openid_configuration_root() {
         use serde_json::json;
-        let oidc_meta = json!({
-            "issuer": "https://issuer.example.com",
-            "authorization_endpoint": "https://issuer.example.com/authorize",
-            "token_endpoint": "https://issuer.example.com/token",
-            "code_challenge_methods_supported": ["S256"],
-        });
         // Only the openid-configuration root URL serves metadata.
-        let (base, server) = spawn_as_fixture(
-            axum::http::StatusCode::NOT_FOUND,
-            None,
-            None,
-            Some(oidc_meta),
-            None,
-        )
+        let (base, server) = spawn_as_fixture(axum::http::StatusCode::NOT_FOUND, |base| {
+            let oidc_meta = json!({
+                "issuer": base,
+                "authorization_endpoint": format!("{base}/authorize"),
+                "token_endpoint": format!("{base}/token"),
+                "code_challenge_methods_supported": ["S256"],
+            });
+            (None, None, Some(oidc_meta), None)
+        })
         .await;
 
         let url = format!("{}/oauth2/default", base);
         let result = discover_authorization_server(&url, true)
             .await
             .expect("openid-configuration root fallback must succeed");
-        assert_eq!(
-            result.authorization_endpoint,
-            "https://issuer.example.com/authorize"
-        );
-        assert_eq!(result.token_endpoint, "https://issuer.example.com/token");
+        assert_eq!(result.authorization_endpoint, format!("{base}/authorize"));
+        assert_eq!(result.token_endpoint, format!("{base}/token"));
 
         server.abort();
     }
@@ -1137,26 +1166,106 @@ mod tests {
     #[tokio::test]
     async fn discover_authorization_server_surfaces_cimd_flag() {
         use serde_json::json;
-        let root_meta = json!({
-            "issuer": "https://example.com",
-            "authorization_endpoint": "https://example.com/authorize",
-            "token_endpoint": "https://example.com/token",
-            "code_challenge_methods_supported": ["S256"],
-            "client_id_metadata_document_supported": true,
-        });
-        let (base, server) = spawn_as_fixture(
-            axum::http::StatusCode::OK,
-            Some(root_meta),
-            None,
-            None,
-            None,
-        )
+        let (base, server) = spawn_as_fixture(axum::http::StatusCode::OK, |base| {
+            let root_meta = json!({
+                "issuer": base,
+                "authorization_endpoint": format!("{base}/authorize"),
+                "token_endpoint": format!("{base}/token"),
+                "code_challenge_methods_supported": ["S256"],
+                "client_id_metadata_document_supported": true,
+            });
+            (Some(root_meta), None, None, None)
+        })
         .await;
 
         let result = discover_authorization_server(&base, true)
             .await
             .expect("discovery must succeed");
         assert!(result.client_id_metadata_document_supported);
+
+        server.abort();
+    }
+
+    // --- RFC 8414 §3.3 issuer-validation tests -------------------------------
+
+    /// Metadata served on the same origin but advertising a DIFFERENT issuer
+    /// than expected must be rejected — discovery must not accept metadata for a
+    /// different AS sharing the origin, and falls through to not-found.
+    #[tokio::test]
+    async fn discover_authorization_server_rejects_issuer_mismatch() {
+        use serde_json::json;
+        // openid-configuration root serves metadata whose issuer points at a
+        // wholly different authorization server. All other candidates 404.
+        let (base, server) = spawn_as_fixture(axum::http::StatusCode::NOT_FOUND, |_base| {
+            let oidc_meta = json!({
+                "issuer": "https://evil.example.com",
+                "authorization_endpoint": "https://evil.example.com/authorize",
+                "token_endpoint": "https://evil.example.com/token",
+                "code_challenge_methods_supported": ["S256"],
+            });
+            (None, None, Some(oidc_meta), None)
+        })
+        .await;
+
+        let result = discover_authorization_server(&base, true).await;
+        assert!(
+            matches!(
+                result,
+                Err(DiscoveryError::AuthServerMetadataNotFound { .. })
+            ),
+            "expected AuthServerMetadataNotFound on issuer mismatch, got {:?}",
+            result.err()
+        );
+
+        server.abort();
+    }
+
+    /// Regression: an `oauth-authorization-server` path-form AS whose issuer
+    /// matches the full input URL is accepted.
+    #[tokio::test]
+    async fn discover_authorization_server_accepts_matching_issuer_path_as() {
+        use serde_json::json;
+        let (base, server) = spawn_as_fixture(axum::http::StatusCode::OK, |base| {
+            let path_meta = json!({
+                "issuer": format!("{base}/login/oauth"),
+                "authorization_endpoint": format!("{base}/login/oauth/authorize"),
+                "token_endpoint": format!("{base}/login/oauth/token"),
+                "code_challenge_methods_supported": ["S256"],
+            });
+            (None, Some(path_meta), None, None)
+        })
+        .await;
+
+        let url = format!("{}/login/oauth", base);
+        let result = discover_authorization_server(&url, true)
+            .await
+            .expect("matching path-form AS must succeed");
+        assert_eq!(result.issuer, format!("{base}/login/oauth"));
+
+        server.abort();
+    }
+
+    /// Regression: an OpenID Connect end-append AS whose issuer matches the full
+    /// input URL is accepted.
+    #[tokio::test]
+    async fn discover_authorization_server_accepts_matching_issuer_oidc_as() {
+        use serde_json::json;
+        let (base, server) = spawn_as_fixture(axum::http::StatusCode::NOT_FOUND, |base| {
+            let oidc_meta = json!({
+                "issuer": format!("{base}/oauth2/default"),
+                "authorization_endpoint": format!("{base}/oauth2/default/authorize"),
+                "token_endpoint": format!("{base}/oauth2/default/token"),
+                "code_challenge_methods_supported": ["S256"],
+            });
+            (None, None, None, Some(oidc_meta))
+        })
+        .await;
+
+        let url = format!("{}/oauth2/default", base);
+        let result = discover_authorization_server(&url, true)
+            .await
+            .expect("matching end-append OIDC AS must succeed");
+        assert_eq!(result.issuer, format!("{base}/oauth2/default"));
 
         server.abort();
     }

--- a/src/oauth/mod.rs
+++ b/src/oauth/mod.rs
@@ -1,3 +1,4 @@
+pub mod client;
 pub mod dcr;
 pub mod discovery;
 pub mod url_guard;


### PR DESCRIPTION
## Summary

Improves OAuth authorization-server discovery and client resolution to support
RFC 9728 protected resource metadata flows and Client ID Metadata Documents
(CIMD). Linear: END-17.

### 1. openid-configuration AS discovery fallback

Adds an end-append `/.well-known/openid-configuration` discovery fallback for
Okta-style authorization servers whose issuer URLs include a path segment. When
the RFC 8414 `oauth-authorization-server` lookup does not resolve, discovery now
also attempts the OpenID Connect end-appended location so these servers are
handled correctly.

### 2. Surface `client_id_metadata_document_supported`

The `DiscoveryResult` now surfaces the `client_id_metadata_document_supported`
flag advertised by the authorization server, so downstream client resolution can
decide whether a Client ID Metadata Document can be used.

### 3. Centralized client resolution (`src/oauth/client.rs`)

Introduces a single resolver that determines which client identity to use, in a
well-defined priority order:

1. **Pre-registered** — an explicit client_id supplied via Add-Server always wins.
2. **CIMD** — Client ID Metadata Document: a zero-config public client (no secret,
   no Dynamic Client Registration round-trip) used when the AS advertises support.
3. **DCR** — Dynamic Client Registration fallback.
4. **Manual** — manual configuration.

CIMD provides a zero-config public client path: no client secret and no DCR
registration are required. An explicit Add-Server `client_id` still takes
precedence over CIMD. Client registration now emits structured logging to make
the resolution path observable.
