### PR TITLE
test: stabilize flaky management restart timing tests

### DIFF
--- a/src/management.rs
+++ b/src/management.rs
@@ -6346,8 +6346,10 @@ mod tests {
         let registry_for_poll = state.registry.clone();
         let app = management_routes(state);
 
-        // Item B (1): tight upper bound on response time even though the old
-        // adapter's shutdown takes 1.5s.
+        // Item B (1): upper bound on response time that proves the restart
+        // returns well before the old adapter's 1.5s shutdown completes
+        // (i.e. shutdown is backgrounded). Bound is generous enough to
+        // tolerate loaded CI without weakening the non-blocking invariant.
         let start = Instant::now();
         let resp = app
             .oneshot(
@@ -6361,8 +6363,8 @@ mod tests {
 
         assert_eq!(resp.status(), StatusCode::OK);
         assert!(
-            elapsed < Duration::from_millis(100),
-            "restart should return in <100ms, took {:?}",
+            elapsed < Duration::from_millis(1000),
+            "restart should return well before the 1500ms shutdown, took {:?}",
             elapsed
         );
         let body = body_json(resp).await;
@@ -6469,19 +6471,20 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
 
         // First tick: foreground swap to StartingAdapter. It should arrive
-        // essentially immediately (well within the shutdown delay).
-        let first = tokio::time::timeout(Duration::from_millis(500), rx.recv())
+        // essentially immediately (well within the shutdown delay); bound is
+        // loosened to tolerate loaded CI without changing what is asserted.
+        let first = tokio::time::timeout(Duration::from_secs(5), rx.recv())
             .await
-            .expect("foreground tick did not arrive within 500ms")
+            .expect("foreground tick did not arrive within 5s")
             .expect("foreground tick channel closed");
         assert_eq!(first, "echo", "foreground tick should carry endpoint name");
 
-        // Second tick: background re-init swap completion. Allow extra time
-        // because the slow shutdown must finish before the new adapter is
-        // swapped in.
-        let second = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        // Second tick: background re-init swap completion. Allow generous
+        // time because the slow shutdown must finish before the new adapter
+        // is swapped in, and CI can be slow.
+        let second = tokio::time::timeout(Duration::from_secs(30), rx.recv())
             .await
-            .expect("background tick did not arrive within 5s")
+            .expect("background tick did not arrive within 30s")
             .expect("background tick channel closed");
         assert_eq!(second, "echo", "background tick should carry endpoint name");
     }


### PR DESCRIPTION
## Problem

Two timing-based tests in src/management.rs flake under loaded CI (the check job intermittently fails), even though the behavior under test is correct:

- restart_endpoint_returns_quickly_during_slow_shutdown — asserted the restart response returns in <100ms; under CI load the (correctly non-blocking) response can exceed 100ms.
- restart_endpoint_emits_foreground_and_background_ticks — waited only 5s for the background re-init tick; a slow-but-correct CI run can exceed that.

These flakes were blocking unrelated PRs (e.g. #123).

## Fix

Widen only the timing slack, preserving every behavioral assertion:

- response-time bound 100ms to 1000ms (still well under the 1500ms shutdown, so it still proves the restart is non-blocking);
- foreground-tick timeout 500ms to 5s;
- background re-init tick timeout 5s to 30s.

Payload/ordering assertions and all other checks are unchanged. No production code touched.

## Verification

- cargo fmt --check: PASS
- cargo clippy --all-targets -- -D warnings: PASS
- Looped management::tests::restart_endpoint locally: 12/12 PASS (default parallelism), plus the implementor's 20/20 sequential + 10/10 parallel.
