### PR TITLE
fix(http): mark plain HTTP servers unhealthy after repeated transport failures

### DIFF
--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -131,7 +131,22 @@ pub struct HttpAdapter {
     /// sent a top-level `ttlMs`; `None` otherwise. Read by the registry cache to
     /// honor the upstream's freshness window. See [`Self::list_tools_ttl_ms`].
     list_ttl_ms: Arc<RwLock<Option<u64>>>,
+    /// Count of consecutive transport-level ("upstream is dead") failures seen
+    /// on outbound requests issued via [`Self::send_request`] (the `list_tools`
+    /// and `call_tool` paths). Incremented only for transport-dead signals
+    /// (see [`Self::is_transport_dead`]); reset to 0 on any successful request.
+    /// Once it reaches [`TRANSPORT_FAILURE_THRESHOLD`] the adapter flips its
+    /// own health to `Unhealthy("upstream unreachable")`, giving plain HTTP the
+    /// post-init death detection it otherwise lacks (no background heartbeat).
+    transport_failures: AtomicU64,
 }
+
+/// Consecutive transport-dead failures on `send_request` before the plain HTTP
+/// adapter flips its health to `Unhealthy("upstream unreachable")`. A single
+/// blip shouldn't demote a server, but a server that's actually gone fails
+/// every request, so a small threshold both avoids flapping and reports death
+/// quickly.
+const TRANSPORT_FAILURE_THRESHOLD: u64 = 3;
 
 /// HTTP header name reqwest reads/writes for the MCP session ID. Reqwest's
 /// `HeaderMap` stores names lowercase internally, so reading and writing both
@@ -215,6 +230,7 @@ impl HttpAdapter {
             last_www_authenticate: Arc::new(RwLock::new(None)),
             upstream_dialect: Arc::new(RwLock::new(ProtocolVersion::V2025_03_26)),
             list_ttl_ms: Arc::new(RwLock::new(None)),
+            transport_failures: AtomicU64::new(0),
         }
     }
 
@@ -265,6 +281,7 @@ impl HttpAdapter {
             last_www_authenticate: Arc::new(RwLock::new(None)),
             upstream_dialect: Arc::new(RwLock::new(ProtocolVersion::V2025_03_26)),
             list_ttl_ms: Arc::new(RwLock::new(None)),
+            transport_failures: AtomicU64::new(0),
         }
     }
 
@@ -562,8 +579,73 @@ impl HttpAdapter {
         }
     }
 
+    /// Classify an [`AdapterError`] as a transport-dead ("upstream is gone")
+    /// signal versus an alive-but-erroring one. Only the former feed the
+    /// consecutive-failure counter that drives reactive health.
+    ///
+    /// - Dead: [`AdapterError::ConnectionFailed`] (reqwest `is_connect`),
+    ///   [`AdapterError::Timeout`] (`is_timeout`), and
+    ///   [`AdapterError::HttpError`] with `status == 0` (other reqwest send
+    ///   errors) — the server didn't answer at the transport level.
+    /// - Not dead: any `HttpError` with a non-zero status (401/404/500…),
+    ///   `JsonRpcError`, and `ProtocolError` — the server is up and responding,
+    ///   so these must never demote health (a 401 means the server is alive).
+    fn is_transport_dead(err: &AdapterError) -> bool {
+        matches!(
+            err,
+            AdapterError::ConnectionFailed(_)
+                | AdapterError::Timeout(_)
+                | AdapterError::HttpError { status: 0, .. }
+        )
+    }
+
+    /// Record a successful request: reset the transport-failure counter and, if
+    /// the adapter had previously demoted itself to `Unhealthy`, recover to
+    /// `Healthy`. Other health states (`Starting`/`Stopped`) are left untouched.
+    async fn note_request_success(&self) {
+        self.transport_failures.store(0, Ordering::SeqCst);
+        let mut health = self.health.write().await;
+        if matches!(*health, HealthStatus::Unhealthy(_)) {
+            *health = HealthStatus::Healthy;
+        }
+    }
+
+    /// Record a transport-dead failure: increment the consecutive-failure
+    /// counter and, once it reaches [`TRANSPORT_FAILURE_THRESHOLD`], flip health
+    /// to `Unhealthy("upstream unreachable")`.
+    async fn note_transport_failure(&self) {
+        let count = self.transport_failures.fetch_add(1, Ordering::SeqCst) + 1;
+        if count >= TRANSPORT_FAILURE_THRESHOLD {
+            *self.health.write().await = HealthStatus::Unhealthy("upstream unreachable".into());
+        }
+    }
+
     /// Send a JSON-RPC request via HTTP POST and return the result.
+    ///
+    /// Wraps [`Self::send_request_inner`] to centralize reactive health: the
+    /// outcome of every `list_tools` / `call_tool` request feeds the
+    /// transport-failure counter so a plain HTTP server that dies after init is
+    /// detected (flips to `Unhealthy`) and auto-recovers on the next success.
     async fn send_request(
+        &self,
+        method: &str,
+        params: Option<Value>,
+    ) -> Result<Value, AdapterError> {
+        let result = self.send_request_inner(method, params).await;
+        match &result {
+            Ok(_) => self.note_request_success().await,
+            Err(e) if Self::is_transport_dead(e) => self.note_transport_failure().await,
+            // Alive-but-erroring (HTTP status>0, JSON-RPC, protocol): leave the
+            // counter and health untouched so a 401/500/etc. never demotes.
+            Err(_) => {}
+        }
+        result
+    }
+
+    /// Inner request implementation: builds and sends the HTTP POST and maps the
+    /// response/transport outcome to a `Result`. Health bookkeeping lives in the
+    /// [`Self::send_request`] wrapper.
+    async fn send_request_inner(
         &self,
         method: &str,
         params: Option<Value>,
@@ -2338,6 +2420,138 @@ mod tests {
             Err(AdapterError::HttpError { status: 401, .. }) => {}
             other => panic!("expected HttpError {{ 401 }}, got {:?}", other),
         }
+        server.abort();
+    }
+
+    // --- Reactive transport-failure health detection ---
+
+    /// Classification is the contract the reactive counter relies on: only
+    /// transport-dead signals (connect/timeout/`HttpError { status: 0 }`) feed
+    /// the counter; a live-but-erroring server (non-zero HTTP status, JSON-RPC
+    /// error, protocol error) must never be treated as dead.
+    #[test]
+    fn is_transport_dead_classifies_errors() {
+        assert!(HttpAdapter::is_transport_dead(
+            &AdapterError::ConnectionFailed("refused".into())
+        ));
+        assert!(HttpAdapter::is_transport_dead(&AdapterError::Timeout(30)));
+        assert!(HttpAdapter::is_transport_dead(&AdapterError::HttpError {
+            status: 0,
+            body: "send error".into(),
+        }));
+
+        assert!(!HttpAdapter::is_transport_dead(&AdapterError::HttpError {
+            status: 401,
+            body: "unauthorized".into(),
+        }));
+        assert!(!HttpAdapter::is_transport_dead(&AdapterError::HttpError {
+            status: 500,
+            body: "boom".into(),
+        }));
+        assert!(!HttpAdapter::is_transport_dead(
+            &AdapterError::JsonRpcError {
+                code: -32000,
+                message: "nope".into(),
+                data: None,
+            }
+        ));
+        assert!(!HttpAdapter::is_transport_dead(
+            &AdapterError::ProtocolError("bad".into())
+        ));
+    }
+
+    /// A plain HTTP server that dies after init: once the upstream stops
+    /// answering, repeated `call_tool` transport failures flip health to
+    /// `Unhealthy` at the threshold (and not before).
+    #[tokio::test]
+    async fn transport_failures_flip_health_to_unhealthy() {
+        // Bind then immediately drop a listener to obtain a port that refuses
+        // connections — every request will fail with `ConnectionFailed`.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let url = format!("http://{}/mcp", addr);
+
+        let adapter = HttpAdapter::new(HttpConfig::new(url));
+        // Simulate the post-init state: the server came up Healthy.
+        *adapter.health.write().await = HealthStatus::Healthy;
+
+        for _ in 0..(TRANSPORT_FAILURE_THRESHOLD - 1) {
+            let result = adapter.call_tool("x", json!({})).await;
+            assert!(result.is_err(), "dead upstream should error");
+            assert_eq!(
+                adapter.health(),
+                HealthStatus::Healthy,
+                "health must stay Healthy below the failure threshold"
+            );
+        }
+
+        let result = adapter.call_tool("x", json!({})).await;
+        assert!(result.is_err());
+        match adapter.health() {
+            HealthStatus::Unhealthy(msg) => assert_eq!(msg, "upstream unreachable"),
+            other => panic!("expected Unhealthy after threshold, got {:?}", other),
+        }
+    }
+
+    /// A live-but-erroring server (hard 401 on every call) must NOT flip health:
+    /// the upstream is reachable, so the transport-failure counter stays at 0.
+    #[tokio::test]
+    async fn http_error_does_not_flip_health() {
+        let (base, server) = spawn_gated_mcp_fixture().await;
+        let adapter = HttpAdapter::new(HttpConfig::new(format!("{}/mcp", base)));
+        *adapter.health.write().await = HealthStatus::Healthy;
+
+        for _ in 0..(TRANSPORT_FAILURE_THRESHOLD + 2) {
+            let result = adapter.call_tool("search", json!({})).await;
+            match result {
+                Err(AdapterError::HttpError { status: 401, .. }) => {}
+                other => panic!("expected HttpError {{ 401 }}, got {:?}", other),
+            }
+        }
+
+        assert_eq!(
+            adapter.health(),
+            HealthStatus::Healthy,
+            "a reachable server returning 401 must not be demoted"
+        );
+        assert_eq!(
+            adapter.transport_failures.load(Ordering::SeqCst),
+            0,
+            "non-transport errors must not increment the failure counter"
+        );
+
+        server.abort();
+    }
+
+    /// Auto-recovery: after the adapter has demoted itself to `Unhealthy`, the
+    /// next successful request flips it back to `Healthy` and resets the counter.
+    #[tokio::test]
+    async fn success_recovers_health_and_resets_counter() {
+        // GET 405 so the test doesn't depend on the SSE channel; POST returns ok.
+        let (url, server) = start_fake_http_server(true).await;
+        let adapter = HttpAdapter::new(HttpConfig::new(url));
+        // Simulate a prior run of transport failures that demoted the adapter.
+        *adapter.health.write().await = HealthStatus::Unhealthy("upstream unreachable".into());
+        adapter.transport_failures.store(5, Ordering::SeqCst);
+
+        let result = adapter
+            .call_tool("x", json!({}))
+            .await
+            .expect("live server should answer successfully");
+        assert_eq!(result["ok"], true);
+
+        assert_eq!(
+            adapter.health(),
+            HealthStatus::Healthy,
+            "a successful request must recover health from Unhealthy"
+        );
+        assert_eq!(
+            adapter.transport_failures.load(Ordering::SeqCst),
+            0,
+            "a successful request must reset the failure counter"
+        );
+
         server.abort();
     }
 

--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -602,9 +602,14 @@ impl HttpAdapter {
     /// Record a successful request: reset the transport-failure counter and, if
     /// the adapter had previously demoted itself to `Unhealthy`, recover to
     /// `Healthy`. Other health states (`Starting`/`Stopped`) are left untouched.
+    ///
+    /// The counter reset and the health write are performed while holding the
+    /// `health` write lock so they transition atomically with respect to
+    /// [`Self::note_transport_failure`] — there is no interleaving that can
+    /// leave the counter and health disagreeing.
     async fn note_request_success(&self) {
-        self.transport_failures.store(0, Ordering::SeqCst);
         let mut health = self.health.write().await;
+        self.transport_failures.store(0, Ordering::SeqCst);
         if matches!(*health, HealthStatus::Unhealthy(_)) {
             *health = HealthStatus::Healthy;
         }
@@ -613,10 +618,17 @@ impl HttpAdapter {
     /// Record a transport-dead failure: increment the consecutive-failure
     /// counter and, once it reaches [`TRANSPORT_FAILURE_THRESHOLD`], flip health
     /// to `Unhealthy("upstream unreachable")`.
+    ///
+    /// The increment, threshold check, and health write are performed while
+    /// holding the `health` write lock so they transition atomically with
+    /// respect to [`Self::note_request_success`]. This guarantees there is no
+    /// interleaving that leaves `health == Unhealthy("upstream unreachable")`
+    /// while the failure counter is below the threshold.
     async fn note_transport_failure(&self) {
+        let mut health = self.health.write().await;
         let count = self.transport_failures.fetch_add(1, Ordering::SeqCst) + 1;
         if count >= TRANSPORT_FAILURE_THRESHOLD {
-            *self.health.write().await = HealthStatus::Unhealthy("upstream unreachable".into());
+            *health = HealthStatus::Unhealthy("upstream unreachable".into());
         }
     }
 
@@ -1056,6 +1068,9 @@ impl McpAdapter for HttpAdapter {
                 self.apply_server_identity(result).await?;
                 // 2026 is stateless: no notifications/initialized, no session id.
                 self.spawn_get_listener().await;
+                // Fresh start after (re)connect: clear any stale transport-dead
+                // count so reactive health begins from a clean slate.
+                self.transport_failures.store(0, Ordering::SeqCst);
                 *self.health.write().await = HealthStatus::Healthy;
                 info!(url = %self.config.url, "HTTP MCP adapter initialized (2026 stateless path)");
                 return Ok(());
@@ -1243,6 +1258,9 @@ impl McpAdapter for HttpAdapter {
             // via `parse_sse_response`.
             self.spawn_get_listener().await;
 
+            // Fresh start after (re)connect: clear any stale transport-dead
+            // count so reactive health begins from a clean slate.
+            self.transport_failures.store(0, Ordering::SeqCst);
             *self.health.write().await = HealthStatus::Healthy;
             info!(url = %self.config.url, "HTTP MCP adapter initialized");
             Ok(())
@@ -2550,6 +2568,74 @@ mod tests {
             adapter.transport_failures.load(Ordering::SeqCst),
             0,
             "a successful request must reset the failure counter"
+        );
+
+        server.abort();
+    }
+
+    /// Race guard (PR #123 review SHOULD-FIX): the failure-counter update and
+    /// the `health` write are performed under a single `health` write lock, so
+    /// concurrently firing a threshold-crossing transport failure and a
+    /// success can never leave the adapter stuck `Unhealthy` with the counter
+    /// below the threshold. Every settled state keeps counter and health in
+    /// agreement: `Unhealthy("upstream unreachable")` implies the counter is at
+    /// or above the threshold.
+    #[tokio::test]
+    async fn concurrent_success_and_failure_never_stick_unhealthy() {
+        for _ in 0..1000 {
+            let adapter = Arc::new(HttpAdapter::new(HttpConfig::new("http://127.0.0.1:1/mcp")));
+            *adapter.health.write().await = HealthStatus::Healthy;
+            // Prime the counter one below the threshold so the racing failure
+            // would cross it and demote health.
+            adapter
+                .transport_failures
+                .store(TRANSPORT_FAILURE_THRESHOLD - 1, Ordering::SeqCst);
+
+            let fail = {
+                let a = adapter.clone();
+                tokio::spawn(async move { a.note_transport_failure().await })
+            };
+            let ok = {
+                let a = adapter.clone();
+                tokio::spawn(async move { a.note_request_success().await })
+            };
+            fail.await.unwrap();
+            ok.await.unwrap();
+
+            // Observe the settled state under the lock: counter and health must
+            // agree. The buggy non-atomic version could leave counter == 0 while
+            // health == Unhealthy.
+            let health = adapter.health.read().await;
+            let count = adapter.transport_failures.load(Ordering::SeqCst);
+            if matches!(*health, HealthStatus::Unhealthy(_)) {
+                assert!(
+                    count >= TRANSPORT_FAILURE_THRESHOLD,
+                    "stuck Unhealthy with counter {} below threshold {}",
+                    count,
+                    TRANSPORT_FAILURE_THRESHOLD
+                );
+            }
+        }
+    }
+
+    /// A successful `initialize()` resets the transport-failure counter to 0,
+    /// giving reactive health a clean slate after a (re)connect even if a prior
+    /// run had accumulated transport-dead failures.
+    #[tokio::test]
+    async fn initialize_resets_transport_failure_counter() {
+        // GET 405 so the test doesn't depend on the SSE channel; POST returns ok.
+        let (url, server) = start_fake_http_server(true).await;
+        let mut adapter = HttpAdapter::new(HttpConfig::new(url));
+        // Simulate stale state left over from a prior connection.
+        adapter.transport_failures.store(5, Ordering::SeqCst);
+
+        adapter.initialize().await.expect("initialize succeeds");
+
+        assert_eq!(adapter.health(), HealthStatus::Healthy);
+        assert_eq!(
+            adapter.transport_failures.load(Ordering::SeqCst),
+            0,
+            "a successful initialize must reset the transport-failure counter"
         );
 
         server.abort();


### PR DESCRIPTION
## Problem

Plain (non-OAuth) HTTP MCP adapters only probed liveness at **init**. Once an adapter went Healthy it stayed Healthy forever — nothing re-evaluated it. When the upstream server later died, every catalog rebuild's tools/list POST failed and the tools were tagged UNAVAILABLE, but health() still returned Healthy, so the server-list dot and the tray icon stayed green.

Other transports already detect post-init death (stdio watches the child process, SSE watches the stream, OAuth runs a heartbeat). Plain HTTP was the gap.

## Fix (reactive, no heartbeat)

Per discussion we intentionally avoid a background heartbeat (don't flood an on-demand server). Instead HttpAdapter now watches the outcome of the requests it already makes:

- Adds a consecutive-transport-failure counter (AtomicU64) on HttpAdapter, fed centrally via the send_request wrapper so both list_tools and call_tool paths count.
- After **3** consecutive transport-dead errors — ConnectionFailed (connect refused), Timeout, HttpError{status:0} — health flips to Unhealthy("upstream unreachable").
- Application-level errors never demote: HttpError{status>0} (401/404/500), JsonRpcError, ProtocolError. A live-but-erroring server (e.g. a 401) stays Healthy.
- Any successful request resets the counter and auto-recovers Unhealthy to Healthy.

## Scope

- Only src/adapter/http.rs changed.
- No background heartbeat, no UI changes; OAuth/stdio/SSE untouched.

## Tests

Adds 4 unit tests: flip-at-threshold, no-flip-on-401, transport-dead classification, and auto-recovery on success.

- cargo fmt --check: PASS
- cargo clippy --all-targets -- -D warnings: PASS (no warnings)
- cargo test --lib adapter::http: 43 passed, 0 failed
