### PR TITLE
feat(oauth): enterprise-managed authorization — organizations + onboarding (END-19)

### DIFF
--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -76,6 +76,10 @@ pub struct EmaConfig {
     pub as_token_endpoint: String,
     /// Target MCP server URL the access token is minted for.
     pub resource: String,
+    /// Optional pre-registered org `client_id` (Okta/Entra). Presented verbatim
+    /// in the IdP authorize URL and every EMA token leg. `None` keeps the legs
+    /// on the hosted CIMD `client_id` ([`ENDARA_CLIENT_METADATA_URL`]).
+    pub client_id: Option<String>,
 }
 
 /// SSO kick-off wiring for an EMA endpoint: the shared OAuth flow manager and
@@ -476,6 +480,7 @@ impl OAuthAdapterInner {
             &ema.as_token_endpoint,
             &ema.resource,
             self.config.allow_insecure_oauth,
+            ema.client_id.as_deref(),
         )
         .await
         {
@@ -527,18 +532,29 @@ impl OAuthAdapterInner {
         let code_challenge = pkce.code_challenge.clone();
         let redirect_uri = format!("http://127.0.0.1:{}/oauth/callback", sso.relay_port);
 
+        // Use the org's pre-registered client_id when set; otherwise fall back to
+        // the hosted CIMD client_id (byte-for-byte unchanged for bare END-18).
+        let client_id = ema
+            .client_id
+            .as_deref()
+            .unwrap_or(ENDARA_CLIENT_METADATA_URL);
+
         let state_param = sso
             .flow_manager
             .start_idp_flow(
                 &self.config.endpoint_name,
                 &ema.idp_token_endpoint,
-                ENDARA_CLIENT_METADATA_URL,
+                client_id,
                 None,
                 pkce,
                 &redirect_uri,
                 Some(&ema.idp_issuer),
                 false,
                 &ema.idp_issuer,
+                // Wave 2: persist the captured ID token under the pooled key
+                // (org name, or issuer for bare END-18 endpoints) so all of an
+                // org's EMA endpoints share one credential.
+                &ema.idp_key,
             )
             .await;
 
@@ -553,7 +569,7 @@ impl OAuthAdapterInner {
             "{}{}response_type=code&client_id={}&redirect_uri={}&state={}&code_challenge={}&code_challenge_method=S256&scope={}",
             ema.idp_authorization_endpoint,
             sep,
-            form_urlencode(ENDARA_CLIENT_METADATA_URL),
+            form_urlencode(client_id),
             form_urlencode(&redirect_uri),
             form_urlencode(&state_param),
             form_urlencode(&code_challenge),
@@ -1487,6 +1503,7 @@ mod tests {
                 as_issuer: format!("{}/as", resource),
                 as_token_endpoint: format!("{}/as/token", resource),
                 resource: resource.to_string(),
+                client_id: None,
             }),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,14 @@ pub struct Config {
     /// plural `[[profiles]]` to match the existing `[[endpoints]]` convention.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub profiles: Option<Vec<ProfileConfig>>,
+    /// Named identity-provider organizations (END-19). Each `[[organizations]]`
+    /// block carries a stable `name` (used in endpoint `auth.organization` refs
+    /// and the credential pool key), a provider template id, and the resolved
+    /// IdP issuer URL. Tokens are NEVER stored here — only in the credential
+    /// store. `#[serde(default)]` keeps pre-existing configs (no org blocks)
+    /// parsing unchanged.
+    #[serde(default)]
+    pub organizations: Vec<ConfigOrganization>,
 }
 
 /// Relay-specific configuration.
@@ -312,16 +320,48 @@ pub fn validate_profiles(config: &Config) -> Result<(), Vec<String>> {
     }
 }
 
+/// A named identity-provider organization (`[[organizations]]`, END-19).
+///
+/// Organizations are the stable identity source EMA endpoints reference via
+/// `auth.organization`, replacing END-18's provisional per-endpoint `idp`
+/// field. The `name` is the stable key used both in endpoint references and as
+/// the credential-pool key (Wave 2). `provider` is a template id
+/// (`okta|entra|google|ping|custom`) and `idp` is the resolved issuer URL.
+///
+/// **Tokens are NEVER part of this struct** — the ID token / refresh token live
+/// only in the credential store (`TokenManager`). Only `name`/`provider`/`idp`
+/// are ever serialized into `config.toml`.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct ConfigOrganization {
+    /// Stable key used in endpoint `auth.organization` refs and the credential
+    /// pool. Human-readable (e.g. `"Acme Corp"`).
+    pub name: String,
+    /// Provider template id: `okta`, `entra`, `google`, `ping`, or `custom`.
+    pub provider: String,
+    /// Resolved IdP issuer URL (built from a provider template or pasted).
+    pub idp: String,
+    /// Optional pre-registered OAuth `client_id` for this org's IdP (e.g. an
+    /// Okta/Entra app registration). When present it is used verbatim across the
+    /// authorize URL and every EMA token leg; when absent the relay falls back to
+    /// the shared resolution chain (CIMD → DCR) and the legs keep sending the
+    /// hosted CIMD `client_id`. Omitted from `config.toml` when unset so existing
+    /// configs round-trip unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_id: Option<String>,
+}
+
 /// Authentication configuration nested under `[endpoints.auth]`.
 ///
 /// Currently the only supported `type` is `"ema"` (Enterprise-Managed
-/// Authorization). An EMA block carries a provisional `idp` (the IdP issuer
-/// URL the relay performs SSO against) and a `resource` (the MCP server URL the
-/// minted access token is scoped to). The `idp` field is a **PROVISIONAL**
-/// END-19 seam: END-19 moves the IdP source to `[[organizations]]`.
+/// Authorization). An EMA block references an org via `organization` (the
+/// preferred END-19 form) and carries a `resource` (the MCP server URL the
+/// minted access token is scoped to). The `idp` field is a **DEPRECATED**
+/// back-compat seam from END-18: a bare `idp` issuer URL (with no
+/// `organization`) still validates so existing configs keep working, but new
+/// configs should reference an `[[organizations]]` entry by name instead.
 ///
-/// `idp`/`resource` are modeled as `Option` (rather than via a serde-tagged
-/// enum) so that a missing field surfaces as a clear
+/// `organization`/`idp`/`resource` are modeled as `Option` (rather than via a
+/// serde-tagged enum) so that a missing field surfaces as a clear
 /// [`ConfigError::ValidationError`] / per-endpoint warning through the existing
 /// validation paths instead of a raw TOML parse error, preserving the graceful
 /// per-endpoint loading model.
@@ -330,8 +370,13 @@ pub struct EndpointAuthConfig {
     /// Discriminator for the auth scheme. Only `"ema"` is currently supported.
     #[serde(rename = "type")]
     pub auth_type: String,
+    /// Name of the `[[organizations]]` entry this EMA endpoint authenticates
+    /// against (the preferred END-19 form). The IdP issuer is resolved from the
+    /// named org.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<String>,
     /// IdP issuer URL for `type = "ema"` (e.g. `https://acme.okta.com`).
-    /// PROVISIONAL END-19 seam.
+    /// **DEPRECATED** END-18 back-compat seam — prefer `organization`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub idp: Option<String>,
     /// Target MCP server URL the EMA access token is minted for.
@@ -520,6 +565,7 @@ pub fn default_config() -> Config {
         relay: RelayConfig::default(),
         endpoints: Vec::new(),
         profiles: None,
+        organizations: Vec::new(),
     }
 }
 
@@ -785,24 +831,31 @@ fn is_valid_endpoint_name(name: &str) -> bool {
 /// Validate an endpoint's `[endpoints.auth]` block.
 ///
 /// Returns `Err(message)` for an unknown `type`, or — for `type = "ema"` — a
-/// missing/empty `idp` or `resource`. Returns `Ok(())` when there is no auth
-/// block or it is valid. The message is suitable for surfacing to the user
-/// (it is prefixed with the endpoint name by callers).
-fn validate_endpoint_auth(ep: &EndpointConfig) -> Result<(), String> {
+/// missing/empty `resource`, or neither an `organization` nor a bare `idp`. An
+/// EMA endpoint is valid when it has `resource` AND (`organization` OR `idp`);
+/// a bare `idp` (no `organization`) still validates for END-18 back-compat but
+/// is deprecated in favor of an `[[organizations]]` reference. Returns `Ok(())`
+/// when there is no auth block or it is valid. The message is suitable for
+/// surfacing to the user (it is prefixed with the endpoint name by callers).
+pub(crate) fn validate_endpoint_auth(ep: &EndpointConfig) -> Result<(), String> {
     let auth = match &ep.auth {
         Some(a) => a,
         None => return Ok(()),
     };
     match auth.auth_type.as_str() {
         "ema" => {
-            if auth.idp.as_deref().unwrap_or("").trim().is_empty() {
-                return Err(
-                    "auth.type = \"ema\" requires a non-empty 'idp' (IdP issuer URL)".to_string(),
-                );
-            }
             if auth.resource.as_deref().unwrap_or("").trim().is_empty() {
                 return Err(
                     "auth.type = \"ema\" requires a non-empty 'resource' (MCP server URL)"
+                        .to_string(),
+                );
+            }
+            let has_org = !auth.organization.as_deref().unwrap_or("").trim().is_empty();
+            let has_idp = !auth.idp.as_deref().unwrap_or("").trim().is_empty();
+            if !has_org && !has_idp {
+                return Err(
+                    "auth.type = \"ema\" requires an 'organization' (the name of an \
+                     [[organizations]] entry) or a bare 'idp' (IdP issuer URL; deprecated)"
                         .to_string(),
                 );
             }
@@ -1038,6 +1091,14 @@ pub struct ConfigDiff {
     /// production reader remains after the watcher's unchanged-loop removal.
     #[allow(dead_code)]
     pub unchanged: Vec<String>,
+    /// `true` when the `[[organizations]]` set differs between the two configs
+    /// (any org added, removed, or changed). EMA endpoints resolve their IdP
+    /// through their named org, so an org change must participate in the
+    /// hot-reload path just like an endpoint change. Wave 2 wires the watcher to
+    /// act on this; it is surfaced here so the diff is the single source of
+    /// truth for what changed.
+    #[allow(dead_code)]
+    pub organizations_changed: bool,
 }
 
 /// Compare two configs and produce a diff of endpoint changes.
@@ -1083,6 +1144,7 @@ pub fn diff_configs(old: &Config, new: &Config) -> ConfigDiff {
         removed,
         changed,
         unchanged,
+        organizations_changed: old.organizations != new.organizations,
     }
 }
 
@@ -1836,6 +1898,7 @@ js_execution = false
             },
             endpoints,
             profiles: None,
+            organizations: Vec::new(),
         }
     }
 
@@ -1906,6 +1969,7 @@ payload_window_minutes = 30
             },
             endpoints: vec![],
             profiles: None,
+            organizations: Vec::new(),
         };
         let toml_str = toml::to_string_pretty(&config).unwrap();
         let parsed: Config = toml::from_str(&toml_str).unwrap();
@@ -2816,12 +2880,14 @@ idp = "https://acme.okta.com"
         let mut ep1 = sse_ep("github-acme", "https://api.githubcopilot.com/mcp/");
         ep1.auth = Some(EndpointAuthConfig {
             auth_type: "ema".to_string(),
+            organization: None,
             idp: Some("https://acme.okta.com".to_string()),
             resource: Some("https://api.githubcopilot.com/mcp/".to_string()),
         });
         let mut ep2 = sse_ep("github-acme", "https://api.githubcopilot.com/mcp/");
         ep2.auth = Some(EndpointAuthConfig {
             auth_type: "ema".to_string(),
+            organization: None,
             idp: Some("https://other.okta.com".to_string()),
             resource: Some("https://api.githubcopilot.com/mcp/".to_string()),
         });
@@ -2831,5 +2897,209 @@ idp = "https://acme.okta.com"
         let diff = diff_configs(&old, &new);
         assert_eq!(diff.changed.len(), 1, "EMA auth change should trigger diff");
         assert!(diff.unchanged.is_empty());
+    }
+
+    // --- [[organizations]] config tests (M1) ---
+
+    #[test]
+    fn organizations_parse_from_toml() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[organizations]]
+name = "Acme Corp"
+provider = "okta"
+idp = "https://acme.okta.com"
+
+[[organizations]]
+name = "Globex"
+provider = "entra"
+idp = "https://login.microsoftonline.com/globex/v2.0"
+"#;
+        let config = parse_and_validate(toml_str).unwrap();
+        assert_eq!(config.organizations.len(), 2);
+        assert_eq!(config.organizations[0].name, "Acme Corp");
+        assert_eq!(config.organizations[0].provider, "okta");
+        assert_eq!(config.organizations[0].idp, "https://acme.okta.com");
+        assert_eq!(config.organizations[1].name, "Globex");
+        assert_eq!(config.organizations[1].provider, "entra");
+    }
+
+    #[test]
+    fn organizations_default_to_empty_when_omitted() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+"#;
+        let config = parse_and_validate(toml_str).unwrap();
+        assert!(config.organizations.is_empty());
+    }
+
+    #[test]
+    fn organizations_round_trip_and_never_carry_tokens() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[organizations]]
+name = "Acme Corp"
+provider = "okta"
+idp = "https://acme.okta.com"
+"#;
+        let config = parse_and_validate(toml_str).unwrap();
+        let serialized = toml::to_string_pretty(&config).unwrap();
+        // The serialized org block must carry only name/provider/idp.
+        assert!(serialized.contains("Acme Corp"));
+        assert!(serialized.contains("okta"));
+        assert!(serialized.contains("https://acme.okta.com"));
+        // Tokens are stored only in the credential store, never in toml.
+        assert!(
+            !serialized.to_lowercase().contains("token"),
+            "org toml must never carry tokens: {}",
+            serialized
+        );
+        let reparsed = parse_and_validate(&serialized).unwrap();
+        assert_eq!(
+            reparsed.organizations, config.organizations,
+            "organizations should survive a serialize → parse round trip"
+        );
+    }
+
+    // --- EMA endpoint organization-ref tests (M3) ---
+
+    #[test]
+    fn ema_endpoint_with_organization_validates() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[organizations]]
+name = "Acme Corp"
+provider = "okta"
+idp = "https://acme.okta.com"
+
+[[endpoints]]
+name = "github-acme"
+url = "https://api.githubcopilot.com/mcp/"
+transport = "http"
+
+[endpoints.auth]
+type = "ema"
+organization = "Acme Corp"
+resource = "https://api.githubcopilot.com/mcp/"
+"#;
+        let config = parse_and_validate(toml_str).unwrap();
+        let auth = config.endpoints[0].auth.as_ref().unwrap();
+        assert_eq!(auth.organization.as_deref(), Some("Acme Corp"));
+        assert!(auth.idp.is_none());
+    }
+
+    #[test]
+    fn ema_endpoint_organization_round_trips_through_serialize() {
+        let mut ep = sse_ep("github-acme", "https://api.githubcopilot.com/mcp/");
+        ep.transport = Transport::Http;
+        ep.auth = Some(EndpointAuthConfig {
+            auth_type: "ema".to_string(),
+            organization: Some("Acme Corp".to_string()),
+            idp: None,
+            resource: Some("https://api.githubcopilot.com/mcp/".to_string()),
+        });
+        let config = make_config(vec![ep]);
+        let serialized = toml::to_string_pretty(&config).unwrap();
+        let reparsed = parse_and_validate(&serialized).unwrap();
+        assert_eq!(reparsed.endpoints[0].auth, config.endpoints[0].auth);
+    }
+
+    #[test]
+    fn ema_endpoint_bare_idp_still_validates() {
+        // END-18 back-compat: a bare `idp` with no `organization` keeps working.
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "github-acme"
+url = "https://api.githubcopilot.com/mcp/"
+transport = "http"
+
+[endpoints.auth]
+type = "ema"
+idp = "https://acme.okta.com"
+resource = "https://api.githubcopilot.com/mcp/"
+"#;
+        let config = parse_and_validate(toml_str).unwrap();
+        let auth = config.endpoints[0].auth.as_ref().unwrap();
+        assert!(auth.organization.is_none());
+        assert_eq!(auth.idp.as_deref(), Some("https://acme.okta.com"));
+    }
+
+    #[test]
+    fn ema_endpoint_without_org_or_idp_is_rejected() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+
+[[endpoints]]
+name = "github-acme"
+url = "https://api.githubcopilot.com/mcp/"
+transport = "http"
+
+[endpoints.auth]
+type = "ema"
+resource = "https://api.githubcopilot.com/mcp/"
+"#;
+        let err = parse_and_validate(toml_str).unwrap_err();
+        match err {
+            ConfigError::ValidationError(msg) => {
+                assert!(msg.contains("ema"), "Error should mention ema: {}", msg);
+                assert!(
+                    msg.contains("organization"),
+                    "Error should mention organization: {}",
+                    msg
+                );
+                assert!(msg.contains("idp"), "Error should mention idp: {}", msg);
+            }
+            other => panic!("Expected ValidationError, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn organization_add_remove_change_triggers_config_diff() {
+        let acme = ConfigOrganization {
+            name: "Acme Corp".to_string(),
+            provider: "okta".to_string(),
+            idp: "https://acme.okta.com".to_string(),
+            client_id: None,
+        };
+        let mut with_org = make_config(vec![stdio_ep("a", "echo")]);
+        with_org.organizations = vec![acme.clone()];
+        let without_org = make_config(vec![stdio_ep("a", "echo")]);
+
+        // Added.
+        assert!(
+            diff_configs(&without_org, &with_org).organizations_changed,
+            "adding an org should be reflected in the diff"
+        );
+        // Removed.
+        assert!(
+            diff_configs(&with_org, &without_org).organizations_changed,
+            "removing an org should be reflected in the diff"
+        );
+        // Changed (idp issuer differs).
+        let mut changed = make_config(vec![stdio_ep("a", "echo")]);
+        changed.organizations = vec![ConfigOrganization {
+            idp: "https://acme.okta.com/changed".to_string(),
+            ..acme.clone()
+        }];
+        assert!(
+            diff_configs(&with_org, &changed).organizations_changed,
+            "changing an org should be reflected in the diff"
+        );
+        // Unchanged.
+        assert!(
+            !diff_configs(&with_org, &with_org).organizations_changed,
+            "identical orgs should not be flagged as changed"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -631,6 +631,9 @@ async fn main() {
             let settled_inits = Arc::new(std::sync::atomic::AtomicUsize::new(0));
             let mut init_handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
             let allow_insecure_oauth = cfg.relay.allow_insecure_oauth.unwrap_or(false);
+            // Named IdP orgs (END-19) threaded into adapter construction so EMA
+            // endpoints resolve their pooled IdP credential key by org name.
+            let organizations = cfg.organizations.clone();
             // JIT wiring for plain-`http` adapters built during initial load —
             // the same bundle the config watcher uses for hot-reloads. The
             // loopback redirect_uri uses the runtime `port`, never hardcoded.
@@ -645,6 +648,7 @@ async fn main() {
                 let settled = settled_inits.clone();
                 let bus = event_bus.clone();
                 let jit_ep = jit.clone();
+                let orgs = organizations.clone();
                 let handle = tokio::spawn(async move {
                     let adapter = watcher::create_adapter(
                         &ep,
@@ -653,6 +657,7 @@ async fn main() {
                         allow_insecure_oauth,
                         Some(&bus),
                         Some(&jit_ep),
+                        &orgs,
                     )
                     .await;
                     let mut entries = reg.entries().write().await;

--- a/src/management.rs
+++ b/src/management.rs
@@ -160,6 +160,31 @@ pub struct EndpointInfo {
     /// endpoints. Omitted for non-stdio transports and before the first spawn.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub isolation_state: Option<crate::adapter::stdio::IsolationState>,
+    /// EMA org-binding summary for endpoints authenticated via Enterprise-Managed
+    /// Authorization (`[endpoints.auth] type = "ema"`). Lets the desktop detect
+    /// already-installed org-bound servers. Omitted for ordinary endpoints,
+    /// keeping their serialization byte-for-byte unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth: Option<EmaAuthSummary>,
+}
+
+/// EMA org-binding summary surfaced on an endpoint listing entry.
+///
+/// Populated from the endpoint's `[endpoints.auth]` block when `type = "ema"`.
+/// Carries no credentials — only the org reference and the MCP server URL the
+/// minted access token is scoped to.
+#[derive(Serialize, Clone)]
+pub struct EmaAuthSummary {
+    /// Auth scheme discriminator; currently always `"ema"`.
+    #[serde(rename = "type")]
+    pub auth_type: String,
+    /// Name of the `[[organizations]]` entry this endpoint binds to. Omitted for
+    /// END-18 bare-`idp` endpoints with no organization reference.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub organization: Option<String>,
+    /// MCP server URL the EMA access token is minted for.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resource: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -268,6 +293,30 @@ async fn get_status(State(state): State<ManagementState>) -> Json<StatusResponse
 
 /// GET /api/endpoints
 async fn get_endpoints(State(state): State<ManagementState>) -> Json<Vec<EndpointInfo>> {
+    // Snapshot EMA org bindings from config, keyed by endpoint name. Only
+    // `type = "ema"` endpoints get an entry; ordinary endpoints are absent so
+    // their listing serialization stays byte-for-byte unchanged.
+    let auth_by_name: HashMap<String, EmaAuthSummary> = {
+        let config = state.config.read().await;
+        config
+            .endpoints
+            .iter()
+            .filter_map(|ep| {
+                let auth = ep.auth.as_ref()?;
+                if auth.auth_type != "ema" {
+                    return None;
+                }
+                Some((
+                    ep.name.clone(),
+                    EmaAuthSummary {
+                        auth_type: auth.auth_type.clone(),
+                        organization: auth.organization.clone(),
+                        resource: auth.resource.clone(),
+                    },
+                ))
+            })
+            .collect()
+    };
     let entries = state.registry.entries().read().await;
     let now = Instant::now();
     let mut endpoints: Vec<EndpointInfo> = Vec::new();
@@ -321,6 +370,7 @@ async fn get_endpoints(State(state): State<ManagementState>) -> Json<Vec<Endpoin
             lifecycle,
             container_stats: entry.adapter.container_stats(),
             isolation_state: entry.adapter.isolation_state(),
+            auth: auth_by_name.get(name).cloned(),
         });
     }
     endpoints.sort_by(|a, b| a.name.cmp(&b.name));
@@ -410,7 +460,7 @@ async fn restart_endpoint(
         }
 
         // Look up the endpoint config to decide between rebuild and re-init.
-        let (ep_config, allow_insecure_oauth) = {
+        let (ep_config, allow_insecure_oauth, organizations) = {
             let cfg = config.read().await;
             (
                 cfg.endpoints
@@ -418,6 +468,7 @@ async fn restart_endpoint(
                     .find(|ep| ep.name == task_name)
                     .cloned(),
                 cfg.relay.allow_insecure_oauth.unwrap_or(false),
+                cfg.organizations.clone(),
             )
         };
 
@@ -441,6 +492,7 @@ async fn restart_endpoint(
                 allow_insecure_oauth,
                 event_bus.as_ref(),
                 jit.as_ref(),
+                &organizations,
             )
             .await
         } else {
@@ -665,6 +717,7 @@ async fn reload_config(State(state): State<ManagementState>) -> Json<ActionRespo
         new_config.relay.allow_insecure_oauth.unwrap_or(false),
         state.event_bus.as_ref(),
         jit.as_ref(),
+        &new_config.organizations,
     )
     .await;
 
@@ -1924,6 +1977,276 @@ async fn oauth_probe(
 }
 
 // ---------------------------------------------------------------------------
+// EMA capability probe (per-organization "which MCP servers can I reach?")
+// ---------------------------------------------------------------------------
+
+/// Concurrency bound for per-resource probes within a single batch.
+const ORG_PROBE_CONCURRENCY: usize = 8;
+
+/// Per-probe wall-clock cap (discovery + token exchange). Bounds a slow or
+/// unreachable resource so it can never stall the whole batch.
+const ORG_PROBE_TIMEOUT_SECS: u64 = 15;
+
+/// TTL for cached probe outcomes keyed by `(org, resource)`. A cache hit within
+/// this window skips re-running discovery + the ID-JAG exchange.
+const ORG_PROBE_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Process-global short-TTL cache of probe outcomes keyed by `(org, resource)`.
+/// A static keeps `ManagementState` (and its many constructors) untouched; the
+/// TTL bounds staleness and entries are uniquely keyed by the desktop-supplied
+/// resource URL.
+static ORG_PROBE_CACHE: std::sync::LazyLock<
+    std::sync::RwLock<HashMap<(String, String), OrgProbeCacheEntry>>,
+> = std::sync::LazyLock::new(|| std::sync::RwLock::new(HashMap::new()));
+
+/// One cached probe outcome plus its insertion time (for TTL expiry).
+struct OrgProbeCacheEntry {
+    status: OrgProbeStatus,
+    server_as_issuer: Option<String>,
+    inserted: Instant,
+}
+
+/// Reachability of a single MCP resource for the requesting organization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum OrgProbeStatus {
+    /// The IdP minted an ID-JAG for this resource (the ID-JAG is discarded —
+    /// the probe persists nothing).
+    Accessible,
+    /// The IdP refused the exchange with a terminal authorization denial.
+    Denied,
+    /// Discovery failed, the exchange hit a transport/expiry error, or the
+    /// per-probe timeout elapsed.
+    Unreachable,
+}
+
+/// Request body for `POST /api/organizations/{org}/probe`.
+#[derive(Deserialize)]
+struct OrgProbeRequest {
+    /// Desktop-supplied candidate MCP server URLs. The relay stays
+    /// catalog-agnostic and only probes exactly these candidates.
+    #[serde(default)]
+    resources: Vec<String>,
+}
+
+/// One probe outcome for a single resource.
+#[derive(Serialize)]
+struct OrgProbeResult {
+    resource: String,
+    status: OrgProbeStatus,
+    /// The resource AS issuer (RFC 8414 `issuer`) discovered for this resource,
+    /// present whenever discovery succeeded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    server_as_issuer: Option<String>,
+}
+
+/// Response body for `POST /api/organizations/{org}/probe`.
+#[derive(Serialize)]
+struct OrgProbeResponse {
+    results: Vec<OrgProbeResult>,
+}
+
+/// Run the discovery → ID-JAG-exchange chain for a single resource and map the
+/// outcome to an [`OrgProbeStatus`]. Persists nothing: a successful exchange's
+/// ID-JAG is discarded and Step 3 (redemption) is never run.
+async fn run_org_probe_chain(
+    resource: &str,
+    idp_token_endpoint: &str,
+    id_token: &str,
+    allow_insecure: bool,
+) -> (OrgProbeStatus, Option<String>) {
+    let resource = resource.trim();
+    let chain = async {
+        let disc =
+            match crate::oauth::discovery::discover_oauth_server(resource, allow_insecure).await {
+                Ok(d) => d,
+                // Discovery failed (no metadata, 404, transport, SSRF guard).
+                Err(_) => return (OrgProbeStatus::Unreachable, None),
+            };
+        let as_issuer = disc.issuer;
+        match crate::oauth::ema::exchange_for_id_jag(
+            idp_token_endpoint,
+            id_token,
+            &as_issuer,
+            resource,
+            allow_insecure,
+        )
+        .await
+        {
+            // Accessible: discard the ID-JAG, persist nothing.
+            Ok(_id_jag) => (OrgProbeStatus::Accessible, Some(as_issuer)),
+            Err(crate::oauth::ema::EmaError::AuthorizationDenied { .. }) => {
+                (OrgProbeStatus::Denied, Some(as_issuer))
+            }
+            // Transport/expiry/validation errors are treated as unreachable; the
+            // AS issuer is still known since discovery succeeded.
+            Err(_) => (OrgProbeStatus::Unreachable, Some(as_issuer)),
+        }
+    };
+
+    match tokio::time::timeout(
+        std::time::Duration::from_secs(ORG_PROBE_TIMEOUT_SECS),
+        chain,
+    )
+    .await
+    {
+        Ok(outcome) => outcome,
+        // Per-probe timeout elapsed.
+        Err(_) => (OrgProbeStatus::Unreachable, None),
+    }
+}
+
+/// Probe one resource, consulting (and populating) the short-TTL cache.
+async fn probe_one_resource(
+    org: String,
+    resource: String,
+    idp_token_endpoint: String,
+    id_token: String,
+    allow_insecure: bool,
+) -> OrgProbeResult {
+    let key = (org, resource.clone());
+
+    // Cache hit within TTL: skip re-discovery + re-exchange.
+    if let Ok(cache) = ORG_PROBE_CACHE.read() {
+        if let Some(entry) = cache.get(&key) {
+            if entry.inserted.elapsed() < ORG_PROBE_CACHE_TTL {
+                return OrgProbeResult {
+                    resource,
+                    status: entry.status,
+                    server_as_issuer: entry.server_as_issuer.clone(),
+                };
+            }
+        }
+    }
+
+    let (status, server_as_issuer) =
+        run_org_probe_chain(&resource, &idp_token_endpoint, &id_token, allow_insecure).await;
+
+    if let Ok(mut cache) = ORG_PROBE_CACHE.write() {
+        cache.insert(
+            key,
+            OrgProbeCacheEntry {
+                status,
+                server_as_issuer: server_as_issuer.clone(),
+                inserted: Instant::now(),
+            },
+        );
+    }
+
+    OrgProbeResult {
+        resource,
+        status,
+        server_as_issuer,
+    }
+}
+
+/// POST /api/organizations/{org}/probe
+///
+/// The "Detecting available MCP servers…" engine. For each desktop-supplied
+/// candidate `resource`, runs RFC 9728 → RFC 8414 discovery and an RFC 8693
+/// ID-JAG token exchange against the org's IdP, mapping the outcome to
+/// `accessible` / `denied` / `unreachable`. Probes run with bounded parallelism
+/// and a per-probe timeout, results are cached briefly per `(org, resource)`,
+/// and the probe persists **nothing** (the ID-JAG is discarded; no token files
+/// are written).
+///
+/// JSON contract:
+///   Request:  `{ "resources": ["<mcp url>", ...] }`
+///   Response: `{ "results": [{ "resource", "status", "server_as_issuer"? }] }`
+async fn probe_organization(
+    State(state): State<ManagementState>,
+    Path(org): Path<String>,
+    Json(body): Json<OrgProbeRequest>,
+) -> impl IntoResponse {
+    // Resolve the org's IdP issuer (and the insecure-loopback policy) from config.
+    let (idp_issuer, allow_insecure) = {
+        let config = state.config.read().await;
+        let Some(found) = config.organizations.iter().find(|o| o.name == org) else {
+            return error_response(
+                StatusCode::NOT_FOUND,
+                "organization not found",
+                Some(&format!("No organization named '{org}'.")),
+            )
+            .into_response();
+        };
+        (
+            found.idp.clone(),
+            config.relay.allow_insecure_oauth.unwrap_or(false),
+        )
+    };
+
+    let Some(token_manager) = state.token_manager.clone() else {
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "token manager not available",
+            None,
+        )
+        .into_response();
+    };
+
+    // Org-keyed pooled IdP credentials (Wave 2). Absence ⇒ the org has not
+    // completed IdP SSO, so no probe can run.
+    let creds = match token_manager.load_idp(&org).await {
+        Ok(Some(c)) => c,
+        Ok(None) => {
+            return error_response(
+                StatusCode::CONFLICT,
+                "organization not authenticated",
+                Some(&format!(
+                    "No IdP credentials stored for organization '{org}'. Authenticate it first."
+                )),
+            )
+            .into_response();
+        }
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "credential store error",
+                Some(&e.to_string()),
+            )
+            .into_response();
+        }
+    };
+
+    // Resolve the IdP token endpoint once for the whole batch (RFC 8414 / OIDC).
+    let idp_token_endpoint =
+        match crate::oauth::discovery::discover_authorization_server(&idp_issuer, allow_insecure)
+            .await
+        {
+            Ok(disc) => disc.token_endpoint,
+            Err(e) => {
+                return error_response(
+                    StatusCode::BAD_GATEWAY,
+                    "idp discovery failed",
+                    Some(&format!(
+                        "Could not resolve IdP token endpoint for '{idp_issuer}': {e}"
+                    )),
+                )
+                .into_response();
+            }
+        };
+
+    let id_token = creds.id_token;
+
+    use futures_util::stream::StreamExt;
+    let results: Vec<OrgProbeResult> =
+        futures_util::stream::iter(body.resources.into_iter().map(|resource| {
+            let org = org.clone();
+            let idp_token_endpoint = idp_token_endpoint.clone();
+            let id_token = id_token.clone();
+            async move {
+                probe_one_resource(org, resource, idp_token_endpoint, id_token, allow_insecure)
+                    .await
+            }
+        }))
+        .buffered(ORG_PROBE_CONCURRENCY)
+        .collect()
+        .await;
+
+    Json(OrgProbeResponse { results }).into_response()
+}
+
+// ---------------------------------------------------------------------------
 // OAuth setup (preflight) route handlers
 // ---------------------------------------------------------------------------
 
@@ -3121,6 +3444,11 @@ pub struct EndpointRequest {
     /// stdio endpoints.
     #[serde(default)]
     pub mounts: Option<Vec<String>>,
+    /// Non-default auth binding for the endpoint (currently `type = "ema"`).
+    /// Threaded into the persisted `[endpoints.auth]` sub-table so onboarding
+    /// can create EMA endpoints via the management API.
+    #[serde(default)]
+    pub auth: Option<crate::config::EndpointAuthConfig>,
     // Forbidden fields — present so we can return a precise 400 instead of
     // silently dropping the value when a client mistakenly includes them.
     #[serde(default)]
@@ -3349,8 +3677,18 @@ fn validate_endpoint_request(
         isolation,
         container_image: req.container_image.clone(),
         mounts: req.mounts.clone(),
-        auth: None,
+        auth: req.auth.clone(),
     };
+
+    // Validate the `[endpoints.auth]` block (currently `type = "ema"`) using
+    // the same rules the config loader applies, so an EMA body is rejected
+    // unless it has a `resource` AND (`organization` OR `idp`).
+    if let Err(msg) = crate::config::validate_endpoint_auth(&new_ep) {
+        return Err(bad_request(
+            "invalid auth",
+            format!("Endpoint '{}': {}", req.name, msg),
+        ));
+    }
 
     Ok(new_ep)
 }
@@ -3444,6 +3782,20 @@ fn endpoint_to_toml_table(
                 .collect();
             t.insert("mounts".into(), toml::Value::Array(arr));
         }
+    }
+    if let Some(ref auth) = ep.auth {
+        let mut auth_table = toml::map::Map::new();
+        auth_table.insert("type".into(), toml::Value::String(auth.auth_type.clone()));
+        if let Some(ref org) = auth.organization {
+            auth_table.insert("organization".into(), toml::Value::String(org.clone()));
+        }
+        if let Some(ref idp) = auth.idp {
+            auth_table.insert("idp".into(), toml::Value::String(idp.clone()));
+        }
+        if let Some(ref resource) = auth.resource {
+            auth_table.insert("resource".into(), toml::Value::String(resource.clone()));
+        }
+        t.insert("auth".into(), toml::Value::Table(auth_table));
     }
     t
 }
@@ -3608,6 +3960,7 @@ async fn apply_endpoint_change(
         relay: old_cfg.relay.clone(),
         endpoints: new_endpoints.clone(),
         profiles: old_cfg.profiles.clone(),
+        organizations: old_cfg.organizations.clone(),
     };
     let diff = crate::config::diff_configs(&old_cfg, &new_cfg);
     let token_manager = state.token_manager.clone().unwrap_or_else(|| {
@@ -3636,6 +3989,7 @@ async fn apply_endpoint_change(
         new_cfg.relay.allow_insecure_oauth.unwrap_or(false),
         state.event_bus.as_ref(),
         jit.as_ref(),
+        &new_cfg.organizations,
     )
     .await;
 
@@ -4333,10 +4687,583 @@ pub fn management_routes(state: ManagementState) -> Router {
             get(get_observability_config).put(update_observability_config),
         )
         .route("/api/observability/events", get(tool_call_events_sse))
+        // END-19 Wave 3: provider templates + organization lifecycle.
+        .route("/api/idp-providers", get(list_idp_providers))
+        .route(
+            "/api/organizations",
+            get(list_organizations).post(create_organization),
+        )
+        .route("/api/organizations/{org}", delete(delete_organization))
+        .route(
+            "/api/organizations/{org}/reauthenticate",
+            post(reauthenticate_organization),
+        )
+        // EMA capability probe: which desktop-supplied MCP servers can this org reach?
+        .route("/api/organizations/{org}/probe", post(probe_organization))
         // No CORS layer: this router is served exclusively over a Unix-domain
         // socket / Windows named pipe (see `management_listener`), which is not
         // reachable from a browser and has no cross-origin attack surface.
         .with_state(state)
+}
+
+// ---------------------------------------------------------------------------
+// END-19 Wave 3: provider templates + organization lifecycle
+// ---------------------------------------------------------------------------
+
+/// Request body for `POST /api/organizations`.
+#[derive(Deserialize)]
+struct CreateOrganizationRequest {
+    /// Display name / stable key (e.g. "Acme Corp"); also the credential-pool key.
+    name: String,
+    /// Provider template id: `okta`, `entra`, `google`, `ping`, or `custom`.
+    provider: String,
+    /// Slug for templated providers (Okta subdomain, Entra tenant, Ping env id).
+    #[serde(default)]
+    slug: Option<String>,
+    /// Full issuer URL for `provider = "custom"` (pasted by the user).
+    #[serde(default)]
+    idp: Option<String>,
+    /// Optional pre-registered OAuth `client_id` for this org's IdP (e.g. an
+    /// Okta/Entra app registration). When provided it wins the resolution chain
+    /// and is persisted on the org; when omitted the relay falls back to CIMD/DCR.
+    #[serde(default)]
+    client_id: Option<String>,
+}
+
+/// One organization entry returned by `GET /api/organizations`.
+#[derive(Serialize)]
+struct OrganizationResponse {
+    name: String,
+    provider: String,
+    idp: String,
+    /// Whether the credential pool holds usable IdP credentials for this org
+    /// (a non-expired ID token or a refresh token to silently re-mint one).
+    authenticated: bool,
+}
+
+/// Response carrying a freshly-composed IdP SSO authorize URL.
+#[derive(Serialize)]
+struct OrganizationSsoResponse {
+    name: String,
+    provider: String,
+    idp: String,
+    authorize_url: String,
+}
+
+/// GET /api/idp-providers
+///
+/// Returns the static provider template table — the single source of truth the
+/// desktop "Add organization" UI renders and `POST /api/organizations` resolves
+/// issuer URLs from.
+async fn list_idp_providers() -> impl IntoResponse {
+    Json(crate::oauth::idp_providers::IDP_PROVIDERS)
+}
+
+/// Validate an IdP issuer via RFC 8414 / OIDC discovery before persisting an
+/// organization. Returns the discovered metadata (used to compose the SSO URL)
+/// or a ready-to-return `400` response. The SSRF guard inside discovery rejects
+/// internal/loopback hosts unless `allow_insecure` is set.
+async fn validate_org_issuer(
+    issuer: &str,
+    allow_insecure: bool,
+) -> Result<crate::oauth::discovery::DiscoveryResult, axum::response::Response> {
+    crate::oauth::discovery::discover_authorization_server(issuer, allow_insecure)
+        .await
+        .map_err(|e| {
+            error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_issuer",
+                Some(&format!("Could not validate IdP issuer '{issuer}': {e}")),
+            )
+            .into_response()
+        })
+}
+
+/// Resolve the OAuth `client_id` for an organization's IdP via the shared
+/// fallback chain (explicit org `client_id` → CIMD when the AS advertises it →
+/// DCR when a registration endpoint exists), returning the resolved id and which
+/// path produced it. A `422 client_id_required` response is returned when the
+/// IdP supports neither CIMD nor DCR and no explicit `client_id` was supplied.
+async fn resolve_org_client(
+    org_client_id: Option<&str>,
+    disc: &crate::oauth::discovery::DiscoveryResult,
+    redirect_uri: &str,
+    org_name: &str,
+    allow_insecure: bool,
+) -> Result<(String, ClientRegistration), axum::response::Response> {
+    let explicit = org_client_id
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| (s.to_string(), None));
+    let dcr_redirect_uri = redirect_uri.to_string();
+    let dcr_org_name = org_name.to_string();
+    let resolved = client::resolve_client(
+        client::ClientInputs {
+            explicit_manual: explicit,
+            preregistered: None,
+            cimd_supported: disc.client_id_metadata_document_supported,
+            registration_endpoint: disc.registration_endpoint.clone(),
+        },
+        |reg_endpoint| async move {
+            let resp = crate::oauth::dcr::register_client(
+                &reg_endpoint,
+                &dcr_redirect_uri,
+                &dcr_org_name,
+                allow_insecure,
+            )
+            .await?;
+            Ok::<_, crate::oauth::dcr::DcrError>(client::DcrOutcome {
+                client_id: resp.client_id,
+                client_secret: resp.client_secret,
+                client_secret_expires_at: resp.client_secret_expires_at,
+            })
+        },
+    )
+    .await;
+
+    match resolved {
+        Ok(r) => Ok((r.client_id, r.registration)),
+        Err(client::ClientResolveError::NoCredentials) => Err(error_response(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "client_id_required",
+            Some(
+                "This IdP advertises neither CIMD nor Dynamic Client Registration; \
+                 provide a pre-registered 'client_id' for the organization.",
+            ),
+        )
+        .into_response()),
+        Err(client::ClientResolveError::Dcr(e)) => Err(error_response(
+            StatusCode::BAD_GATEWAY,
+            "dcr_failed",
+            Some(&format!("Dynamic Client Registration failed: {e}")),
+        )
+        .into_response()),
+    }
+}
+
+/// Compose the IdP SSO authorize URL for an organization and register the
+/// pending IdP flow via [`OAuthFlowManager::start_idp_flow`], mirroring the EMA
+/// adapter's `compose_idp_authorize_url`. The captured ID token is keyed by the
+/// org `name` so every EMA endpoint in the org shares one credential. The
+/// requested scope is `openid offline_access` (M1) so the IdP returns a refresh
+/// token. The configured `issuer` (not the discovered canonical form) is stored
+/// in the flow so the credentials match the issuer the EMA chain re-discovers.
+/// The `client_id` is the value resolved by [`resolve_org_client`] (explicit /
+/// CIMD / DCR) and is presented identically in the URL and the pending flow.
+async fn compose_org_sso_url(
+    flow_mgr: &OAuthFlowManager,
+    relay_port: u16,
+    org_name: &str,
+    issuer: &str,
+    disc: &crate::oauth::discovery::DiscoveryResult,
+    client_id: &str,
+) -> String {
+    let pkce = PkceChallenge::generate();
+    let code_challenge = pkce.code_challenge.clone();
+    let redirect_uri = format!("http://127.0.0.1:{}/oauth/callback", relay_port);
+
+    let state_param = flow_mgr
+        .start_idp_flow(
+            org_name,
+            &disc.token_endpoint,
+            client_id,
+            None,
+            pkce,
+            &redirect_uri,
+            Some(issuer),
+            false,
+            issuer,
+            org_name,
+        )
+        .await;
+
+    let sep = if disc.authorization_endpoint.contains('?') {
+        '&'
+    } else {
+        '?'
+    };
+    format!(
+        "{}{}response_type=code&client_id={}&redirect_uri={}&state={}&code_challenge={}&code_challenge_method=S256&scope={}",
+        disc.authorization_endpoint,
+        sep,
+        urlencoding(client_id),
+        urlencoding(&redirect_uri),
+        urlencoding(&state_param),
+        urlencoding(&code_challenge),
+        urlencoding("openid offline_access"),
+    )
+}
+
+/// Persist the updated organization list back to `config.toml`, preserving the
+/// rest of the document. Mirrors [`write_profiles_to_disk`]. Tokens are never
+/// written here — only `name`/`provider`/`idp` round-trip through `config.toml`.
+fn write_organizations_to_disk(
+    config_path: &std::path::Path,
+    organizations: &[crate::config::ConfigOrganization],
+) -> Result<(), (StatusCode, &'static str, String)> {
+    let contents = std::fs::read_to_string(config_path).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to read config file",
+            e.to_string(),
+        )
+    })?;
+    let mut parsed: toml::Table = contents.parse().map_err(|e: toml::de::Error| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to parse config file",
+            e.to_string(),
+        )
+    })?;
+
+    if organizations.is_empty() {
+        parsed.remove("organizations");
+    } else {
+        let arr: Vec<toml::Value> = organizations
+            .iter()
+            .map(|o| {
+                toml::Value::try_from(o)
+                    .expect("ConfigOrganization is Serialize and round-trips through toml::Value")
+            })
+            .collect();
+        parsed.insert("organizations".into(), toml::Value::Array(arr));
+    }
+
+    let new_contents = toml::to_string_pretty(&parsed).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to serialize config",
+            e.to_string(),
+        )
+    })?;
+    crate::config::write_config_file(config_path, &new_contents).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to write config file",
+            e.to_string(),
+        )
+    })?;
+    Ok(())
+}
+
+/// POST /api/organizations
+///
+/// Builds the IdP issuer from a provider template (`{provider, slug}`) or takes
+/// a pasted custom issuer (`{provider: "custom", idp}`), validates it via
+/// discovery **before** persisting, writes the org to `config.toml`, and returns
+/// an SSO authorize URL (reusing `start_idp_flow` + `/oauth/callback`).
+async fn create_organization(
+    State(state): State<ManagementState>,
+    Json(body): Json<CreateOrganizationRequest>,
+) -> impl IntoResponse {
+    let Some(ref flow_mgr) = state.oauth_flow_manager else {
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "OAuth not configured",
+            None,
+        )
+        .into_response();
+    };
+    let Some(ref config_path) = state.config_path else {
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "config_path not configured",
+            None,
+        )
+        .into_response();
+    };
+
+    let name = body.name.trim().to_string();
+    if name.is_empty() {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_name",
+            Some("Organization name must not be empty."),
+        )
+        .into_response();
+    }
+
+    // Snapshot the SSRF opt-out and reject duplicate org names.
+    let allow_insecure = {
+        let config = state.config.read().await;
+        if config.organizations.iter().any(|o| o.name == name) {
+            return error_response(
+                StatusCode::CONFLICT,
+                "organization_exists",
+                Some(&format!(
+                    "An organization named '{name}' already exists. Use a different name."
+                )),
+            )
+            .into_response();
+        }
+        config.relay.allow_insecure_oauth.unwrap_or(false)
+    };
+
+    // Resolve the issuer: a pasted custom URL, or built from a provider template.
+    let issuer = if body.provider == "custom" {
+        match body
+            .idp
+            .as_ref()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+        {
+            Some(idp) => idp.to_string(),
+            None => {
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    "missing_idp",
+                    Some("provider 'custom' requires a full 'idp' issuer URL."),
+                )
+                .into_response();
+            }
+        }
+    } else {
+        let Some(provider) = crate::oauth::idp_providers::find_provider(&body.provider) else {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "unknown_provider",
+                Some(&format!(
+                    "Unknown provider '{}'. Use GET /api/idp-providers to list templates.",
+                    body.provider
+                )),
+            )
+            .into_response();
+        };
+        match provider.build_issuer(body.slug.as_deref()) {
+            Ok(issuer) => issuer,
+            Err(e) => {
+                return error_response(StatusCode::BAD_REQUEST, "invalid_slug", Some(&e))
+                    .into_response();
+            }
+        }
+    };
+
+    // Validate the issuer via discovery BEFORE persisting (DoD: bad issuer
+    // rejected pre-save; custom paste validated via discovery).
+    let disc = match validate_org_issuer(&issuer, allow_insecure).await {
+        Ok(d) => d,
+        Err(resp) => return resp,
+    };
+
+    // Resolve the org's OAuth client_id via the shared fallback chain BEFORE
+    // persisting (explicit org client_id → CIMD → DCR → 422). The resolved id is
+    // used verbatim for the authorize URL and every later EMA token leg.
+    let redirect_uri = format!("http://127.0.0.1:{}/oauth/callback", state.relay_port);
+    let (resolved_client_id, registration) = match resolve_org_client(
+        body.client_id.as_deref(),
+        &disc,
+        &redirect_uri,
+        &name,
+        allow_insecure,
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+    // CIMD resolves to the hosted CIMD URL (the runtime default), so persist
+    // `None` to keep the org config round-tripping unchanged and the legs on
+    // their byte-for-byte CIMD behavior. An explicit or DCR-registered id is
+    // persisted so every leg reuses the same client_id.
+    let persisted_client_id = match registration {
+        ClientRegistration::Cimd => None,
+        _ => Some(resolved_client_id.clone()),
+    };
+
+    // Persist the org to config.toml, then mirror into the in-memory config.
+    let new_org = crate::config::ConfigOrganization {
+        name: name.clone(),
+        provider: body.provider.clone(),
+        idp: issuer.clone(),
+        client_id: persisted_client_id,
+    };
+    let mut orgs = { state.config.read().await.organizations.clone() };
+    orgs.push(new_org.clone());
+    let resolved = crate::config::expand_tilde(config_path);
+    if let Err((status, msg, detail)) = write_organizations_to_disk(&resolved, &orgs) {
+        return error_response(status, msg, Some(&detail)).into_response();
+    }
+    state.config.write().await.organizations = orgs;
+
+    let authorize_url = compose_org_sso_url(
+        flow_mgr,
+        state.relay_port,
+        &name,
+        &issuer,
+        &disc,
+        &resolved_client_id,
+    )
+    .await;
+
+    info!(organization = %name, provider = %body.provider, "Organization created; SSO authorize URL composed");
+
+    (
+        StatusCode::CREATED,
+        Json(OrganizationSsoResponse {
+            name,
+            provider: body.provider,
+            idp: issuer,
+            authorize_url,
+        }),
+    )
+        .into_response()
+}
+
+/// GET /api/organizations
+///
+/// Lists configured organizations with their authentication status, read from
+/// the credential pool (`TokenManager::load_idp`, keyed by org name).
+async fn list_organizations(State(state): State<ManagementState>) -> impl IntoResponse {
+    let orgs = { state.config.read().await.organizations.clone() };
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    let mut out = Vec::with_capacity(orgs.len());
+    for org in orgs {
+        let authenticated = if let Some(ref tm) = state.token_manager {
+            match tm.load_idp(&org.name).await {
+                Ok(Some(creds)) => {
+                    let id_valid = creds.id_token_expires_at.map(|e| e > now).unwrap_or(true);
+                    id_valid || creds.refresh_token.is_some()
+                }
+                _ => false,
+            }
+        } else {
+            false
+        };
+        out.push(OrganizationResponse {
+            name: org.name,
+            provider: org.provider,
+            idp: org.idp,
+            authenticated,
+        });
+    }
+    Json(out).into_response()
+}
+
+/// DELETE /api/organizations/{org}
+///
+/// Removes the organization from `config.toml` and purges its credential-pool
+/// entry (`TokenManager::delete_idp`, keyed by org name).
+async fn delete_organization(
+    State(state): State<ManagementState>,
+    Path(org): Path<String>,
+) -> impl IntoResponse {
+    let Some(ref config_path) = state.config_path else {
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "config_path not configured",
+            None,
+        )
+        .into_response();
+    };
+
+    let mut orgs = { state.config.read().await.organizations.clone() };
+    let before = orgs.len();
+    orgs.retain(|o| o.name != org);
+    if orgs.len() == before {
+        return error_response(
+            StatusCode::NOT_FOUND,
+            "organization not found",
+            Some(&format!("No organization named '{org}'.")),
+        )
+        .into_response();
+    }
+
+    let resolved = crate::config::expand_tilde(config_path);
+    if let Err((status, msg, detail)) = write_organizations_to_disk(&resolved, &orgs) {
+        return error_response(status, msg, Some(&detail)).into_response();
+    }
+    state.config.write().await.organizations = orgs;
+
+    // Purge the pooled IdP credentials (no-op if none were captured).
+    if let Some(ref tm) = state.token_manager {
+        if let Err(e) = tm.delete_idp(&org).await {
+            warn!(organization = %org, error = %e, "Failed to purge IdP credentials on org delete");
+        }
+    }
+
+    info!(organization = %org, "Organization deleted and credentials purged");
+    Json(serde_json::json!({ "ok": true, "name": org })).into_response()
+}
+
+/// POST /api/organizations/{org}/reauthenticate
+///
+/// Re-discovers the org's IdP issuer (endpoints are not stored in config) and
+/// returns a fresh SSO authorize URL for re-running the IdP sign-in.
+async fn reauthenticate_organization(
+    State(state): State<ManagementState>,
+    Path(org): Path<String>,
+) -> impl IntoResponse {
+    let Some(ref flow_mgr) = state.oauth_flow_manager else {
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "OAuth not configured",
+            None,
+        )
+        .into_response();
+    };
+
+    let (issuer, provider, org_client_id, allow_insecure) = {
+        let config = state.config.read().await;
+        let Some(found) = config.organizations.iter().find(|o| o.name == org) else {
+            return error_response(
+                StatusCode::NOT_FOUND,
+                "organization not found",
+                Some(&format!("No organization named '{org}'.")),
+            )
+            .into_response();
+        };
+        (
+            found.idp.clone(),
+            found.provider.clone(),
+            found.client_id.clone(),
+            config.relay.allow_insecure_oauth.unwrap_or(false),
+        )
+    };
+
+    let disc = match validate_org_issuer(&issuer, allow_insecure).await {
+        Ok(d) => d,
+        Err(resp) => return resp,
+    };
+
+    // Resolve the client_id via the same chain so re-auth uses the org's
+    // pre-registered/CIMD/DCR client consistently with creation.
+    let redirect_uri = format!("http://127.0.0.1:{}/oauth/callback", state.relay_port);
+    let (resolved_client_id, _registration) = match resolve_org_client(
+        org_client_id.as_deref(),
+        &disc,
+        &redirect_uri,
+        &org,
+        allow_insecure,
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+
+    let authorize_url = compose_org_sso_url(
+        flow_mgr,
+        state.relay_port,
+        &org,
+        &issuer,
+        &disc,
+        &resolved_client_id,
+    )
+    .await;
+
+    info!(organization = %org, "Organization re-authentication SSO authorize URL composed");
+
+    Json(OrganizationSsoResponse {
+        name: org,
+        provider,
+        idp: issuer,
+        authorize_url,
+    })
+    .into_response()
 }
 
 /// GET /api/endpoints/:name/tools
@@ -4697,6 +5624,7 @@ mod tests {
                 auth: None,
             }],
             profiles: None,
+            organizations: Vec::new(),
         }
     }
 
@@ -4830,6 +5758,97 @@ mod tests {
         assert_eq!(arr[1]["health"], "offline");
         assert_eq!(arr[1]["error"], "down");
         assert_eq!(arr[1]["tool_count"], 0);
+    }
+
+    #[tokio::test]
+    async fn management_endpoints_list_surfaces_ema_auth_binding() {
+        let state = test_state(vec![
+            ("github-acme", MockAdapter::healthy_with_tools(vec![])),
+            ("plain", MockAdapter::healthy_with_tools(vec![])),
+        ])
+        .await;
+        // Replace the seeded config so the listing has a matching EMA endpoint
+        // and an ordinary one to compare against.
+        {
+            let mut cfg = state.config.write().await;
+            cfg.endpoints = vec![
+                EndpointConfig {
+                    name: "github-acme".to_string(),
+                    description: None,
+                    tool_prefix: None,
+                    transport: Transport::Http,
+                    command: None,
+                    args: None,
+                    url: Some("https://api.githubcopilot.com/mcp/".to_string()),
+                    env: None,
+                    headers: None,
+                    disabled: false,
+                    disabled_tools: Vec::new(),
+                    oauth_server_url: None,
+                    client_id: None,
+                    client_secret: None,
+                    scopes: None,
+                    token_endpoint: None,
+                    server_type_override: None,
+                    isolation: None,
+                    container_image: None,
+                    mounts: None,
+                    auth: Some(crate::config::EndpointAuthConfig {
+                        auth_type: "ema".to_string(),
+                        organization: Some("Acme Corp".to_string()),
+                        idp: None,
+                        resource: Some("https://api.githubcopilot.com/mcp/".to_string()),
+                    }),
+                },
+                EndpointConfig {
+                    name: "plain".to_string(),
+                    description: None,
+                    tool_prefix: None,
+                    transport: Transport::Stdio,
+                    command: Some("echo".to_string()),
+                    args: None,
+                    url: None,
+                    env: None,
+                    headers: None,
+                    disabled: false,
+                    disabled_tools: Vec::new(),
+                    oauth_server_url: None,
+                    client_id: None,
+                    client_secret: None,
+                    scopes: None,
+                    token_endpoint: None,
+                    server_type_override: None,
+                    isolation: None,
+                    container_image: None,
+                    mounts: None,
+                    auth: None,
+                },
+            ];
+        }
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(Request::get("/api/endpoints").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let arr = body.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        // Sorted by name: github-acme, plain.
+        assert_eq!(arr[0]["name"], "github-acme");
+        assert_eq!(arr[0]["auth"]["type"], "ema");
+        assert_eq!(arr[0]["auth"]["organization"], "Acme Corp");
+        assert_eq!(
+            arr[0]["auth"]["resource"],
+            "https://api.githubcopilot.com/mcp/"
+        );
+        // Ordinary endpoint serializes with no `auth` key at all.
+        assert_eq!(arr[1]["name"], "plain");
+        assert!(
+            arr[1].get("auth").is_none(),
+            "non-EMA endpoint must not carry an auth summary, got {:?}",
+            arr[1]
+        );
     }
 
     #[tokio::test]
@@ -7032,6 +8051,7 @@ command = "echo"
                 auth: None,
             }],
             profiles: None,
+            organizations: Vec::new(),
         };
         let state = ManagementState {
             registry: Arc::new(AdapterRegistry::new()),
@@ -7253,6 +8273,7 @@ command = "echo"
                 auth: None,
             }],
             profiles: None,
+            organizations: Vec::new(),
         };
         let state = ManagementState {
             registry: Arc::new(AdapterRegistry::new()),
@@ -7771,6 +8792,7 @@ command = "echo"
                 auth: None,
             }],
             profiles: None,
+            organizations: Vec::new(),
         }
     }
 
@@ -7873,6 +8895,7 @@ client_id = "client123"
             },
             endpoints: vec![],
             profiles: None,
+            organizations: Vec::new(),
         };
         let state = ManagementState {
             registry: Arc::new(AdapterRegistry::new()),
@@ -7962,6 +8985,7 @@ client_id = "client123"
                 })
                 .collect(),
             profiles: None,
+            organizations: Vec::new(),
         }
     }
 
@@ -8520,6 +9544,7 @@ client_id = "client123"
                 auth: None,
             }],
             profiles: None,
+            organizations: Vec::new(),
         };
         let toml_str = toml::to_string_pretty(&cfg).unwrap();
         std::fs::write(config_file, toml_str).unwrap();
@@ -8703,6 +9728,213 @@ client_id = "client123"
         assert_eq!(
             before, after,
             "rejected creates must not write to config.toml"
+        );
+    }
+
+    #[tokio::test]
+    async fn endpoint_create_with_ema_auth_persists_and_round_trips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_file = tmp.path().join("config.toml");
+        let state = endpoints_test_state(&config_file).await;
+        let app = management_routes(state.clone());
+
+        let body = serde_json::json!({
+            "name": "github-acme",
+            "transport": "http",
+            "url": "https://api.githubcopilot.com/mcp/",
+            "auth": {
+                "type": "ema",
+                "organization": "Acme Corp",
+                "resource": "https://api.githubcopilot.com/mcp/",
+            },
+        });
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/api/endpoints")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        // The `[endpoints.auth]` sub-table is written to config.toml.
+        let on_disk = std::fs::read_to_string(&config_file).unwrap();
+        assert!(
+            on_disk.contains("[endpoints.auth]") || on_disk.contains("[[endpoints]]"),
+            "config.toml should contain the new endpoint: {}",
+            on_disk
+        );
+
+        // Re-parse from disk: the auth binding survives so the watcher /
+        // adapter rebuild path sees it as an EMA endpoint.
+        let reparsed = crate::config::load_config(&config_file).unwrap();
+        let ep = reparsed
+            .endpoints
+            .iter()
+            .find(|e| e.name == "github-acme")
+            .expect("created EMA endpoint should be present on disk");
+        let auth = ep.auth.as_ref().expect("auth binding must round-trip");
+        assert_eq!(auth.auth_type, "ema");
+        assert_eq!(auth.organization.as_deref(), Some("Acme Corp"));
+        assert_eq!(
+            auth.resource.as_deref(),
+            Some("https://api.githubcopilot.com/mcp/")
+        );
+
+        // In-memory config (post-rebuild) also reflects the auth binding.
+        let cfg = state.config.read().await;
+        let mem_ep = cfg
+            .endpoints
+            .iter()
+            .find(|e| e.name == "github-acme")
+            .unwrap();
+        assert_eq!(
+            mem_ep.auth.as_ref().map(|a| a.auth_type.as_str()),
+            Some("ema")
+        );
+    }
+
+    #[tokio::test]
+    async fn endpoint_create_rejects_invalid_ema_auth() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_file = tmp.path().join("config.toml");
+        let state = endpoints_test_state(&config_file).await;
+        let before = std::fs::read_to_string(&config_file).unwrap();
+        let app = management_routes(state);
+
+        let cases: Vec<(&str, serde_json::Value)> = vec![
+            (
+                "ema missing resource",
+                serde_json::json!({
+                    "name": "bad-ema-1",
+                    "transport": "http",
+                    "url": "https://api.githubcopilot.com/mcp/",
+                    "auth": { "type": "ema", "organization": "Acme Corp" },
+                }),
+            ),
+            (
+                "ema missing organization and idp",
+                serde_json::json!({
+                    "name": "bad-ema-2",
+                    "transport": "http",
+                    "url": "https://api.githubcopilot.com/mcp/",
+                    "auth": { "type": "ema", "resource": "https://api.githubcopilot.com/mcp/" },
+                }),
+            ),
+            (
+                "unknown auth type",
+                serde_json::json!({
+                    "name": "bad-ema-3",
+                    "transport": "http",
+                    "url": "https://api.githubcopilot.com/mcp/",
+                    "auth": { "type": "saml", "resource": "https://api.githubcopilot.com/mcp/" },
+                }),
+            ),
+        ];
+
+        for (label, body) in cases {
+            let resp = app
+                .clone()
+                .oneshot(
+                    Request::post("/api/endpoints")
+                        .header("content-type", "application/json")
+                        .body(Body::from(body.to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert!(
+                resp.status().is_client_error(),
+                "case '{}' should reject with a 4xx, got {}",
+                label,
+                resp.status()
+            );
+        }
+        let after = std::fs::read_to_string(&config_file).unwrap();
+        assert_eq!(
+            before, after,
+            "rejected EMA creates must not write to config.toml"
+        );
+    }
+
+    #[tokio::test]
+    async fn endpoint_create_without_auth_omits_auth_table() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_file = tmp.path().join("config.toml");
+        let state = endpoints_test_state(&config_file).await;
+        let app = management_routes(state);
+
+        let body = serde_json::json!({
+            "name": "plainstdio",
+            "transport": "stdio",
+            "command": "echo",
+        });
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        let reparsed = crate::config::load_config(&config_file).unwrap();
+        let ep = reparsed
+            .endpoints
+            .iter()
+            .find(|e| e.name == "plainstdio")
+            .unwrap();
+        assert!(
+            ep.auth.is_none(),
+            "no-auth create must not persist an auth binding"
+        );
+    }
+
+    #[tokio::test]
+    async fn endpoint_update_round_trips_ema_auth() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_file = tmp.path().join("config.toml");
+        let state = endpoints_test_state(&config_file).await;
+        let app = management_routes(state);
+
+        let body = serde_json::json!({
+            "name": "existing",
+            "transport": "http",
+            "url": "https://api.githubcopilot.com/mcp/",
+            "auth": {
+                "type": "ema",
+                "idp": "https://acme.okta.com",
+                "resource": "https://api.githubcopilot.com/mcp/",
+            },
+        });
+        let resp = app
+            .oneshot(
+                Request::put("/api/endpoints/existing")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let reparsed = crate::config::load_config(&config_file).unwrap();
+        let ep = reparsed
+            .endpoints
+            .iter()
+            .find(|e| e.name == "existing")
+            .unwrap();
+        let auth = ep.auth.as_ref().expect("updated auth must round-trip");
+        assert_eq!(auth.auth_type, "ema");
+        assert_eq!(auth.idp.as_deref(), Some("https://acme.okta.com"));
+        assert_eq!(
+            auth.resource.as_deref(),
+            Some("https://api.githubcopilot.com/mcp/")
         );
     }
 
@@ -8939,6 +10171,552 @@ client_id = "client123"
             text.contains("\"request_id\":\"rid-1\""),
             "expected request_id in SSE body, got: {}",
             text
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // END-19 Wave 3: provider templates + organization lifecycle
+    // -----------------------------------------------------------------------
+
+    /// Build a ManagementState wired for organization CRUD: a real config.toml
+    /// on disk, a token manager (credential pool), and an OAuth flow manager.
+    async fn test_state_orgs(tmp: &std::path::Path, allow_insecure: bool) -> ManagementState {
+        let config_path = tmp.join("config.toml");
+        std::fs::write(&config_path, "[relay]\nmachine_name = \"test-machine\"\n").unwrap();
+        let token_manager = Arc::new(TokenManager::new(tmp.to_path_buf()));
+        let flow_mgr = Arc::new(OAuthFlowManager::new());
+        let mut cfg = test_config();
+        cfg.relay.allow_insecure_oauth = Some(allow_insecure);
+        cfg.organizations = Vec::new();
+        ManagementState {
+            registry: Arc::new(AdapterRegistry::new()),
+            config: Arc::new(RwLock::new(cfg)),
+            start_time: Instant::now(),
+            config_path: Some(config_path),
+            oauth_flow_manager: Some(flow_mgr),
+            relay_port: 9400,
+            oauth_adapter_inners: None,
+            token_manager: Some(token_manager),
+            setup_manager: None,
+            profile_registry: None,
+            event_bus: None,
+        }
+    }
+
+    /// Mock AS serving RFC 8414 metadata whose issuer matches its own origin.
+    /// Advertises CIMD so an org created without an explicit `client_id` resolves
+    /// to the hosted CIMD `client_id` (the zero-config public-client default).
+    fn org_well_known_router() -> Router {
+        async fn well_known(headers: axum::http::HeaderMap) -> Json<Value> {
+            let issuer = mock_issuer(&headers);
+            Json(serde_json::json!({
+                "issuer": issuer,
+                "authorization_endpoint": format!("{issuer}/authorize"),
+                "token_endpoint": format!("{issuer}/token"),
+                "code_challenge_methods_supported": ["S256"],
+                "client_id_metadata_document_supported": true,
+            }))
+        }
+        Router::new().route("/.well-known/oauth-authorization-server", get(well_known))
+    }
+
+    /// Mock AS advertising a `registration_endpoint` (DCR) but NOT CIMD, plus a
+    /// `/register` handler returning a fixed dynamically-registered `client_id`.
+    fn org_well_known_router_with_dcr() -> Router {
+        async fn well_known(headers: axum::http::HeaderMap) -> Json<Value> {
+            let issuer = mock_issuer(&headers);
+            Json(serde_json::json!({
+                "issuer": issuer,
+                "authorization_endpoint": format!("{issuer}/authorize"),
+                "token_endpoint": format!("{issuer}/token"),
+                "registration_endpoint": format!("{issuer}/register"),
+                "code_challenge_methods_supported": ["S256"],
+            }))
+        }
+        async fn register() -> Json<Value> {
+            Json(serde_json::json!({ "client_id": "dcr-registered-client" }))
+        }
+        Router::new()
+            .route("/.well-known/oauth-authorization-server", get(well_known))
+            .route("/register", axum::routing::post(register))
+    }
+
+    /// Mock AS advertising NEITHER CIMD nor DCR: an org created here without an
+    /// explicit `client_id` cannot resolve one and must return `422`.
+    fn org_well_known_router_no_client() -> Router {
+        async fn well_known(headers: axum::http::HeaderMap) -> Json<Value> {
+            let issuer = mock_issuer(&headers);
+            Json(serde_json::json!({
+                "issuer": issuer,
+                "authorization_endpoint": format!("{issuer}/authorize"),
+                "token_endpoint": format!("{issuer}/token"),
+                "code_challenge_methods_supported": ["S256"],
+            }))
+        }
+        Router::new().route("/.well-known/oauth-authorization-server", get(well_known))
+    }
+
+    #[tokio::test]
+    async fn idp_providers_endpoint_returns_table() {
+        let state = test_state(vec![]).await;
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::get("/api/idp-providers")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let arr = body.as_array().expect("providers array");
+        let ids: Vec<&str> = arr.iter().filter_map(|p| p["id"].as_str()).collect();
+        for expected in ["okta", "entra", "google", "ping", "custom"] {
+            assert!(
+                ids.contains(&expected),
+                "missing provider '{expected}' in {ids:?}"
+            );
+        }
+        // Templated providers carry an issuer_pattern; custom does not.
+        let okta = arr.iter().find(|p| p["id"] == "okta").unwrap();
+        assert_eq!(okta["issuer_pattern"], "https://{slug}.okta.com");
+        let custom = arr.iter().find(|p| p["id"] == "custom").unwrap();
+        assert!(custom.get("issuer_pattern").is_none());
+    }
+
+    #[tokio::test]
+    async fn create_organization_custom_validates_and_returns_sso_url() {
+        let (base_url, _server) = spawn_mock_as(org_well_known_router()).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_orgs(tmp.path(), true).await;
+        let config = state.config.clone();
+        let config_path = state.config_path.clone().unwrap();
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::post("/api/organizations")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "name": "Acme Corp",
+                            "provider": "custom",
+                            "idp": base_url,
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let body = body_json(resp).await;
+        assert_eq!(body["name"], "Acme Corp");
+        assert_eq!(body["idp"], base_url);
+        let authorize_url = body["authorize_url"].as_str().unwrap();
+        assert!(
+            authorize_url.starts_with(&format!("{base_url}/authorize?")),
+            "expected discovered authorize endpoint, got: {authorize_url}"
+        );
+        assert!(authorize_url.contains("response_type=code"));
+        assert!(authorize_url.contains("scope=openid"));
+
+        // Persisted both in memory and on disk.
+        assert_eq!(config.read().await.organizations.len(), 1);
+        let disk = std::fs::read_to_string(&config_path).unwrap();
+        assert!(disk.contains("[[organizations]]"));
+        assert!(disk.contains("Acme Corp"));
+        // Tokens are never written to config.toml.
+        assert!(!disk.contains("id_token"));
+    }
+
+    #[tokio::test]
+    async fn create_organization_rejects_bad_issuer_pre_save() {
+        async fn not_found() -> StatusCode {
+            StatusCode::NOT_FOUND
+        }
+        let router = Router::new().route("/.well-known/oauth-authorization-server", get(not_found));
+        let (base_url, _server) = spawn_mock_as(router).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_orgs(tmp.path(), true).await;
+        let config = state.config.clone();
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::post("/api/organizations")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "name": "Bad Org",
+                            "provider": "custom",
+                            "idp": base_url,
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = body_json(resp).await;
+        assert_eq!(body["error"], "invalid_issuer");
+        // Bad issuer must NOT be persisted.
+        assert!(config.read().await.organizations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn create_organization_blocks_loopback_without_allow_insecure() {
+        // allow_insecure=false → the discovery SSRF guard rejects the loopback
+        // mock host before any metadata is fetched, so the org is not saved.
+        let (base_url, _server) = spawn_mock_as(org_well_known_router()).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_orgs(tmp.path(), false).await;
+        let config = state.config.clone();
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::post("/api/organizations")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "name": "SSRF Org",
+                            "provider": "custom",
+                            "idp": base_url,
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = body_json(resp).await;
+        assert_eq!(body["error"], "invalid_issuer");
+        assert!(config.read().await.organizations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn create_organization_rejects_unknown_provider_and_missing_idp() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_orgs(tmp.path(), true).await;
+        let app = management_routes(state);
+
+        // Unknown provider id.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/api/organizations")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "name": "X", "provider": "nope" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(body_json(resp).await["error"], "unknown_provider");
+
+        // Custom without an idp URL.
+        let resp = app
+            .oneshot(
+                Request::post("/api/organizations")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "name": "Y", "provider": "custom" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(body_json(resp).await["error"], "missing_idp");
+    }
+
+    #[tokio::test]
+    async fn organization_lifecycle_get_delete_purges_credential_pool() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_orgs(tmp.path(), true).await;
+        let tm = state.token_manager.clone().unwrap();
+        let config = state.config.clone();
+
+        // Seed an org + a credential-pool entry keyed by the org name.
+        config.write().await.organizations = vec![crate::config::ConfigOrganization {
+            name: "Acme Corp".to_string(),
+            provider: "okta".to_string(),
+            idp: "https://acme.okta.com".to_string(),
+            client_id: None,
+        }];
+        tm.save_idp(
+            "Acme Corp",
+            &crate::token_manager::IdpCredentials {
+                idp_issuer: "https://acme.okta.com".to_string(),
+                id_token: "id-tok".to_string(),
+                refresh_token: Some("refresh-tok".to_string()),
+                id_token_expires_at: None,
+                obtained_at: 0,
+            },
+        )
+        .await
+        .unwrap();
+
+        let app = management_routes(state);
+
+        // GET reports the org as authenticated (creds present).
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::get("/api/organizations")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let arr = body.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["name"], "Acme Corp");
+        assert_eq!(arr[0]["authenticated"], true);
+
+        // DELETE removes the org and purges its credentials.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::delete("/api/organizations/Acme%20Corp")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(config.read().await.organizations.is_empty());
+        assert!(tm.load_idp("Acme Corp").await.unwrap().is_none());
+
+        // GET now returns an empty list.
+        let resp = app
+            .oneshot(
+                Request::get("/api/organizations")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = body_json(resp).await;
+        assert!(body.as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn delete_organization_missing_returns_404() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_orgs(tmp.path(), true).await;
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::delete("/api/organizations/ghost")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn reauthenticate_organization_returns_fresh_sso_url() {
+        let (base_url, _server) = spawn_mock_as(org_well_known_router()).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_orgs(tmp.path(), true).await;
+        state.config.write().await.organizations = vec![crate::config::ConfigOrganization {
+            name: "Acme Corp".to_string(),
+            provider: "custom".to_string(),
+            idp: base_url.clone(),
+            client_id: None,
+        }];
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::post("/api/organizations/Acme%20Corp/reauthenticate")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["name"], "Acme Corp");
+        let authorize_url = body["authorize_url"].as_str().unwrap();
+        assert!(authorize_url.starts_with(&format!("{base_url}/authorize?")));
+        assert!(authorize_url.contains("scope=openid"));
+    }
+
+    /// Resolution chain — explicit: an org created with an explicit `client_id`
+    /// uses it verbatim in the authorize URL (over the CIMD the AS advertises)
+    /// and persists it on the org both in memory and on disk.
+    #[tokio::test]
+    async fn create_organization_explicit_client_id_wins_and_is_persisted() {
+        let (base_url, _server) = spawn_mock_as(org_well_known_router()).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_orgs(tmp.path(), true).await;
+        let config = state.config.clone();
+        let config_path = state.config_path.clone().unwrap();
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::post("/api/organizations")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "name": "Acme Corp",
+                            "provider": "custom",
+                            "idp": base_url,
+                            "client_id": "explicit-okta-client",
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let body = body_json(resp).await;
+        let authorize_url = body["authorize_url"].as_str().unwrap();
+        assert!(
+            authorize_url.contains("client_id=explicit-okta-client"),
+            "explicit client_id must win over CIMD, got: {authorize_url}"
+        );
+
+        let orgs = config.read().await.organizations.clone();
+        assert_eq!(orgs.len(), 1);
+        assert_eq!(orgs[0].client_id.as_deref(), Some("explicit-okta-client"));
+        let disk = std::fs::read_to_string(&config_path).unwrap();
+        assert!(disk.contains("explicit-okta-client"));
+    }
+
+    /// Resolution chain — CIMD: an org on a CIMD-advertising AS with no explicit
+    /// `client_id` uses the hosted CIMD `client_id` and persists `None` (so the
+    /// org config round-trips unchanged).
+    #[tokio::test]
+    async fn create_organization_cimd_used_when_no_explicit_client_id() {
+        let (base_url, _server) = spawn_mock_as(org_well_known_router()).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_orgs(tmp.path(), true).await;
+        let config = state.config.clone();
+        let config_path = state.config_path.clone().unwrap();
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::post("/api/organizations")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "name": "Acme Corp",
+                            "provider": "custom",
+                            "idp": base_url,
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let body = body_json(resp).await;
+        let authorize_url = body["authorize_url"].as_str().unwrap();
+        assert!(
+            authorize_url.contains(&format!(
+                "client_id={}",
+                urlencoding(crate::oauth::client::ENDARA_CLIENT_METADATA_URL)
+            )),
+            "CIMD client_id expected, got: {authorize_url}"
+        );
+
+        let orgs = config.read().await.organizations.clone();
+        assert_eq!(orgs.len(), 1);
+        assert!(orgs[0].client_id.is_none(), "CIMD must persist None");
+        let disk = std::fs::read_to_string(&config_path).unwrap();
+        assert!(!disk.contains("client_id"));
+    }
+
+    /// Resolution chain — DCR: an org on an AS that advertises DCR (no CIMD, no
+    /// explicit client_id) registers a client and uses/persists the registered
+    /// `client_id`.
+    #[tokio::test]
+    async fn create_organization_dcr_registers_and_persists_client_id() {
+        let (base_url, _server) = spawn_mock_as(org_well_known_router_with_dcr()).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_orgs(tmp.path(), true).await;
+        let config = state.config.clone();
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::post("/api/organizations")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "name": "Acme Corp",
+                            "provider": "custom",
+                            "idp": base_url,
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let body = body_json(resp).await;
+        let authorize_url = body["authorize_url"].as_str().unwrap();
+        assert!(
+            authorize_url.contains("client_id=dcr-registered-client"),
+            "DCR-registered client_id expected, got: {authorize_url}"
+        );
+
+        let orgs = config.read().await.organizations.clone();
+        assert_eq!(orgs.len(), 1);
+        assert_eq!(orgs[0].client_id.as_deref(), Some("dcr-registered-client"));
+    }
+
+    /// Resolution chain — 422: an org on an AS advertising neither CIMD nor DCR,
+    /// with no explicit `client_id`, returns `422 client_id_required` and is not
+    /// persisted.
+    #[tokio::test]
+    async fn create_organization_returns_422_when_no_client_id_resolvable() {
+        let (base_url, _server) = spawn_mock_as(org_well_known_router_no_client()).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_orgs(tmp.path(), true).await;
+        let config = state.config.clone();
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::post("/api/organizations")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "name": "Acme Corp",
+                            "provider": "custom",
+                            "idp": base_url,
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = body_json(resp).await;
+        assert_eq!(body["error"], "client_id_required");
+        assert!(
+            config.read().await.organizations.is_empty(),
+            "org must not be persisted when client_id is unresolvable"
         );
     }
 }

--- a/src/oauth/ema.rs
+++ b/src/oauth/ema.rs
@@ -106,23 +106,27 @@ fn build_id_jag_exchange_form(id_token: &str, resource_as_issuer: &str, resource
 
 /// Build the RFC 7523 jwt-bearer form body for the ID-JAG → access-token leg
 /// (M7). No client secret is sent: the relay is a public client identified by
-/// its CIMD `client_id`.
-fn build_jwt_bearer_form(id_jag: &str) -> String {
+/// `client_id` — the org's pre-registered id when present, else the hosted CIMD
+/// `client_id` ([`ENDARA_CLIENT_METADATA_URL`]) when `None`.
+fn build_jwt_bearer_form(id_jag: &str, client_id: Option<&str>) -> String {
+    let client_id = client_id.unwrap_or(ENDARA_CLIENT_METADATA_URL);
     url::form_urlencoded::Serializer::new(String::new())
         .append_pair("grant_type", GRANT_TYPE_JWT_BEARER)
         .append_pair("assertion", id_jag)
-        .append_pair("client_id", ENDARA_CLIENT_METADATA_URL)
+        .append_pair("client_id", client_id)
         .finish()
 }
 
 /// Build the OIDC `refresh_token` grant body used to mint a fresh ID Token at
-/// the IdP (M9). The relay is a public client identified by its CIMD
-/// `client_id`; no secret is sent.
-fn build_refresh_token_form(refresh_token: &str) -> String {
+/// the IdP (M9). The relay is a public client identified by `client_id` — the
+/// org's pre-registered id when present, else the hosted CIMD `client_id`
+/// ([`ENDARA_CLIENT_METADATA_URL`]) when `None`; no secret is sent.
+fn build_refresh_token_form(refresh_token: &str, client_id: Option<&str>) -> String {
+    let client_id = client_id.unwrap_or(ENDARA_CLIENT_METADATA_URL);
     url::form_urlencoded::Serializer::new(String::new())
         .append_pair("grant_type", GRANT_TYPE_REFRESH_TOKEN)
         .append_pair("refresh_token", refresh_token)
-        .append_pair("client_id", ENDARA_CLIENT_METADATA_URL)
+        .append_pair("client_id", client_id)
         .append_pair("scope", REFRESH_SCOPE)
         .finish()
 }
@@ -218,9 +222,10 @@ pub async fn redeem_id_jag(
     as_token_endpoint: &str,
     id_jag: &str,
     allow_insecure: bool,
+    client_id: Option<&str>,
 ) -> Result<TokenSet, EmaError> {
     let client = url_guard::validated_client(as_token_endpoint, allow_insecure).await?;
-    let form_body = build_jwt_bearer_form(id_jag);
+    let form_body = build_jwt_bearer_form(id_jag, client_id);
 
     let resp = client
         .post(as_token_endpoint)
@@ -382,9 +387,10 @@ async fn refresh_idp_token(
     idp_token_endpoint: &str,
     refresh_token: &str,
     allow_insecure: bool,
+    client_id: Option<&str>,
 ) -> Result<RefreshedIdToken, EmaError> {
     let client = url_guard::validated_client(idp_token_endpoint, allow_insecure).await?;
-    let form_body = build_refresh_token_form(refresh_token);
+    let form_body = build_refresh_token_form(refresh_token, client_id);
 
     let resp = client
         .post(idp_token_endpoint)
@@ -457,6 +463,7 @@ async fn refresh_and_persist_idp_token(
     idp_key: &str,
     creds: &IdpCredentials,
     allow_insecure: bool,
+    client_id: Option<&str>,
 ) -> Result<String, EmaError> {
     let refresh_token = creds
         .refresh_token
@@ -465,7 +472,7 @@ async fn refresh_and_persist_idp_token(
             reason: "ID Token expired and no IdP refresh token is stored".to_string(),
         })?;
 
-    let refreshed = refresh_idp_token(idp_token_endpoint, refresh_token, allow_insecure)
+    let refreshed = refresh_idp_token(idp_token_endpoint, refresh_token, allow_insecure, client_id)
         .await
         .map_err(|e| EmaError::ReauthRequired {
             reason: format!("IdP refresh-token grant failed: {e}"),
@@ -517,6 +524,7 @@ pub async fn ensure_access_token(
     as_token_endpoint: &str,
     resource: &str,
     allow_insecure: bool,
+    client_id: Option<&str>,
 ) -> Result<TokenSet, EmaError> {
     // Fast path: a still-valid persisted token needs neither lock nor network.
     if let Some(ts) = load_token(token_manager, endpoint).await? {
@@ -554,6 +562,7 @@ pub async fn ensure_access_token(
             idp_key,
             &creds,
             allow_insecure,
+            client_id,
         )
         .await?;
         refreshed = true;
@@ -578,6 +587,7 @@ pub async fn ensure_access_token(
                 idp_key,
                 &creds,
                 allow_insecure,
+                client_id,
             )
             .await?;
             exchange_for_id_jag(
@@ -594,7 +604,7 @@ pub async fn ensure_access_token(
 
     // M6 claim validation, then Step 3 (RFC 7523) → access token.
     validate_id_jag(&id_jag, &idp_issuer, as_issuer, resource)?;
-    let token_set = redeem_id_jag(as_token_endpoint, &id_jag, allow_insecure).await?;
+    let token_set = redeem_id_jag(as_token_endpoint, &id_jag, allow_insecure, client_id).await?;
     token_manager
         .save(endpoint, &token_set)
         .await
@@ -667,7 +677,7 @@ mod tests {
 
     #[test]
     fn jwt_bearer_form_has_exact_rfc7523_params_and_no_secret() {
-        let body = build_jwt_bearer_form("the-id-jag");
+        let body = build_jwt_bearer_form("the-id-jag", None);
         let f = parse_form(&body);
         assert_eq!(
             f.get("grant_type").map(String::as_str),
@@ -683,6 +693,59 @@ mod tests {
             "public client must not send a secret"
         );
         assert_eq!(f.len(), 3, "exactly three params, no extras");
+    }
+
+    /// An explicit org `client_id` is sent verbatim on the Step 3 jwt-bearer
+    /// form; `None` keeps the hosted CIMD `client_id`.
+    #[test]
+    fn jwt_bearer_form_client_id_some_vs_none() {
+        let with_explicit = build_jwt_bearer_form("the-id-jag", Some("org-okta-client"));
+        let f = parse_form(&with_explicit);
+        assert_eq!(
+            f.get("client_id").map(String::as_str),
+            Some("org-okta-client")
+        );
+        assert!(!f.contains_key("client_secret"));
+        assert_eq!(f.len(), 3, "exactly three params, no extras");
+
+        let with_none = build_jwt_bearer_form("the-id-jag", None);
+        let f = parse_form(&with_none);
+        assert_eq!(
+            f.get("client_id").map(String::as_str),
+            Some(ENDARA_CLIENT_METADATA_URL)
+        );
+    }
+
+    /// An explicit org `client_id` is sent verbatim on the IdP refresh form;
+    /// `None` keeps the hosted CIMD `client_id`. `scope` and absence of a secret
+    /// are preserved in both cases.
+    #[test]
+    fn refresh_token_form_client_id_some_vs_none() {
+        let with_explicit = build_refresh_token_form("the-refresh", Some("org-okta-client"));
+        let f = parse_form(&with_explicit);
+        assert_eq!(
+            f.get("grant_type").map(String::as_str),
+            Some("refresh_token")
+        );
+        assert_eq!(
+            f.get("refresh_token").map(String::as_str),
+            Some("the-refresh")
+        );
+        assert_eq!(
+            f.get("client_id").map(String::as_str),
+            Some("org-okta-client")
+        );
+        assert_eq!(f.get("scope").map(String::as_str), Some(REFRESH_SCOPE));
+        assert!(!f.contains_key("client_secret"));
+        assert_eq!(f.len(), 4, "exactly four params, no extras");
+
+        let with_none = build_refresh_token_form("the-refresh", None);
+        let f = parse_form(&with_none);
+        assert_eq!(
+            f.get("client_id").map(String::as_str),
+            Some(ENDARA_CLIENT_METADATA_URL)
+        );
+        assert_eq!(f.get("scope").map(String::as_str), Some(REFRESH_SCOPE));
     }
 
     // ---- M6: ID-JAG validation -----------------------------------------------
@@ -1002,6 +1065,7 @@ mod tests {
             "http://127.0.0.1:1/as/token",
             RESOURCE,
             true,
+            None,
         )
         .await
         .expect("valid cached token must be returned");
@@ -1026,7 +1090,7 @@ mod tests {
         let lock = Mutex::new(());
 
         let ts = ensure_access_token(
-            &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, true,
+            &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, true, None,
         )
         .await
         .expect("chain must succeed");
@@ -1065,7 +1129,7 @@ mod tests {
         let lock = Mutex::new(());
 
         let ts = ensure_access_token(
-            &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, true,
+            &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, true, None,
         )
         .await
         .expect("refresh then chain must succeed");
@@ -1110,7 +1174,7 @@ mod tests {
         let lock = Mutex::new(());
 
         let ts = ensure_access_token(
-            &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, true,
+            &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, true, None,
         )
         .await
         .expect("reactive refresh then retry must succeed");
@@ -1143,7 +1207,7 @@ mod tests {
         let lock = Mutex::new(());
 
         let err = ensure_access_token(
-            &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, true,
+            &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, true, None,
         )
         .await
         .unwrap_err();
@@ -1175,6 +1239,7 @@ mod tests {
             "http://127.0.0.1:1/as/token",
             RESOURCE,
             true,
+            None,
         )
         .await
         .unwrap_err();
@@ -1201,6 +1266,7 @@ mod tests {
             "http://127.0.0.1:1/as/token",
             RESOURCE,
             true,
+            None,
         )
         .await
         .unwrap_err();
@@ -1234,7 +1300,7 @@ mod tests {
             let as_ep = as_ep.clone();
             handles.push(tokio::spawn(async move {
                 ensure_access_token(
-                    &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, true,
+                    &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, true, None,
                 )
                 .await
             }));

--- a/src/oauth/idp_providers.rs
+++ b/src/oauth/idp_providers.rs
@@ -1,0 +1,164 @@
+//! Static identity-provider templates (END-19, Wave 3).
+//!
+//! One source of truth for the provider table the desktop "Add organization" UI
+//! renders and the `POST /api/organizations` handler resolves issuer URLs from.
+//! Each template maps a provider id to an issuer URL pattern carrying a single
+//! `{slug}` placeholder (or no placeholder for fixed-issuer providers like
+//! Google), plus a human-readable hint describing what the slug is.
+//!
+//! `custom` carries no pattern: callers paste a full issuer URL via the request
+//! `idp` field instead, and it is validated by discovery like any other issuer.
+
+/// A single identity-provider template surfaced by `GET /api/idp-providers`.
+#[derive(Debug, Clone, serde::Serialize, PartialEq)]
+pub struct IdpProvider {
+    /// Stable provider id: `okta`, `entra`, `google`, `ping`, or `custom`.
+    pub id: &'static str,
+    /// Human-readable provider name for display.
+    pub name: &'static str,
+    /// Issuer URL pattern. Carries a `{slug}` placeholder for tenant-scoped
+    /// providers, a fixed issuer with no placeholder for Google, or `None` for
+    /// `custom` (the caller pastes a full issuer URL instead).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issuer_pattern: Option<&'static str>,
+    /// Human-readable hint describing the slug the user must supply. `None` for
+    /// providers that take no slug (Google) or a free-form issuer (custom).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slug_hint: Option<&'static str>,
+}
+
+impl IdpProvider {
+    /// Resolve the issuer URL from this template and an optional `slug`.
+    ///
+    /// - Templated providers (`{slug}` placeholder) require a non-empty slug and
+    ///   substitute it after rejecting characters that could break out of the
+    ///   issuer host/path.
+    /// - Fixed-issuer providers (Google) ignore the slug and return the pattern.
+    /// - `custom` (no pattern) returns an error: the caller must supply a full
+    ///   issuer URL via the request `idp` field instead.
+    pub fn build_issuer(&self, slug: Option<&str>) -> Result<String, String> {
+        let Some(pattern) = self.issuer_pattern else {
+            return Err(format!(
+                "provider '{}' has no issuer template; supply a custom issuer URL",
+                self.id
+            ));
+        };
+        if !pattern.contains("{slug}") {
+            // Fixed issuer (e.g. Google): the slug, if any, is irrelevant.
+            return Ok(pattern.to_string());
+        }
+        let slug = slug
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| format!("provider '{}' requires a 'slug'", self.id))?;
+        // Reject slugs that could alter the issuer's host or path structure.
+        if slug.contains(['/', ':', '?', '#', '@', '\\', ' ']) || slug.contains("..") {
+            return Err(format!("invalid slug '{slug}' for provider '{}'", self.id));
+        }
+        Ok(pattern.replace("{slug}", slug))
+    }
+}
+
+/// The static provider table — the single source of truth shared by the
+/// `GET /api/idp-providers` response and `POST /api/organizations` resolution.
+pub const IDP_PROVIDERS: &[IdpProvider] = &[
+    IdpProvider {
+        id: "okta",
+        name: "Okta",
+        issuer_pattern: Some("https://{slug}.okta.com"),
+        slug_hint: Some("Your Okta org subdomain (e.g. \"acme\" for https://acme.okta.com)"),
+    },
+    IdpProvider {
+        id: "entra",
+        name: "Microsoft Entra ID",
+        issuer_pattern: Some("https://login.microsoftonline.com/{slug}/v2.0"),
+        slug_hint: Some("Your Entra tenant ID or domain (e.g. \"contoso.onmicrosoft.com\")"),
+    },
+    IdpProvider {
+        id: "google",
+        name: "Google",
+        issuer_pattern: Some("https://accounts.google.com"),
+        slug_hint: None,
+    },
+    IdpProvider {
+        id: "ping",
+        name: "PingOne",
+        issuer_pattern: Some("https://auth.pingone.com/{slug}/as"),
+        slug_hint: Some("Your PingOne environment ID"),
+    },
+    IdpProvider {
+        id: "custom",
+        name: "Custom",
+        issuer_pattern: None,
+        slug_hint: None,
+    },
+];
+
+/// Look up a provider template by its stable id.
+pub fn find_provider(id: &str) -> Option<&'static IdpProvider> {
+    IDP_PROVIDERS.iter().find(|p| p.id == id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn okta_builds_issuer_from_slug() {
+        let p = find_provider("okta").unwrap();
+        assert_eq!(
+            p.build_issuer(Some("acme")).unwrap(),
+            "https://acme.okta.com"
+        );
+    }
+
+    #[test]
+    fn entra_and_ping_substitute_slug() {
+        assert_eq!(
+            find_provider("entra")
+                .unwrap()
+                .build_issuer(Some("tenant-1"))
+                .unwrap(),
+            "https://login.microsoftonline.com/tenant-1/v2.0"
+        );
+        assert_eq!(
+            find_provider("ping")
+                .unwrap()
+                .build_issuer(Some("env-9"))
+                .unwrap(),
+            "https://auth.pingone.com/env-9/as"
+        );
+    }
+
+    #[test]
+    fn google_ignores_slug_and_needs_none() {
+        let p = find_provider("google").unwrap();
+        assert_eq!(p.build_issuer(None).unwrap(), "https://accounts.google.com");
+        assert_eq!(
+            p.build_issuer(Some("x")).unwrap(),
+            "https://accounts.google.com"
+        );
+    }
+
+    #[test]
+    fn templated_provider_requires_non_empty_slug() {
+        let p = find_provider("okta").unwrap();
+        assert!(p.build_issuer(None).is_err());
+        assert!(p.build_issuer(Some("   ")).is_err());
+    }
+
+    #[test]
+    fn rejects_slug_with_path_traversal_or_separators() {
+        let p = find_provider("okta").unwrap();
+        assert!(p.build_issuer(Some("a/b")).is_err());
+        assert!(p.build_issuer(Some("a:b")).is_err());
+        assert!(p.build_issuer(Some("..")).is_err());
+    }
+
+    #[test]
+    fn custom_has_no_template() {
+        let p = find_provider("custom").unwrap();
+        assert!(p.issuer_pattern.is_none());
+        assert!(p.build_issuer(Some("anything")).is_err());
+    }
+}

--- a/src/oauth/mod.rs
+++ b/src/oauth/mod.rs
@@ -1,6 +1,7 @@
 pub mod client;
 pub mod dcr;
 pub mod discovery;
+pub mod idp_providers;
 // EMA grant clients (END-18). Not yet wired into the binary's adapter/config in
 // this slice, so the binary crate (private `mod oauth;`) sees it as dead; the
 // lib crate exposes it as public API and the unit tests exercise it.
@@ -108,6 +109,13 @@ pub struct PendingFlow {
     /// keyed by this issuer. `None` for ordinary resource OAuth flows, which are
     /// left completely unaffected.
     pub idp_issuer: Option<String>,
+    /// Credential-pool key the captured `IdpCredentials` are persisted under
+    /// (Wave 2). For an END-19 org-referencing EMA endpoint this is the org
+    /// name, so every endpoint in the org shares one ID token; for a bare
+    /// END-18 `idp` endpoint it is the issuer URL (back-compat). `None` for
+    /// ordinary resource OAuth flows. When `None` on an EMA flow the callback
+    /// falls back to `idp_issuer` as the key.
+    pub idp_credential_key: Option<String>,
     pub created_at: Instant,
 }
 
@@ -151,6 +159,7 @@ impl OAuthFlowManager {
             issuer: issuer.map(|s| s.to_string()),
             iss_parameter_supported,
             idp_issuer: None,
+            idp_credential_key: None,
             created_at: Instant::now(),
         };
         self.pending.write().await.insert(state.clone(), flow);
@@ -163,6 +172,12 @@ impl OAuthFlowManager {
     /// the IdP refresh token and ID-Token expiry) and persists it as
     /// `IdpCredentials`. Callers request the `openid offline_access` scope (M1)
     /// when composing the authorize URL so the IdP returns a refresh token.
+    ///
+    /// `idp_credential_key` is the credential-pool key the callback persists the
+    /// captured `IdpCredentials` under (Wave 2): the org name for an END-19
+    /// org-referencing endpoint (so the whole org shares one ID token), or the
+    /// issuer URL for a bare END-18 `idp` endpoint. `idp_issuer` always remains
+    /// the real issuer URL stored inside the credentials.
     ///
     /// Consumed by the EMA OAuth adapter (END-18 T6) when it composes the IdP
     /// authorize URL for an endpoint that needs (re-)SSO.
@@ -178,6 +193,7 @@ impl OAuthFlowManager {
         issuer: Option<&str>,
         iss_parameter_supported: bool,
         idp_issuer: &str,
+        idp_credential_key: &str,
     ) -> String {
         let state = generate_state();
         let flow = PendingFlow {
@@ -190,6 +206,7 @@ impl OAuthFlowManager {
             issuer: issuer.map(|s| s.to_string()),
             iss_parameter_supported,
             idp_issuer: Some(idp_issuer.to_string()),
+            idp_credential_key: Some(idp_credential_key.to_string()),
             created_at: Instant::now(),
         };
         self.pending.write().await.insert(state.clone(), flow);

--- a/src/server.rs
+++ b/src/server.rs
@@ -1902,14 +1902,24 @@ async fn oauth_callback(
     // issuer. Ordinary resource OAuth flows leave `idp_issuer` unset and are
     // byte-for-byte unaffected by this block.
     if let Some(ref idp_issuer) = flow.idp_issuer {
+        // Wave 2: persist under the credential-pool key (org name for END-19, or
+        // the issuer URL for bare END-18 endpoints), so all of an org's EMA
+        // endpoints share one ID token. The credentials still carry the real
+        // `idp_issuer` (used for discovery + ID-JAG validation). Older flows
+        // without a key fall back to the issuer to preserve existing behavior.
+        let credential_key = flow
+            .idp_credential_key
+            .as_deref()
+            .unwrap_or(idp_issuer.as_str());
         match build_idp_credentials(idp_issuer, &token_json, now_secs) {
             Some(creds) => {
                 if let Some(ref tm) = state.token_manager {
-                    if let Err(e) = tm.save_idp(idp_issuer, &creds).await {
-                        error!(idp_issuer = %idp_issuer, error = %e, "Failed to persist IdP credentials");
+                    if let Err(e) = tm.save_idp(credential_key, &creds).await {
+                        error!(idp_issuer = %idp_issuer, credential_key = %credential_key, error = %e, "Failed to persist IdP credentials");
                     } else {
                         info!(
                             idp_issuer = %idp_issuer,
+                            credential_key = %credential_key,
                             "Captured and persisted IdP credentials (EMA Step 1)"
                         );
                     }
@@ -5196,6 +5206,7 @@ mod tests {
                 None,
                 false,
                 idp_issuer,
+                idp_issuer,
             )
             .await;
 
@@ -5257,6 +5268,7 @@ mod tests {
                 "http://127.0.0.1:9400/oauth/callback",
                 None,
                 false,
+                idp_issuer,
                 idp_issuer,
             )
             .await;

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -4,7 +4,7 @@ use crate::adapter::oauth::{EmaConfig, EmaSsoWiring, OAuthAdapter, OAuthAdapterC
 use crate::adapter::sse::{SseAdapter, SseConfig};
 use crate::adapter::stdio::{IsolationMode, StdioAdapter, StdioConfig};
 use crate::adapter::{FailedAdapter, McpAdapter, StartingAdapter};
-use crate::config::{self, Config, ConfigDiff, EndpointConfig, Transport};
+use crate::config::{self, Config, ConfigDiff, ConfigOrganization, EndpointConfig, Transport};
 use crate::events::ToolCallEventBus;
 use crate::oauth::OAuthFlowManager;
 use crate::profile_registry::ProfileRegistry;
@@ -210,6 +210,7 @@ async fn reload_and_apply(
         new_config.relay.allow_insecure_oauth.unwrap_or(false),
         event_bus,
         jit,
+        &new_config.organizations,
     )
     .await;
 
@@ -261,6 +262,7 @@ pub async fn apply_diff(
     allow_insecure_oauth: bool,
     event_bus: Option<&ToolCallEventBus>,
     jit: Option<&JitWiring>,
+    organizations: &[ConfigOrganization],
 ) {
     // Remove endpoints
     for name in &diff.removed {
@@ -322,6 +324,7 @@ pub async fn apply_diff(
         let oai = oauth_adapter_inners.clone();
         let bus = event_bus.cloned();
         let jit_owned = jit.cloned();
+        let orgs = organizations.to_vec();
         let init_span = tracing::info_span!("endpoint_init", endpoint = %name_clone);
         tokio::spawn(
             async move {
@@ -332,6 +335,7 @@ pub async fn apply_diff(
                     allow_insecure_oauth,
                     bus.as_ref(),
                     jit_owned.as_ref(),
+                    &orgs,
                 )
                 .await;
                 let mut entries = reg.entries().write().await;
@@ -381,6 +385,7 @@ pub async fn apply_diff(
         let oai = oauth_adapter_inners.clone();
         let bus = event_bus.cloned();
         let jit_owned = jit.cloned();
+        let orgs = organizations.to_vec();
         let init_span = tracing::info_span!("endpoint_init", endpoint = %ep_clone.name);
         tokio::spawn(
             async move {
@@ -391,6 +396,7 @@ pub async fn apply_diff(
                     allow_insecure_oauth,
                     bus.as_ref(),
                     jit_owned.as_ref(),
+                    &orgs,
                 )
                 .await;
                 let mut entries = reg.entries().write().await;
@@ -425,6 +431,7 @@ pub async fn apply_diff_graceful(
     allow_insecure_oauth: bool,
     event_bus: Option<&ToolCallEventBus>,
     jit: Option<&JitWiring>,
+    organizations: &[ConfigOrganization],
 ) {
     // Build warning message map
     let warning_messages: std::collections::HashMap<String, String> = {
@@ -525,6 +532,7 @@ pub async fn apply_diff_graceful(
         let oai = oauth_adapter_inners.clone();
         let bus = event_bus.cloned();
         let jit_owned = jit.cloned();
+        let orgs = organizations.to_vec();
         let init_span = tracing::info_span!("endpoint_init", endpoint = %name_clone);
         tokio::spawn(
             async move {
@@ -535,6 +543,7 @@ pub async fn apply_diff_graceful(
                     allow_insecure_oauth,
                     bus.as_ref(),
                     jit_owned.as_ref(),
+                    &orgs,
                 )
                 .await;
                 let mut entries = reg.entries().write().await;
@@ -611,6 +620,7 @@ pub async fn apply_diff_graceful(
         let oai = oauth_adapter_inners.clone();
         let bus = event_bus.cloned();
         let jit_owned = jit.cloned();
+        let orgs = organizations.to_vec();
         let init_span = tracing::info_span!("endpoint_init", endpoint = %ep_clone.name);
         tokio::spawn(
             async move {
@@ -621,6 +631,7 @@ pub async fn apply_diff_graceful(
                     allow_insecure_oauth,
                     bus.as_ref(),
                     jit_owned.as_ref(),
+                    &orgs,
                 )
                 .await;
                 let mut entries = reg.entries().write().await;
@@ -760,26 +771,93 @@ pub struct JitWiring {
     pub flow_manager: Arc<OAuthFlowManager>,
 }
 
-/// Returns `(idp_issuer, resource)` when `ep` declares a complete EMA auth
-/// block (`[endpoints.auth] type = "ema"` with non-empty `idp` and `resource`).
-/// Incomplete blocks are surfaced as per-endpoint validation warnings elsewhere,
-/// so an EMA block missing a field falls through to the ordinary transport path.
-fn ema_auth(ep: &EndpointConfig) -> Option<(&str, &str)> {
+/// Returns `true` when `ep` declares an EMA auth block (`[endpoints.auth]
+/// type = "ema"`), regardless of whether it references an `[[organizations]]`
+/// entry (END-19) or carries a bare `idp` issuer (END-18 back-compat). The
+/// concrete IdP coordinates are resolved separately by [`resolve_ema_idp`];
+/// incomplete blocks are surfaced as per-endpoint validation warnings elsewhere.
+fn is_ema_endpoint(ep: &EndpointConfig) -> bool {
+    ep.auth.as_ref().is_some_and(|auth| auth.auth_type == "ema")
+}
+
+/// Resolved EMA IdP coordinates for an endpoint: the credential-pool key, the
+/// real IdP issuer URL, and the resource the access token is minted for.
+///
+/// The `idp_key` is what makes an org's EMA endpoints share a single IdP ID
+/// token (Wave 2): every endpoint that resolves to the same key reads and
+/// writes the same `IdpCredentials` record. For an END-19 `organization`
+/// reference the key is the org `name`; for a bare END-18 `idp` endpoint the
+/// key is the issuer URL itself, so pre-existing per-issuer `.idp.json` files
+/// keep resolving (back-compat).
+struct ResolvedEmaIdp {
+    idp_key: String,
+    idp_issuer: String,
+    resource: String,
+    /// Optional pre-registered org `client_id` (Okta/Entra). `None` for bare
+    /// END-18 `idp` endpoints and orgs that resolve to CIMD; the EMA legs then
+    /// keep sending the hosted CIMD `client_id`.
+    client_id: Option<String>,
+}
+
+/// Resolve an EMA endpoint's IdP coordinates, preferring the END-19
+/// `organization` reference over the deprecated END-18 bare `idp`.
+///
+/// Returns `None` when `ep` is not an EMA endpoint, is missing `resource`,
+/// references an unknown/empty-issuer org, or has neither an `organization`
+/// nor a bare `idp`. The caller registers a [`FailedAdapter`] in that case.
+fn resolve_ema_idp(
+    ep: &EndpointConfig,
+    organizations: &[ConfigOrganization],
+) -> Option<ResolvedEmaIdp> {
     let auth = ep.auth.as_ref()?;
     if auth.auth_type != "ema" {
         return None;
     }
-    let idp = auth
-        .idp
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())?;
     let resource = auth
         .resource
         .as_deref()
         .map(str::trim)
         .filter(|s| !s.is_empty())?;
-    Some((idp, resource))
+
+    // Preferred END-19 form: reference a named `[[organizations]]` entry. All
+    // EMA endpoints sharing an org name share one pooled IdP credential.
+    if let Some(org_name) = auth
+        .organization
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        let org = organizations.iter().find(|o| o.name == org_name)?;
+        let idp_issuer = org.idp.trim();
+        if idp_issuer.is_empty() {
+            return None;
+        }
+        return Some(ResolvedEmaIdp {
+            idp_key: org.name.clone(),
+            idp_issuer: idp_issuer.to_string(),
+            resource: resource.to_string(),
+            client_id: org
+                .client_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string),
+        });
+    }
+
+    // END-18 back-compat: a bare `idp` issuer with no `organization`. Key the
+    // pool by the issuer URL so existing per-issuer credentials keep resolving.
+    let idp_issuer = auth
+        .idp
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())?;
+    Some(ResolvedEmaIdp {
+        idp_key: idp_issuer.to_string(),
+        idp_issuer: idp_issuer.to_string(),
+        resource: resource.to_string(),
+        client_id: None,
+    })
 }
 
 /// Resolve EMA discovery into an [`EmaConfig`]: RFC 8414 metadata for the IdP
@@ -789,19 +867,21 @@ fn ema_auth(ep: &EndpointConfig) -> Option<(&str, &str)> {
 /// fails so the caller can register a [`FailedAdapter`].
 async fn resolve_ema_config(
     ep: &EndpointConfig,
-    idp: &str,
+    idp_key: &str,
+    idp_issuer: &str,
     resource: &str,
+    client_id: Option<&str>,
     allow_insecure_oauth: bool,
 ) -> Option<EmaConfig> {
     let idp_disc = match crate::oauth::discovery::discover_authorization_server(
-        idp,
+        idp_issuer,
         allow_insecure_oauth,
     )
     .await
     {
         Ok(d) => d,
         Err(e) => {
-            warn!(endpoint = %ep.name, idp = %idp, error = %e, "EMA IdP discovery failed at adapter init");
+            warn!(endpoint = %ep.name, idp = %idp_issuer, error = %e, "EMA IdP discovery failed at adapter init");
             return None;
         }
     };
@@ -818,14 +898,20 @@ async fn resolve_ema_config(
         }
     };
     Some(EmaConfig {
-        // v1 keys IdP credentials by the (sanitized) issuer; END-19 re-keys to org.
-        idp_key: idp.to_string(),
-        idp_issuer: idp.to_string(),
+        // Wave 2: EMA endpoints sharing an org (or a bare END-18 issuer) share
+        // this credential-pool key, so they reuse a single IdP ID token. The
+        // `idp_issuer` remains the real issuer URL (used for discovery + ID-JAG
+        // validation) even when the pool key is an org name.
+        idp_key: idp_key.to_string(),
+        idp_issuer: idp_issuer.to_string(),
         idp_authorization_endpoint: idp_disc.authorization_endpoint,
         idp_token_endpoint: idp_disc.token_endpoint,
         as_issuer: as_disc.issuer,
         as_token_endpoint: as_disc.token_endpoint,
         resource: resource.to_string(),
+        // Org's pre-registered client_id (when set); `None` keeps the EMA legs
+        // on the hosted CIMD `client_id`.
+        client_id: client_id.map(str::to_string),
     })
 }
 
@@ -841,16 +927,21 @@ async fn build_ema_adapter(
     allow_insecure_oauth: bool,
     event_bus: Option<&ToolCallEventBus>,
     jit: Option<&JitWiring>,
+    organizations: &[ConfigOrganization],
 ) -> Box<dyn McpAdapter> {
-    // The caller only reaches this path when `ema_auth(ep)` matched, so both
-    // fields are present here.
-    let (idp, resource) = match ema_auth(ep) {
+    // The caller only reaches this path when `is_ema_endpoint(ep)` matched.
+    // Resolve the org-pooled (or bare-idp back-compat) IdP coordinates; an
+    // unresolvable org reference / missing field is surfaced as a FailedAdapter.
+    let resolved = match resolve_ema_idp(ep, organizations) {
         Some(v) => v,
         None => {
-            return Box::new(FailedAdapter::new(format!(
-                "EMA endpoint '{}' is missing required idp/resource",
-                ep.name
-            )))
+            return Box::new(
+                FailedAdapter::new(format!(
+                    "EMA endpoint '{}' is missing a resolvable organization/idp and resource",
+                    ep.name
+                ))
+                .with_server_type_override(ep.server_type_override.clone()),
+            )
         }
     };
 
@@ -878,7 +969,16 @@ async fn build_ema_adapter(
             .with_server_type_override(ep.server_type_override.clone()),
         );
     }
-    let ema = match resolve_ema_config(ep, idp, resource, allow_insecure_oauth).await {
+    let ema = match resolve_ema_config(
+        ep,
+        &resolved.idp_key,
+        &resolved.idp_issuer,
+        &resolved.resource,
+        resolved.client_id.as_deref(),
+        allow_insecure_oauth,
+    )
+    .await
+    {
         Some(e) => e,
         None => {
             warn!(endpoint = %ep.name, "EMA endpoint discovery failed; registering as failed");
@@ -944,12 +1044,13 @@ pub(crate) async fn create_adapter(
     allow_insecure_oauth: bool,
     event_bus: Option<&ToolCallEventBus>,
     jit: Option<&JitWiring>,
+    organizations: &[ConfigOrganization],
 ) -> Box<dyn McpAdapter> {
     // EMA endpoints (`[endpoints.auth] type = "ema"`) wrap the upstream HTTP MCP
     // server in an `OAuthAdapter` whose refresh path runs the ID-JAG chain
     // (decision D1 / M10). Detected up front so it applies regardless of the
     // declared transport.
-    if ema_auth(ep).is_some() {
+    if is_ema_endpoint(ep) {
         return build_ema_adapter(
             ep,
             token_manager,
@@ -957,6 +1058,7 @@ pub(crate) async fn create_adapter(
             allow_insecure_oauth,
             event_bus,
             jit,
+            organizations,
         )
         .await;
     }
@@ -1213,6 +1315,7 @@ mod tests {
             removed: vec![],
             changed: vec![],
             unchanged: vec![],
+            organizations_changed: false,
         }
     }
 
@@ -1357,7 +1460,7 @@ mod tests {
 
         // PRODUCTION construction path — the interceptor is attached inside
         // create_adapter, never by the test.
-        let adapter = create_adapter(&ep, &tm, &inners, true, None, Some(&jit)).await;
+        let adapter = create_adapter(&ep, &tm, &inners, true, None, Some(&jit), &[]).await;
         assert!(matches!(adapter.health(), HealthStatus::Healthy));
 
         let result = adapter.call_tool("search", json!({})).await;
@@ -1398,7 +1501,7 @@ mod tests {
         let (tm, inners) = test_oauth_infra();
         let ep = http_endpoint("plain_http", &format!("{}/mcp", base));
 
-        let adapter = create_adapter(&ep, &tm, &inners, true, None, None).await;
+        let adapter = create_adapter(&ep, &tm, &inners, true, None, None, &[]).await;
         let result = adapter.call_tool("search", json!({})).await;
         match result {
             Err(AdapterError::HttpError { status: 401, .. }) => {}
@@ -1418,10 +1521,123 @@ mod tests {
         ep.url = url.map(|u| u.to_string());
         ep.auth = Some(crate::config::EndpointAuthConfig {
             auth_type: "ema".to_string(),
+            organization: None,
             idp: Some("https://idp.example.com".to_string()),
             resource: Some("https://api.example.com/mcp".to_string()),
         });
         ep
+    }
+
+    /// Build an END-19 org-referencing EMA endpoint (no bare `idp`).
+    fn ema_org_endpoint(name: &str, organization: &str, resource: &str) -> EndpointConfig {
+        let mut ep = http_endpoint(name, resource);
+        ep.transport = Transport::Http;
+        ep.url = Some(resource.to_string());
+        ep.auth = Some(crate::config::EndpointAuthConfig {
+            auth_type: "ema".to_string(),
+            organization: Some(organization.to_string()),
+            idp: None,
+            resource: Some(resource.to_string()),
+        });
+        ep
+    }
+
+    fn org_entry(name: &str, idp: &str) -> ConfigOrganization {
+        ConfigOrganization {
+            name: name.to_string(),
+            provider: "okta".to_string(),
+            idp: idp.to_string(),
+            client_id: None,
+        }
+    }
+
+    // ---- Wave 2: resolve_ema_idp (org pool + bare-idp back-compat) ----------
+
+    /// An END-19 `organization` reference keys the credential pool by the org
+    /// `name` (so every endpoint in the org shares one ID token) while the
+    /// resolved `idp_issuer` is the org's real issuer URL.
+    #[test]
+    fn resolve_ema_idp_org_reference_keys_by_org_name() {
+        let ep = ema_org_endpoint("github-acme", "Acme Corp", "https://api.example.com/mcp");
+        let orgs = vec![org_entry("Acme Corp", "https://acme.okta.com")];
+        let r = resolve_ema_idp(&ep, &orgs).expect("org ref resolves");
+        assert_eq!(r.idp_key, "Acme Corp");
+        assert_eq!(r.idp_issuer, "https://acme.okta.com");
+        assert_eq!(r.resource, "https://api.example.com/mcp");
+    }
+
+    /// A bare END-18 `idp` endpoint (no `organization`) keys the pool by the
+    /// issuer URL itself, so pre-existing per-issuer `.idp.json` credentials keep
+    /// resolving (migration/back-compat).
+    #[test]
+    fn resolve_ema_idp_bare_idp_keys_by_issuer() {
+        let ep = ema_endpoint(
+            "legacy-bare",
+            Transport::Http,
+            Some("https://api.example.com/mcp"),
+        );
+        let r = resolve_ema_idp(&ep, &[]).expect("bare idp resolves");
+        assert_eq!(r.idp_key, "https://idp.example.com");
+        assert_eq!(r.idp_issuer, "https://idp.example.com");
+        assert_eq!(
+            r.idp_key, r.idp_issuer,
+            "bare-idp key must equal its issuer"
+        );
+    }
+
+    /// Two endpoints referencing the same org resolve to the SAME `idp_key`,
+    /// which is what makes them share a single pooled IdP credential.
+    #[test]
+    fn resolve_ema_idp_two_endpoints_same_org_share_key() {
+        let a = ema_org_endpoint("github-acme", "Acme Corp", "https://api.example.com/gh");
+        let b = ema_org_endpoint("jira-acme", "Acme Corp", "https://api.example.com/jira");
+        let orgs = vec![org_entry("Acme Corp", "https://acme.okta.com")];
+        let ra = resolve_ema_idp(&a, &orgs).expect("a resolves");
+        let rb = resolve_ema_idp(&b, &orgs).expect("b resolves");
+        assert_eq!(ra.idp_key, rb.idp_key, "same org → same pool key");
+        assert_ne!(ra.resource, rb.resource, "distinct resources preserved");
+    }
+
+    /// An `organization` reference that names no configured `[[organizations]]`
+    /// entry resolves to `None` (caller registers a FailedAdapter) rather than
+    /// silently falling through to a bare-idp or non-EMA path.
+    #[test]
+    fn resolve_ema_idp_unknown_org_returns_none() {
+        let ep = ema_org_endpoint("github-acme", "Nope Inc", "https://api.example.com/mcp");
+        let orgs = vec![org_entry("Acme Corp", "https://acme.okta.com")];
+        assert!(resolve_ema_idp(&ep, &orgs).is_none());
+    }
+
+    /// When both an `organization` and a bare `idp` are present, the org
+    /// reference wins (END-19 precedence): the key is the org name and the
+    /// issuer is the org's issuer, not the bare `idp`.
+    #[test]
+    fn resolve_ema_idp_org_takes_precedence_over_bare_idp() {
+        let mut ep = ema_org_endpoint("github-acme", "Acme Corp", "https://api.example.com/mcp");
+        ep.auth.as_mut().unwrap().idp = Some("https://stale.okta.com".to_string());
+        let orgs = vec![org_entry("Acme Corp", "https://acme.okta.com")];
+        let r = resolve_ema_idp(&ep, &orgs).expect("org ref resolves");
+        assert_eq!(r.idp_key, "Acme Corp");
+        assert_eq!(r.idp_issuer, "https://acme.okta.com");
+    }
+
+    /// An EMA block missing `resource` resolves to `None`.
+    #[test]
+    fn resolve_ema_idp_missing_resource_returns_none() {
+        let mut ep = ema_endpoint(
+            "no-res",
+            Transport::Http,
+            Some("https://api.example.com/mcp"),
+        );
+        ep.auth.as_mut().unwrap().resource = None;
+        assert!(resolve_ema_idp(&ep, &[]).is_none());
+    }
+
+    /// A non-EMA endpoint is never treated as EMA by the resolver.
+    #[test]
+    fn resolve_ema_idp_non_ema_returns_none() {
+        let ep = http_endpoint("plain", "https://api.example.com/mcp");
+        assert!(resolve_ema_idp(&ep, &[]).is_none());
     }
 
     /// EMA detection runs before the transport match, so a `stdio` (non-HTTP)
@@ -1436,7 +1652,7 @@ mod tests {
             Some("https://api.example.com/mcp"),
         );
 
-        let adapter = create_adapter(&ep, &tm, &inners, true, None, None).await;
+        let adapter = create_adapter(&ep, &tm, &inners, true, None, None, &[]).await;
         match adapter.health() {
             HealthStatus::Unhealthy(msg) => {
                 assert!(
@@ -1455,7 +1671,7 @@ mod tests {
         let (tm, inners) = test_oauth_infra();
         let ep = ema_endpoint("ema_no_url", Transport::Http, None);
 
-        let adapter = create_adapter(&ep, &tm, &inners, true, None, None).await;
+        let adapter = create_adapter(&ep, &tm, &inners, true, None, None, &[]).await;
         match adapter.health() {
             HealthStatus::Unhealthy(msg) => {
                 assert!(
@@ -1482,7 +1698,17 @@ mod tests {
             )
             .await;
 
-        apply_diff(&empty_diff(), &registry, &tm, &inners, false, None, None).await;
+        apply_diff(
+            &empty_diff(),
+            &registry,
+            &tm,
+            &inners,
+            false,
+            None,
+            None,
+            &[],
+        )
+        .await;
 
         // Existing adapter should still be there, not shut down
         assert!(!shutdown.load(std::sync::atomic::Ordering::SeqCst));
@@ -1509,7 +1735,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &inners, false, None, None).await;
+        apply_diff(&diff, &registry, &tm, &inners, false, None, None, &[]).await;
 
         assert!(shutdown.load(std::sync::atomic::Ordering::SeqCst));
         assert!(registry.merged_catalog().await.is_empty());
@@ -1525,7 +1751,7 @@ mod tests {
         };
 
         // Should not panic
-        apply_diff(&diff, &registry, &tm, &inners, false, None, None).await;
+        apply_diff(&diff, &registry, &tm, &inners, false, None, None, &[]).await;
     }
 
     #[tokio::test]
@@ -1573,7 +1799,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &inners, false, None, None).await;
+        apply_diff(&diff, &registry, &tm, &inners, false, None, None, &[]).await;
 
         // Old adapter should have been shut down
         assert!(shutdown.load(std::sync::atomic::Ordering::SeqCst));
@@ -1612,7 +1838,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &inners, false, None, None).await;
+        apply_diff(&diff, &registry, &tm, &inners, false, None, None, &[]).await;
 
         // Wait for background initialization to complete
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -1664,7 +1890,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &inners, false, None, None).await;
+        apply_diff(&diff, &registry, &tm, &inners, false, None, None, &[]).await;
 
         // "keep" should still be alive
         assert!(!shutdown_keep.load(std::sync::atomic::Ordering::SeqCst));
@@ -1709,7 +1935,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &inners, false, None, None).await;
+        apply_diff(&diff, &registry, &tm, &inners, false, None, None, &[]).await;
 
         // Wait for background initialization to complete
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -1782,7 +2008,7 @@ mod tests {
             ..empty_diff()
         };
 
-        apply_diff(&diff, &registry, &tm, &inners, true, None, None).await;
+        apply_diff(&diff, &registry, &tm, &inners, true, None, None, &[]).await;
 
         // Wait for background initialization to register the OAuth adapter inner.
         let stop = std::time::Instant::now() + std::time::Duration::from_secs(2);
@@ -1831,6 +2057,7 @@ mod tests {
             false,
             None,
             None,
+            &[],
         )
         .await;
 
@@ -1878,7 +2105,16 @@ mod tests {
             warnings.iter().map(|w| w.endpoint_name.clone()).collect();
 
         apply_diff_graceful(
-            &diff, &registry, &warnings, &warned, &tm, &inners, false, None, None,
+            &diff,
+            &registry,
+            &warnings,
+            &warned,
+            &tm,
+            &inners,
+            false,
+            None,
+            None,
+            &[],
         )
         .await;
 
@@ -1931,7 +2167,16 @@ mod tests {
         let warned: std::collections::HashSet<String> = ["ep".to_string()].into_iter().collect();
 
         apply_diff_graceful(
-            &diff, &registry, &warnings, &warned, &tm, &inners, false, None, None,
+            &diff,
+            &registry,
+            &warnings,
+            &warned,
+            &tm,
+            &inners,
+            false,
+            None,
+            None,
+            &[],
         )
         .await;
 
@@ -1988,7 +2233,16 @@ mod tests {
         let warned: std::collections::HashSet<String> = std::collections::HashSet::new();
 
         apply_diff_graceful(
-            &diff, &registry, &warnings, &warned, &tm, &inners, true, None, None,
+            &diff,
+            &registry,
+            &warnings,
+            &warned,
+            &tm,
+            &inners,
+            true,
+            None,
+            None,
+            &[],
         )
         .await;
 

--- a/tests/ema_integration.rs
+++ b/tests/ema_integration.rs
@@ -21,13 +21,16 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use axum::extract::State;
 use axum::http::{header::AUTHORIZATION, HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
-use axum::routing::post;
+use axum::routing::{get, post};
 use axum::{Json, Router};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use serde_json::{json, Value};
 
 use endara_relay::adapter::oauth::{EmaConfig, OAuthAdapter, OAuthAdapterConfig, OAuthState};
 use endara_relay::adapter::McpAdapter;
+use endara_relay::config::{Config, ConfigOrganization, RelayConfig};
+use endara_relay::management::{management_routes, ManagementState};
+use endara_relay::registry::AdapterRegistry;
 use endara_relay::token_manager::{IdpCredentials, TokenManager, TokenSet};
 
 /// Logical IdP issuer (also the IdP-credential store key in v1).
@@ -276,6 +279,7 @@ fn ema_config(urls: &FxUrls) -> OAuthAdapterConfig {
             as_issuer: AS_ISS.to_string(),
             as_token_endpoint: urls.as_token_endpoint.clone(),
             resource: RESOURCE.to_string(),
+            client_id: None,
         }),
     }
 }
@@ -572,4 +576,402 @@ async fn concurrent_refreshes_coalesce_into_single_exchange() {
     assert_eq!(c.redeem, 1, "coalesced: exactly one Step 3");
     drop(c);
     server.abort();
+}
+
+// ---------------------------------------------------------------------------
+// Wave 2 (END-19) credential pooling: two EMA endpoints that reference the same
+// org share ONE pooled IdP credential, keyed by the org name (`idp_key`) rather
+// than the issuer. A single `.idp.json` drives both adapters' EMA chains; each
+// persists its OWN resource `TokenSet` under its own endpoint name.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn org_pool_two_endpoints_share_one_idp_credential() {
+    const ORG_KEY: &str = "Acme Corp";
+
+    let state = fx(RefreshOutcome::Fail, "good-id-token");
+    let (urls, server) = spawn_ema_fixture(state.clone()).await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+
+    // ONE IdP credential, saved under the ORG key (not the raw issuer). Its
+    // `idp_issuer` remains the real issuer URL the EMA chain validates against.
+    tm.save_idp(
+        ORG_KEY,
+        &idp_creds("good-id-token", Some(now_unix() + 3600), None),
+    )
+    .await
+    .unwrap();
+
+    // Two endpoints in the same org: distinct endpoint names, same pooled key.
+    let mut cfg_a = ema_config(&urls);
+    cfg_a.endpoint_name = "github-acme".to_string();
+    cfg_a.ema.as_mut().unwrap().idp_key = ORG_KEY.to_string();
+    let mut cfg_b = ema_config(&urls);
+    cfg_b.endpoint_name = "jira-acme".to_string();
+    cfg_b.ema.as_mut().unwrap().idp_key = ORG_KEY.to_string();
+
+    let mut adapter_a = OAuthAdapter::new(cfg_a, tm.clone());
+    let mut adapter_b = OAuthAdapter::new(cfg_b, tm.clone());
+    adapter_a.initialize().await.unwrap();
+    adapter_b.initialize().await.unwrap();
+
+    assert_eq!(
+        *adapter_a.shared_inner().state.read().await,
+        OAuthState::Authenticated
+    );
+    assert_eq!(
+        *adapter_b.shared_inner().state.read().await,
+        OAuthState::Authenticated
+    );
+
+    // Each endpoint persisted its OWN resource TokenSet from the shared cred...
+    let tok_a = tm
+        .load("github-acme")
+        .await
+        .unwrap()
+        .expect("endpoint A token");
+    let tok_b = tm
+        .load("jira-acme")
+        .await
+        .unwrap()
+        .expect("endpoint B token");
+    assert!(tok_a.is_valid() && tok_b.is_valid());
+    assert_ne!(
+        tok_a.access_token, tok_b.access_token,
+        "two endpoints mint distinct resource access tokens"
+    );
+
+    // ...from the SINGLE pooled IdP credential: exactly one `.idp.json` on disk,
+    // resolvable by the org key.
+    let idp_file_count = std::fs::read_dir(tmp.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().ends_with(".idp.json"))
+        .count();
+    assert_eq!(
+        idp_file_count, 1,
+        "org pool must use exactly one IdP credential file"
+    );
+    assert!(
+        tm.load_idp(ORG_KEY).await.unwrap().is_some(),
+        "the pooled credential resolves by org key"
+    );
+
+    server.abort();
+}
+
+// ---------------------------------------------------------------------------
+// Wave 4 (END-19): EMA capability-probe API.
+//
+// `POST /api/organizations/{org}/probe` runs, per desktop-supplied resource,
+// RFC 9728 → 8414 discovery + an RFC 8693 ID-JAG exchange against the org IdP
+// and maps the outcome to accessible / denied / unreachable. These tests drive
+// the real management router (served over TCP, exercised with `reqwest`) against
+// a combined discovery + IdP-token mock, and pin the "persist nothing" rule.
+// ---------------------------------------------------------------------------
+
+/// Mock state for the probe fixture: counts ID-JAG exchange hits and selects a
+/// granting vs. denying IdP token endpoint.
+#[derive(Clone)]
+struct ProbeFx {
+    /// Number of RFC 8693 token-exchange (ID-JAG) hits on `/token`.
+    exchange: Arc<AtomicU64>,
+    /// When true, `/token` returns HTTP 400 `access_denied` (→ denied).
+    deny: bool,
+}
+
+/// Build a mock origin issuer from the request `Host` header so the AS metadata
+/// advertises an issuer matching its own origin (RFC 8414 §3.3), exactly like
+/// the management-layer org mocks.
+fn probe_mock_issuer(headers: &HeaderMap) -> String {
+    let host = headers
+        .get(axum::http::header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("127.0.0.1");
+    format!("http://{host}")
+}
+
+/// Spawn a single-origin mock that serves RFC 9728 protected-resource metadata,
+/// RFC 8414 AS metadata (used for BOTH the resource AS and the org IdP issuer),
+/// and the IdP token-exchange endpoint. Returns its base URL and task handle.
+async fn spawn_probe_fixture(fx: ProbeFx) -> (String, tokio::task::JoinHandle<()>) {
+    async fn protected_resource(headers: HeaderMap) -> Response {
+        let issuer = probe_mock_issuer(&headers);
+        Json(json!({
+            "resource": issuer,
+            "authorization_servers": [issuer],
+        }))
+        .into_response()
+    }
+    async fn auth_server(headers: HeaderMap) -> Response {
+        let issuer = probe_mock_issuer(&headers);
+        Json(json!({
+            "issuer": issuer,
+            "authorization_endpoint": format!("{issuer}/authorize"),
+            "token_endpoint": format!("{issuer}/token"),
+            "code_challenge_methods_supported": ["S256"],
+        }))
+        .into_response()
+    }
+    async fn token(State(fx): State<ProbeFx>, _body: String) -> Response {
+        fx.exchange.fetch_add(1, Ordering::SeqCst);
+        if fx.deny {
+            return (
+                StatusCode::BAD_REQUEST,
+                r#"{"error":"access_denied","error_description":"group not entitled"}"#,
+            )
+                .into_response();
+        }
+        // The probe discards the ID-JAG, so any structural token works.
+        Json(json!({ "access_token": make_jwt(json!({"sub": "u"})) })).into_response()
+    }
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    let router = Router::new()
+        .route(
+            "/.well-known/oauth-protected-resource",
+            get(protected_resource),
+        )
+        .route("/.well-known/oauth-authorization-server", get(auth_server))
+        .route("/token", post(token))
+        .with_state(fx);
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, router).await.ok();
+    });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    (base, handle)
+}
+
+/// Build a `ManagementState` with one organization (`Acme`, IdP issuer
+/// `idp_issuer`) and a token manager rooted at `token_dir`, with insecure
+/// (loopback) OAuth permitted so the mock fixtures pass the SSRF guard.
+fn probe_management_state(
+    idp_issuer: &str,
+    token_dir: std::path::PathBuf,
+) -> (ManagementState, Arc<TokenManager>) {
+    let tm = Arc::new(TokenManager::new(token_dir));
+    let cfg = Config {
+        relay: RelayConfig {
+            allow_insecure_oauth: Some(true),
+            ..Default::default()
+        },
+        endpoints: Vec::new(),
+        profiles: None,
+        organizations: vec![ConfigOrganization {
+            name: "Acme".to_string(),
+            provider: "custom".to_string(),
+            idp: idp_issuer.to_string(),
+            client_id: None,
+        }],
+    };
+    let state = ManagementState {
+        registry: Arc::new(AdapterRegistry::new()),
+        config: Arc::new(tokio::sync::RwLock::new(cfg)),
+        start_time: std::time::Instant::now(),
+        config_path: None,
+        oauth_flow_manager: None,
+        relay_port: 9400,
+        oauth_adapter_inners: None,
+        token_manager: Some(tm.clone()),
+        setup_manager: None,
+        profile_registry: None,
+        event_bus: None,
+    };
+    (state, tm)
+}
+
+/// Serve `management_routes` over an ephemeral TCP port and return its base URL.
+async fn serve_management(state: ManagementState) -> (String, tokio::task::JoinHandle<()>) {
+    let app = management_routes(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.ok();
+    });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    (base, handle)
+}
+
+/// Seed the org-keyed pooled IdP credential (Wave 2) the probe loads.
+async fn seed_org_idp(tm: &TokenManager, idp_issuer: &str) {
+    tm.save_idp(
+        "Acme",
+        &IdpCredentials {
+            idp_issuer: idp_issuer.to_string(),
+            id_token: "good-id-token".to_string(),
+            refresh_token: None,
+            id_token_expires_at: Some(now_unix() + 3600),
+            obtained_at: now_unix(),
+        },
+    )
+    .await
+    .unwrap();
+}
+
+/// POST a probe request and return the parsed JSON body.
+async fn post_probe(mgmt_base: &str, resources: &[&str]) -> Value {
+    let resp = reqwest::Client::new()
+        .post(format!("{mgmt_base}/api/organizations/Acme/probe"))
+        .json(&json!({ "resources": resources }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::OK,
+        "probe must return 200"
+    );
+    resp.json().await.unwrap()
+}
+
+#[tokio::test]
+async fn ema_probe_accessible_when_idp_grants() {
+    let fx = ProbeFx {
+        exchange: Arc::new(AtomicU64::new(0)),
+        deny: false,
+    };
+    let (base, fixture) = spawn_probe_fixture(fx).await;
+    let tmp = tempfile::tempdir().unwrap();
+    let (state, tm) = probe_management_state(&base, tmp.path().to_path_buf());
+    seed_org_idp(&tm, &base).await;
+    let (mgmt, server) = serve_management(state).await;
+
+    let body = post_probe(&mgmt, &[&base]).await;
+    let results = body["results"].as_array().expect("results array");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["resource"], base);
+    assert_eq!(results[0]["status"], "accessible");
+    assert_eq!(results[0]["server_as_issuer"], base);
+
+    server.abort();
+    fixture.abort();
+}
+
+#[tokio::test]
+async fn ema_probe_denied_on_access_denied() {
+    let fx = ProbeFx {
+        exchange: Arc::new(AtomicU64::new(0)),
+        deny: true,
+    };
+    let (base, fixture) = spawn_probe_fixture(fx).await;
+    let tmp = tempfile::tempdir().unwrap();
+    let (state, tm) = probe_management_state(&base, tmp.path().to_path_buf());
+    seed_org_idp(&tm, &base).await;
+    let (mgmt, server) = serve_management(state).await;
+
+    let body = post_probe(&mgmt, &[&base]).await;
+    let results = body["results"].as_array().expect("results array");
+    assert_eq!(results[0]["status"], "denied");
+    // Discovery succeeded, so the resource AS issuer is still reported.
+    assert_eq!(results[0]["server_as_issuer"], base);
+
+    server.abort();
+    fixture.abort();
+}
+
+#[tokio::test]
+async fn ema_probe_unreachable_on_discovery_failure() {
+    // The org IdP fixture is reachable (so IdP discovery resolves), but the
+    // probed resource points at a dead loopback port: discovery fails.
+    let fx = ProbeFx {
+        exchange: Arc::new(AtomicU64::new(0)),
+        deny: false,
+    };
+    let (base, fixture) = spawn_probe_fixture(fx.clone()).await;
+    let tmp = tempfile::tempdir().unwrap();
+    let (state, tm) = probe_management_state(&base, tmp.path().to_path_buf());
+    seed_org_idp(&tm, &base).await;
+    let (mgmt, server) = serve_management(state).await;
+
+    let body = post_probe(&mgmt, &["http://127.0.0.1:1/mcp"]).await;
+    let results = body["results"].as_array().expect("results array");
+    assert_eq!(results[0]["status"], "unreachable");
+    assert!(
+        results[0].get("server_as_issuer").is_none(),
+        "discovery failed, so no AS issuer is known"
+    );
+    assert_eq!(
+        fx.exchange.load(Ordering::SeqCst),
+        0,
+        "a discovery failure must never reach the ID-JAG exchange"
+    );
+
+    server.abort();
+    fixture.abort();
+}
+
+#[tokio::test]
+async fn ema_probe_persists_no_token_files() {
+    let fx = ProbeFx {
+        exchange: Arc::new(AtomicU64::new(0)),
+        deny: false,
+    };
+    let (base, fixture) = spawn_probe_fixture(fx).await;
+    let tmp = tempfile::tempdir().unwrap();
+    let (state, tm) = probe_management_state(&base, tmp.path().to_path_buf());
+    seed_org_idp(&tm, &base).await;
+    let (mgmt, server) = serve_management(state).await;
+
+    let body = post_probe(&mgmt, &[&base]).await;
+    assert_eq!(body["results"][0]["status"], "accessible");
+
+    // A probe mints an ID-JAG then discards it: NO access-token files are
+    // written, and the only credential file is the seeded org `.idp.json`.
+    let entries: Vec<String> = std::fs::read_dir(tmp.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    let token_files = entries
+        .iter()
+        .filter(|n| n.ends_with(".token.json"))
+        .count();
+    let idp_files = entries.iter().filter(|n| n.ends_with(".idp.json")).count();
+    assert_eq!(
+        token_files, 0,
+        "a probe must not persist any resource access-token files, found: {entries:?}"
+    );
+    assert_eq!(
+        idp_files, 1,
+        "only the pre-seeded org IdP credential should exist, found: {entries:?}"
+    );
+
+    server.abort();
+    fixture.abort();
+}
+
+#[tokio::test]
+async fn ema_probe_cache_hit_skips_second_exchange() {
+    let fx = ProbeFx {
+        exchange: Arc::new(AtomicU64::new(0)),
+        deny: false,
+    };
+    let (base, fixture) = spawn_probe_fixture(fx.clone()).await;
+    let tmp = tempfile::tempdir().unwrap();
+    let (state, tm) = probe_management_state(&base, tmp.path().to_path_buf());
+    seed_org_idp(&tm, &base).await;
+    let (mgmt, server) = serve_management(state).await;
+
+    let first = post_probe(&mgmt, &[&base]).await;
+    assert_eq!(first["results"][0]["status"], "accessible");
+    assert_eq!(
+        fx.exchange.load(Ordering::SeqCst),
+        1,
+        "first probe runs exactly one ID-JAG exchange"
+    );
+
+    // Second probe of the same (org, resource) within the TTL is served from
+    // cache: the ID-JAG exchange is NOT re-run.
+    let second = post_probe(&mgmt, &[&base]).await;
+    assert_eq!(second["results"][0]["status"], "accessible");
+    assert_eq!(
+        fx.exchange.load(Ordering::SeqCst),
+        1,
+        "cache hit within TTL must skip the re-exchange"
+    );
+
+    server.abort();
+    fixture.abort();
 }

--- a/tests/hot_reload_integration.rs
+++ b/tests/hot_reload_integration.rs
@@ -94,6 +94,7 @@ async fn test_config_diff_add_endpoint() {
             auth: None,
         }],
         profiles: None,
+        organizations: Vec::new(),
     };
 
     let new_config = config::Config {
@@ -157,6 +158,7 @@ async fn test_config_diff_add_endpoint() {
             },
         ],
         profiles: None,
+        organizations: Vec::new(),
     };
 
     let diff = config::diff_configs(&old_config, &new_config);
@@ -178,6 +180,7 @@ async fn test_config_diff_add_endpoint() {
         false,
         None,
         None,
+        &[],
     )
     .await;
 
@@ -308,6 +311,7 @@ async fn test_config_diff_remove_endpoint() {
             },
         ],
         profiles: None,
+        organizations: Vec::new(),
     };
 
     let new_config = config::Config {
@@ -346,6 +350,7 @@ async fn test_config_diff_remove_endpoint() {
             auth: None,
         }],
         profiles: None,
+        organizations: Vec::new(),
     };
 
     let diff = config::diff_configs(&old_config, &new_config);
@@ -365,6 +370,7 @@ async fn test_config_diff_remove_endpoint() {
         false,
         None,
         None,
+        &[],
     )
     .await;
 

--- a/tests/management_api_integration.rs
+++ b/tests/management_api_integration.rs
@@ -120,6 +120,7 @@ fn test_config() -> Config {
             auth: None,
         }],
         profiles: None,
+        organizations: Vec::new(),
     }
 }
 

--- a/tests/oauth_setup_integration.rs
+++ b/tests/oauth_setup_integration.rs
@@ -55,6 +55,7 @@ fn empty_config() -> Config {
             auth: None,
         }],
         profiles: None,
+        organizations: Vec::new(),
     }
 }
 


### PR DESCRIPTION
## Enterprise-Managed Authorization (EMA) — organizations + onboarding (END-19)

Adds organization-scoped EMA to the relay. EMA lets multiple MCP endpoints share a single per-organization IdP sign-in (Identity Assertion / ID-JAG) instead of each server doing its own resource OAuth.

### What's included
- **`[[organizations]]` config** + endpoint organization references.
- **`(org, resource)` credential pool** with bare-idp migration and wiring.
- **Provider templates + organization lifecycle APIs** (create/list/delete, re-authenticate, SSO).
- **EMA capability-probe API** (`POST /api/organizations/{org}/probe`) and `GET /api/idp-providers`.
- **`auth` block accepted on `POST`/`PUT /api/endpoints`** so endpoints can be bound to an org.
- **Org IdP `client_id` resolution** — explicit org `client_id` → CIMD (only when the IdP advertises it) → DCR (only when a registration endpoint exists) → pre-registered fallback — with persistence and reuse through callback, silent refresh, and ID-JAG redeem.
- **EMA binding surfaced on `GET /api/endpoints`** (`auth: { type, organization, resource }`) so clients can tell which endpoints are org-bound.

### Status — preview
The full chain (SSO → exchange for ID-JAG → redeem at resource AS → call MCP) is implemented and exercised by the mock-IdP + mock-AS integration tests. A live end-to-end run currently requires both an IdP that issues ID-JAGs and a resource AS that redeems them; no production catalog provider redeems ID-JAGs today, so EMA ships as a forward-looking/preview capability.

### Verification
- `cargo fmt --check` ✓
- `cargo clippy --all-targets -- -D warnings` ✓
- `cargo test` ✓ (incl. `management_endpoints_list_surfaces_ema_auth_binding` and the EMA integration suite)
