### PR TITLE
feat(oauth): EMA token-exchange client — ID Token → ID-JAG → access token (END-18)

### DIFF
--- a/src/adapter/oauth/heartbeat.rs
+++ b/src/adapter/oauth/heartbeat.rs
@@ -392,6 +392,7 @@ mod tests {
             probe_failure_threshold: threshold,
             server_type_override: None,
             allow_insecure_oauth: false,
+            ema: None,
         }
     }
 

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -481,6 +481,10 @@ impl OAuthAdapterInner {
         {
             Ok(token_set) => {
                 self.metrics.inc_refresh_success();
+                // The endpoint is authenticated again; drop any stale IdP
+                // sign-in URL composed by a prior re-SSO-required outcome so
+                // callers don't keep surfacing it (M9).
+                *self.pending_authorize_url.write().await = None;
                 info!("EMA token exchange successful");
                 Ok(token_set)
             }
@@ -1519,6 +1523,40 @@ mod tests {
             .await
             .expect("EMA refresh returns the cached token");
         assert_eq!(ts.access_token, "cached-ema-access");
+    }
+
+    /// A successful EMA refresh clears any stale IdP authorize URL left over from
+    /// a prior re-SSO-required outcome, so callers stop surfacing a sign-in link
+    /// once the endpoint re-authenticates.
+    #[tokio::test]
+    async fn ema_refresh_success_clears_pending_authorize_url() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let token = TokenSet {
+            access_token: "cached-ema-access".to_string(),
+            refresh_token: None,
+            expires_at: Some(now_secs() + 3600),
+            token_type: "Bearer".to_string(),
+            scope: None,
+            issued_at: Some(now_secs()),
+        };
+        tm.save("ema-ep", &token).await.unwrap();
+
+        let config = make_ema_config("http://127.0.0.1:1", "http://127.0.0.1:2");
+        let adapter = OAuthAdapter::new(config, tm);
+        // Seed a stale authorize URL as if a prior refresh required re-SSO.
+        *adapter.inner.pending_authorize_url.write().await =
+            Some("https://stale.example/authorize".to_string());
+
+        adapter
+            .inner
+            .do_token_refresh()
+            .await
+            .expect("EMA refresh returns the cached token");
+        assert!(
+            adapter.inner.pending_authorize_url().await.is_none(),
+            "stale authorize URL must be cleared after a successful EMA refresh"
+        );
     }
 
     /// With no stored IdP credentials the EMA chain is terminal: the adapter

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -10,8 +10,10 @@ use self::metrics::{generate_correlation_id, OAuthMetrics};
 use super::http::{HttpAdapter, HttpConfig};
 use super::server_type_resolution::effective_server_type;
 use super::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
+use crate::oauth::client::ENDARA_CLIENT_METADATA_URL;
 use crate::oauth::discovery::{discover_oauth_server, DiscoveryResult};
-use crate::oauth::OAuthError;
+use crate::oauth::ema::{self, EmaError};
+use crate::oauth::{OAuthError, OAuthFlowManager, PkceChallenge};
 use crate::token_manager::{TokenManager, TokenSet};
 use async_trait::async_trait;
 use reqwest::Client;
@@ -37,6 +39,12 @@ fn fallback_refresh_deadline(now: Instant, expires_at: Instant) -> Instant {
     target.max(now)
 }
 
+/// `application/x-www-form-urlencoded` byte-serialize a single value for use in
+/// an authorize-URL query parameter (mirrors the JIT path's encoder).
+fn form_urlencode(s: &str) -> String {
+    url::form_urlencoded::byte_serialize(s.as_bytes()).collect()
+}
+
 /// Wall-clock timeout applied to the OAuth refresh `reqwest::Client`.
 ///
 /// Bounds recovery time when the configured token endpoint stops responding
@@ -45,6 +53,41 @@ fn fallback_refresh_deadline(now: Instant, expires_at: Instant) -> Instant {
 /// gives `refresh_http_client_uses_30s_timeout` a stable hook to assert
 /// against and forces a deliberate review of any future change.
 const REFRESH_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Resolved Enterprise-Managed Authorization (EMA, END-18) parameters for an
+/// endpoint whose `[endpoints.auth] type = "ema"`. Present on
+/// [`OAuthAdapterConfig::ema`] only for EMA endpoints; `None` leaves the adapter
+/// on the standard OAuth `refresh_token` grant. The URLs are resolved via
+/// discovery at construction time and are re-validated through `url_guard`
+/// inside [`crate::oauth::ema`] on every leg.
+#[derive(Debug, Clone)]
+pub struct EmaConfig {
+    /// Token-store key for the IdP credentials (a sanitized IdP issuer in v1).
+    pub idp_key: String,
+    /// IdP issuer URL (e.g. `https://acme.okta.com`).
+    pub idp_issuer: String,
+    /// IdP authorization endpoint (for the SSO kick-off authorize URL).
+    pub idp_authorization_endpoint: String,
+    /// IdP token endpoint (token-exchange Step 2 + IdP refresh grant).
+    pub idp_token_endpoint: String,
+    /// Resource AS issuer (RFC 8693 `audience`; ID-JAG `aud` claim).
+    pub as_issuer: String,
+    /// Resource AS token endpoint (RFC 7523 Step 3 redemption).
+    pub as_token_endpoint: String,
+    /// Target MCP server URL the access token is minted for.
+    pub resource: String,
+}
+
+/// SSO kick-off wiring for an EMA endpoint: the shared OAuth flow manager and
+/// the relay loopback port used to compose the IdP authorize URL and register
+/// the pending IdP SSO flow (via [`OAuthFlowManager::start_idp_flow`]). Kept off
+/// [`OAuthAdapterConfig`] (which is `Debug`/`Clone`) because it carries shared
+/// runtime handles.
+#[derive(Clone)]
+pub struct EmaSsoWiring {
+    pub flow_manager: Arc<OAuthFlowManager>,
+    pub relay_port: u16,
+}
 
 /// Configuration for an OAuth-authenticated MCP endpoint.
 #[derive(Debug, Clone)]
@@ -76,6 +119,13 @@ pub struct OAuthAdapterConfig {
     /// production callers and is set to `true` only by tests that mock the
     /// well-known endpoints on `127.0.0.1`.
     pub allow_insecure_oauth: bool,
+    /// Enterprise-Managed Authorization (EMA, END-18) parameters. `Some(_)` for
+    /// `[endpoints.auth] type = "ema"` endpoints, routing token acquisition /
+    /// 401-expiry refresh through [`crate::oauth::ema::ensure_access_token`]
+    /// instead of the standard `refresh_token` grant; post-token behaviour
+    /// (`tools/list`, `tools/call`) is identical to OAuth (decision D1). `None`
+    /// for ordinary OAuth endpoints, which are completely unaffected.
+    pub ema: Option<EmaConfig>,
 }
 
 /// Outcome of a single POST to the OAuth token endpoint. Returned by
@@ -162,6 +212,14 @@ pub struct OAuthAdapterInner {
     /// token swap shares the same slot — the outer `set_event_bus` call
     /// thus reaches both the current inner adapter and any future one.
     event_bus: Arc<OnceLock<crate::events::ToolCallEventBus>>,
+    /// EMA (END-18) SSO kick-off wiring. `Some(_)` only for EMA endpoints built
+    /// with a flow manager + relay port; consulted by [`compose_idp_authorize_url`]
+    /// to register the IdP SSO pending flow and compose the authorize URL when
+    /// the EMA chain reports re-authentication is required.
+    ema_sso: Option<EmaSsoWiring>,
+    /// The most recent EMA IdP authorize URL composed when the chain surfaced a
+    /// re-SSO-required state. Surfaced to callers/desktop and asserted by tests.
+    pending_authorize_url: RwLock<Option<String>>,
 }
 
 impl OAuthAdapterInner {
@@ -260,6 +318,15 @@ impl OAuthAdapterInner {
     /// adapter transitions to `AuthRequired` (matching the pre-existing
     /// non-2xx behavior).
     pub async fn do_token_refresh(self: &Arc<Self>) -> Result<TokenSet, OAuthError> {
+        // EMA (END-18) endpoints mint/refresh their access token through the
+        // ID-JAG chain (Steps 2+3, with a stored ID Token) instead of the
+        // `refresh_token` grant. `ensure_access_token` coalesces concurrent
+        // refreshes on the same per-endpoint `refresh_mutex` (S2), so branch
+        // before acquiring it here to avoid a double lock.
+        if self.config.ema.is_some() {
+            return self.do_ema_refresh().await;
+        }
+
         // Snapshot the current access token before acquiring the mutex.
         // If it changes while we wait, another concurrent refresh succeeded.
         let pre_token = {
@@ -380,6 +447,126 @@ impl OAuthAdapterInner {
                 Err(OAuthError::Http(e))
             }
         }
+    }
+
+    /// EMA (END-18) refresh path: mint or refresh the endpoint's access token
+    /// through the full ID-JAG chain ([`ema::ensure_access_token`]) instead of
+    /// the OAuth `refresh_token` grant. Drives the same state machine as
+    /// `do_token_refresh` (Refreshing → Authenticated on success; AuthRequired /
+    /// ConnectionFailed on failure) and reuses the adapter's per-endpoint
+    /// `refresh_mutex` for coalescing (S2). On a re-SSO-required outcome it
+    /// composes and stores an IdP authorize URL (M1/M9) so the user can sign in.
+    async fn do_ema_refresh(self: &Arc<Self>) -> Result<TokenSet, OAuthError> {
+        let ema = self
+            .config
+            .ema
+            .as_ref()
+            .expect("do_ema_refresh called without EMA config");
+
+        self.transition_to(OAuthState::Refreshing, "starting EMA token exchange")
+            .await;
+
+        match ema::ensure_access_token(
+            &self.token_manager,
+            &self.refresh_mutex,
+            &self.config.endpoint_name,
+            &ema.idp_key,
+            &ema.idp_token_endpoint,
+            &ema.as_issuer,
+            &ema.as_token_endpoint,
+            &ema.resource,
+            self.config.allow_insecure_oauth,
+        )
+        .await
+        {
+            Ok(token_set) => {
+                self.metrics.inc_refresh_success();
+                info!("EMA token exchange successful");
+                Ok(token_set)
+            }
+            Err(e) => {
+                self.metrics.inc_refresh_failure();
+                // A re-SSO-required outcome surfaces an IdP authorize URL so the
+                // user can sign in again (no silent loop, M9).
+                if matches!(e, EmaError::ReauthRequired { .. }) {
+                    if let Some(url) = self.compose_idp_authorize_url().await {
+                        *self.pending_authorize_url.write().await = Some(url);
+                    }
+                }
+                // Re-auth and policy denials are terminal (AuthRequired);
+                // transport/expiry-class errors are retryable (ConnectionFailed).
+                let (target, reason): (OAuthState, &str) = match &e {
+                    EmaError::ReauthRequired { .. } | EmaError::AuthorizationDenied { .. } => {
+                        (OAuthState::AuthRequired, "EMA re-authentication required")
+                    }
+                    _ => (OAuthState::ConnectionFailed, "EMA token exchange failed"),
+                };
+                error!(error = %e, "EMA token exchange failed");
+                self.transition_to(target, reason).await;
+                Err(OAuthError::Ema(e.to_string()))
+            }
+        }
+    }
+
+    /// Compose the IdP authorize URL for this EMA endpoint's Step-1 SSO and
+    /// register the pending IdP flow via [`OAuthFlowManager::start_idp_flow`]
+    /// (which tags the flow with `idp_issuer` so the `/oauth/callback` handler
+    /// persists the returned ID Token as `IdpCredentials`). The requested scope
+    /// is `openid offline_access` (M1) so the IdP returns a refresh token the
+    /// EMA chain can later use to re-mint ID Tokens silently. Returns `None`
+    /// when the adapter was built without EMA SSO wiring (e.g. unit tests).
+    async fn compose_idp_authorize_url(&self) -> Option<String> {
+        let ema = self.config.ema.as_ref()?;
+        let sso = self.ema_sso.as_ref()?;
+
+        let pkce = PkceChallenge::generate();
+        let code_challenge = pkce.code_challenge.clone();
+        let redirect_uri = format!("http://127.0.0.1:{}/oauth/callback", sso.relay_port);
+
+        let state_param = sso
+            .flow_manager
+            .start_idp_flow(
+                &self.config.endpoint_name,
+                &ema.idp_token_endpoint,
+                ENDARA_CLIENT_METADATA_URL,
+                None,
+                pkce,
+                &redirect_uri,
+                Some(&ema.idp_issuer),
+                false,
+                &ema.idp_issuer,
+            )
+            .await;
+
+        // Append a `?` or `&` depending on whether the discovered IdP authorize
+        // endpoint already carries a query string (mirrors the JIT path).
+        let sep = if ema.idp_authorization_endpoint.contains('?') {
+            '&'
+        } else {
+            '?'
+        };
+        let authorize_url = format!(
+            "{}{}response_type=code&client_id={}&redirect_uri={}&state={}&code_challenge={}&code_challenge_method=S256&scope={}",
+            ema.idp_authorization_endpoint,
+            sep,
+            form_urlencode(ENDARA_CLIENT_METADATA_URL),
+            form_urlencode(&redirect_uri),
+            form_urlencode(&state_param),
+            form_urlencode(&code_challenge),
+            form_urlencode("openid offline_access"),
+        );
+        info!(
+            endpoint = %self.config.endpoint_name,
+            idp_issuer = %ema.idp_issuer,
+            "EMA IdP SSO authorize URL composed (scope=openid offline_access)"
+        );
+        Some(authorize_url)
+    }
+
+    /// The most recent EMA IdP authorize URL composed when the chain surfaced a
+    /// re-SSO-required state, if any.
+    pub async fn pending_authorize_url(&self) -> Option<String> {
+        self.pending_authorize_url.read().await.clone()
     }
 
     /// Drive the discovery-and-retry fallback for an HTTP 404 from the token
@@ -646,7 +833,11 @@ impl OAuthAdapterInner {
         //    tokens persisted before `issued_at` was added will deserialize
         //    with `issued_at: None` (it's `#[serde(default)]`), but still
         //    deserve a proactive refresh.
-        let deadline = if !has_refresh_token {
+        // EMA endpoints refresh through the ID-JAG chain (using stored IdP
+        // credentials), so they schedule a proactive refresh whenever an
+        // `expires_at` is known even if the persisted `TokenSet` carries no
+        // `refresh_token`. Non-EMA endpoints still require a refresh token.
+        let deadline = if !has_refresh_token && self.config.ema.is_none() {
             info!("No refresh token, skipping proactive refresh");
             None
         } else if let Some(expires) = expires_at_secs {
@@ -843,6 +1034,25 @@ pub struct OAuthAdapter {
 impl OAuthAdapter {
     /// Create a new OAuthAdapter.
     pub fn new(config: OAuthAdapterConfig, token_manager: Arc<TokenManager>) -> Self {
+        Self::new_inner(config, token_manager, None)
+    }
+
+    /// Create a new OAuthAdapter for an EMA endpoint, attaching the SSO kick-off
+    /// wiring (flow manager + relay port) used to compose the IdP authorize URL
+    /// when the chain reports re-authentication is required.
+    pub fn new_ema(
+        config: OAuthAdapterConfig,
+        token_manager: Arc<TokenManager>,
+        ema_sso: EmaSsoWiring,
+    ) -> Self {
+        Self::new_inner(config, token_manager, Some(ema_sso))
+    }
+
+    fn new_inner(
+        config: OAuthAdapterConfig,
+        token_manager: Arc<TokenManager>,
+        ema_sso: Option<EmaSsoWiring>,
+    ) -> Self {
         let (outer_tools_changed_tx, _) = broadcast::channel(16);
         let span = tracing::info_span!(
             "endpoint",
@@ -872,6 +1082,8 @@ impl OAuthAdapter {
                 inner_forwarder_handle: Mutex::new(None),
                 span,
                 event_bus: Arc::new(OnceLock::new()),
+                ema_sso,
+                pending_authorize_url: RwLock::new(None),
             }),
         }
     }
@@ -887,6 +1099,42 @@ impl McpAdapter for OAuthAdapter {
     async fn initialize(&mut self) -> Result<(), AdapterError> {
         let span = self.inner.span.clone();
         async {
+            // EMA endpoints acquire/refresh their access token through the
+            // ID-JAG chain rather than loading a `refresh_token` from disk.
+            // `do_token_refresh` dispatches to the EMA path, which returns a
+            // valid cached token without network when one is persisted, mints a
+            // fresh one from stored IdP credentials otherwise, or surfaces a
+            // re-SSO-required state (composing an IdP authorize URL) when there
+            // are none.
+            if self.inner.config.ema.is_some() {
+                match self.inner.do_token_refresh().await {
+                    Ok(new_tokens) => {
+                        self.inner.apply_tokens(new_tokens).await;
+                    }
+                    Err(e) => {
+                        warn!(
+                            error = %e,
+                            "EMA token acquisition at startup failed (sign-in may be required)"
+                        );
+                        // `do_ema_refresh` already transitioned to a terminal
+                        // state (AuthRequired / ConnectionFailed) on its error
+                        // path.
+                    }
+                }
+
+                // Spawn the heartbeat probe loop (shared with the OAuth path).
+                let weak = Arc::downgrade(&self.inner);
+                let hb_span = self.inner.span.clone();
+                let handle = tokio::spawn(heartbeat::heartbeat_loop(weak).instrument(hb_span));
+                self.inner
+                    .heartbeat_task_handle
+                    .lock()
+                    .await
+                    .replace(handle);
+
+                return Ok(());
+            }
+
             // Try to load existing tokens from disk
             let loaded = self
                 .inner
@@ -1203,6 +1451,7 @@ mod tests {
             probe_failure_threshold: 3,
             server_type_override: None,
             allow_insecure_oauth: false,
+            ema: None,
         }
     }
 
@@ -1210,6 +1459,163 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap().keep();
         let tm = Arc::new(TokenManager::new(tmp));
         OAuthAdapter::new(config, tm)
+    }
+
+    // --- EMA refresh branch (END-18 T6) -------------------------------------
+
+    fn make_ema_config(idp: &str, resource: &str) -> OAuthAdapterConfig {
+        OAuthAdapterConfig {
+            endpoint_name: "ema-ep".to_string(),
+            url: resource.to_string(),
+            token_endpoint_url: format!("{}/as/token", resource),
+            client_id: ENDARA_CLIENT_METADATA_URL.to_string(),
+            client_secret: None,
+            heartbeat_interval_secs: 30,
+            probe_timeout_secs: 10,
+            probe_failure_threshold: 3,
+            server_type_override: None,
+            allow_insecure_oauth: true,
+            ema: Some(EmaConfig {
+                idp_key: idp.to_string(),
+                idp_issuer: idp.to_string(),
+                idp_authorization_endpoint: format!("{}/authorize", idp),
+                idp_token_endpoint: format!("{}/token", idp),
+                as_issuer: format!("{}/as", resource),
+                as_token_endpoint: format!("{}/as/token", resource),
+                resource: resource.to_string(),
+            }),
+        }
+    }
+
+    fn now_secs() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    }
+
+    /// An EMA endpoint's refresh routes through `ema::ensure_access_token`; a
+    /// still-valid persisted access token is returned via the chain's fast path
+    /// with no network contact (the bogus IdP/AS endpoints are never hit).
+    #[tokio::test]
+    async fn ema_refresh_returns_valid_cached_token_without_network() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let token = TokenSet {
+            access_token: "cached-ema-access".to_string(),
+            refresh_token: None,
+            expires_at: Some(now_secs() + 3600),
+            token_type: "Bearer".to_string(),
+            scope: None,
+            issued_at: Some(now_secs()),
+        };
+        tm.save("ema-ep", &token).await.unwrap();
+
+        let config = make_ema_config("http://127.0.0.1:1", "http://127.0.0.1:2");
+        let adapter = OAuthAdapter::new(config, tm);
+        let ts = adapter
+            .inner
+            .do_token_refresh()
+            .await
+            .expect("EMA refresh returns the cached token");
+        assert_eq!(ts.access_token, "cached-ema-access");
+    }
+
+    /// With no stored IdP credentials the EMA chain is terminal: the adapter
+    /// reports the EMA error, transitions to `AuthRequired`, and — without SSO
+    /// wiring — composes no authorize URL.
+    #[tokio::test]
+    async fn ema_refresh_without_idp_credentials_sets_auth_required() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let config = make_ema_config("http://127.0.0.1:1", "http://127.0.0.1:2");
+        let adapter = OAuthAdapter::new(config, tm);
+
+        let err = adapter.inner.do_token_refresh().await.unwrap_err();
+        assert!(matches!(err, OAuthError::Ema(_)), "got {err:?}");
+        assert!(adapter.inner.pending_authorize_url().await.is_none());
+        assert_eq!(
+            adapter.inner.state.read().await.clone(),
+            OAuthState::AuthRequired
+        );
+    }
+
+    /// When SSO wiring is present, a re-auth-required EMA refresh composes an
+    /// IdP authorize URL via `start_idp_flow` with scope `openid offline_access`
+    /// (M1) and registers a pending flow tagged with the IdP issuer so the
+    /// `/oauth/callback` handler persists `IdpCredentials`.
+    #[tokio::test]
+    async fn ema_refresh_reauth_composes_idp_authorize_url_with_offline_scope() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let flow_mgr = Arc::new(OAuthFlowManager::new());
+        let config = make_ema_config("https://acme.okta.com", "https://api.example.com/mcp");
+        let adapter = OAuthAdapter::new_ema(
+            config,
+            tm,
+            EmaSsoWiring {
+                flow_manager: flow_mgr.clone(),
+                relay_port: 9400,
+            },
+        );
+
+        let err = adapter.inner.do_token_refresh().await.unwrap_err();
+        assert!(matches!(err, OAuthError::Ema(_)), "got {err:?}");
+
+        let url = adapter
+            .inner
+            .pending_authorize_url()
+            .await
+            .expect("authorize URL composed on re-auth");
+        assert!(
+            url.starts_with("https://acme.okta.com/authorize?"),
+            "got {url}"
+        );
+        assert!(
+            url.contains("scope=openid+offline_access"),
+            "scope must include openid offline_access; got {url}"
+        );
+        assert!(url.contains("code_challenge_method=S256"), "got {url}");
+        assert!(
+            url.contains(&format!(
+                "client_id={}",
+                form_urlencode(ENDARA_CLIENT_METADATA_URL)
+            )),
+            "got {url}"
+        );
+
+        let parsed = url::Url::parse(&url).unwrap();
+        let state_param = parsed
+            .query_pairs()
+            .find(|(k, _)| k == "state")
+            .map(|(_, v)| v.into_owned())
+            .expect("state param present");
+        let flow = flow_mgr
+            .consume_flow(&state_param)
+            .await
+            .expect("pending IdP flow registered");
+        assert_eq!(flow.endpoint_name, "ema-ep");
+        assert_eq!(flow.idp_issuer.as_deref(), Some("https://acme.okta.com"));
+        assert_eq!(flow.client_id, ENDARA_CLIENT_METADATA_URL);
+        assert_eq!(flow.token_endpoint, "https://acme.okta.com/token");
+        assert_eq!(
+            adapter.inner.state.read().await.clone(),
+            OAuthState::AuthRequired
+        );
+    }
+
+    /// A non-EMA adapter is unaffected: `do_token_refresh` follows the standard
+    /// `refresh_token` path and fails with `NoRefreshToken` (never the EMA
+    /// branch) when no refresh token is present.
+    #[tokio::test]
+    async fn non_ema_refresh_uses_standard_path() {
+        let mut adapter = make_adapter(make_config());
+        adapter.initialize().await.unwrap();
+        let err = adapter.inner.do_token_refresh().await.unwrap_err();
+        assert!(
+            matches!(err, OAuthError::NoRefreshToken { .. }),
+            "got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -312,6 +312,33 @@ pub fn validate_profiles(config: &Config) -> Result<(), Vec<String>> {
     }
 }
 
+/// Authentication configuration nested under `[endpoints.auth]`.
+///
+/// Currently the only supported `type` is `"ema"` (Enterprise-Managed
+/// Authorization). An EMA block carries a provisional `idp` (the IdP issuer
+/// URL the relay performs SSO against) and a `resource` (the MCP server URL the
+/// minted access token is scoped to). The `idp` field is a **PROVISIONAL**
+/// END-19 seam: END-19 moves the IdP source to `[[organizations]]`.
+///
+/// `idp`/`resource` are modeled as `Option` (rather than via a serde-tagged
+/// enum) so that a missing field surfaces as a clear
+/// [`ConfigError::ValidationError`] / per-endpoint warning through the existing
+/// validation paths instead of a raw TOML parse error, preserving the graceful
+/// per-endpoint loading model.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct EndpointAuthConfig {
+    /// Discriminator for the auth scheme. Only `"ema"` is currently supported.
+    #[serde(rename = "type")]
+    pub auth_type: String,
+    /// IdP issuer URL for `type = "ema"` (e.g. `https://acme.okta.com`).
+    /// PROVISIONAL END-19 seam.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idp: Option<String>,
+    /// Target MCP server URL the EMA access token is minted for.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource: Option<String>,
+}
+
 /// Configuration for a single MCP endpoint.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct EndpointConfig {
@@ -369,6 +396,11 @@ pub struct EndpointConfig {
     /// `isolation = "container"`. Default: no host filesystem access.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mounts: Option<Vec<String>>,
+    /// Optional `[endpoints.auth]` block. Present only for endpoints using a
+    /// non-default auth scheme (currently `type = "ema"`). Omitted for ordinary
+    /// stdio/sse/http/oauth endpoints, keeping pre-existing configs unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth: Option<EndpointAuthConfig>,
 }
 
 impl EndpointConfig {
@@ -391,6 +423,8 @@ impl EndpointConfig {
 /// OAuth fields are included — changing OAuth config should trigger adapter restart.
 /// Isolation fields (`isolation`, `container_image`, `mounts`) are included —
 /// changing them should trigger adapter restart.
+/// The `auth` block is included — changing an EMA endpoint's IdP/resource (or
+/// adding/removing the block) should trigger adapter restart.
 impl PartialEq for EndpointConfig {
     fn eq(&self, other: &Self) -> bool {
         self.name == other.name
@@ -409,6 +443,7 @@ impl PartialEq for EndpointConfig {
             && self.isolation == other.isolation
             && self.container_image == other.container_image
             && self.mounts == other.mounts
+            && self.auth == other.auth
     }
 }
 
@@ -747,6 +782,39 @@ fn is_valid_endpoint_name(name: &str) -> bool {
     chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-')
 }
 
+/// Validate an endpoint's `[endpoints.auth]` block.
+///
+/// Returns `Err(message)` for an unknown `type`, or — for `type = "ema"` — a
+/// missing/empty `idp` or `resource`. Returns `Ok(())` when there is no auth
+/// block or it is valid. The message is suitable for surfacing to the user
+/// (it is prefixed with the endpoint name by callers).
+fn validate_endpoint_auth(ep: &EndpointConfig) -> Result<(), String> {
+    let auth = match &ep.auth {
+        Some(a) => a,
+        None => return Ok(()),
+    };
+    match auth.auth_type.as_str() {
+        "ema" => {
+            if auth.idp.as_deref().unwrap_or("").trim().is_empty() {
+                return Err(
+                    "auth.type = \"ema\" requires a non-empty 'idp' (IdP issuer URL)".to_string(),
+                );
+            }
+            if auth.resource.as_deref().unwrap_or("").trim().is_empty() {
+                return Err(
+                    "auth.type = \"ema\" requires a non-empty 'resource' (MCP server URL)"
+                        .to_string(),
+                );
+            }
+            Ok(())
+        }
+        other => Err(format!(
+            "unknown auth.type '{}' — supported values: \"ema\"",
+            other
+        )),
+    }
+}
+
 impl Config {
     /// Validate the config, collecting **all** errors instead of stopping at the first.
     ///
@@ -821,6 +889,10 @@ impl Config {
                         ));
                     }
                 }
+            }
+
+            if let Err(msg) = validate_endpoint_auth(ep) {
+                errors.push(format!("Endpoint '{}': {}", ep.name, msg));
             }
         }
 
@@ -932,6 +1004,14 @@ fn validate_graceful(config: &Config, warnings: &mut Vec<EndpointValidationWarni
                         ),
                     });
                 }
+            }
+
+            // Validate the `[endpoints.auth]` block (currently `type = "ema"`).
+            if let Err(msg) = validate_endpoint_auth(ep) {
+                warnings.push(EndpointValidationWarning {
+                    endpoint_name: ep.name.clone(),
+                    message: msg,
+                });
             }
         }
     }
@@ -1854,6 +1934,7 @@ payload_window_minutes = 30
             isolation: None,
             container_image: None,
             mounts: None,
+            auth: None,
         }
     }
 
@@ -1879,6 +1960,7 @@ payload_window_minutes = 30
             isolation: None,
             container_image: None,
             mounts: None,
+            auth: None,
         }
     }
 
@@ -2322,6 +2404,7 @@ scopes = ["openid", "profile", "email"]
             isolation: None,
             container_image: None,
             mounts: None,
+            auth: None,
         };
 
         let mut ep2 = ep1.clone();
@@ -2520,6 +2603,233 @@ isolation = "{}"
         let new = make_config(vec![ep2]);
         let diff = diff_configs(&old, &new);
         assert_eq!(diff.changed.len(), 1, "mounts change should trigger diff");
+        assert!(diff.unchanged.is_empty());
+    }
+
+    // --- EMA endpoint auth tests (M10) ---
+
+    #[test]
+    fn ema_endpoint_parses() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "github-acme"
+url = "https://api.githubcopilot.com/mcp/"
+transport = "http"
+
+[endpoints.auth]
+type = "ema"
+idp = "https://acme.okta.com"
+resource = "https://api.githubcopilot.com/mcp/"
+"#;
+        let config = parse_and_validate(toml_str).unwrap();
+        let auth = config.endpoints[0].auth.as_ref().unwrap();
+        assert_eq!(auth.auth_type, "ema");
+        assert_eq!(auth.idp.as_deref(), Some("https://acme.okta.com"));
+        assert_eq!(
+            auth.resource.as_deref(),
+            Some("https://api.githubcopilot.com/mcp/")
+        );
+    }
+
+    #[test]
+    fn ema_endpoint_round_trips_through_serialize() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "github-acme"
+url = "https://api.githubcopilot.com/mcp/"
+transport = "http"
+
+[endpoints.auth]
+type = "ema"
+idp = "https://acme.okta.com"
+resource = "https://api.githubcopilot.com/mcp/"
+"#;
+        let config = parse_and_validate(toml_str).unwrap();
+        let serialized = toml::to_string_pretty(&config).unwrap();
+        let reparsed = parse_and_validate(&serialized).unwrap();
+        assert_eq!(
+            reparsed.endpoints[0].auth, config.endpoints[0].auth,
+            "EMA auth block should survive a serialize → parse round trip"
+        );
+    }
+
+    #[test]
+    fn ema_missing_resource_is_rejected() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "github-acme"
+url = "https://api.githubcopilot.com/mcp/"
+transport = "http"
+
+[endpoints.auth]
+type = "ema"
+idp = "https://acme.okta.com"
+"#;
+        let err = parse_and_validate(toml_str).unwrap_err();
+        match err {
+            ConfigError::ValidationError(msg) => {
+                assert!(
+                    msg.contains("resource"),
+                    "Error should mention resource: {}",
+                    msg
+                );
+                assert!(msg.contains("ema"), "Error should mention ema: {}", msg);
+            }
+            other => panic!("Expected ValidationError, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn ema_missing_idp_is_rejected() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "github-acme"
+url = "https://api.githubcopilot.com/mcp/"
+transport = "http"
+
+[endpoints.auth]
+type = "ema"
+resource = "https://api.githubcopilot.com/mcp/"
+"#;
+        let err = parse_and_validate(toml_str).unwrap_err();
+        match err {
+            ConfigError::ValidationError(msg) => {
+                assert!(msg.contains("idp"), "Error should mention idp: {}", msg);
+                assert!(msg.contains("ema"), "Error should mention ema: {}", msg);
+            }
+            other => panic!("Expected ValidationError, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn ema_empty_idp_is_rejected() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "github-acme"
+url = "https://api.githubcopilot.com/mcp/"
+transport = "http"
+
+[endpoints.auth]
+type = "ema"
+idp = "   "
+resource = "https://api.githubcopilot.com/mcp/"
+"#;
+        let err = parse_and_validate(toml_str).unwrap_err();
+        match err {
+            ConfigError::ValidationError(msg) => {
+                assert!(msg.contains("idp"), "Error should mention idp: {}", msg);
+            }
+            other => panic!("Expected ValidationError, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn unknown_auth_type_is_rejected() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "github-acme"
+url = "https://api.githubcopilot.com/mcp/"
+transport = "http"
+
+[endpoints.auth]
+type = "saml"
+idp = "https://acme.okta.com"
+resource = "https://api.githubcopilot.com/mcp/"
+"#;
+        let err = parse_and_validate(toml_str).unwrap_err();
+        match err {
+            ConfigError::ValidationError(msg) => {
+                assert!(
+                    msg.contains("unknown auth.type"),
+                    "Error should mention unknown auth.type: {}",
+                    msg
+                );
+                assert!(
+                    msg.contains("saml"),
+                    "Error should mention the value: {}",
+                    msg
+                );
+            }
+            other => panic!("Expected ValidationError, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn non_ema_config_unaffected_by_auth_field() {
+        // A config without any `[endpoints.auth]` block parses unchanged and
+        // leaves `auth` as `None` (backward compatibility).
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "plain"
+transport = "stdio"
+command = "echo"
+"#;
+        let config = parse_and_validate(toml_str).unwrap();
+        assert!(config.endpoints[0].auth.is_none());
+    }
+
+    #[test]
+    fn ema_missing_fields_surface_as_graceful_warning() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "github-acme"
+url = "https://api.githubcopilot.com/mcp/"
+transport = "http"
+
+[endpoints.auth]
+type = "ema"
+idp = "https://acme.okta.com"
+"#;
+        let (config, warnings) = parse_and_validate_graceful(toml_str).unwrap();
+        assert_eq!(config.endpoints.len(), 1);
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].endpoint_name, "github-acme");
+        assert!(warnings[0].message.contains("resource"));
+    }
+
+    #[test]
+    fn ema_auth_change_triggers_config_diff() {
+        let mut ep1 = sse_ep("github-acme", "https://api.githubcopilot.com/mcp/");
+        ep1.auth = Some(EndpointAuthConfig {
+            auth_type: "ema".to_string(),
+            idp: Some("https://acme.okta.com".to_string()),
+            resource: Some("https://api.githubcopilot.com/mcp/".to_string()),
+        });
+        let mut ep2 = sse_ep("github-acme", "https://api.githubcopilot.com/mcp/");
+        ep2.auth = Some(EndpointAuthConfig {
+            auth_type: "ema".to_string(),
+            idp: Some("https://other.okta.com".to_string()),
+            resource: Some("https://api.githubcopilot.com/mcp/".to_string()),
+        });
+
+        let old = make_config(vec![ep1]);
+        let new = make_config(vec![ep2]);
+        let diff = diff_configs(&old, &new);
+        assert_eq!(diff.changed.len(), 1, "EMA auth change should trigger diff");
         assert!(diff.unchanged.is_empty());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -553,6 +553,10 @@ async fn main() {
                         // `relay.allow_insecure_oauth` for the initial discovery
                         // see consistent behavior on rediscovery.
                         allow_insecure_oauth,
+                        // This branch only handles `transport = "oauth"`
+                        // endpoints; EMA endpoints (`auth.type = "ema"`) are
+                        // built via `create_adapter` in the deferred-init path.
+                        ema: None,
                     };
 
                     let adapter = OAuthAdapter::new(oauth_config, token_manager.clone());

--- a/src/management.rs
+++ b/src/management.rs
@@ -3349,6 +3349,7 @@ fn validate_endpoint_request(
         isolation,
         container_image: req.container_image.clone(),
         mounts: req.mounts.clone(),
+        auth: None,
     };
 
     Ok(new_ep)
@@ -4693,6 +4694,7 @@ mod tests {
                 isolation: Some("none".to_string()),
                 container_image: None,
                 mounts: None,
+                auth: None,
             }],
             profiles: None,
         }
@@ -7026,6 +7028,7 @@ command = "echo"
                 isolation: None,
                 container_image: None,
                 mounts: None,
+                auth: None,
             }],
             profiles: None,
         };
@@ -7246,6 +7249,7 @@ command = "echo"
                 isolation: None,
                 container_image: None,
                 mounts: None,
+                auth: None,
             }],
             profiles: None,
         };
@@ -7763,6 +7767,7 @@ command = "echo"
                 isolation: None,
                 container_image: None,
                 mounts: None,
+                auth: None,
             }],
             profiles: None,
         }
@@ -7952,6 +7957,7 @@ client_id = "client123"
                     isolation: None,
                     container_image: None,
                     mounts: None,
+                    auth: None,
                 })
                 .collect(),
             profiles: None,
@@ -8510,6 +8516,7 @@ client_id = "client123"
                 isolation: None,
                 container_image: None,
                 mounts: None,
+                auth: None,
             }],
             profiles: None,
         };
@@ -8807,6 +8814,7 @@ client_id = "client123"
                 isolation: None,
                 container_image: None,
                 mounts: None,
+                auth: None,
             });
             let toml_str = toml::to_string_pretty(&*cfg).unwrap();
             std::fs::write(&config_file, toml_str).unwrap();

--- a/src/management.rs
+++ b/src/management.rs
@@ -6016,6 +6016,7 @@ command = "echo"
             probe_failure_threshold: 3,
             server_type_override: None,
             allow_insecure_oauth: false,
+            ema: None,
         }
     }
 

--- a/src/oauth/ema.rs
+++ b/src/oauth/ema.rs
@@ -1,0 +1,1256 @@
+//! Enterprise-Managed Authorization (EMA) token-exchange grant clients.
+//!
+//! Implements the two new token-exchange legs of the EMA chain plus ID-JAG
+//! claim validation. Step 1 (IdP SSO) reuses the existing authorization-code
+//! machinery; this module covers:
+//!
+//! - Step 2 (RFC 8693): ID Token → ID-JAG ([`exchange_for_id_jag`], M4/M5).
+//! - ID-JAG claim validation between steps ([`validate_id_jag`], M6).
+//! - Step 3 (RFC 7523): ID-JAG → access token ([`redeem_id_jag`], M7/M8).
+//!
+//! Every URL is routed through [`url_guard`] (M11). Per D4/S1, the relay does
+//! NOT verify the ID-JAG signature against the IdP JWKS for v1: the assertion
+//! arrives over TLS from the IdP and the downstream AS verifies the signature
+//! in Step 3. This is a documented hardening follow-up.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use reqwest::StatusCode;
+use serde_json::Value;
+use tokio::sync::Mutex;
+
+use crate::oauth::client::ENDARA_CLIENT_METADATA_URL;
+use crate::oauth::url_guard::{self, UrlGuardError};
+use crate::token_manager::{IdpCredentials, TokenManager, TokenSet};
+
+/// RFC 8693 token-exchange grant type (Step 2 request `grant_type`).
+const GRANT_TYPE_TOKEN_EXCHANGE: &str = "urn:ietf:params:oauth:grant-type:token-exchange";
+/// RFC 8693 `requested_token_type` selecting an ID-JAG (Step 2).
+const REQUESTED_TOKEN_TYPE_ID_JAG: &str = "urn:ietf:params:oauth:token-type:id-jag";
+/// RFC 8693 `subject_token_type` for the inbound OIDC ID Token (Step 2).
+const SUBJECT_TOKEN_TYPE_ID_TOKEN: &str = "urn:ietf:params:oauth:token-type:id_token";
+/// RFC 7523 JWT-bearer grant type (Step 3 request `grant_type`).
+const GRANT_TYPE_JWT_BEARER: &str = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+/// OIDC `refresh_token` grant type used to mint a fresh ID Token at the IdP.
+const GRANT_TYPE_REFRESH_TOKEN: &str = "refresh_token";
+/// Scope requested on the IdP refresh grant: `openid` to re-mint an ID Token,
+/// `offline_access` to keep a refresh token.
+const REFRESH_SCOPE: &str = "openid offline_access";
+
+/// Clock-skew buffer (seconds), mirroring `TokenSet::is_valid`.
+const EXP_SKEW_SECS: u64 = 30;
+
+/// Dedicated error type for EMA token-exchange failures.
+///
+/// IdP authorization denials ([`EmaError::AuthorizationDenied`]) are kept
+/// distinct from transport/expiry-class failures ([`EmaError::TokenEndpoint`],
+/// [`EmaError::Http`]) so the refresh chain can surface a terminal,
+/// non-retryable "your org hasn't approved this server" state (M5).
+#[derive(Debug, thiserror::Error)]
+pub enum EmaError {
+    /// IdP rejected the exchange because the user's group lacks access. The
+    /// `error` is the OAuth error code; non-retryable (M5).
+    #[error("IdP denied authorization (non-retryable): {error}: {description}")]
+    AuthorizationDenied { error: String, description: String },
+
+    /// The ID-JAG failed claim validation (iss/aud/resource/exp/sub) or could
+    /// not be decoded (M6).
+    #[error("ID-JAG validation failed: {reason}")]
+    InvalidIdJag { reason: String },
+
+    /// The IdP refresh token is gone/rejected; interactive re-SSO is required.
+    /// Surfaced so the caller never loops silently (M9).
+    #[error("re-authentication (SSO) required: {reason}")]
+    ReauthRequired { reason: String },
+
+    /// A token endpoint returned a non-success status that is not a terminal
+    /// authorization denial (transport/expiry-class; may be retried).
+    #[error("token endpoint returned {status}: {body}")]
+    TokenEndpoint { status: StatusCode, body: String },
+
+    /// A token endpoint response was missing a required field.
+    #[error("token endpoint response missing field '{field}'")]
+    MalformedResponse { field: String },
+
+    /// Underlying transport failure (connect/TLS/timeout).
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// Token endpoint returned a body that could not be parsed as JSON.
+    #[error("JSON parse error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// An IdP/AS/token URL was rejected by the SSRF guard (M11).
+    #[error("EMA URL rejected by SSRF guard: {0}")]
+    UrlGuard(#[from] UrlGuardError),
+
+    /// A token-store read/write failed while loading IdP credentials or
+    /// persisting the resulting access token.
+    #[error("token storage error: {0}")]
+    Storage(String),
+}
+
+/// Build the RFC 8693 token-exchange form body for the ID Token → ID-JAG leg
+/// (M4). Kept pure so the exact wire form can be asserted in isolation.
+fn build_id_jag_exchange_form(id_token: &str, resource_as_issuer: &str, resource: &str) -> String {
+    url::form_urlencoded::Serializer::new(String::new())
+        .append_pair("grant_type", GRANT_TYPE_TOKEN_EXCHANGE)
+        .append_pair("requested_token_type", REQUESTED_TOKEN_TYPE_ID_JAG)
+        .append_pair("audience", resource_as_issuer)
+        .append_pair("resource", resource)
+        .append_pair("subject_token", id_token)
+        .append_pair("subject_token_type", SUBJECT_TOKEN_TYPE_ID_TOKEN)
+        .finish()
+}
+
+/// Build the RFC 7523 jwt-bearer form body for the ID-JAG → access-token leg
+/// (M7). No client secret is sent: the relay is a public client identified by
+/// its CIMD `client_id`.
+fn build_jwt_bearer_form(id_jag: &str) -> String {
+    url::form_urlencoded::Serializer::new(String::new())
+        .append_pair("grant_type", GRANT_TYPE_JWT_BEARER)
+        .append_pair("assertion", id_jag)
+        .append_pair("client_id", ENDARA_CLIENT_METADATA_URL)
+        .finish()
+}
+
+/// Build the OIDC `refresh_token` grant body used to mint a fresh ID Token at
+/// the IdP (M9). The relay is a public client identified by its CIMD
+/// `client_id`; no secret is sent.
+fn build_refresh_token_form(refresh_token: &str) -> String {
+    url::form_urlencoded::Serializer::new(String::new())
+        .append_pair("grant_type", GRANT_TYPE_REFRESH_TOKEN)
+        .append_pair("refresh_token", refresh_token)
+        .append_pair("client_id", ENDARA_CLIENT_METADATA_URL)
+        .append_pair("scope", REFRESH_SCOPE)
+        .finish()
+}
+
+/// Map a non-success IdP token-exchange response to an [`EmaError`] (M5).
+///
+/// An OAuth `access_denied` (or `authorization_request_denied`) error on HTTP
+/// 400 is a terminal authorization denial; every other status/body is treated
+/// as a transport/expiry-class failure the refresh chain may retry.
+fn classify_exchange_error(status: StatusCode, body: &str) -> EmaError {
+    if status == StatusCode::BAD_REQUEST {
+        if let Ok(Value::Object(map)) = serde_json::from_str::<Value>(body) {
+            if let Some(err) = map.get("error").and_then(|v| v.as_str()) {
+                if err == "access_denied" || err == "authorization_request_denied" {
+                    let description = map
+                        .get("error_description")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    return EmaError::AuthorizationDenied {
+                        error: err.to_string(),
+                        description,
+                    };
+                }
+            }
+        }
+    }
+    EmaError::TokenEndpoint {
+        status,
+        body: body.to_string(),
+    }
+}
+
+/// Current Unix time in whole seconds.
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// Step 2 (RFC 8693): exchange an OIDC ID Token for an ID-JAG scoped to a
+/// single resource (M4).
+///
+/// POSTs the token-exchange grant to the **IdP** token endpoint and returns the
+/// ID-JAG JWT (the response `access_token`). The URL is validated through
+/// [`url_guard`] (M11). HTTP 400 `access_denied` maps to a terminal
+/// [`EmaError::AuthorizationDenied`]; other failures stay transport/expiry-class
+/// (M5).
+pub async fn exchange_for_id_jag(
+    idp_token_endpoint: &str,
+    id_token: &str,
+    resource_as_issuer: &str,
+    resource: &str,
+    allow_insecure: bool,
+) -> Result<String, EmaError> {
+    let client = url_guard::validated_client(idp_token_endpoint, allow_insecure).await?;
+    let form_body = build_id_jag_exchange_form(id_token, resource_as_issuer, resource);
+
+    let resp = client
+        .post(idp_token_endpoint)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(form_body)
+        .send()
+        .await?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(classify_exchange_error(status, &body));
+    }
+
+    let json: Value = resp.json().await?;
+    let id_jag = json["access_token"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    if id_jag.is_empty() {
+        return Err(EmaError::MalformedResponse {
+            field: "access_token".to_string(),
+        });
+    }
+    Ok(id_jag)
+}
+
+/// Step 3 (RFC 7523): redeem an ID-JAG for an ordinary access token at the
+/// resource AS (M7/M8).
+///
+/// POSTs the jwt-bearer grant to the **resource AS** token endpoint with
+/// `client_id=ENDARA_CLIENT_METADATA_URL` and no secret, then parses the
+/// response into a [`TokenSet`] mirroring the existing OAuth token parsing.
+pub async fn redeem_id_jag(
+    as_token_endpoint: &str,
+    id_jag: &str,
+    allow_insecure: bool,
+) -> Result<TokenSet, EmaError> {
+    let client = url_guard::validated_client(as_token_endpoint, allow_insecure).await?;
+    let form_body = build_jwt_bearer_form(id_jag);
+
+    let resp = client
+        .post(as_token_endpoint)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(form_body)
+        .send()
+        .await?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(EmaError::TokenEndpoint { status, body });
+    }
+
+    let json: Value = resp.json().await?;
+    let access_token = json["access_token"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    if access_token.is_empty() {
+        return Err(EmaError::MalformedResponse {
+            field: "access_token".to_string(),
+        });
+    }
+    let now_secs = now_unix();
+    Ok(TokenSet {
+        access_token,
+        refresh_token: json["refresh_token"].as_str().map(|s| s.to_string()),
+        expires_at: json["expires_in"].as_u64().map(|secs| now_secs + secs),
+        token_type: json["token_type"].as_str().unwrap_or("Bearer").to_string(),
+        scope: json["scope"].as_str().map(|s| s.to_string()),
+        issued_at: Some(now_secs),
+    })
+}
+
+/// Claims carried out of a validated ID-JAG for downstream use/attribution.
+#[derive(Debug, Clone)]
+pub struct IdJagClaims {
+    pub iss: String,
+    pub aud: String,
+    pub resource: String,
+    pub sub: String,
+    pub exp: u64,
+}
+
+/// Decode the (unverified) claims segment of a compact JWS. No signature
+/// verification is performed (D4/S1).
+fn decode_jwt_claims(jwt: &str) -> Result<Value, EmaError> {
+    let mut parts = jwt.split('.');
+    let payload = match (parts.next(), parts.next(), parts.next()) {
+        (Some(_header), Some(payload), Some(_sig)) => payload,
+        _ => {
+            return Err(EmaError::InvalidIdJag {
+                reason: "malformed JWT: expected three dot-separated segments".to_string(),
+            })
+        }
+    };
+    let payload = payload.trim_end_matches('=');
+    let bytes = URL_SAFE_NO_PAD
+        .decode(payload)
+        .map_err(|e| EmaError::InvalidIdJag {
+            reason: format!("base64url decode of claims failed: {e}"),
+        })?;
+    serde_json::from_slice(&bytes).map_err(|e| EmaError::InvalidIdJag {
+        reason: format!("claims are not valid JSON: {e}"),
+    })
+}
+
+/// Extract a required string claim, erroring with a typed reason if absent.
+fn require_str<'a>(claims: &'a Value, field: &str) -> Result<&'a str, EmaError> {
+    claims[field]
+        .as_str()
+        .ok_or_else(|| EmaError::InvalidIdJag {
+            reason: format!("missing or non-string '{field}' claim"),
+        })
+}
+
+/// RFC 7519 `aud` may be a single string or an array of strings.
+fn aud_contains(aud: &Value, expected: &str) -> bool {
+    match aud {
+        Value::String(s) => s == expected,
+        Value::Array(items) => items.iter().any(|v| v.as_str() == Some(expected)),
+        _ => false,
+    }
+}
+
+/// Validate an ID-JAG's claims before redemption (M6).
+///
+/// Checks `iss`/`aud`/`resource` equality, requires `exp` to be more than
+/// [`EXP_SKEW_SECS`] in the future, and requires `sub`. Signature is NOT
+/// verified (D4/S1). Returns the validated claims on success; a typed
+/// [`EmaError::InvalidIdJag`] on any mismatch.
+pub fn validate_id_jag(
+    jwt: &str,
+    expected_iss: &str,
+    expected_aud: &str,
+    expected_resource: &str,
+) -> Result<IdJagClaims, EmaError> {
+    let claims = decode_jwt_claims(jwt)?;
+
+    let iss = require_str(&claims, "iss")?;
+    if iss != expected_iss {
+        return Err(EmaError::InvalidIdJag {
+            reason: format!("iss mismatch: expected '{expected_iss}', got '{iss}'"),
+        });
+    }
+
+    if !aud_contains(&claims["aud"], expected_aud) {
+        return Err(EmaError::InvalidIdJag {
+            reason: format!("aud mismatch: expected '{expected_aud}'"),
+        });
+    }
+
+    let resource = require_str(&claims, "resource")?;
+    if resource != expected_resource {
+        return Err(EmaError::InvalidIdJag {
+            reason: format!("resource mismatch: expected '{expected_resource}', got '{resource}'"),
+        });
+    }
+
+    let exp = claims["exp"]
+        .as_u64()
+        .ok_or_else(|| EmaError::InvalidIdJag {
+            reason: "missing or non-numeric 'exp' claim".to_string(),
+        })?;
+    let now = now_unix();
+    if exp <= now + EXP_SKEW_SECS {
+        return Err(EmaError::InvalidIdJag {
+            reason: format!("token expired or within skew window (exp={exp}, now={now})"),
+        });
+    }
+
+    let sub = require_str(&claims, "sub")?;
+
+    Ok(IdJagClaims {
+        iss: iss.to_string(),
+        aud: expected_aud.to_string(),
+        resource: resource.to_string(),
+        sub: sub.to_string(),
+        exp,
+    })
+}
+
+/// A fresh ID Token (plus any rotated refresh token) minted by the IdP
+/// `refresh_token` grant.
+struct RefreshedIdToken {
+    id_token: String,
+    refresh_token: Option<String>,
+    id_token_expires_at: Option<u64>,
+}
+
+/// OIDC `refresh_token` grant at the IdP: trade the stored refresh token for a
+/// fresh ID Token (M9). POSTs to the **IdP** token endpoint (routed through
+/// [`url_guard`], M11) and parses the new `id_token` (+ rotation) from the
+/// response. Any non-success status is surfaced as transport/expiry-class
+/// [`EmaError::TokenEndpoint`]; the caller maps a failed refresh to
+/// [`EmaError::ReauthRequired`].
+async fn refresh_idp_token(
+    idp_token_endpoint: &str,
+    refresh_token: &str,
+    allow_insecure: bool,
+) -> Result<RefreshedIdToken, EmaError> {
+    let client = url_guard::validated_client(idp_token_endpoint, allow_insecure).await?;
+    let form_body = build_refresh_token_form(refresh_token);
+
+    let resp = client
+        .post(idp_token_endpoint)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(form_body)
+        .send()
+        .await?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(EmaError::TokenEndpoint { status, body });
+    }
+
+    let json: Value = resp.json().await?;
+    let id_token = json["id_token"].as_str().unwrap_or_default().to_string();
+    if id_token.is_empty() {
+        return Err(EmaError::MalformedResponse {
+            field: "id_token".to_string(),
+        });
+    }
+    // Prefer the ID Token's own `exp` claim; fall back to `expires_in`.
+    let id_token_expires_at = id_token_exp(&id_token)
+        .or_else(|| json["expires_in"].as_u64().map(|secs| now_unix() + secs));
+    Ok(RefreshedIdToken {
+        id_token,
+        refresh_token: json["refresh_token"].as_str().map(|s| s.to_string()),
+        id_token_expires_at,
+    })
+}
+
+/// Best-effort extraction of the `exp` claim from a (compact) JWT ID Token.
+/// Returns `None` if the token can't be decoded or carries no numeric `exp`.
+fn id_token_exp(id_token: &str) -> Option<u64> {
+    decode_jwt_claims(id_token)
+        .ok()
+        .and_then(|c| c["exp"].as_u64())
+}
+
+/// True when the stored ID Token is known to be expired (or within the skew
+/// window). Credentials without a recorded expiry are treated as not-expired;
+/// a failed exchange still triggers a reactive refresh.
+fn id_token_expired(creds: &IdpCredentials) -> bool {
+    match creds.id_token_expires_at {
+        Some(exp) => exp <= now_unix() + EXP_SKEW_SECS,
+        None => false,
+    }
+}
+
+/// True when a Step 2 failure looks like an expired/invalid subject token
+/// (refreshable) rather than a policy denial or other terminal error. Used to
+/// decide whether to attempt a single IdP-token refresh before retrying.
+fn is_subject_token_invalid(err: &EmaError) -> bool {
+    match err {
+        EmaError::TokenEndpoint { status, body } => {
+            *status == StatusCode::UNAUTHORIZED
+                || body.contains("invalid_grant")
+                || body.contains("invalid_token")
+        }
+        _ => false,
+    }
+}
+
+/// Run the IdP `refresh_token` grant, persist the rotated credentials, and
+/// return the fresh ID Token. A missing refresh token or any grant failure is
+/// surfaced as [`EmaError::ReauthRequired`] (M9: no silent loop).
+async fn refresh_and_persist_idp_token(
+    token_manager: &TokenManager,
+    idp_token_endpoint: &str,
+    idp_key: &str,
+    creds: &IdpCredentials,
+    allow_insecure: bool,
+) -> Result<String, EmaError> {
+    let refresh_token = creds
+        .refresh_token
+        .as_deref()
+        .ok_or_else(|| EmaError::ReauthRequired {
+            reason: "ID Token expired and no IdP refresh token is stored".to_string(),
+        })?;
+
+    let refreshed = refresh_idp_token(idp_token_endpoint, refresh_token, allow_insecure)
+        .await
+        .map_err(|e| EmaError::ReauthRequired {
+            reason: format!("IdP refresh-token grant failed: {e}"),
+        })?;
+
+    let new_creds = IdpCredentials {
+        idp_issuer: creds.idp_issuer.clone(),
+        id_token: refreshed.id_token.clone(),
+        refresh_token: refreshed
+            .refresh_token
+            .or_else(|| creds.refresh_token.clone()),
+        id_token_expires_at: refreshed.id_token_expires_at,
+        obtained_at: now_unix(),
+    };
+    token_manager
+        .save_idp(idp_key, &new_creds)
+        .await
+        .map_err(|e| EmaError::Storage(e.to_string()))?;
+
+    Ok(refreshed.id_token)
+}
+
+/// Ensure a valid access token for an EMA endpoint, minting one through the
+/// full ID-JAG chain when needed (§4.5, M9/S2).
+///
+/// Order of operations:
+/// 1. If a still-valid `TokenSet` is persisted for `endpoint`, return it (no
+///    lock, no network).
+/// 2. Acquire `refresh_mutex` to coalesce concurrent refreshes per endpoint
+///    (S2), then re-check the persisted token in case a peer just refreshed.
+/// 3. Load the IdP credentials (`idp_key`); absence ⇒ [`EmaError::ReauthRequired`].
+/// 4. Step 2 (`exchange_for_id_jag`). If the ID Token is known-expired this is
+///    preceded by a refresh; an `invalid_grant`/`401` exchange failure triggers
+///    a single refresh-and-retry. A failed refresh ⇒ [`EmaError::ReauthRequired`]
+///    (no silent loop); an [`EmaError::AuthorizationDenied`] propagates as-is (M5).
+/// 5. [`validate_id_jag`] (M6) then Step 3 (`redeem_id_jag`), persisting the
+///    resulting `TokenSet` via [`TokenManager::save`] (M8).
+///
+/// `refresh_mutex` is supplied by the caller (the OAuth adapter owns one per
+/// endpoint), mirroring the adapter's existing refresh-coalescing guard.
+#[allow(clippy::too_many_arguments)]
+pub async fn ensure_access_token(
+    token_manager: &TokenManager,
+    refresh_mutex: &Mutex<()>,
+    endpoint: &str,
+    idp_key: &str,
+    idp_token_endpoint: &str,
+    as_issuer: &str,
+    as_token_endpoint: &str,
+    resource: &str,
+    allow_insecure: bool,
+) -> Result<TokenSet, EmaError> {
+    // Fast path: a still-valid persisted token needs neither lock nor network.
+    if let Some(ts) = load_token(token_manager, endpoint).await? {
+        if ts.is_valid() {
+            return Ok(ts);
+        }
+    }
+
+    // Coalesce concurrent refreshes (S2): only one caller runs the chain; the
+    // rest wait here and reuse the token it persists.
+    let _guard = refresh_mutex.lock().await;
+    if let Some(ts) = load_token(token_manager, endpoint).await? {
+        if ts.is_valid() {
+            return Ok(ts);
+        }
+    }
+
+    let creds = token_manager
+        .load_idp(idp_key)
+        .await
+        .map_err(|e| EmaError::Storage(e.to_string()))?
+        .ok_or_else(|| EmaError::ReauthRequired {
+            reason: format!("no stored IdP credentials for key '{idp_key}'"),
+        })?;
+
+    let idp_issuer = creds.idp_issuer.clone();
+    let mut id_token = creds.id_token.clone();
+    let mut refreshed = false;
+
+    // Proactively refresh a known-expired ID Token before a doomed exchange.
+    if id_token_expired(&creds) {
+        id_token = refresh_and_persist_idp_token(
+            token_manager,
+            idp_token_endpoint,
+            idp_key,
+            &creds,
+            allow_insecure,
+        )
+        .await?;
+        refreshed = true;
+    }
+
+    // Step 2 (RFC 8693): ID Token → ID-JAG, with a single refresh-and-retry on
+    // an invalid/expired subject token.
+    let id_jag = match exchange_for_id_jag(
+        idp_token_endpoint,
+        &id_token,
+        as_issuer,
+        resource,
+        allow_insecure,
+    )
+    .await
+    {
+        Ok(jag) => jag,
+        Err(e) if !refreshed && is_subject_token_invalid(&e) => {
+            let new_id_token = refresh_and_persist_idp_token(
+                token_manager,
+                idp_token_endpoint,
+                idp_key,
+                &creds,
+                allow_insecure,
+            )
+            .await?;
+            exchange_for_id_jag(
+                idp_token_endpoint,
+                &new_id_token,
+                as_issuer,
+                resource,
+                allow_insecure,
+            )
+            .await?
+        }
+        Err(e) => return Err(e),
+    };
+
+    // M6 claim validation, then Step 3 (RFC 7523) → access token.
+    validate_id_jag(&id_jag, &idp_issuer, as_issuer, resource)?;
+    let token_set = redeem_id_jag(as_token_endpoint, &id_jag, allow_insecure).await?;
+    token_manager
+        .save(endpoint, &token_set)
+        .await
+        .map_err(|e| EmaError::Storage(e.to_string()))?;
+    Ok(token_set)
+}
+
+/// Load the persisted access token for `endpoint`, mapping store errors into
+/// [`EmaError::Storage`].
+async fn load_token(
+    token_manager: &TokenManager,
+    endpoint: &str,
+) -> Result<Option<TokenSet>, EmaError> {
+    token_manager
+        .load(endpoint)
+        .await
+        .map_err(|e| EmaError::Storage(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    const IDP_ISS: &str = "https://acme.okta.com";
+    const AS_ISS: &str = "https://as.example.com";
+    const RESOURCE: &str = "https://api.githubcopilot.com/mcp/";
+
+    fn parse_form(body: &str) -> HashMap<String, String> {
+        url::form_urlencoded::parse(body.as_bytes())
+            .into_owned()
+            .collect()
+    }
+
+    fn make_jwt(claims: Value) -> String {
+        let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"none","typ":"JWT"}"#);
+        let payload = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&claims).unwrap());
+        format!("{header}.{payload}.sig")
+    }
+
+    // ---- M4: token-exchange (Step 2) form exactness --------------------------
+
+    #[test]
+    fn id_jag_exchange_form_has_exact_rfc8693_params() {
+        let body = build_id_jag_exchange_form("the-id-token", AS_ISS, RESOURCE);
+        let f = parse_form(&body);
+        assert_eq!(
+            f.get("grant_type").map(String::as_str),
+            Some("urn:ietf:params:oauth:grant-type:token-exchange")
+        );
+        assert_eq!(
+            f.get("requested_token_type").map(String::as_str),
+            Some("urn:ietf:params:oauth:token-type:id-jag")
+        );
+        assert_eq!(f.get("audience").map(String::as_str), Some(AS_ISS));
+        assert_eq!(f.get("resource").map(String::as_str), Some(RESOURCE));
+        assert_eq!(
+            f.get("subject_token").map(String::as_str),
+            Some("the-id-token")
+        );
+        assert_eq!(
+            f.get("subject_token_type").map(String::as_str),
+            Some("urn:ietf:params:oauth:token-type:id_token")
+        );
+        assert_eq!(f.len(), 6, "exactly six params, no extras");
+    }
+
+    // ---- M7: jwt-bearer (Step 3) form exactness ------------------------------
+
+    #[test]
+    fn jwt_bearer_form_has_exact_rfc7523_params_and_no_secret() {
+        let body = build_jwt_bearer_form("the-id-jag");
+        let f = parse_form(&body);
+        assert_eq!(
+            f.get("grant_type").map(String::as_str),
+            Some("urn:ietf:params:oauth:grant-type:jwt-bearer")
+        );
+        assert_eq!(f.get("assertion").map(String::as_str), Some("the-id-jag"));
+        assert_eq!(
+            f.get("client_id").map(String::as_str),
+            Some(ENDARA_CLIENT_METADATA_URL)
+        );
+        assert!(
+            !f.contains_key("client_secret"),
+            "public client must not send a secret"
+        );
+        assert_eq!(f.len(), 3, "exactly three params, no extras");
+    }
+
+    // ---- M6: ID-JAG validation -----------------------------------------------
+
+    fn good_claims() -> Value {
+        serde_json::json!({
+            "iss": IDP_ISS,
+            "aud": AS_ISS,
+            "resource": RESOURCE,
+            "sub": "user-123",
+            "exp": now_unix() + 600,
+        })
+    }
+
+    #[test]
+    fn validate_passes_on_good_claims() {
+        let jwt = make_jwt(good_claims());
+        let claims = validate_id_jag(&jwt, IDP_ISS, AS_ISS, RESOURCE).expect("should validate");
+        assert_eq!(claims.sub, "user-123");
+        assert_eq!(claims.resource, RESOURCE);
+    }
+
+    #[test]
+    fn validate_accepts_aud_as_array() {
+        let mut c = good_claims();
+        c["aud"] = serde_json::json!(["other", AS_ISS]);
+        let jwt = make_jwt(c);
+        assert!(validate_id_jag(&jwt, IDP_ISS, AS_ISS, RESOURCE).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_iss_mismatch() {
+        let jwt = make_jwt(good_claims());
+        let err = validate_id_jag(&jwt, "https://evil.okta.com", AS_ISS, RESOURCE).unwrap_err();
+        assert!(matches!(err, EmaError::InvalidIdJag { .. }));
+    }
+
+    #[test]
+    fn validate_rejects_aud_mismatch() {
+        let jwt = make_jwt(good_claims());
+        let err =
+            validate_id_jag(&jwt, IDP_ISS, "https://other-as.example.com", RESOURCE).unwrap_err();
+        assert!(matches!(err, EmaError::InvalidIdJag { .. }));
+    }
+
+    #[test]
+    fn validate_rejects_resource_mismatch() {
+        let jwt = make_jwt(good_claims());
+        let err =
+            validate_id_jag(&jwt, IDP_ISS, AS_ISS, "https://other.example.com/mcp/").unwrap_err();
+        assert!(matches!(err, EmaError::InvalidIdJag { .. }));
+    }
+
+    #[test]
+    fn validate_rejects_expired_exp() {
+        let mut c = good_claims();
+        c["exp"] = serde_json::json!(now_unix() + 5); // within the 30s skew window
+        let jwt = make_jwt(c);
+        let err = validate_id_jag(&jwt, IDP_ISS, AS_ISS, RESOURCE).unwrap_err();
+        assert!(matches!(err, EmaError::InvalidIdJag { .. }));
+    }
+
+    #[test]
+    fn validate_rejects_missing_sub() {
+        let mut c = good_claims();
+        c.as_object_mut().unwrap().remove("sub");
+        let jwt = make_jwt(c);
+        let err = validate_id_jag(&jwt, IDP_ISS, AS_ISS, RESOURCE).unwrap_err();
+        assert!(matches!(err, EmaError::InvalidIdJag { .. }));
+    }
+
+    #[test]
+    fn validate_rejects_malformed_jwt() {
+        let err = validate_id_jag("not-a-jwt", IDP_ISS, AS_ISS, RESOURCE).unwrap_err();
+        assert!(matches!(err, EmaError::InvalidIdJag { .. }));
+    }
+
+    // ---- M5: denial vs transport classification ------------------------------
+
+    #[test]
+    fn access_denied_400_maps_to_authorization_denied() {
+        let body = r#"{"error":"access_denied","error_description":"not in group"}"#;
+        let err = classify_exchange_error(StatusCode::BAD_REQUEST, body);
+        match err {
+            EmaError::AuthorizationDenied { error, description } => {
+                assert_eq!(error, "access_denied");
+                assert_eq!(description, "not in group");
+            }
+            other => panic!("expected AuthorizationDenied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn server_error_is_transport_class_not_denial() {
+        let err = classify_exchange_error(StatusCode::SERVICE_UNAVAILABLE, "upstream down");
+        assert!(
+            matches!(err, EmaError::TokenEndpoint { .. }),
+            "5xx must be retryable transport-class, distinct from AuthorizationDenied"
+        );
+    }
+
+    #[test]
+    fn invalid_grant_400_is_transport_class_not_denial() {
+        // An expired subject token (invalid_grant) is an expiry/refresh signal,
+        // not a policy denial — must stay distinct from AuthorizationDenied.
+        let body = r#"{"error":"invalid_grant","error_description":"token expired"}"#;
+        let err = classify_exchange_error(StatusCode::BAD_REQUEST, body);
+        assert!(matches!(err, EmaError::TokenEndpoint { .. }));
+    }
+
+    // ---- §4.5 / M9 / S2: ensure_access_token orchestration -------------------
+
+    /// Per-grant request counters recorded by the mock token server.
+    #[derive(Default)]
+    struct FxCounts {
+        /// RFC 8693 token-exchange (Step 2) hits on the IdP endpoint.
+        exchange: u32,
+        /// OIDC `refresh_token` (M9) hits on the IdP endpoint.
+        refresh: u32,
+        /// RFC 7523 jwt-bearer (Step 3) hits on the AS endpoint.
+        redeem: u32,
+    }
+
+    /// Programmed behaviour for the IdP `refresh_token` grant.
+    #[derive(Clone)]
+    enum RefreshOutcome {
+        /// Refresh fails with 400 `invalid_grant` (→ `ReauthRequired`).
+        Fail,
+        /// Refresh succeeds and returns `new_id_token`, which also becomes the
+        /// only subject token the exchange leg will accept afterwards.
+        Succeed { new_id_token: String },
+    }
+
+    /// Shared state for the mock token server. `accept_id_token` is the single
+    /// subject token the exchange leg accepts; a successful refresh rotates it.
+    #[derive(Clone)]
+    struct TokenFx {
+        counts: Arc<std::sync::Mutex<FxCounts>>,
+        accept_id_token: Arc<std::sync::Mutex<String>>,
+        refresh: RefreshOutcome,
+        delay_ms: u64,
+    }
+
+    /// Spawn a mock token server on `127.0.0.1:0` exposing the IdP token
+    /// endpoint (`/idp/token`, serving both token-exchange and refresh grants)
+    /// and the AS token endpoint (`/as/token`, serving jwt-bearer). Returns
+    /// `(idp_token_endpoint, as_token_endpoint, counts, handle)`.
+    async fn spawn_token_fixture(
+        refresh: RefreshOutcome,
+        accept_id_token: &str,
+        delay_ms: u64,
+    ) -> (
+        String,
+        String,
+        Arc<std::sync::Mutex<FxCounts>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        use axum::extract::State;
+        use axum::http::StatusCode;
+        use axum::response::IntoResponse;
+        use axum::routing::post;
+        use axum::{Json, Router};
+
+        async fn idp_token(State(fx): State<TokenFx>, body: String) -> axum::response::Response {
+            let form: HashMap<String, String> = url::form_urlencoded::parse(body.as_bytes())
+                .into_owned()
+                .collect();
+            let grant = form
+                .get("grant_type")
+                .map(String::as_str)
+                .unwrap_or_default();
+
+            if grant == GRANT_TYPE_REFRESH_TOKEN {
+                fx.counts.lock().unwrap().refresh += 1;
+                return match &fx.refresh {
+                    RefreshOutcome::Fail => (
+                        StatusCode::BAD_REQUEST,
+                        r#"{"error":"invalid_grant","error_description":"refresh expired"}"#,
+                    )
+                        .into_response(),
+                    RefreshOutcome::Succeed { new_id_token } => {
+                        *fx.accept_id_token.lock().unwrap() = new_id_token.clone();
+                        let resp = serde_json::json!({
+                            "id_token": new_id_token,
+                            "refresh_token": "rotated-refresh",
+                            "expires_in": 3600,
+                        });
+                        (StatusCode::OK, Json(resp)).into_response()
+                    }
+                };
+            }
+
+            // Token-exchange (Step 2).
+            fx.counts.lock().unwrap().exchange += 1;
+            if fx.delay_ms > 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(fx.delay_ms)).await;
+            }
+            let subject = form
+                .get("subject_token")
+                .map(String::as_str)
+                .unwrap_or_default();
+            if subject != fx.accept_id_token.lock().unwrap().as_str() {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    r#"{"error":"invalid_grant","error_description":"subject token expired"}"#,
+                )
+                    .into_response();
+            }
+            let id_jag = make_jwt(serde_json::json!({
+                "iss": IDP_ISS,
+                "aud": AS_ISS,
+                "resource": RESOURCE,
+                "sub": "user-123",
+                "exp": now_unix() + 600,
+            }));
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({ "access_token": id_jag })),
+            )
+                .into_response()
+        }
+
+        async fn as_token(State(fx): State<TokenFx>, _body: String) -> axum::response::Response {
+            fx.counts.lock().unwrap().redeem += 1;
+            let resp = serde_json::json!({
+                "access_token": "final-access-token",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "scope": "mcp",
+            });
+            (StatusCode::OK, Json(resp)).into_response()
+        }
+
+        let counts = Arc::new(std::sync::Mutex::new(FxCounts::default()));
+        let fx = TokenFx {
+            counts: counts.clone(),
+            accept_id_token: Arc::new(std::sync::Mutex::new(accept_id_token.to_string())),
+            refresh,
+            delay_ms,
+        };
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let base = format!("http://127.0.0.1:{}", addr.port());
+
+        let router = Router::new()
+            .route("/idp/token", post(idp_token))
+            .route("/as/token", post(as_token))
+            .with_state(fx);
+
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        (
+            format!("{base}/idp/token"),
+            format!("{base}/as/token"),
+            counts,
+            handle,
+        )
+    }
+
+    fn idp_creds(
+        id_token: &str,
+        id_token_expires_at: Option<u64>,
+        refresh_token: Option<&str>,
+    ) -> IdpCredentials {
+        IdpCredentials {
+            idp_issuer: IDP_ISS.to_string(),
+            id_token: id_token.to_string(),
+            refresh_token: refresh_token.map(|s| s.to_string()),
+            id_token_expires_at,
+            obtained_at: now_unix(),
+        }
+    }
+
+    fn valid_token_set(access: &str) -> TokenSet {
+        TokenSet {
+            access_token: access.to_string(),
+            refresh_token: None,
+            expires_at: Some(now_unix() + 3600),
+            token_type: "Bearer".to_string(),
+            scope: None,
+            issued_at: Some(now_unix()),
+        }
+    }
+
+    fn expired_token_set() -> TokenSet {
+        TokenSet {
+            access_token: "stale-access".to_string(),
+            refresh_token: None,
+            expires_at: Some(1000),
+            token_type: "Bearer".to_string(),
+            scope: None,
+            issued_at: Some(900),
+        }
+    }
+
+    /// A still-valid persisted token short-circuits before any lock or network:
+    /// the bogus endpoints are never contacted.
+    #[tokio::test]
+    async fn ensure_returns_valid_cached_token_without_network() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        mgr.save("ep", &valid_token_set("cached-access"))
+            .await
+            .unwrap();
+        let lock = Mutex::new(());
+
+        let ts = ensure_access_token(
+            &mgr,
+            &lock,
+            "ep",
+            IDP_ISS,
+            "http://127.0.0.1:1/idp/token",
+            AS_ISS,
+            "http://127.0.0.1:1/as/token",
+            RESOURCE,
+            true,
+        )
+        .await
+        .expect("valid cached token must be returned");
+        assert_eq!(ts.access_token, "cached-access");
+    }
+
+    /// Access token expired but the ID Token is fine: Steps 2+3 re-run once and
+    /// the fresh token is persisted. No IdP refresh occurs.
+    #[tokio::test]
+    async fn ensure_reruns_chain_on_access_token_expiry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        mgr.save("ep", &expired_token_set()).await.unwrap();
+        mgr.save_idp(
+            IDP_ISS,
+            &idp_creds("good-id-token", Some(now_unix() + 3600), None),
+        )
+        .await
+        .unwrap();
+        let (idp_ep, as_ep, counts, server) =
+            spawn_token_fixture(RefreshOutcome::Fail, "good-id-token", 0).await;
+        let lock = Mutex::new(());
+
+        let ts = ensure_access_token(
+            &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, true,
+        )
+        .await
+        .expect("chain must succeed");
+
+        assert_eq!(ts.access_token, "final-access-token");
+        {
+            let c = counts.lock().unwrap();
+            assert_eq!(c.exchange, 1, "one Step 2");
+            assert_eq!(c.refresh, 0, "no IdP refresh needed");
+            assert_eq!(c.redeem, 1, "one Step 3");
+        }
+        assert!(mgr.load("ep").await.unwrap().unwrap().is_valid());
+        server.abort();
+    }
+
+    /// ID Token known-expired: a proactive IdP refresh precedes the exchange,
+    /// the rotated credentials are persisted, then Steps 2+3 complete.
+    #[tokio::test]
+    async fn ensure_refreshes_id_token_then_runs_chain() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        mgr.save_idp(
+            IDP_ISS,
+            &idp_creds("old-id-token", Some(1000), Some("idp-refresh")),
+        )
+        .await
+        .unwrap();
+        let (idp_ep, as_ep, counts, server) = spawn_token_fixture(
+            RefreshOutcome::Succeed {
+                new_id_token: "fresh-id-token".to_string(),
+            },
+            "old-id-token",
+            0,
+        )
+        .await;
+        let lock = Mutex::new(());
+
+        let ts = ensure_access_token(
+            &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, true,
+        )
+        .await
+        .expect("refresh then chain must succeed");
+
+        assert_eq!(ts.access_token, "final-access-token");
+        {
+            let c = counts.lock().unwrap();
+            assert_eq!(c.refresh, 1, "one proactive IdP refresh");
+            assert_eq!(c.exchange, 1, "one Step 2 with the fresh ID Token");
+            assert_eq!(c.redeem, 1, "one Step 3");
+        }
+        let rotated = mgr.load_idp(IDP_ISS).await.unwrap().unwrap();
+        assert_eq!(
+            rotated.id_token, "fresh-id-token",
+            "rotated creds persisted"
+        );
+        assert_eq!(rotated.refresh_token.as_deref(), Some("rotated-refresh"));
+        server.abort();
+    }
+
+    /// Exchange reports the subject token invalid (stale ID Token with no
+    /// recorded expiry): a single refresh-and-retry mints a fresh ID Token and
+    /// the second exchange succeeds.
+    #[tokio::test]
+    async fn ensure_refreshes_reactively_when_exchange_rejects_subject() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        mgr.save_idp(
+            IDP_ISS,
+            &idp_creds("stale-id-token", None, Some("idp-refresh")),
+        )
+        .await
+        .unwrap();
+        let (idp_ep, as_ep, counts, server) = spawn_token_fixture(
+            RefreshOutcome::Succeed {
+                new_id_token: "fresh-id-token".to_string(),
+            },
+            "fresh-id-token",
+            0,
+        )
+        .await;
+        let lock = Mutex::new(());
+
+        let ts = ensure_access_token(
+            &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, true,
+        )
+        .await
+        .expect("reactive refresh then retry must succeed");
+
+        assert_eq!(ts.access_token, "final-access-token");
+        let c = counts.lock().unwrap();
+        assert_eq!(
+            c.exchange, 2,
+            "first exchange rejected, retry after refresh"
+        );
+        assert_eq!(c.refresh, 1, "one reactive refresh");
+        assert_eq!(c.redeem, 1, "one Step 3 after the retry");
+        drop(c);
+        server.abort();
+    }
+
+    /// A failing IdP refresh surfaces `ReauthRequired` instead of looping.
+    #[tokio::test]
+    async fn ensure_surfaces_reauth_required_on_refresh_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        mgr.save_idp(
+            IDP_ISS,
+            &idp_creds("old-id-token", Some(1000), Some("idp-refresh")),
+        )
+        .await
+        .unwrap();
+        let (idp_ep, as_ep, _counts, server) =
+            spawn_token_fixture(RefreshOutcome::Fail, "old-id-token", 0).await;
+        let lock = Mutex::new(());
+
+        let err = ensure_access_token(
+            &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, true,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(err, EmaError::ReauthRequired { .. }),
+            "got {err:?}"
+        );
+        server.abort();
+    }
+
+    /// An expired ID Token with no stored refresh token is terminal:
+    /// `ReauthRequired`, with no network call.
+    #[tokio::test]
+    async fn ensure_reauth_required_when_no_refresh_token() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        mgr.save_idp(IDP_ISS, &idp_creds("old-id-token", Some(1000), None))
+            .await
+            .unwrap();
+        let lock = Mutex::new(());
+
+        let err = ensure_access_token(
+            &mgr,
+            &lock,
+            "ep",
+            IDP_ISS,
+            "http://127.0.0.1:1/idp/token",
+            AS_ISS,
+            "http://127.0.0.1:1/as/token",
+            RESOURCE,
+            true,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(err, EmaError::ReauthRequired { .. }),
+            "got {err:?}"
+        );
+    }
+
+    /// Missing IdP credentials are terminal: `ReauthRequired`.
+    #[tokio::test]
+    async fn ensure_reauth_required_when_no_idp_credentials() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        let lock = Mutex::new(());
+
+        let err = ensure_access_token(
+            &mgr,
+            &lock,
+            "ep",
+            IDP_ISS,
+            "http://127.0.0.1:1/idp/token",
+            AS_ISS,
+            "http://127.0.0.1:1/as/token",
+            RESOURCE,
+            true,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(err, EmaError::ReauthRequired { .. }),
+            "got {err:?}"
+        );
+    }
+
+    /// Concurrent callers coalesce behind `refresh_mutex`: only one runs the
+    /// chain; the rest reuse the token it persists. Exactly one Step 2 fires.
+    #[tokio::test]
+    async fn ensure_coalesces_concurrent_refreshes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        mgr.save_idp(
+            IDP_ISS,
+            &idp_creds("good-id-token", Some(now_unix() + 3600), None),
+        )
+        .await
+        .unwrap();
+        let (idp_ep, as_ep, counts, server) =
+            spawn_token_fixture(RefreshOutcome::Fail, "good-id-token", 100).await;
+        let lock = Arc::new(Mutex::new(()));
+
+        let mut handles = Vec::new();
+        for _ in 0..5 {
+            let mgr = mgr.clone();
+            let lock = lock.clone();
+            let idp_ep = idp_ep.clone();
+            let as_ep = as_ep.clone();
+            handles.push(tokio::spawn(async move {
+                ensure_access_token(
+                    &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, true,
+                )
+                .await
+            }));
+        }
+        for h in handles {
+            let ts = h.await.unwrap().expect("each caller must get a token");
+            assert_eq!(ts.access_token, "final-access-token");
+        }
+
+        let c = counts.lock().unwrap();
+        assert_eq!(
+            c.exchange, 1,
+            "coalesced: exactly one Step 2 across 5 callers"
+        );
+        assert_eq!(c.redeem, 1, "coalesced: exactly one Step 3");
+        drop(c);
+        server.abort();
+    }
+}

--- a/src/oauth/mod.rs
+++ b/src/oauth/mod.rs
@@ -43,6 +43,9 @@ pub enum OAuthError {
 
     #[error("Token storage error: {0}")]
     Storage(#[from] TokenError),
+
+    #[error("EMA token exchange failed: {0}")]
+    Ema(String),
 }
 
 /// PKCE (Proof Key for Code Exchange) challenge pair for OAuth 2.0 S256.
@@ -161,10 +164,8 @@ impl OAuthFlowManager {
     /// `IdpCredentials`. Callers request the `openid offline_access` scope (M1)
     /// when composing the authorize URL so the IdP returns a refresh token.
     ///
-    /// The binary crate doesn't yet call this (the EMA adapter wiring lands in a
-    /// later task); the lib crate exposes it as public API and the `server`
-    /// tests exercise it, so the bin build sees it as dead until then.
-    #[allow(dead_code)]
+    /// Consumed by the EMA OAuth adapter (END-18 T6) when it composes the IdP
+    /// authorize URL for an endpoint that needs (re-)SSO.
     #[allow(clippy::too_many_arguments)]
     pub async fn start_idp_flow(
         &self,

--- a/src/oauth/mod.rs
+++ b/src/oauth/mod.rs
@@ -1,6 +1,11 @@
 pub mod client;
 pub mod dcr;
 pub mod discovery;
+// EMA grant clients (END-18). Not yet wired into the binary's adapter/config in
+// this slice, so the binary crate (private `mod oauth;`) sees it as dead; the
+// lib crate exposes it as public API and the unit tests exercise it.
+#[allow(dead_code)]
+pub mod ema;
 pub mod url_guard;
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
@@ -93,6 +98,13 @@ pub struct PendingFlow {
     /// authorization-response `iss` parameter. When `true`, a missing `iss` on
     /// the callback is rejected; when `false`, a missing `iss` is tolerated.
     pub iss_parameter_supported: bool,
+    /// EMA (END-18) Step-1 marker. When `Some(idp_issuer)`, this
+    /// authorization-code flow is an IdP SSO for an EMA endpoint, and the
+    /// `/oauth/callback` handler captures the returned `id_token` (plus the IdP
+    /// refresh token and ID-Token expiry) and persists it as `IdpCredentials`
+    /// keyed by this issuer. `None` for ordinary resource OAuth flows, which are
+    /// left completely unaffected.
+    pub idp_issuer: Option<String>,
     pub created_at: Instant,
 }
 
@@ -135,6 +147,48 @@ impl OAuthFlowManager {
             redirect_uri: redirect_uri.to_string(),
             issuer: issuer.map(|s| s.to_string()),
             iss_parameter_supported,
+            idp_issuer: None,
+            created_at: Instant::now(),
+        };
+        self.pending.write().await.insert(state.clone(), flow);
+        state
+    }
+
+    /// Register a pending **EMA IdP SSO** flow (END-18 Step 1). Behaves exactly
+    /// like [`start_flow`] but tags the pending flow with the IdP `idp_issuer`
+    /// so the `/oauth/callback` handler captures the returned `id_token` (plus
+    /// the IdP refresh token and ID-Token expiry) and persists it as
+    /// `IdpCredentials`. Callers request the `openid offline_access` scope (M1)
+    /// when composing the authorize URL so the IdP returns a refresh token.
+    ///
+    /// The binary crate doesn't yet call this (the EMA adapter wiring lands in a
+    /// later task); the lib crate exposes it as public API and the `server`
+    /// tests exercise it, so the bin build sees it as dead until then.
+    #[allow(dead_code)]
+    #[allow(clippy::too_many_arguments)]
+    pub async fn start_idp_flow(
+        &self,
+        endpoint_name: &str,
+        token_endpoint: &str,
+        client_id: &str,
+        client_secret: Option<&str>,
+        pkce: PkceChallenge,
+        redirect_uri: &str,
+        issuer: Option<&str>,
+        iss_parameter_supported: bool,
+        idp_issuer: &str,
+    ) -> String {
+        let state = generate_state();
+        let flow = PendingFlow {
+            endpoint_name: endpoint_name.to_string(),
+            code_verifier: pkce.code_verifier,
+            token_endpoint: token_endpoint.to_string(),
+            client_id: client_id.to_string(),
+            client_secret: client_secret.map(|s| s.to_string()),
+            redirect_uri: redirect_uri.to_string(),
+            issuer: issuer.map(|s| s.to_string()),
+            iss_parameter_supported,
+            idp_issuer: Some(idp_issuer.to_string()),
             created_at: Instant::now(),
         };
         self.pending.write().await.insert(state.clone(), flow);

--- a/src/server.rs
+++ b/src/server.rs
@@ -1922,6 +1922,18 @@ async fn oauth_callback(
                 );
             }
         }
+
+        // EMA IdP SSO is complete: the IdP `token_set` above is the IdP's own
+        // access token, NOT the Step-3 resource access token. Persisting or
+        // applying it to the endpoint would let the adapter treat it as a valid
+        // resource token and skip/loop the EMA exchange on 401s. Return here so
+        // the resource token is always minted via `ema::ensure_access_token`
+        // on the adapter's next refresh. Ordinary resource OAuth flows leave
+        // `idp_issuer` unset and fall through to the save/apply path below.
+        return oauth_html_response(format!(
+            "<html><body><h1>Login Successful</h1><p>Identity provider sign-in for <strong>{}</strong> is complete. The connection will finish authenticating automatically.</p><p>You can close this window.</p></body></html>",
+            html_escape(&flow.endpoint_name)
+        ));
     }
 
     // Check if this is a setup session callback (preflight flow)
@@ -5209,6 +5221,67 @@ mod tests {
         assert_eq!(creds.id_token, id_token);
         assert_eq!(creds.refresh_token.as_deref(), Some("idp-refresh"));
         assert_eq!(creds.id_token_expires_at, Some(1_900_000_000));
+    }
+
+    #[tokio::test]
+    async fn oauth_callback_ema_flow_does_not_save_endpoint_token() {
+        // On an EMA IdP SSO callback the token response's `access_token` is the
+        // IdP's own token, NOT the Step-3 resource access token. It must never be
+        // persisted as the endpoint TokenSet — otherwise the adapter would treat
+        // it as a valid resource token and skip/loop the EMA exchange on 401s.
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let flow_mgr = Arc::new(OAuthFlowManager::new());
+
+        let id_token = id_token_with_exp(1_900_000_000);
+        let body = json!({
+            "access_token": "idp-access-not-resource",
+            "id_token": id_token,
+            "refresh_token": "idp-refresh",
+            "token_type": "Bearer",
+            "expires_in": 3600u64,
+        })
+        .to_string();
+        let (token_endpoint, _server) = spawn_idp_token_endpoint(body).await;
+
+        let pkce = crate::oauth::PkceChallenge::generate();
+        let idp_issuer = "https://acme.okta.com";
+        let endpoint_name = "github-acme";
+        let state_param = flow_mgr
+            .start_idp_flow(
+                endpoint_name,
+                &token_endpoint,
+                "client123",
+                None,
+                pkce,
+                "http://127.0.0.1:9400/oauth/callback",
+                None,
+                false,
+                idp_issuer,
+            )
+            .await;
+
+        let mut app_state = test_app_state();
+        app_state.oauth_flow_manager = Some(flow_mgr);
+        app_state.token_manager = Some(tm.clone());
+
+        let params = OAuthCallbackParams {
+            code: Some("authcode".to_string()),
+            state: Some(state_param),
+            error: None,
+            iss: None,
+        };
+        let resp = oauth_callback(State(app_state), Query(params)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // IdP credentials are captured for the EMA chain...
+        assert!(tm.load_idp(idp_issuer).await.unwrap().is_some());
+        // ...but the endpoint TokenSet must NOT have been written from the IdP
+        // token response. The resource token is minted later via the EMA chain.
+        assert!(
+            tm.load(endpoint_name).await.unwrap().is_none(),
+            "EMA IdP SSO must not persist the IdP access token as the endpoint TokenSet"
+        );
     }
 
     #[tokio::test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1684,6 +1684,55 @@ fn oauth_html_response(body: String) -> Response {
         .into_response()
 }
 
+/// Best-effort extraction of the OIDC ID Token expiry (seconds since the Unix
+/// epoch) for an EMA Step-1 capture. Prefers the ID Token's own `exp` claim
+/// (decoded without signature verification — the downstream AS verifies it,
+/// D4/S1), falling back to the token response's `expires_in` relative to
+/// `now_secs`. Returns `None` when neither is available.
+fn idp_id_token_expiry(id_token: &str, token_json: &Value, now_secs: u64) -> Option<u64> {
+    let exp_from_jwt = {
+        let mut parts = id_token.split('.');
+        match (parts.next(), parts.next(), parts.next()) {
+            (Some(_header), Some(payload), Some(_sig)) => {
+                use base64::Engine;
+                base64::engine::general_purpose::URL_SAFE_NO_PAD
+                    .decode(payload.trim_end_matches('='))
+                    .ok()
+                    .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
+                    .and_then(|claims| claims["exp"].as_u64())
+            }
+            _ => None,
+        }
+    };
+    exp_from_jwt.or_else(|| {
+        token_json["expires_in"]
+            .as_u64()
+            .map(|secs| now_secs + secs)
+    })
+}
+
+/// Build an [`IdpCredentials`](crate::token_manager::IdpCredentials) record from
+/// a successful IdP token-endpoint response (EMA Step 1, END-18). Returns `None`
+/// when the response carries no `id_token` — the ID Token is required, so a
+/// missing one is not an IdP SSO the relay can persist.
+fn build_idp_credentials(
+    idp_issuer: &str,
+    token_json: &Value,
+    now_secs: u64,
+) -> Option<crate::token_manager::IdpCredentials> {
+    let id_token = token_json["id_token"].as_str().unwrap_or_default();
+    if id_token.is_empty() {
+        return None;
+    }
+    Some(crate::token_manager::IdpCredentials {
+        idp_issuer: idp_issuer.to_string(),
+        id_token: id_token.to_string(),
+        refresh_token: token_json["refresh_token"].as_str().map(|s| s.to_string()),
+        id_token_expires_at: idp_id_token_expiry(id_token, token_json, now_secs),
+        obtained_at: now_secs,
+    })
+}
+
 /// GET /oauth/callback
 ///
 /// The OAuth authorization server redirects the user's browser here after login.
@@ -1846,6 +1895,34 @@ async fn oauth_callback(
         scope: token_json["scope"].as_str().map(|s| s.to_string()),
         issued_at: Some(now_secs),
     };
+
+    // EMA Step 1 (END-18): when this authorization-code flow was an IdP SSO for
+    // an EMA endpoint, capture the ID Token (plus the IdP refresh token and
+    // ID-Token expiry) and persist it as `IdpCredentials` keyed by the IdP
+    // issuer. Ordinary resource OAuth flows leave `idp_issuer` unset and are
+    // byte-for-byte unaffected by this block.
+    if let Some(ref idp_issuer) = flow.idp_issuer {
+        match build_idp_credentials(idp_issuer, &token_json, now_secs) {
+            Some(creds) => {
+                if let Some(ref tm) = state.token_manager {
+                    if let Err(e) = tm.save_idp(idp_issuer, &creds).await {
+                        error!(idp_issuer = %idp_issuer, error = %e, "Failed to persist IdP credentials");
+                    } else {
+                        info!(
+                            idp_issuer = %idp_issuer,
+                            "Captured and persisted IdP credentials (EMA Step 1)"
+                        );
+                    }
+                }
+            }
+            None => {
+                warn!(
+                    idp_issuer = %idp_issuer,
+                    "IdP token response carried no id_token; skipping IdpCredentials persistence"
+                );
+            }
+        }
+    }
 
     // Check if this is a setup session callback (preflight flow)
     if let Some(session_id_str) = flow.endpoint_name.strip_prefix("setup:") {
@@ -5000,6 +5077,193 @@ mod tests {
             !body_str.contains("issuer mismatch"),
             "missing iss must be tolerated when support is not advertised; body = {body_str}"
         );
+    }
+
+    // --- EMA Step 1 (END-18): ID Token capture & persistence -----------------
+
+    /// Build a compact-JWS ID Token whose claims segment carries the given
+    /// `exp`. Header/signature are placeholders (no signature verification in
+    /// v1 per D4/S1); only the base64url claims payload is decoded.
+    fn id_token_with_exp(exp: u64) -> String {
+        use base64::Engine;
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(format!("{{\"sub\":\"user-1\",\"exp\":{exp}}}"));
+        format!("hdr.{payload}.sig")
+    }
+
+    #[test]
+    fn build_idp_credentials_surfaces_id_token_refresh_and_jwt_exp() {
+        let id_token = id_token_with_exp(1_700_010_000);
+        let token_json = json!({
+            "access_token": "ignored-access",
+            "id_token": id_token,
+            "refresh_token": "idp-refresh",
+            "expires_in": 3600u64,
+        });
+        let creds = build_idp_credentials("https://acme.okta.com", &token_json, 1_700_000_000)
+            .expect("id_token present → credentials built");
+        assert_eq!(creds.idp_issuer, "https://acme.okta.com");
+        assert_eq!(creds.id_token, id_token);
+        assert_eq!(creds.refresh_token.as_deref(), Some("idp-refresh"));
+        // JWT `exp` claim is preferred over `expires_in`.
+        assert_eq!(creds.id_token_expires_at, Some(1_700_010_000));
+        assert_eq!(creds.obtained_at, 1_700_000_000);
+    }
+
+    #[test]
+    fn build_idp_credentials_falls_back_to_expires_in_without_jwt_exp() {
+        // An opaque (non-JWT) id_token has no decodable `exp`; expiry derives
+        // from `expires_in` relative to `now_secs`.
+        let token_json = json!({
+            "id_token": "opaque-id-token",
+            "expires_in": 3600u64,
+        });
+        let creds = build_idp_credentials("https://acme.okta.com", &token_json, 1_700_000_000)
+            .expect("id_token present → credentials built");
+        assert_eq!(creds.id_token_expires_at, Some(1_700_003_600));
+        assert!(creds.refresh_token.is_none());
+    }
+
+    #[test]
+    fn build_idp_credentials_returns_none_without_id_token() {
+        let token_json = json!({
+            "access_token": "only-access",
+            "refresh_token": "r",
+            "expires_in": 3600u64,
+        });
+        assert!(build_idp_credentials("https://acme.okta.com", &token_json, 1).is_none());
+    }
+
+    /// Spawn a mock IdP token endpoint that always returns `body` (a JSON
+    /// string) with HTTP 200, mirroring the OAuth fixtures elsewhere.
+    async fn spawn_idp_token_endpoint(body: String) -> (String, tokio::task::JoinHandle<()>) {
+        use axum::{routing::post, Router};
+        let router = Router::new().route(
+            "/token",
+            post(move || {
+                let b = body.clone();
+                async move { b }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        (format!("http://127.0.0.1:{}/token", addr.port()), handle)
+    }
+
+    #[tokio::test]
+    async fn oauth_callback_ema_flow_persists_idp_credentials() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let flow_mgr = Arc::new(OAuthFlowManager::new());
+
+        let id_token = id_token_with_exp(1_900_000_000);
+        let body = json!({
+            "access_token": "as-access",
+            "id_token": id_token,
+            "refresh_token": "idp-refresh",
+            "token_type": "Bearer",
+            "expires_in": 3600u64,
+        })
+        .to_string();
+        let (token_endpoint, _server) = spawn_idp_token_endpoint(body).await;
+
+        let pkce = crate::oauth::PkceChallenge::generate();
+        let idp_issuer = "https://acme.okta.com";
+        let state_param = flow_mgr
+            .start_idp_flow(
+                "github-acme",
+                &token_endpoint,
+                "client123",
+                None,
+                pkce,
+                "http://127.0.0.1:9400/oauth/callback",
+                None,
+                false,
+                idp_issuer,
+            )
+            .await;
+
+        let mut app_state = test_app_state();
+        app_state.oauth_flow_manager = Some(flow_mgr);
+        app_state.token_manager = Some(tm.clone());
+
+        let params = OAuthCallbackParams {
+            code: Some("authcode".to_string()),
+            state: Some(state_param),
+            error: None,
+            iss: None,
+        };
+        let resp = oauth_callback(State(app_state), Query(params)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let creds = tm
+            .load_idp(idp_issuer)
+            .await
+            .unwrap()
+            .expect("EMA SSO must persist IdpCredentials");
+        assert_eq!(creds.idp_issuer, idp_issuer);
+        assert_eq!(creds.id_token, id_token);
+        assert_eq!(creds.refresh_token.as_deref(), Some("idp-refresh"));
+        assert_eq!(creds.id_token_expires_at, Some(1_900_000_000));
+    }
+
+    #[tokio::test]
+    async fn oauth_callback_non_ema_flow_writes_no_idp_credentials() {
+        // A regular resource OAuth flow (`start_flow`, no idp marker) must NOT
+        // create any IdP-credential file — non-EMA flows are unaffected.
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let flow_mgr = Arc::new(OAuthFlowManager::new());
+
+        let body = json!({
+            "access_token": "as-access",
+            "id_token": "should-be-ignored",
+            "refresh_token": "resource-refresh",
+            "token_type": "Bearer",
+            "expires_in": 3600u64,
+        })
+        .to_string();
+        let (token_endpoint, _server) = spawn_idp_token_endpoint(body).await;
+
+        let pkce = crate::oauth::PkceChallenge::generate();
+        let state_param = flow_mgr
+            .start_flow(
+                "regular-ep",
+                &token_endpoint,
+                "client123",
+                None,
+                pkce,
+                "http://127.0.0.1:9400/oauth/callback",
+                None,
+                false,
+            )
+            .await;
+
+        let mut app_state = test_app_state();
+        app_state.oauth_flow_manager = Some(flow_mgr);
+        app_state.token_manager = Some(tm.clone());
+
+        let params = OAuthCallbackParams {
+            code: Some("authcode".to_string()),
+            state: Some(state_param),
+            error: None,
+            iss: None,
+        };
+        let resp = oauth_callback(State(app_state), Query(params)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // No IdP credentials were keyed off the (ignored) id_token issuer.
+        assert!(tm
+            .load_idp("https://acme.okta.com")
+            .await
+            .unwrap()
+            .is_none());
+        // But the ordinary access token was still saved for the endpoint.
+        assert!(tm.load("regular-ep").await.unwrap().is_some());
     }
 
     // --- /mcp/sse + initialize tools.listChanged capability ---

--- a/src/token_manager.rs
+++ b/src/token_manager.rs
@@ -83,19 +83,19 @@ pub struct IdpCredentials {
 
 /// Sanitize a logical IdP key into a filesystem-safe filename stem. Issuer URLs
 /// carry `/`, `:` and other characters unsafe for paths, so map anything that
-/// isn't ASCII alphanumeric, `-`, or `_` to `_`. Deterministic so the same key
-/// always resolves to the same `.idp.json` file. END-19 swaps the key *source*
-/// (issuer → org) without touching this sanitization.
+/// isn't ASCII alphanumeric, `-`, or `_` to `_`. A simple character map can
+/// collide distinct issuers (e.g. `a/b` and `a_b`), letting one IdP overwrite
+/// another's `*.idp.json`. To make the stem collision-resistant we hash the key
+/// with SHA-256 and encode it URL-safely (the alphabet `[A-Za-z0-9_-]` is
+/// filename-safe). Deterministic so the same key always resolves to the same
+/// `.idp.json` file; the original issuer is still stored inside the JSON.
+/// END-19 swaps the key *source* (issuer → org) without touching this hashing.
 fn sanitize_idp_key(key: &str) -> String {
-    key.chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect()
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(key.as_bytes());
+    URL_SAFE_NO_PAD.encode(hasher.finalize())
 }
 
 /// Decide whether persisted DCR credentials may be reused with the current
@@ -753,6 +753,44 @@ mod tests {
             sanitize_idp_key("https://acme.okta.com"),
             sanitize_idp_key("https://other.okta.com")
         );
+    }
+
+    #[test]
+    fn idp_keys_that_collided_under_char_map_now_resolve_distinctly() {
+        // Under the previous character-map sanitization (every non
+        // `[A-Za-z0-9_-]` char → `_`), these distinct issuers both mapped to the
+        // same stem `https___acme.example.com_a_b`, so one IdP's credentials
+        // overwrote the other's. Hashing must keep them in separate files.
+        assert_ne!(
+            sanitize_idp_key("https://acme.example.com/a/b"),
+            sanitize_idp_key("https://acme.example.com/a_b"),
+        );
+        assert_ne!(
+            sanitize_idp_key("https://acme.example.com:8443"),
+            sanitize_idp_key("https://acme.example.com_8443"),
+        );
+    }
+
+    #[tokio::test]
+    async fn idp_colliding_keys_do_not_clobber_each_other() {
+        // End-to-end guard: saving under two issuers that previously collided
+        // must persist two independent records, not overwrite one with the other.
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        let mut a = make_idp_creds();
+        a.idp_issuer = "https://acme.example.com/a/b".to_string();
+        a.id_token = "token-a".to_string();
+        let mut b = make_idp_creds();
+        b.idp_issuer = "https://acme.example.com/a_b".to_string();
+        b.id_token = "token-b".to_string();
+
+        mgr.save_idp(&a.idp_issuer, &a).await.unwrap();
+        mgr.save_idp(&b.idp_issuer, &b).await.unwrap();
+
+        let loaded_a = mgr.load_idp(&a.idp_issuer).await.unwrap().unwrap();
+        let loaded_b = mgr.load_idp(&b.idp_issuer).await.unwrap().unwrap();
+        assert_eq!(loaded_a.id_token, "token-a");
+        assert_eq!(loaded_b.id_token, "token-b");
     }
 
     #[cfg(unix)]

--- a/src/token_manager.rs
+++ b/src/token_manager.rs
@@ -60,6 +60,44 @@ pub struct DcrCredentials {
     pub issuer: Option<String>,
 }
 
+/// Per-IdP credentials captured during EMA Step 1 (IdP SSO). Holds the ID Token
+/// and IdP refresh token used to mint per-resource ID-JAG grants (RFC 8693).
+///
+/// Persisted via `TokenManager::{save_idp,load_idp,delete_idp}`, keyed by a
+/// caller-supplied key (a sanitized IdP issuer in v1; END-19 re-keys to org).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+pub struct IdpCredentials {
+    /// IdP issuer these credentials belong to, e.g. `https://acme.okta.com`.
+    pub idp_issuer: String,
+    /// OIDC ID Token from the IdP token response.
+    pub id_token: String,
+    /// IdP refresh token (present when `offline_access` was granted).
+    #[serde(default)]
+    pub refresh_token: Option<String>,
+    /// Unix timestamp (seconds) when the ID Token expires.
+    #[serde(default)]
+    pub id_token_expires_at: Option<u64>,
+    /// Unix timestamp (seconds) when these credentials were obtained.
+    pub obtained_at: u64,
+}
+
+/// Sanitize a logical IdP key into a filesystem-safe filename stem. Issuer URLs
+/// carry `/`, `:` and other characters unsafe for paths, so map anything that
+/// isn't ASCII alphanumeric, `-`, or `_` to `_`. Deterministic so the same key
+/// always resolves to the same `.idp.json` file. END-19 swaps the key *source*
+/// (issuer → org) without touching this sanitization.
+fn sanitize_idp_key(key: &str) -> String {
+    key.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
 /// Decide whether persisted DCR credentials may be reused with the current
 /// authorization server, or must be discarded and re-registered (RFC 7591).
 ///
@@ -182,6 +220,47 @@ impl TokenManager {
     /// Delete DCR credentials for an endpoint. No-op if file doesn't exist.
     pub async fn delete_dcr(&self, endpoint_name: &str) -> Result<(), TokenError> {
         let path = self.token_dir.join(format!("{}.dcr.json", endpoint_name));
+        match tokio::fs::remove_file(&path).await {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(TokenError::Io(e)),
+        }
+    }
+
+    /// Save IdP credentials under `key` (a sanitized IdP issuer in v1; END-19
+    /// re-keys to org). File written atomically (write to .tmp, rename).
+    /// File permissions: 0600 on Unix.
+    pub async fn save_idp(&self, key: &str, creds: &IdpCredentials) -> Result<(), TokenError> {
+        let stem = sanitize_idp_key(key);
+        let path = self.token_dir.join(format!("{}.idp.json", stem));
+        let tmp_path = self.token_dir.join(format!(".{}.idp.json.tmp", stem));
+        let json = serde_json::to_string_pretty(creds)?;
+        tokio::fs::write(&tmp_path, json.as_bytes()).await?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            tokio::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600)).await?;
+        }
+        tokio::fs::rename(&tmp_path, &path).await?;
+        Ok(())
+    }
+
+    /// Load IdP credentials for `key`. Returns None if file doesn't exist.
+    pub async fn load_idp(&self, key: &str) -> Result<Option<IdpCredentials>, TokenError> {
+        let stem = sanitize_idp_key(key);
+        let path = self.token_dir.join(format!("{}.idp.json", stem));
+        match tokio::fs::read_to_string(&path).await {
+            Ok(json) => Ok(Some(serde_json::from_str(&json)?)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(TokenError::Io(e)),
+        }
+    }
+
+    /// Delete IdP credentials for `key`. No-op if file doesn't exist.
+    #[allow(dead_code)]
+    pub async fn delete_idp(&self, key: &str) -> Result<(), TokenError> {
+        let stem = sanitize_idp_key(key);
+        let path = self.token_dir.join(format!("{}.idp.json", stem));
         match tokio::fs::remove_file(&path).await {
             Ok(()) => Ok(()),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
@@ -561,6 +640,134 @@ mod tests {
         let mgr = TokenManager::new(tmp.path().to_path_buf());
         mgr.save_dcr("perm-test", &make_dcr_creds()).await.unwrap();
         let path = tmp.path().join("perm-test.dcr.json");
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "Expected 0600, got {:o}", mode & 0o777);
+    }
+
+    // --- IdP credential persistence tests ---
+
+    fn make_idp_creds() -> IdpCredentials {
+        IdpCredentials {
+            idp_issuer: "https://acme.okta.com".to_string(),
+            id_token: "idp-id-token".to_string(),
+            refresh_token: Some("idp-refresh-token".to_string()),
+            id_token_expires_at: Some(1700003600),
+            obtained_at: 1700000000,
+        }
+    }
+
+    #[tokio::test]
+    async fn idp_save_and_load_round_trip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        let creds = make_idp_creds();
+
+        mgr.save_idp("https://acme.okta.com", &creds).await.unwrap();
+        let loaded = mgr
+            .load_idp("https://acme.okta.com")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(loaded, creds);
+    }
+
+    #[tokio::test]
+    async fn idp_load_nonexistent_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        let result = mgr.load_idp("https://nobody.okta.com").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn idp_delete_existing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        mgr.save_idp("https://acme.okta.com", &make_idp_creds())
+            .await
+            .unwrap();
+        assert!(mgr
+            .load_idp("https://acme.okta.com")
+            .await
+            .unwrap()
+            .is_some());
+        mgr.delete_idp("https://acme.okta.com").await.unwrap();
+        assert!(mgr
+            .load_idp("https://acme.okta.com")
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn idp_delete_nonexistent_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        // Should not error on first or second call
+        mgr.delete_idp("https://nobody.okta.com").await.unwrap();
+        mgr.delete_idp("https://nobody.okta.com").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn idp_save_without_optional_fields() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        let creds = IdpCredentials {
+            idp_issuer: "https://acme.okta.com".to_string(),
+            id_token: "idp-id-token".to_string(),
+            refresh_token: None,
+            id_token_expires_at: None,
+            obtained_at: 1700000000,
+        };
+
+        mgr.save_idp("https://acme.okta.com", &creds).await.unwrap();
+        let loaded = mgr
+            .load_idp("https://acme.okta.com")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(loaded, creds);
+        assert!(loaded.refresh_token.is_none());
+        assert!(loaded.id_token_expires_at.is_none());
+    }
+
+    #[test]
+    fn idp_tolerates_missing_optional_fields_on_deserialize() {
+        // Records written without the optional fields must still deserialize,
+        // with refresh_token = None and id_token_expires_at = None.
+        let json =
+            r#"{"idp_issuer":"https://acme.okta.com","id_token":"tok","obtained_at":1700000000}"#;
+        let creds: IdpCredentials = serde_json::from_str(json).unwrap();
+        assert_eq!(creds.idp_issuer, "https://acme.okta.com");
+        assert_eq!(creds.id_token, "tok");
+        assert_eq!(creds.refresh_token, None);
+        assert_eq!(creds.id_token_expires_at, None);
+        assert_eq!(creds.obtained_at, 1700000000);
+    }
+
+    #[test]
+    fn idp_distinct_issuers_resolve_to_distinct_files() {
+        // The sanitized key must keep different issuers in different files so
+        // multiple IdPs don't clobber one another.
+        assert_ne!(
+            sanitize_idp_key("https://acme.okta.com"),
+            sanitize_idp_key("https://other.okta.com")
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn idp_saved_file_has_0600_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        mgr.save_idp("https://acme.okta.com", &make_idp_creds())
+            .await
+            .unwrap();
+        let path = tmp.path().join(format!(
+            "{}.idp.json",
+            sanitize_idp_key("https://acme.okta.com")
+        ));
         let mode = std::fs::metadata(&path).unwrap().permissions().mode();
         assert_eq!(mode & 0o777, 0o600, "Expected 0600, got {:o}", mode & 0o777);
     }

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,6 +1,6 @@
 use crate::adapter::http::{HttpAdapter, HttpConfig};
 use crate::adapter::oauth::jit::JitInterceptor;
-use crate::adapter::oauth::{OAuthAdapter, OAuthAdapterConfig};
+use crate::adapter::oauth::{EmaConfig, EmaSsoWiring, OAuthAdapter, OAuthAdapterConfig};
 use crate::adapter::sse::{SseAdapter, SseConfig};
 use crate::adapter::stdio::{IsolationMode, StdioAdapter, StdioConfig};
 use crate::adapter::{FailedAdapter, McpAdapter, StartingAdapter};
@@ -760,6 +760,154 @@ pub struct JitWiring {
     pub flow_manager: Arc<OAuthFlowManager>,
 }
 
+/// Returns `(idp_issuer, resource)` when `ep` declares a complete EMA auth
+/// block (`[endpoints.auth] type = "ema"` with non-empty `idp` and `resource`).
+/// Incomplete blocks are surfaced as per-endpoint validation warnings elsewhere,
+/// so an EMA block missing a field falls through to the ordinary transport path.
+fn ema_auth(ep: &EndpointConfig) -> Option<(&str, &str)> {
+    let auth = ep.auth.as_ref()?;
+    if auth.auth_type != "ema" {
+        return None;
+    }
+    let idp = auth
+        .idp
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())?;
+    let resource = auth
+        .resource
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())?;
+    Some((idp, resource))
+}
+
+/// Resolve EMA discovery into an [`EmaConfig`]: RFC 8414 metadata for the IdP
+/// issuer (authorization + token endpoints) and RFC 9728 → 8414 metadata for the
+/// resource AS (issuer + token endpoint). All URLs are routed through
+/// `url_guard` inside the discovery clients. Returns `None` if either discovery
+/// fails so the caller can register a [`FailedAdapter`].
+async fn resolve_ema_config(
+    ep: &EndpointConfig,
+    idp: &str,
+    resource: &str,
+    allow_insecure_oauth: bool,
+) -> Option<EmaConfig> {
+    let idp_disc = match crate::oauth::discovery::discover_authorization_server(
+        idp,
+        allow_insecure_oauth,
+    )
+    .await
+    {
+        Ok(d) => d,
+        Err(e) => {
+            warn!(endpoint = %ep.name, idp = %idp, error = %e, "EMA IdP discovery failed at adapter init");
+            return None;
+        }
+    };
+    let as_disc = match crate::oauth::discovery::discover_oauth_server(
+        resource,
+        allow_insecure_oauth,
+    )
+    .await
+    {
+        Ok(d) => d,
+        Err(e) => {
+            warn!(endpoint = %ep.name, resource = %resource, error = %e, "EMA resource AS discovery failed at adapter init");
+            return None;
+        }
+    };
+    Some(EmaConfig {
+        // v1 keys IdP credentials by the (sanitized) issuer; END-19 re-keys to org.
+        idp_key: idp.to_string(),
+        idp_issuer: idp.to_string(),
+        idp_authorization_endpoint: idp_disc.authorization_endpoint,
+        idp_token_endpoint: idp_disc.token_endpoint,
+        as_issuer: as_disc.issuer,
+        as_token_endpoint: as_disc.token_endpoint,
+        resource: resource.to_string(),
+    })
+}
+
+/// Build an [`OAuthAdapter`] for an EMA endpoint: post-Step-3 the adapter is an
+/// ordinary OAuth adapter (decision D1), but its refresh path runs the ID-JAG
+/// chain. The CIMD `client_id` is presented at the resource AS (Step 3, M7) and
+/// the SSO kick-off wiring (flow manager + relay port) is threaded through so an
+/// expired/missing IdP credential composes an IdP authorize URL.
+async fn build_ema_adapter(
+    ep: &EndpointConfig,
+    token_manager: &Arc<TokenManager>,
+    oauth_adapter_inners: &OAuthAdapterInners,
+    allow_insecure_oauth: bool,
+    event_bus: Option<&ToolCallEventBus>,
+    jit: Option<&JitWiring>,
+) -> Box<dyn McpAdapter> {
+    // The caller only reaches this path when `ema_auth(ep)` matched, so both
+    // fields are present here.
+    let (idp, resource) = match ema_auth(ep) {
+        Some(v) => v,
+        None => {
+            return Box::new(FailedAdapter::new(format!(
+                "EMA endpoint '{}' is missing required idp/resource",
+                ep.name
+            )))
+        }
+    };
+    let ema = match resolve_ema_config(ep, idp, resource, allow_insecure_oauth).await {
+        Some(e) => e,
+        None => {
+            warn!(endpoint = %ep.name, "EMA endpoint discovery failed; registering as failed");
+            return Box::new(
+                FailedAdapter::new(format!(
+                    "EMA endpoint '{}' could not resolve IdP/resource discovery",
+                    ep.name
+                ))
+                .with_server_type_override(ep.server_type_override.clone()),
+            );
+        }
+    };
+
+    let oauth_config = OAuthAdapterConfig {
+        endpoint_name: ep.name.clone(),
+        url: ep.url.clone().unwrap_or_default(),
+        // Step 3 (RFC 7523) redeems at the resource AS token endpoint.
+        token_endpoint_url: ema.as_token_endpoint.clone(),
+        // EMA is a public client identified by the relay's CIMD URL (M7).
+        client_id: crate::oauth::client::ENDARA_CLIENT_METADATA_URL.to_string(),
+        client_secret: None,
+        heartbeat_interval_secs: 30,
+        probe_timeout_secs: 10,
+        probe_failure_threshold: 3,
+        server_type_override: ep.server_type_override.clone(),
+        allow_insecure_oauth,
+        ema: Some(ema),
+    };
+
+    let mut adapter = match jit {
+        Some(j) => OAuthAdapter::new_ema(
+            oauth_config,
+            token_manager.clone(),
+            EmaSsoWiring {
+                flow_manager: j.flow_manager.clone(),
+                relay_port: j.relay_port,
+            },
+        ),
+        None => OAuthAdapter::new(oauth_config, token_manager.clone()),
+    };
+    if let Some(bus) = event_bus {
+        adapter.set_event_bus(bus.clone());
+    }
+    let shared_inner = adapter.shared_inner();
+    oauth_adapter_inners
+        .write()
+        .await
+        .insert(ep.name.clone(), shared_inner);
+
+    adapter.initialize().await.ok();
+    info!(endpoint = %ep.name, "EMA OAuth adapter initialized");
+    Box::new(adapter)
+}
+
 /// Create an adapter from an endpoint configuration.
 ///
 /// Always returns an adapter. If initialization fails, returns a [`FailedAdapter`]
@@ -772,6 +920,22 @@ pub(crate) async fn create_adapter(
     event_bus: Option<&ToolCallEventBus>,
     jit: Option<&JitWiring>,
 ) -> Box<dyn McpAdapter> {
+    // EMA endpoints (`[endpoints.auth] type = "ema"`) wrap the upstream HTTP MCP
+    // server in an `OAuthAdapter` whose refresh path runs the ID-JAG chain
+    // (decision D1 / M10). Detected up front so it applies regardless of the
+    // declared transport.
+    if ema_auth(ep).is_some() {
+        return build_ema_adapter(
+            ep,
+            token_manager,
+            oauth_adapter_inners,
+            allow_insecure_oauth,
+            event_bus,
+            jit,
+        )
+        .await;
+    }
+
     match ep.transport {
         Transport::Stdio => {
             let stdio_config = StdioConfig {
@@ -869,6 +1033,7 @@ pub(crate) async fn create_adapter(
                 probe_failure_threshold: 3,
                 server_type_override: ep.server_type_override.clone(),
                 allow_insecure_oauth,
+                ema: None,
             };
 
             let mut adapter = OAuthAdapter::new(oauth_config, token_manager.clone());

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -853,6 +853,31 @@ async fn build_ema_adapter(
             )))
         }
     };
+
+    // EMA wraps an upstream HTTP MCP server in an `OAuthAdapter`, which speaks
+    // streamable HTTP and requires a concrete `url`. EMA detection runs before
+    // the transport match (so it applies regardless of the declared transport),
+    // so guard here against incompatible configs that would otherwise default
+    // `url` to an empty string and fail confusingly at runtime: reject non-HTTP
+    // transports and a missing/empty `url` up front with a clear message.
+    if !matches!(ep.transport, Transport::Http | Transport::Oauth) {
+        return Box::new(
+            FailedAdapter::new(format!(
+                "EMA endpoint '{}' requires transport \"http\" or \"oauth\", got \"{}\"",
+                ep.name, ep.transport
+            ))
+            .with_server_type_override(ep.server_type_override.clone()),
+        );
+    }
+    if ep.url.as_deref().map(str::trim).unwrap_or("").is_empty() {
+        return Box::new(
+            FailedAdapter::new(format!(
+                "EMA endpoint '{}' requires a non-empty 'url' (upstream MCP server URL)",
+                ep.name
+            ))
+            .with_server_type_override(ep.server_type_override.clone()),
+        );
+    }
     let ema = match resolve_ema_config(ep, idp, resource, allow_insecure_oauth).await {
         Some(e) => e,
         None => {
@@ -1381,6 +1406,65 @@ mod tests {
         }
 
         server.abort();
+    }
+
+    /// Build an EMA endpoint config with the given transport/url for the
+    /// transport-validation tests. Uses loopback issuer/resource so that, if the
+    /// validation guard were ever removed, the test would surface a discovery
+    /// failure rather than reaching the network.
+    fn ema_endpoint(name: &str, transport: Transport, url: Option<&str>) -> EndpointConfig {
+        let mut ep = http_endpoint(name, url.unwrap_or(""));
+        ep.transport = transport;
+        ep.url = url.map(|u| u.to_string());
+        ep.auth = Some(crate::config::EndpointAuthConfig {
+            auth_type: "ema".to_string(),
+            idp: Some("https://idp.example.com".to_string()),
+            resource: Some("https://api.example.com/mcp".to_string()),
+        });
+        ep
+    }
+
+    /// EMA detection runs before the transport match, so a `stdio` (non-HTTP)
+    /// transport must be rejected up front with a clear FailedAdapter message
+    /// instead of silently defaulting `url` to an empty string.
+    #[tokio::test]
+    async fn create_adapter_ema_rejects_non_http_transport() {
+        let (tm, inners) = test_oauth_infra();
+        let ep = ema_endpoint(
+            "ema_stdio",
+            Transport::Stdio,
+            Some("https://api.example.com/mcp"),
+        );
+
+        let adapter = create_adapter(&ep, &tm, &inners, true, None, None).await;
+        match adapter.health() {
+            HealthStatus::Unhealthy(msg) => {
+                assert!(
+                    msg.contains("transport") && msg.contains("ema_stdio"),
+                    "expected a transport-validation message, got: {msg}"
+                );
+            }
+            other => panic!("expected Unhealthy FailedAdapter, got: {other:?}"),
+        }
+    }
+
+    /// An EMA endpoint with no `url` must be rejected up front rather than
+    /// defaulting to an empty upstream URL that fails confusingly at runtime.
+    #[tokio::test]
+    async fn create_adapter_ema_requires_non_empty_url() {
+        let (tm, inners) = test_oauth_infra();
+        let ep = ema_endpoint("ema_no_url", Transport::Http, None);
+
+        let adapter = create_adapter(&ep, &tm, &inners, true, None, None).await;
+        match adapter.health() {
+            HealthStatus::Unhealthy(msg) => {
+                assert!(
+                    msg.contains("url") && msg.contains("ema_no_url"),
+                    "expected a url-validation message, got: {msg}"
+                );
+            }
+            other => panic!("expected Unhealthy FailedAdapter, got: {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1013,6 +1013,7 @@ mod tests {
             isolation: Some("none".to_string()),
             container_image: None,
             mounts: None,
+            auth: None,
         }
     }
 
@@ -1056,6 +1057,7 @@ mod tests {
             isolation: Some("none".to_string()),
             container_image: None,
             mounts: None,
+            auth: None,
         }
     }
 
@@ -1315,6 +1317,7 @@ mod tests {
             isolation: Some("none".to_string()),
             container_image: None,
             mounts: None,
+            auth: None,
         };
         let diff = ConfigDiff {
             changed: vec![("ep".to_string(), changed_ep)],
@@ -1353,6 +1356,7 @@ mod tests {
             isolation: Some("none".to_string()),
             container_image: None,
             mounts: None,
+            auth: None,
         };
         let diff = ConfigDiff {
             added: vec![new_ep],
@@ -1449,6 +1453,7 @@ mod tests {
             isolation: None,
             container_image: None,
             mounts: None,
+            auth: None,
         };
         let diff = ConfigDiff {
             added: vec![new_ep],
@@ -1521,6 +1526,7 @@ mod tests {
             isolation: None,
             container_image: None,
             mounts: None,
+            auth: None,
         };
         let diff = ConfigDiff {
             added: vec![new_ep],
@@ -1723,6 +1729,7 @@ mod tests {
             isolation: None,
             container_image: None,
             mounts: None,
+            auth: None,
         };
         let diff = ConfigDiff {
             added: vec![new_ep],
@@ -1882,6 +1889,7 @@ mod tests {
             isolation: None,
             container_image: None,
             mounts: None,
+            auth: None,
         }
     }
 
@@ -2011,6 +2019,7 @@ mod tests {
             isolation: None,
             container_image: None,
             mounts: None,
+            auth: None,
         }
     }
 

--- a/tests/ema_integration.rs
+++ b/tests/ema_integration.rs
@@ -1,0 +1,575 @@
+//! Enterprise-Managed Authorization (EMA, END-18) end-to-end integration tests.
+//!
+//! These are the acceptance-gate tests for the engineering spec §7: they drive
+//! the *real* [`OAuthAdapter`] (initialize → ID-JAG chain → inner MCP handshake
+//! → `tools/call`) against axum mock fixtures for the IdP token endpoint
+//! (RFC 8693 token-exchange + OIDC `refresh_token` grant), the resource AS token
+//! endpoint (RFC 7523 jwt-bearer), and the resource MCP server. They mirror the
+//! `spawn_*_fixture` pattern used in `oauth_integration.rs` / `ema.rs`.
+//!
+//! Unit-level coverage of the grant clients and `ensure_access_token`
+//! orchestration lives in `src/oauth/ema.rs`; here we pin the adapter *wiring*:
+//! the full chain (M4–M8), silent refresh on a 401 (M9), IdP-token refresh (M9),
+//! the no-silent-loop `ReauthRequired` surface (M9), the SSRF guard (M11), and
+//! coalesced concurrent refreshes (S2).
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use axum::extract::State;
+use axum::http::{header::AUTHORIZATION, HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use axum::{Json, Router};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use serde_json::{json, Value};
+
+use endara_relay::adapter::oauth::{EmaConfig, OAuthAdapter, OAuthAdapterConfig, OAuthState};
+use endara_relay::adapter::McpAdapter;
+use endara_relay::token_manager::{IdpCredentials, TokenManager, TokenSet};
+
+/// Logical IdP issuer (also the IdP-credential store key in v1).
+const IDP_ISS: &str = "https://acme.okta.com";
+/// Logical resource AS issuer (RFC 8693 `audience`; ID-JAG `aud` claim).
+const AS_ISS: &str = "https://as.example.com";
+/// Logical MCP resource identifier (ID-JAG `resource` claim).
+const RESOURCE: &str = "https://api.example.com/mcp/";
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// Build an unsigned (`alg=none`) compact JWS carrying `claims`. The relay does
+/// not verify the ID-JAG signature in v1 (design D4/S1), so a structural JWT is
+/// enough for the validation + redemption path.
+fn make_jwt(claims: Value) -> String {
+    let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"none","typ":"JWT"}"#);
+    let payload = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&claims).unwrap());
+    format!("{header}.{payload}.sig")
+}
+
+/// Per-grant request counters recorded by the mock fixture.
+#[derive(Default)]
+struct FxCounts {
+    /// RFC 8693 token-exchange (Step 2) hits on the IdP endpoint.
+    exchange: u32,
+    /// OIDC `refresh_token` (M9) hits on the IdP endpoint.
+    refresh: u32,
+    /// RFC 7523 jwt-bearer (Step 3) hits on the AS endpoint.
+    redeem: u32,
+}
+
+/// Programmed behaviour for the IdP `refresh_token` grant.
+#[derive(Clone)]
+enum RefreshOutcome {
+    /// Refresh fails with 400 `invalid_grant` (→ `ReauthRequired`).
+    Fail,
+    /// Refresh succeeds, returning `new_id_token` (which the exchange leg then
+    /// accepts as the only valid subject token).
+    Succeed { new_id_token: String },
+}
+
+/// Shared mock state. `accept_id_token` is the single subject token the exchange
+/// leg accepts (a successful refresh rotates it); `live_token` is the only
+/// bearer the MCP server's `tools/call` accepts (each redemption rotates it, so
+/// a stale access token yields a 401 that drives the silent-refresh path).
+#[derive(Clone)]
+struct Fx {
+    counts: Arc<StdMutex<FxCounts>>,
+    accept_id_token: Arc<StdMutex<String>>,
+    refresh: RefreshOutcome,
+    exchange_delay_ms: u64,
+    access_seq: Arc<AtomicU64>,
+    live_token: Arc<StdMutex<String>>,
+    as_expires_in: u64,
+}
+
+/// Endpoints exposed by [`spawn_ema_fixture`].
+struct FxUrls {
+    idp_token_endpoint: String,
+    as_token_endpoint: String,
+    mcp_url: String,
+}
+
+/// Spawn the combined IdP + AS + MCP mock on `127.0.0.1:0`. Returns the resolved
+/// endpoint URLs, the shared [`Fx`] handle (for counter/state assertions), and
+/// the server task handle.
+async fn spawn_ema_fixture(fx: Fx) -> (FxUrls, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    let router = Router::new()
+        .route("/idp/token", post(idp_token))
+        .route("/as/token", post(as_token))
+        .route("/mcp", post(mcp))
+        .with_state(fx);
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, router).await.ok();
+    });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    let urls = FxUrls {
+        idp_token_endpoint: format!("{base}/idp/token"),
+        as_token_endpoint: format!("{base}/as/token"),
+        mcp_url: format!("{base}/mcp"),
+    };
+    (urls, handle)
+}
+
+fn parse_form(body: &str) -> HashMap<String, String> {
+    url::form_urlencoded::parse(body.as_bytes())
+        .into_owned()
+        .collect()
+}
+
+/// Mock IdP token endpoint: serves both the RFC 8693 token-exchange (Step 2)
+/// and the OIDC `refresh_token` grant (M9), distinguished by `grant_type`.
+async fn idp_token(State(fx): State<Fx>, body: String) -> Response {
+    let form = parse_form(&body);
+    let grant = form
+        .get("grant_type")
+        .map(String::as_str)
+        .unwrap_or_default();
+
+    if grant == "refresh_token" {
+        fx.counts.lock().unwrap().refresh += 1;
+        return match &fx.refresh {
+            RefreshOutcome::Fail => (
+                StatusCode::BAD_REQUEST,
+                r#"{"error":"invalid_grant","error_description":"refresh expired"}"#,
+            )
+                .into_response(),
+            RefreshOutcome::Succeed { new_id_token } => {
+                *fx.accept_id_token.lock().unwrap() = new_id_token.clone();
+                let resp = json!({
+                    "id_token": new_id_token,
+                    "refresh_token": "rotated-refresh",
+                    "expires_in": 3600,
+                });
+                (StatusCode::OK, Json(resp)).into_response()
+            }
+        };
+    }
+
+    // Token-exchange (Step 2): only the currently-accepted subject token works.
+    fx.counts.lock().unwrap().exchange += 1;
+    if fx.exchange_delay_ms > 0 {
+        tokio::time::sleep(Duration::from_millis(fx.exchange_delay_ms)).await;
+    }
+    let subject = form
+        .get("subject_token")
+        .map(String::as_str)
+        .unwrap_or_default();
+    if subject != fx.accept_id_token.lock().unwrap().as_str() {
+        return (
+            StatusCode::BAD_REQUEST,
+            r#"{"error":"invalid_grant","error_description":"subject token expired"}"#,
+        )
+            .into_response();
+    }
+    let id_jag = make_jwt(json!({
+        "iss": IDP_ISS,
+        "aud": AS_ISS,
+        "resource": RESOURCE,
+        "sub": "user-123",
+        "exp": now_unix() + 600,
+    }));
+    (StatusCode::OK, Json(json!({ "access_token": id_jag }))).into_response()
+}
+
+/// Mock resource AS token endpoint (RFC 7523 jwt-bearer, Step 3). Each call
+/// mints a fresh `access-{n}` token and rotates `live_token` so the MCP server
+/// only accepts the most recently minted token.
+async fn as_token(State(fx): State<Fx>, _body: String) -> Response {
+    fx.counts.lock().unwrap().redeem += 1;
+    let n = fx.access_seq.fetch_add(1, Ordering::SeqCst) + 1;
+    let access = format!("access-{n}");
+    *fx.live_token.lock().unwrap() = access.clone();
+    let resp = json!({
+        "access_token": access,
+        "token_type": "Bearer",
+        "expires_in": fx.as_expires_in,
+        "scope": "mcp",
+    });
+    (StatusCode::OK, Json(resp)).into_response()
+}
+
+/// Mock resource MCP server. `initialize`/`tools/list`/notifications are
+/// ungated so the handshake and heartbeat probe always succeed; `tools/call` is
+/// gated on `live_token` so a stale bearer returns HTTP 401 (the seam the
+/// adapter's silent-refresh path keys on).
+async fn mcp(State(fx): State<Fx>, headers: HeaderMap, body: String) -> Response {
+    let req: Value = serde_json::from_str(&body).unwrap_or(Value::Null);
+    let id = req.get("id").cloned().unwrap_or(Value::Null);
+    let method = req.get("method").and_then(|m| m.as_str()).unwrap_or("");
+    match method {
+        "initialize" => Json(json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "ema-mcp", "version": "0.0.1"},
+            },
+        }))
+        .into_response(),
+        "tools/list" => Json(json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": {"tools": [{
+                "name": "echo",
+                "description": "echo",
+                "inputSchema": {"type": "object"},
+            }]},
+        }))
+        .into_response(),
+        "tools/call" => {
+            let want = format!("Bearer {}", fx.live_token.lock().unwrap());
+            let got = headers
+                .get(AUTHORIZATION)
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            if got != want {
+                return (StatusCode::UNAUTHORIZED, "token expired").into_response();
+            }
+            Json(json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": {"content": [{"type": "text", "text": "ok"}]},
+            }))
+            .into_response()
+        }
+        _ => {
+            // notifications/initialized and other JSON-RPC notifications.
+            if req.get("id").is_none() {
+                (StatusCode::ACCEPTED, "").into_response()
+            } else {
+                Json(json!({"jsonrpc": "2.0", "id": id, "result": {}})).into_response()
+            }
+        }
+    }
+}
+
+/// Build an `auth.type="ema"` adapter config pointed at the fixture endpoints.
+/// `allow_insecure_oauth` is `true` so the loopback fixture URLs pass the SSRF
+/// guard; the SSRF test overrides it to `false`.
+fn ema_config(urls: &FxUrls) -> OAuthAdapterConfig {
+    OAuthAdapterConfig {
+        endpoint_name: "ema-ep".to_string(),
+        url: urls.mcp_url.clone(),
+        token_endpoint_url: urls.as_token_endpoint.clone(),
+        client_id: "https://endara.ai/oauth/client-metadata.json".to_string(),
+        client_secret: None,
+        heartbeat_interval_secs: 3600,
+        probe_timeout_secs: 10,
+        probe_failure_threshold: 3,
+        server_type_override: None,
+        allow_insecure_oauth: true,
+        ema: Some(EmaConfig {
+            idp_key: IDP_ISS.to_string(),
+            idp_issuer: IDP_ISS.to_string(),
+            idp_authorization_endpoint: format!("{IDP_ISS}/authorize"),
+            idp_token_endpoint: urls.idp_token_endpoint.clone(),
+            as_issuer: AS_ISS.to_string(),
+            as_token_endpoint: urls.as_token_endpoint.clone(),
+            resource: RESOURCE.to_string(),
+        }),
+    }
+}
+
+fn idp_creds(
+    id_token: &str,
+    id_token_expires_at: Option<u64>,
+    refresh_token: Option<&str>,
+) -> IdpCredentials {
+    IdpCredentials {
+        idp_issuer: IDP_ISS.to_string(),
+        id_token: id_token.to_string(),
+        refresh_token: refresh_token.map(|s| s.to_string()),
+        id_token_expires_at,
+        obtained_at: now_unix(),
+    }
+}
+
+/// An access `TokenSet` whose `expires_at` is in the past so `is_valid()` is
+/// false and `ensure_access_token` is forced to re-mint.
+fn expired_token_set() -> TokenSet {
+    TokenSet {
+        access_token: "stale-access".to_string(),
+        refresh_token: None,
+        expires_at: Some(1000),
+        token_type: "Bearer".to_string(),
+        scope: None,
+        issued_at: Some(900),
+    }
+}
+
+/// Default fixture state: the exchange accepts `accept_id_token`, the refresh
+/// grant behaves per `refresh`, redemptions mint long-lived (`3600s`) tokens,
+/// and the exchange responds without delay.
+fn fx(refresh: RefreshOutcome, accept_id_token: &str) -> Fx {
+    Fx {
+        counts: Arc::new(StdMutex::new(FxCounts::default())),
+        accept_id_token: Arc::new(StdMutex::new(accept_id_token.to_string())),
+        refresh,
+        exchange_delay_ms: 0,
+        access_seq: Arc::new(AtomicU64::new(0)),
+        live_token: Arc::new(StdMutex::new(String::new())),
+        as_expires_in: 3600,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Happy path (M4–M8): mock IdP ID Token → token-exchange ID-JAG → AS access
+// token → valid TokenSet → a `tools/call` through `OAuthAdapter` succeeds.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn happy_path_full_chain_tools_call_succeeds() {
+    let state = fx(RefreshOutcome::Fail, "good-id-token");
+    let (urls, server) = spawn_ema_fixture(state.clone()).await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+    tm.save_idp(
+        IDP_ISS,
+        &idp_creds("good-id-token", Some(now_unix() + 3600), None),
+    )
+    .await
+    .unwrap();
+
+    let mut adapter = OAuthAdapter::new(ema_config(&urls), tm.clone());
+    adapter.initialize().await.unwrap();
+
+    // The full ID-JAG chain ran once and left the adapter authenticated.
+    assert_eq!(
+        *adapter.shared_inner().state.read().await,
+        OAuthState::Authenticated,
+        "EMA chain must leave the adapter Authenticated"
+    );
+    let persisted = tm.load("ema-ep").await.unwrap().expect("token persisted");
+    assert!(persisted.is_valid(), "minted access token must be valid");
+
+    let result = adapter.call_tool("echo", json!({})).await.unwrap();
+    assert_eq!(result["content"][0]["text"].as_str(), Some("ok"));
+
+    {
+        let c = state.counts.lock().unwrap();
+        assert_eq!(c.exchange, 1, "exactly one Step 2");
+        assert_eq!(c.redeem, 1, "exactly one Step 3");
+        assert_eq!(c.refresh, 0, "no IdP refresh on the happy path");
+    }
+    server.abort();
+}
+
+// ---------------------------------------------------------------------------
+// Access-token expiry (M9): a 401 on `tools/call` drives a silent Steps 2+3
+// re-run (no IdP refresh, no new SSO) and the retried call succeeds.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn access_token_expiry_silently_reruns_chain_via_call_tool() {
+    let state = fx(RefreshOutcome::Fail, "good-id-token");
+    let (urls, server) = spawn_ema_fixture(state.clone()).await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+    tm.save_idp(
+        IDP_ISS,
+        &idp_creds("good-id-token", Some(now_unix() + 3600), None),
+    )
+    .await
+    .unwrap();
+
+    let mut adapter = OAuthAdapter::new(ema_config(&urls), tm.clone());
+    adapter.initialize().await.unwrap();
+
+    // Simulate access-token expiry at the resource server: the live token no
+    // longer matches the bearer the inner adapter holds, and the persisted
+    // TokenSet is expired so the chain is forced to re-mint.
+    *state.live_token.lock().unwrap() = "__expired__".to_string();
+    tm.save("ema-ep", &expired_token_set()).await.unwrap();
+
+    let result = adapter.call_tool("echo", json!({})).await.unwrap();
+    assert_eq!(
+        result["content"][0]["text"].as_str(),
+        Some("ok"),
+        "retry after silent refresh must succeed"
+    );
+
+    {
+        let c = state.counts.lock().unwrap();
+        assert_eq!(c.exchange, 2, "initial + silent re-run = two Step 2");
+        assert_eq!(c.redeem, 2, "initial + silent re-run = two Step 3");
+        assert_eq!(
+            c.refresh, 0,
+            "silent refresh must NOT touch the IdP refresh grant"
+        );
+    }
+    server.abort();
+}
+
+// ---------------------------------------------------------------------------
+// ID-Token expiry (M9): a known-expired ID Token triggers a `refresh_token`
+// grant at the IdP, the rotated credentials are persisted, then Steps 2+3 run.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn id_token_expiry_refreshes_then_runs_chain() {
+    let state = fx(
+        RefreshOutcome::Succeed {
+            new_id_token: "fresh-id-token".to_string(),
+        },
+        "old-id-token",
+    );
+    let (urls, server) = spawn_ema_fixture(state.clone()).await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+    tm.save_idp(
+        IDP_ISS,
+        &idp_creds("old-id-token", Some(1000), Some("idp-refresh")),
+    )
+    .await
+    .unwrap();
+
+    let adapter = OAuthAdapter::new(ema_config(&urls), tm.clone());
+    let inner = adapter.shared_inner();
+    let tokens = inner
+        .do_token_refresh()
+        .await
+        .expect("refresh then chain must succeed");
+    assert!(tokens.is_valid());
+
+    {
+        let c = state.counts.lock().unwrap();
+        assert_eq!(c.refresh, 1, "one proactive IdP refresh");
+        assert_eq!(c.exchange, 1, "one Step 2 with the fresh ID Token");
+        assert_eq!(c.redeem, 1, "one Step 3");
+    }
+    let rotated = tm.load_idp(IDP_ISS).await.unwrap().unwrap();
+    assert_eq!(
+        rotated.id_token, "fresh-id-token",
+        "rotated creds persisted"
+    );
+    assert_eq!(rotated.refresh_token.as_deref(), Some("rotated-refresh"));
+    server.abort();
+}
+
+// ---------------------------------------------------------------------------
+// Refresh-token failure (M9): a failed IdP refresh surfaces `ReauthRequired`
+// (mapped to `AuthRequired`) with exactly one refresh attempt — no silent loop.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn refresh_token_failure_surfaces_reauth_required_without_loop() {
+    let state = fx(RefreshOutcome::Fail, "old-id-token");
+    let (urls, server) = spawn_ema_fixture(state.clone()).await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+    tm.save_idp(
+        IDP_ISS,
+        &idp_creds("old-id-token", Some(1000), Some("idp-refresh")),
+    )
+    .await
+    .unwrap();
+
+    let adapter = OAuthAdapter::new(ema_config(&urls), tm.clone());
+    let inner = adapter.shared_inner();
+    let err = inner.do_token_refresh().await.unwrap_err();
+    assert!(
+        err.to_string().to_lowercase().contains("re-auth")
+            || err.to_string().to_lowercase().contains("sso"),
+        "expected a re-auth-required error, got: {err}"
+    );
+    assert_eq!(
+        *inner.state.read().await,
+        OAuthState::AuthRequired,
+        "a re-auth-required outcome must be terminal (AuthRequired)"
+    );
+    {
+        let c = state.counts.lock().unwrap();
+        assert_eq!(c.refresh, 1, "exactly one refresh attempt — no silent loop");
+        assert_eq!(c.exchange, 0, "no exchange once the refresh fails");
+    }
+    server.abort();
+}
+
+// ---------------------------------------------------------------------------
+// SSRF (M11): an IdP token URL that resolves to loopback is rejected by the
+// url_guard when `allow_insecure_oauth` is false, before any request is sent.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn ssrf_blocked_idp_url_is_rejected_by_url_guard() {
+    let tmp = tempfile::tempdir().unwrap();
+    let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+    tm.save_idp(
+        IDP_ISS,
+        &idp_creds("good-id-token", Some(now_unix() + 3600), None),
+    )
+    .await
+    .unwrap();
+
+    // Loopback IdP token endpoint over https + secure mode ⇒ AddressNotAllowed.
+    let mut config = ema_config(&FxUrls {
+        idp_token_endpoint: "https://127.0.0.1:9/idp/token".to_string(),
+        as_token_endpoint: "https://127.0.0.1:9/as/token".to_string(),
+        mcp_url: "https://127.0.0.1:9/mcp".to_string(),
+    });
+    config.allow_insecure_oauth = false;
+
+    let adapter = OAuthAdapter::new(config, tm.clone());
+    let inner = adapter.shared_inner();
+    let err = inner.do_token_refresh().await.unwrap_err();
+    assert!(
+        err.to_string().to_lowercase().contains("ssrf"),
+        "expected an SSRF-guard rejection, got: {err}"
+    );
+    assert_eq!(
+        *inner.state.read().await,
+        OAuthState::ConnectionFailed,
+        "a guard rejection is transport-class (ConnectionFailed)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency (S2): N concurrent refreshes coalesce behind the adapter's
+// per-endpoint refresh mutex into a single exchange + redemption.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn concurrent_refreshes_coalesce_into_single_exchange() {
+    let mut state = fx(RefreshOutcome::Fail, "good-id-token");
+    state.exchange_delay_ms = 100;
+    let (urls, server) = spawn_ema_fixture(state.clone()).await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+    tm.save_idp(
+        IDP_ISS,
+        &idp_creds("good-id-token", Some(now_unix() + 3600), None),
+    )
+    .await
+    .unwrap();
+
+    let adapter = OAuthAdapter::new(ema_config(&urls), tm.clone());
+    let inner = adapter.shared_inner();
+
+    let mut handles = Vec::new();
+    for _ in 0..5 {
+        let inner = inner.clone();
+        handles.push(tokio::spawn(async move { inner.do_token_refresh().await }));
+    }
+    for h in handles {
+        let ts = h.await.unwrap().expect("each caller must get a token");
+        assert!(ts.is_valid());
+    }
+
+    let c = state.counts.lock().unwrap();
+    assert_eq!(
+        c.exchange, 1,
+        "coalesced: exactly one Step 2 across 5 callers"
+    );
+    assert_eq!(c.redeem, 1, "coalesced: exactly one Step 3");
+    drop(c);
+    server.abort();
+}

--- a/tests/hot_reload_integration.rs
+++ b/tests/hot_reload_integration.rs
@@ -91,6 +91,7 @@ async fn test_config_diff_add_endpoint() {
             isolation: Some("none".to_string()),
             container_image: None,
             mounts: None,
+            auth: None,
         }],
         profiles: None,
     };
@@ -129,6 +130,7 @@ async fn test_config_diff_add_endpoint() {
                 isolation: Some("none".to_string()),
                 container_image: None,
                 mounts: None,
+                auth: None,
             },
             config::EndpointConfig {
                 name: "multi-ep".to_string(),
@@ -151,6 +153,7 @@ async fn test_config_diff_add_endpoint() {
                 isolation: Some("none".to_string()),
                 container_image: None,
                 mounts: None,
+                auth: None,
             },
         ],
         profiles: None,
@@ -278,6 +281,7 @@ async fn test_config_diff_remove_endpoint() {
                 isolation: Some("none".to_string()),
                 container_image: None,
                 mounts: None,
+                auth: None,
             },
             config::EndpointConfig {
                 name: "multi-ep".to_string(),
@@ -300,6 +304,7 @@ async fn test_config_diff_remove_endpoint() {
                 isolation: Some("none".to_string()),
                 container_image: None,
                 mounts: None,
+                auth: None,
             },
         ],
         profiles: None,
@@ -338,6 +343,7 @@ async fn test_config_diff_remove_endpoint() {
             isolation: Some("none".to_string()),
             container_image: None,
             mounts: None,
+            auth: None,
         }],
         profiles: None,
     };

--- a/tests/management_api_integration.rs
+++ b/tests/management_api_integration.rs
@@ -117,6 +117,7 @@ fn test_config() -> Config {
             isolation: Some("none".to_string()),
             container_image: None,
             mounts: None,
+            auth: None,
         }],
         profiles: None,
     }

--- a/tests/oauth_integration.rs
+++ b/tests/oauth_integration.rs
@@ -1506,6 +1506,7 @@ async fn refresh_404_triggers_discovery_then_caches_new_token_endpoint() {
         // Required for the mock to be reachable via 127.0.0.1 from the
         // SSRF-aware discovery client.
         allow_insecure_oauth: true,
+        ema: None,
     };
     let adapter = OAuthAdapter::new(config, token_manager);
     let inner = adapter.shared_inner();

--- a/tests/oauth_setup_integration.rs
+++ b/tests/oauth_setup_integration.rs
@@ -52,6 +52,7 @@ fn empty_config() -> Config {
             isolation: None,
             container_image: None,
             mounts: None,
+            auth: None,
         }],
         profiles: None,
     }


### PR DESCRIPTION
## END-18 — EMA token-exchange client

Implements the three-leg Enterprise-Managed Authorization (EMA) token chain so the relay can obtain a per-user access token for an MCP server from an enterprise IdP (Okta), without the MCP server pre-trusting Endara:

1. **Step 1 — SSO** (auth-code + PKCE): capture & persist the IdP `id_token` (+ refresh token).
2. **Step 2 — Token exchange** (RFC 8693): `id_token` → **ID-JAG** at the IdP.
3. **Step 3 — JWT-bearer grant** (RFC 7523): ID-JAG → normal access token at the resource AS.

EMA endpoints then serve `tools/list` / `tools/call` through the **unmodified** `OAuthAdapter`, with silent refresh and a clear re-auth state on failure.

## Commits (scoped)

| Commit | Area |
|--------|------|
| `feat(oauth)` | Capture & persist IdP ID Token on EMA SSO callback (T4) |
| `feat(token_manager)` | `IdpCredentials` storage — `save/load/delete_idp` (T1) |
| `feat(config)` | `auth.type="ema"` endpoint config — `idp` + `resource` (T3) |
| `feat(oauth)` | EMA token-exchange module — RFC 8693/7523 grants, ID-JAG validation, `ensure_access_token` refresh orchestration (T2, T5) |
| `feat(adapter)` | Route EMA endpoints through `ema::ensure_access_token` + `openid offline_access` SSO scope (T6) |
| `test` | EMA full-chain integration tests (mock IdP + AS) (T7) |

## Key design decisions

- **D1** — Step-3 output is a normal access token; post-token behaviour is identical to OAuth, served by the unmodified adapter (EMA branch gated behind `config.ema.is_some()`).
- **D2** — EMA logic isolated in `src/oauth/ema.rs`.
- **D3** — Provisional per-endpoint `idp` field is the END-19 seam (no `[[organizations]]` / credential pool / multi-IdP here).
- **D4** — No IdP-JWKS signature verification of the ID-JAG in v1 (deferred hardening; claim/exp validation only).
- **D5** — Serial Steps 2+3 acceptable.

## Security

- All IdP/AS/token network legs route through `url_guard::validated_client` (SSRF guard); an integration test asserts a blocked/loopback URL is rejected by the guard, not by a generic failure.
- IdP authorization denials map to a non-retryable `EmaError::AuthorizationDenied`, distinct from transport/expiry.
- Tokens & `IdpCredentials` persist via `TokenManager` with `0600` perms + atomic temp→rename writes.
- RFC 9207 `iss` validation runs before the EMA persistence block on the shared callback.

## Tests

- Full relay suite: **2297 passed / 0 failed**.
- `tests/ema_integration.rs`: **6/6** end-to-end scenarios driving the real `OAuthAdapter` against axum mock IdP + AS + MCP fixtures — happy path (M4–M8), access-token expiry → silent re-exchange (M9), ID-token expiry → IdP refresh then re-exchange (M9), refresh-token failure → `ReauthRequired` with no silent loop (M9), SSRF rejection (M11), and concurrency coalescing to a single exchange (S2).
- `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean.
- Non-EMA OAuth endpoints are byte-for-byte unaffected (covered by existing + a dedicated `non_ema_refresh_uses_standard_path` test).

## Out of scope (follow-ups)

- `[[organizations]]` config + shared `(org, resource)` credential pool + multi-IdP → **END-19**.
- Desktop org tabs / EMA catalog filtering → **END-20**.
- IdP-JWKS signature verification of the ID-JAG → deferred hardening (D4).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author