### PR TITLE
perf(observability): keyset pagination, slim list DTO, and SQL aggregation

### DIFF
--- a/src/management.rs
+++ b/src/management.rs
@@ -3822,8 +3822,50 @@ impl From<CallRecord> for CallRecordDto {
     }
 }
 
+/// Slim per-row DTO for the calls list. Drops the verbose
+/// transport/client/payload-byte detail columns the table doesn't render so a
+/// 100-row page stays a few KB instead of tens of KB on the wire. The full
+/// row (`CallRecordDto`) is still served by the drill-through detail route.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CallSummaryDto {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    request_uid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    server_name: Option<String>,
+    tool: String,
+    ts_start: i64,
+    duration_ms: i64,
+    success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error_message: Option<String>,
+    request_bytes: i64,
+    response_bytes: i64,
+}
+
+impl From<CallRecord> for CallSummaryDto {
+    fn from(r: CallRecord) -> Self {
+        CallSummaryDto {
+            id: r.id,
+            request_uid: r.request_uid,
+            server_name: r.server_name,
+            tool: r.tool,
+            ts_start: r.ts_start,
+            duration_ms: r.duration_ms,
+            success: r.success,
+            error_message: r.error_message,
+            request_bytes: r.request_bytes,
+            response_bytes: r.response_bytes,
+        }
+    }
+}
+
 /// Query string for `GET /api/observability/calls`. All filters are optional
-/// and ANDed; `since`/`until` bound `ts_start` as epoch milliseconds.
+/// and ANDed; `since`/`until` bound `ts_start` as epoch milliseconds. `cursor`
+/// is an opaque base64url token returned as `nextCursor` on the previous page;
+/// omit it to fetch the first page.
 #[derive(Deserialize)]
 struct CallsQuery {
     server_name: Option<String>,
@@ -3833,21 +3875,42 @@ struct CallsQuery {
     since: Option<i64>,
     until: Option<i64>,
     limit: Option<i64>,
-    offset: Option<i64>,
+    cursor: Option<String>,
 }
 
-/// Response for `GET /api/observability/calls`.
+/// Response for `GET /api/observability/calls`. `next_cursor` is the opaque
+/// token to pass back as `cursor` for the next page; absent when the page is
+/// the last one.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct CallsResponse {
-    calls: Vec<CallRecordDto>,
+    calls: Vec<CallSummaryDto>,
     limit: i64,
-    offset: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    next_cursor: Option<String>,
 }
 
 /// Default and maximum page sizes for the calls list.
 const CALLS_DEFAULT_LIMIT: i64 = 100;
 const CALLS_MAX_LIMIT: i64 = 1000;
+
+/// Encode a `(ts_start, id)` keyset cursor as a stable, opaque base64url token.
+/// The format is intentionally undocumented to the client — it's a substring
+/// of the response, not a contract.
+fn encode_calls_cursor(ts_start: i64, id: i64) -> String {
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    URL_SAFE_NO_PAD.encode(format!("{ts_start}:{id}"))
+}
+
+/// Decode a `(ts_start, id)` keyset cursor. Returns `None` for any malformed
+/// input so the caller can reject it with a 400.
+fn decode_calls_cursor(token: &str) -> Option<(i64, i64)> {
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    let bytes = URL_SAFE_NO_PAD.decode(token).ok()?;
+    let s = std::str::from_utf8(&bytes).ok()?;
+    let (ts, id) = s.split_once(':')?;
+    Some((ts.parse().ok()?, id.parse().ok()?))
+}
 
 /// 503 body used when the observability subsystem is unwired (e.g. the metadata
 /// store failed to open at startup). Distinct from a wired-but-disabled handle:
@@ -3871,7 +3934,9 @@ fn now_epoch_ms() -> i64 {
 }
 
 /// GET /api/observability/calls — filtered, paged metadata list (payloads
-/// excluded; use the drill-through route for those).
+/// excluded; use the drill-through route for those). Pagination is keyset on
+/// `(ts_start, id)` via the opaque `cursor` query param so paging stays
+/// stable across concurrent inserts and is O(limit) at any depth.
 async fn get_observability_calls(
     State(state): State<ManagementState>,
     Query(q): Query<CallsQuery>,
@@ -3883,7 +3948,20 @@ async fn get_observability_calls(
         .limit
         .unwrap_or(CALLS_DEFAULT_LIMIT)
         .clamp(1, CALLS_MAX_LIMIT);
-    let offset = q.offset.unwrap_or(0).max(0);
+    let cursor = match q.cursor.as_deref() {
+        Some(token) => match decode_calls_cursor(token) {
+            Some(c) => Some(c),
+            None => {
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    "invalid cursor",
+                    Some("The cursor query parameter is not a valid continuation token."),
+                )
+                .into_response();
+            }
+        },
+        None => None,
+    };
     let filter = QueryFilter {
         server_name: q.server_name,
         tool: q.tool,
@@ -3895,14 +3973,26 @@ async fn get_observability_calls(
     // Offload the synchronous rusqlite query to a blocking thread so a slow
     // query never stalls the async runtime serving management + relay tasks.
     let store = Arc::clone(obs.store());
-    let queried = tokio::task::spawn_blocking(move || store.query(&filter, limit, offset)).await;
+    let queried = tokio::task::spawn_blocking(move || store.query(&filter, limit, cursor)).await;
     match queried {
-        Ok(Ok(rows)) => Json(CallsResponse {
-            calls: rows.into_iter().map(CallRecordDto::from).collect(),
-            limit,
-            offset,
-        })
-        .into_response(),
+        Ok(Ok(rows)) => {
+            // Emit a continuation token only when the page filled the limit —
+            // otherwise we're at the tail and there's no more to fetch. The
+            // token encodes the last row's `(ts_start, id)`, which the next
+            // request feeds back via `?cursor=`.
+            let next_cursor = if rows.len() as i64 >= limit {
+                rows.last()
+                    .and_then(|r| r.id.map(|id| encode_calls_cursor(r.ts_start, id)))
+            } else {
+                None
+            };
+            Json(CallsResponse {
+                calls: rows.into_iter().map(CallSummaryDto::from).collect(),
+                limit,
+                next_cursor,
+            })
+            .into_response()
+        }
         Ok(Err(e)) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             "failed to query observability records",
@@ -5512,7 +5602,7 @@ command = "cat"
                     ..Default::default()
                 },
                 100,
-                0,
+                None,
             )
             .unwrap();
         assert!(echo_rows.is_empty(), "echo metadata rows should be deleted");
@@ -5527,7 +5617,7 @@ command = "cat"
                     ..Default::default()
                 },
                 100,
-                0,
+                None,
             )
             .unwrap();
         assert_eq!(keep_rows.len(), 2, "keep-me metadata rows should survive");

--- a/src/observability/store.rs
+++ b/src/observability/store.rs
@@ -75,6 +75,12 @@ pub struct AggregateBucket {
     pub p95_ms: u64,
 }
 
+/// Opaque keyset cursor for [`Store::query`] — the `(ts_start, id)` of the last
+/// row returned by the previous page. Encodes as a `(ts_start, id)` row-value
+/// `<` comparison so paging stays stable across concurrent inserts and is
+/// O(limit) at any depth.
+pub type QueryCursor = (i64, i64);
+
 /// Outcome of [`Store::enforce_size_cap`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SizeCapResult {
@@ -190,12 +196,16 @@ impl Store {
         Ok(records.len())
     }
 
-    /// Query records (newest first), filtered by `filter`, with `limit`/`offset` paging.
+    /// Query records (newest first), filtered by `filter`, paged by an opaque
+    /// `(ts_start, id)` keyset `cursor` (`None` for the first page). The next
+    /// page's cursor is the last returned row's `(ts_start, id)`. Uses
+    /// SQLite's row-value `<` comparison so paging is stable under concurrent
+    /// inserts and O(limit) at any depth.
     pub fn query(
         &self,
         filter: &QueryFilter,
         limit: i64,
-        offset: i64,
+        cursor: Option<QueryCursor>,
     ) -> rusqlite::Result<Vec<CallRecord>> {
         let mut sql = format!("SELECT {SELECT_COLUMNS} FROM calls WHERE 1=1");
         let mut args: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
@@ -223,9 +233,13 @@ impl Store {
             sql.push_str(" AND ts_start < ?");
             args.push(Box::new(until));
         }
-        sql.push_str(" ORDER BY ts_start DESC, id DESC LIMIT ? OFFSET ?");
+        if let Some((cur_ts, cur_id)) = cursor {
+            sql.push_str(" AND (ts_start, id) < (?, ?)");
+            args.push(Box::new(cur_ts));
+            args.push(Box::new(cur_id));
+        }
+        sql.push_str(" ORDER BY ts_start DESC, id DESC LIMIT ?");
         args.push(Box::new(limit));
-        args.push(Box::new(offset));
 
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(&sql)?;
@@ -289,6 +303,13 @@ impl Store {
     /// [`AggregateBucket`] per (server, bucket) plus a global series
     /// (`server == None`). `bucket_seconds` is the bucket width; buckets are
     /// aligned to multiples of the width from the epoch.
+    ///
+    /// Aggregation is pushed into SQLite via `GROUP BY bucket` plus a window-
+    /// function CTE for nearest-rank percentiles, so the relay never
+    /// materializes every row of the window into a `Vec<CallRecord>` just to
+    /// count/percentile it. The per-server and global series are two
+    /// independent grouped queries; the global series is then zero-filled
+    /// across the aligned window so the sparkline draws a real time-shape.
     pub fn aggregate(
         &self,
         bucket_seconds: i64,
@@ -297,53 +318,107 @@ impl Store {
     ) -> rusqlite::Result<Vec<AggregateBucket>> {
         let bucket_ms = bucket_seconds.max(1) * 1000;
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
-            "SELECT server_name, ts_start, duration_ms, success FROM calls \
-             WHERE ts_start >= ?1 AND ts_start < ?2 ORDER BY ts_start ASC",
-        )?;
-        let rows = stmt.query_map(params![since, until], |row| {
-            let server: Option<String> = row.get(0)?;
-            let ts: i64 = row.get(1)?;
-            let dur: i64 = row.get(2)?;
-            let ok: i64 = row.get(3)?;
-            Ok((server, ts, dur.max(0) as u64, ok != 0))
-        })?;
+
+        // Per-(server, bucket) aggregate. The CTE ranks rows by duration within
+        // each (server, bucket) partition and tags each with the partition
+        // size `n`; the outer `GROUP BY` then picks count/error_count plus the
+        // single row whose `rn` is the nearest-rank index for p50 and p95
+        // (`ceil(p/100 * n)`, clamped to `[1, n]`, expressed as integer
+        // ceiling-division `(p*n + 99)/100`).
+        let per_server_sql = "WITH ranked AS (\n\
+                SELECT server_name, \n\
+                       (ts_start / ?1) * ?1 AS bucket_start, \n\
+                       MAX(duration_ms, 0) AS dur, \n\
+                       success, \n\
+                       ROW_NUMBER() OVER ( \n\
+                           PARTITION BY server_name, (ts_start / ?1) * ?1 \n\
+                           ORDER BY MAX(duration_ms, 0) \n\
+                       ) AS rn, \n\
+                       COUNT(*) OVER ( \n\
+                           PARTITION BY server_name, (ts_start / ?1) * ?1 \n\
+                       ) AS n \n\
+                FROM calls \n\
+                WHERE ts_start >= ?2 AND ts_start < ?3 AND server_name IS NOT NULL \n\
+            ) \n\
+            SELECT server_name, bucket_start, \n\
+                   MAX(n) AS count, \n\
+                   SUM(CASE WHEN success = 0 THEN 1 ELSE 0 END) AS error_count, \n\
+                   MAX(CASE WHEN rn = MAX(1, MIN(n, (50 * n + 99) / 100)) THEN dur END) AS p50, \n\
+                   MAX(CASE WHEN rn = MAX(1, MIN(n, (95 * n + 99) / 100)) THEN dur END) AS p95 \n\
+            FROM ranked \n\
+            GROUP BY server_name, bucket_start";
+
+        // Global series: same shape, but partitioned only by bucket so all
+        // servers' rows roll up into the same percentile/count pool.
+        let global_sql = "WITH ranked AS (\n\
+                SELECT (ts_start / ?1) * ?1 AS bucket_start, \n\
+                       MAX(duration_ms, 0) AS dur, \n\
+                       success, \n\
+                       ROW_NUMBER() OVER ( \n\
+                           PARTITION BY (ts_start / ?1) * ?1 \n\
+                           ORDER BY MAX(duration_ms, 0) \n\
+                       ) AS rn, \n\
+                       COUNT(*) OVER ( \n\
+                           PARTITION BY (ts_start / ?1) * ?1 \n\
+                       ) AS n \n\
+                FROM calls \n\
+                WHERE ts_start >= ?2 AND ts_start < ?3 \n\
+            ) \n\
+            SELECT bucket_start, \n\
+                   MAX(n) AS count, \n\
+                   SUM(CASE WHEN success = 0 THEN 1 ELSE 0 END) AS error_count, \n\
+                   MAX(CASE WHEN rn = MAX(1, MIN(n, (50 * n + 99) / 100)) THEN dur END) AS p50, \n\
+                   MAX(CASE WHEN rn = MAX(1, MIN(n, (95 * n + 99) / 100)) THEN dur END) AS p95 \n\
+            FROM ranked \n\
+            GROUP BY bucket_start";
+
+        let mut per_server: Vec<AggregateBucket> = {
+            let mut stmt = conn.prepare(per_server_sql)?;
+            let rows = stmt.query_map(params![bucket_ms, since, until], |row| {
+                Ok(AggregateBucket {
+                    server: row.get::<_, Option<String>>(0)?,
+                    bucket_start: row.get(1)?,
+                    count: row.get::<_, i64>(2)?.max(0) as u64,
+                    error_count: row.get::<_, i64>(3)?.max(0) as u64,
+                    p50_ms: row.get::<_, Option<i64>>(4)?.unwrap_or(0).max(0) as u64,
+                    p95_ms: row.get::<_, Option<i64>>(5)?.unwrap_or(0).max(0) as u64,
+                })
+            })?;
+            rows.collect::<rusqlite::Result<Vec<_>>>()?
+        };
 
         use std::collections::BTreeMap;
-        // key: (server, bucket_start) -> (durations, error_count)
-        let mut acc: BTreeMap<(Option<String>, i64), (Vec<u64>, u64)> = BTreeMap::new();
-        for row in rows {
-            let (server, ts, dur, ok) = row?;
-            let bucket = (ts / bucket_ms) * bucket_ms;
-            for key in [(server.clone(), bucket), (None, bucket)] {
-                let entry = acc.entry(key).or_default();
-                entry.0.push(dur);
-                if !ok {
-                    entry.1 += 1;
-                }
+        let mut global: BTreeMap<i64, AggregateBucket> = BTreeMap::new();
+        {
+            let mut stmt = conn.prepare(global_sql)?;
+            let rows = stmt.query_map(params![bucket_ms, since, until], |row| {
+                let bucket_start: i64 = row.get(0)?;
+                Ok((
+                    bucket_start,
+                    AggregateBucket {
+                        server: None,
+                        bucket_start,
+                        count: row.get::<_, i64>(1)?.max(0) as u64,
+                        error_count: row.get::<_, i64>(2)?.max(0) as u64,
+                        p50_ms: row.get::<_, Option<i64>>(3)?.unwrap_or(0).max(0) as u64,
+                        p95_ms: row.get::<_, Option<i64>>(4)?.unwrap_or(0).max(0) as u64,
+                    },
+                ))
+            })?;
+            for r in rows {
+                let (k, v) = r?;
+                global.insert(k, v);
             }
         }
 
-        // Build populated buckets, keeping global (server == None) separate so
-        // we can zero-fill it into a contiguous series spanning the window.
-        let mut global: BTreeMap<i64, AggregateBucket> = BTreeMap::new();
-        let mut per_server = Vec::new();
-        for ((server, bucket_start), (mut durations, error_count)) in acc {
-            durations.sort_unstable();
-            let bucket = AggregateBucket {
-                server: server.clone(),
-                bucket_start,
-                count: durations.len() as u64,
-                error_count,
-                p50_ms: percentile(&durations, 50),
-                p95_ms: percentile(&durations, 95),
-            };
-            if server.is_none() {
-                global.insert(bucket_start, bucket);
-            } else {
-                per_server.push(bucket);
-            }
-        }
+        // Stable order for per-server buckets matches the previous BTreeMap
+        // emission order, which the existing wire-shape tests depend on
+        // (sorted by server name, then by bucket_start ascending).
+        per_server.sort_by(|a, b| {
+            a.server
+                .cmp(&b.server)
+                .then_with(|| a.bucket_start.cmp(&b.bucket_start))
+        });
 
         // Emit one global bucket per step across the aligned `[since, until)`
         // window, filling gaps with zeros so the sparkline draws a real
@@ -441,17 +516,6 @@ impl Store {
     }
 }
 
-/// Nearest-rank percentile (`p` in `0..=100`) over a pre-sorted slice.
-fn percentile(sorted: &[u64], p: u64) -> u64 {
-    if sorted.is_empty() {
-        return 0;
-    }
-    let n = sorted.len();
-    let rank = ((p as f64 / 100.0) * n as f64).ceil() as usize;
-    let idx = rank.saturating_sub(1).min(n - 1);
-    sorted[idx]
-}
-
 /// Current wall-clock time in epoch milliseconds.
 fn now_ms() -> i64 {
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -498,7 +562,7 @@ mod tests {
         assert!(dir.path().join("observability.db").exists());
         // Re-open: schema creation must be idempotent and data persists.
         let store = Store::open(dir.path()).unwrap();
-        let rows = store.query(&QueryFilter::default(), 10, 0).unwrap();
+        let rows = store.query(&QueryFilter::default(), 10, None).unwrap();
         assert_eq!(rows.len(), 1);
     }
 
@@ -514,7 +578,7 @@ mod tests {
             .unwrap();
 
         // Newest-first ordering.
-        let all = store.query(&QueryFilter::default(), 10, 0).unwrap();
+        let all = store.query(&QueryFilter::default(), 10, None).unwrap();
         assert_eq!(all.len(), 3);
         assert_eq!(all[0].ts_start, 3000);
         assert_eq!(all[2].ts_start, 1000);
@@ -527,7 +591,7 @@ mod tests {
                     ..Default::default()
                 },
                 10,
-                0,
+                None,
             )
             .unwrap();
         assert_eq!(alpha.len(), 2);
@@ -540,7 +604,7 @@ mod tests {
                     ..Default::default()
                 },
                 10,
-                0,
+                None,
             )
             .unwrap();
         assert_eq!(alph.len(), 2);
@@ -553,7 +617,7 @@ mod tests {
                     ..Default::default()
                 },
                 10,
-                0,
+                None,
             )
             .unwrap();
         assert_eq!(mid.len(), 2);
@@ -566,7 +630,7 @@ mod tests {
                     ..Default::default()
                 },
                 10,
-                0,
+                None,
             )
             .unwrap();
         assert_eq!(by_tool.len(), 1);
@@ -580,13 +644,21 @@ mod tests {
                     ..Default::default()
                 },
                 10,
-                0,
+                None,
             )
             .unwrap();
         assert_eq!(failed.len(), 1);
         assert_eq!(failed[0].server_name.as_deref(), Some("beta"));
 
-        let page2 = store.query(&QueryFilter::default(), 1, 1).unwrap();
+        // Keyset paging: the first page returns the newest row, and feeding
+        // back its `(ts_start, id)` advances to the next-newest row.
+        let page1 = store.query(&QueryFilter::default(), 1, None).unwrap();
+        assert_eq!(page1.len(), 1);
+        assert_eq!(page1[0].ts_start, 3000);
+        let cursor = (page1[0].ts_start, page1[0].id.expect("row id"));
+        let page2 = store
+            .query(&QueryFilter::default(), 1, Some(cursor))
+            .unwrap();
         assert_eq!(page2.len(), 1);
         assert_eq!(page2[0].ts_start, 2000);
 
@@ -618,7 +690,7 @@ mod tests {
                     ..Default::default()
                 },
                 10,
-                0,
+                None,
             )
             .unwrap();
         assert_eq!(underscore.len(), 1);
@@ -633,7 +705,7 @@ mod tests {
                     ..Default::default()
                 },
                 10,
-                0,
+                None,
             )
             .unwrap();
         assert_eq!(percent.len(), 1);
@@ -722,7 +794,7 @@ mod tests {
             .unwrap();
         let deleted = store.enforce_retention(7).unwrap();
         assert_eq!(deleted, 1);
-        let rows = store.query(&QueryFilter::default(), 10, 0).unwrap();
+        let rows = store.query(&QueryFilter::default(), 10, None).unwrap();
         assert_eq!(rows.len(), 1);
     }
 
@@ -745,7 +817,10 @@ mod tests {
         assert!(zero.evicted);
         assert!(zero.deleted_rows > 0);
         assert_eq!(zero.oldest_retained_ts, None);
-        assert_eq!(store.query(&QueryFilter::default(), 1, 0).unwrap().len(), 0);
+        assert_eq!(
+            store.query(&QueryFilter::default(), 1, None).unwrap().len(),
+            0
+        );
     }
 
     #[test]
@@ -762,13 +837,19 @@ mod tests {
         let removed = store.delete_for_server("alpha").unwrap();
         assert_eq!(removed, 2);
         assert_eq!(
-            store.query(&QueryFilter::default(), 10, 0).unwrap().len(),
+            store
+                .query(&QueryFilter::default(), 10, None)
+                .unwrap()
+                .len(),
             1
         );
 
         store.purge_all().unwrap();
         assert_eq!(
-            store.query(&QueryFilter::default(), 10, 0).unwrap().len(),
+            store
+                .query(&QueryFilter::default(), 10, None)
+                .unwrap()
+                .len(),
             0
         );
     }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1901,7 +1901,7 @@ mod tests {
         // Drain: poll until both rows land via the background consumer.
         let mut rows = Vec::new();
         for _ in 0..50 {
-            rows = store.query(&QueryFilter::default(), 10, 0).unwrap();
+            rows = store.query(&QueryFilter::default(), 10, None).unwrap();
             if rows.len() >= 2 {
                 break;
             }

--- a/tests/management_api_integration.rs
+++ b/tests/management_api_integration.rs
@@ -872,7 +872,8 @@ async fn test_observability_calls_list_filter_and_paging() {
     let (addr, _store, _payloads, _handle) = start_observability_server(None, true).await;
     let client = reqwest::Client::new();
 
-    // Full list, newest-first.
+    // Full list, newest-first. The first page returns a slim per-row DTO and
+    // omits `nextCursor` because it fits under the default limit.
     let resp = client
         .get(format!("http://{}/api/observability/calls", addr))
         .send()
@@ -885,7 +886,10 @@ async fn test_observability_calls_list_filter_and_paging() {
     assert_eq!(calls[0]["tsStart"], 3000);
     assert_eq!(calls[0]["serverName"], "beta");
     assert_eq!(body["limit"], 100);
-    assert_eq!(body["offset"], 0);
+    assert!(body.get("nextCursor").is_none() || body["nextCursor"].is_null());
+    // The slim list DTO drops transport/client/payload-byte detail.
+    assert!(calls[0].get("transport").is_none());
+    assert!(calls[0].get("clientName").is_none());
 
     // Filter by server.
     let resp = client
@@ -913,11 +917,25 @@ async fn test_observability_calls_list_filter_and_paging() {
     assert_eq!(calls.len(), 1);
     assert_eq!(calls[0]["requestUid"], "uid-a2");
 
-    // Paging: second page of size 1 is the middle record (ts 2000).
+    // Keyset paging: a limit-1 page returns the newest record plus a
+    // `nextCursor` token; feeding it back walks to the next-newest record.
+    let resp = client
+        .get(format!("http://{}/api/observability/calls?limit=1", addr))
+        .send()
+        .await
+        .expect("request failed");
+    let body: Value = resp.json().await.unwrap();
+    let calls = body["calls"].as_array().unwrap();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0]["tsStart"], 3000);
+    let cursor = body["nextCursor"]
+        .as_str()
+        .expect("nextCursor on full page");
+
     let resp = client
         .get(format!(
-            "http://{}/api/observability/calls?limit=1&offset=1",
-            addr
+            "http://{}/api/observability/calls?limit=1&cursor={}",
+            addr, cursor
         ))
         .send()
         .await
@@ -926,6 +944,18 @@ async fn test_observability_calls_list_filter_and_paging() {
     let calls = body["calls"].as_array().unwrap();
     assert_eq!(calls.len(), 1);
     assert_eq!(calls[0]["tsStart"], 2000);
+
+    // An unparseable cursor is rejected as 400 — the token is opaque, but
+    // garbage in must not silently return the first page.
+    let resp = client
+        .get(format!(
+            "http://{}/api/observability/calls?cursor=not-a-real-token",
+            addr
+        ))
+        .send()
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status().as_u16(), 400);
 }
 
 #[tokio::test]
@@ -1032,7 +1062,7 @@ async fn test_observability_purge() {
             .query(
                 &endara_relay::observability::store::QueryFilter::default(),
                 10,
-                0
+                None,
             )
             .unwrap()
             .len(),


### PR DESCRIPTION
## Summary
Reduces data transferred and improves the Observability calls path with three coherent changes:

1. **Keyset / continuation-token pagination** — `/observability/calls` now uses an opaque base64url continuation token keyed on `(ts_start, id)` instead of `offset`. Stable across live inserts (no dupes/skips), O(limit) at any depth. Invalid/garbage cursors return HTTP 400. Limit clamp `[1, 1000]` (default 100) is unchanged.
2. **Slim list DTO** — the calls-list response now returns a `CallSummaryDto` with only the columns the table renders (`id, requestUid, serverName, tool, tsStart, durationMs, success, errorMessage, requestBytes, responseBytes`). The drill-through detail route still returns the full `CallRecordDto`.
3. **SQL aggregation** — `aggregate()` is rewritten as window-function CTEs (`ROW_NUMBER() OVER` + `COUNT(*) OVER`, nearest-rank percentile in SQL), so the relay no longer materializes every row in the window to build sparkline buckets. The zero-filled global series and per-server series are preserved.

## Verification
- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` — store tests 9/9, integration 22/22 (only a pre-existing, unrelated oauth socket-bind flake)

Existing aggregate tests (`aggregate_buckets_with_percentiles_and_global_series`, `aggregate_global_series_is_zero_filled_across_window`) pass unchanged. Output contract is byte-for-byte compatible for aggregates.

Pairs with the desktop PR that consumes the new cursor + slim DTO.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author