### PR TITLE
feat(mcp): proxy resources & prompts with reversible URI namespacing (MCP Apps support)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,6 +730,7 @@ dependencies = [
  "hyper-util",
  "jsonschema",
  "notify",
+ "percent-encoding",
  "rand 0.10.1",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ hyper = { version = "1", features = ["server", "http1", "http2"] }
 hyper-util = { version = "0.1", features = ["http1", "http2", "server", "server-auto", "tokio"] }
 jsonschema = "0.46.5"
 notify = "7"
+percent-encoding = "2.3.2"
 rand = "0.10.1"
 regex = "1.12.3"
 reqwest = { version = "0.13.2", features = ["json", "stream"] }

--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -1202,6 +1202,69 @@ impl McpAdapter for HttpAdapter {
         *self.list_ttl_ms.read().await
     }
 
+    async fn list_resources(&self) -> Result<Vec<Value>, AdapterError> {
+        async {
+            let result = self.send_request("resources/list", None).await?;
+            match result.get("resources") {
+                Some(Value::Array(items)) => Ok(items.clone()),
+                _ => Ok(vec![]),
+            }
+        }
+        .instrument(self.span.clone())
+        .await
+    }
+
+    async fn list_resource_templates(&self) -> Result<Vec<Value>, AdapterError> {
+        async {
+            let result = self.send_request("resources/templates/list", None).await?;
+            match result.get("resourceTemplates") {
+                Some(Value::Array(items)) => Ok(items.clone()),
+                _ => Ok(vec![]),
+            }
+        }
+        .instrument(self.span.clone())
+        .await
+    }
+
+    async fn read_resource(&self, uri: &str) -> Result<Value, AdapterError> {
+        async {
+            let params = serde_json::json!({ "uri": uri });
+            self.send_request("resources/read", Some(params)).await
+        }
+        .instrument(self.span.clone())
+        .await
+    }
+
+    async fn list_prompts(&self) -> Result<Vec<Value>, AdapterError> {
+        async {
+            let result = self.send_request("prompts/list", None).await?;
+            match result.get("prompts") {
+                Some(Value::Array(items)) => Ok(items.clone()),
+                _ => Ok(vec![]),
+            }
+        }
+        .instrument(self.span.clone())
+        .await
+    }
+
+    async fn get_prompt(
+        &self,
+        name: &str,
+        arguments: Option<Value>,
+    ) -> Result<Value, AdapterError> {
+        async {
+            let mut params = serde_json::Map::new();
+            params.insert("name".to_string(), Value::String(name.to_string()));
+            if let Some(args) = arguments {
+                params.insert("arguments".to_string(), args);
+            }
+            self.send_request("prompts/get", Some(Value::Object(params)))
+                .await
+        }
+        .instrument(self.span.clone())
+        .await
+    }
+
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
         self.call_tool_with_request_params(name, arguments, serde_json::Map::new())
             .await

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -64,7 +64,24 @@ impl fmt::Display for HealthStatus {
 }
 
 /// Information about a tool exposed by an MCP server.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// Fields beyond the four originals (`name`, `description`, `inputSchema`,
+/// `annotations`) are preserved verbatim so the merged `tools/list` catalog
+/// stays lossless for MCP Apps clients:
+/// - `title`, `output_schema` (`outputSchema`), and `_meta` are modeled
+///   explicitly because they carry MCP Apps UI pointers
+///   (`_meta.ui.resourceUri`, OpenAI alias `_meta["openai/outputTemplate"]`)
+///   and structured-output metadata the relay must round-trip without
+///   inventing or dropping siblings.
+/// - `extra` catches any future tool-descriptor field not modeled above via
+///   `#[serde(flatten)]` so the relay survives upstream schema additions
+///   without a code change.
+///
+/// All new fields are `#[serde(default, skip_serializing_if = ...)]` so an
+/// upstream tool that sends none of them re-serializes byte-for-byte
+/// identically to the pre-extension shape, and `#[derive(Default)]` lets
+/// existing struct literals stay terse via `..Default::default()`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ToolInfo {
     pub name: String,
@@ -72,6 +89,26 @@ pub struct ToolInfo {
     pub input_schema: Value,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<Value>,
+    /// User-facing tool title (MCP 2026-07-28). Passed through verbatim from
+    /// the upstream tool descriptor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// Structured-output schema describing the shape of `structuredContent`
+    /// in `tools/call` results. Passed through verbatim; the relay does not
+    /// validate against it today (mirrors `inputSchema` passthrough).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_schema: Option<Value>,
+    /// Tool-level `_meta` object. Preserved verbatim so downstream MCP Apps
+    /// pointers (`_meta.ui.resourceUri`, alias `_meta["openai/outputTemplate"]`)
+    /// and arbitrary upstream metadata reach the client. Subsequent tasks
+    /// (T6) wrap UI pointers in place without losing siblings.
+    #[serde(default, rename = "_meta", skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
+    /// Catch-all for any tool-descriptor field not modeled above. Preserved
+    /// across deserialize → re-serialize so future MCP spec additions survive
+    /// aggregation through `merged_catalog` without a relay code change.
+    #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub extra: serde_json::Map<String, Value>,
 }
 
 /// Max character count retained from `HttpError.body` when formatting an
@@ -184,6 +221,105 @@ pub trait McpAdapter: Send + Sync {
         _request_params: serde_json::Map<String, Value>,
     ) -> Result<Value, AdapterError> {
         self.call_tool(name, arguments).await
+    }
+
+    /// List concrete resources advertised by the upstream MCP server.
+    ///
+    /// Returns the raw `resources` array from the upstream `resources/list`
+    /// response (each element preserved verbatim so MCP fields like `name`,
+    /// `description`, `mimeType`, `_meta`, etc. round-trip untouched). The
+    /// registry wraps each `uri` per slot #4 before forwarding to the client.
+    ///
+    /// The default implementation returns an empty list so adapters that do
+    /// not support resources (placeholder adapters, transports that haven't
+    /// implemented the passthrough yet) participate silently. Concrete
+    /// transports override this to forward `resources/list` upstream.
+    async fn list_resources(&self) -> Result<Vec<Value>, AdapterError> {
+        Ok(vec![])
+    }
+
+    /// List resource templates (RFC 6570 URI templates) advertised by the
+    /// upstream MCP server.
+    ///
+    /// Returns the raw `resourceTemplates` array from the upstream
+    /// `resources/templates/list` response. The registry wraps each
+    /// `uriTemplate` per slot #5 before forwarding to the client; the
+    /// wrapper-scheme encoding preserves RFC 6570 `{var}` braces so variable
+    /// expansion on the client side is unaffected.
+    ///
+    /// The default implementation returns an empty list so adapters that do
+    /// not support resource templates participate silently.
+    async fn list_resource_templates(&self) -> Result<Vec<Value>, AdapterError> {
+        Ok(vec![])
+    }
+
+    /// List prompts advertised by the upstream MCP server.
+    ///
+    /// Returns the raw `prompts` array from the upstream `prompts/list`
+    /// response (each element preserved verbatim so MCP fields like
+    /// `description`, `arguments`, `_meta`, etc. round-trip untouched). The
+    /// registry namespaces each `name` per slot #8 before forwarding to the
+    /// client, mirroring the tool-prefix scheme so a prefixed prompt name
+    /// later routes back to its owning upstream.
+    ///
+    /// The default implementation returns an empty list so adapters that do
+    /// not support prompts (placeholder adapters, transports that haven't
+    /// implemented the passthrough yet) participate silently. Concrete
+    /// transports override this to forward `prompts/list` upstream.
+    async fn list_prompts(&self) -> Result<Vec<Value>, AdapterError> {
+        Ok(vec![])
+    }
+
+    /// Fetch a single prompt by name from the upstream MCP server.
+    ///
+    /// `name` is the original (reverse-prefixed) prompt name — slot #9 inbound
+    /// name un-prefixing happens in the registry before dispatch, so adapters
+    /// receive the same name the upstream originally advertised via
+    /// `prompts/list`. `arguments` is the optional client-supplied `arguments`
+    /// object (forwarded verbatim, `null`/missing → no field on the wire). The
+    /// returned `Value` is the raw `result` object from the upstream
+    /// (`{ messages: [...] , description?: "..." }`); the registry rewrites
+    /// the enumerated slot #9 URIs on the returned messages before forwarding
+    /// to the client.
+    ///
+    /// The default implementation returns a JSON-RPC method-not-found error so
+    /// adapters that do not support prompts (placeholder adapters, transports
+    /// that haven't implemented the passthrough yet) reject fetches cleanly
+    /// instead of silently succeeding with an empty payload. Concrete
+    /// transports override this to forward `prompts/get` upstream.
+    async fn get_prompt(
+        &self,
+        _name: &str,
+        _arguments: Option<Value>,
+    ) -> Result<Value, AdapterError> {
+        Err(AdapterError::JsonRpcError {
+            code: -32601,
+            message: "prompts/get not supported by this adapter".to_string(),
+            data: None,
+        })
+    }
+
+    /// Read a single resource by URI from the upstream MCP server.
+    ///
+    /// `uri` is the original (de-wrapped) resource URI — slot #6 reverse
+    /// rewriting happens in the registry before dispatch, so adapters receive
+    /// the same URI the upstream originally advertised via `resources/list` or
+    /// `resources/templates/list`. The returned `Value` is the raw `result`
+    /// object from the upstream (`{ contents: [...] }`); per DD2 the relay
+    /// returns it to the client unmodified — URIs inside the resource body
+    /// are not rewritten in v1.
+    ///
+    /// The default implementation returns a JSON-RPC method-not-found error so
+    /// adapters that do not support resources (placeholder adapters, transports
+    /// that haven't implemented the passthrough yet) reject reads cleanly
+    /// instead of silently succeeding with an empty payload. Concrete
+    /// transports override this to forward `resources/read` upstream.
+    async fn read_resource(&self, _uri: &str) -> Result<Value, AdapterError> {
+        Err(AdapterError::JsonRpcError {
+            code: -32601,
+            message: "resources/read not supported by this adapter".to_string(),
+            data: None,
+        })
     }
 
     /// Get the current health status.

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -1307,6 +1307,33 @@ impl McpAdapter for OAuthAdapter {
         }
     }
 
+    async fn list_prompts(&self) -> Result<Vec<Value>, AdapterError> {
+        // Delegate to the inner transport adapter. Upstreams that do not
+        // expose `prompts/list` return `-32601`, which the registry
+        // tolerates by skipping the endpoint.
+        let guard = self.inner.inner_adapter.read().await;
+        match guard.as_ref() {
+            Some(adapter) => adapter.list_prompts().await,
+            None => Ok(vec![]),
+        }
+    }
+
+    async fn get_prompt(
+        &self,
+        name: &str,
+        arguments: Option<Value>,
+    ) -> Result<Value, AdapterError> {
+        // Delegate to the inner transport adapter. The inner adapter forwards
+        // `prompts/get` upstream and returns the raw `result`; the registry
+        // rewrites any enumerated resource URIs on returned messages before
+        // forwarding to the client.
+        let guard = self.inner.inner_adapter.read().await;
+        match guard.as_ref() {
+            Some(adapter) => adapter.get_prompt(name, arguments).await,
+            None => Err(AdapterError::NotInitialized),
+        }
+    }
+
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
         self.call_tool_with_request_params(name, arguments, serde_json::Map::new())
             .await

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -1277,6 +1277,36 @@ impl McpAdapter for OAuthAdapter {
         }
     }
 
+    async fn list_resources(&self) -> Result<Vec<Value>, AdapterError> {
+        // Delegate to the inner transport adapter. Upstreams that do not
+        // expose `resources/list` return `-32601`, which the registry
+        // tolerates by skipping the endpoint.
+        let guard = self.inner.inner_adapter.read().await;
+        match guard.as_ref() {
+            Some(adapter) => adapter.list_resources().await,
+            None => Ok(vec![]),
+        }
+    }
+
+    async fn list_resource_templates(&self) -> Result<Vec<Value>, AdapterError> {
+        let guard = self.inner.inner_adapter.read().await;
+        match guard.as_ref() {
+            Some(adapter) => adapter.list_resource_templates().await,
+            None => Ok(vec![]),
+        }
+    }
+
+    async fn read_resource(&self, uri: &str) -> Result<Value, AdapterError> {
+        // Delegate to the inner transport adapter. The inner adapter forwards
+        // `resources/read` upstream and returns the raw `result`; the registry
+        // returns it to the client unmodified per DD2.
+        let guard = self.inner.inner_adapter.read().await;
+        match guard.as_ref() {
+            Some(adapter) => adapter.read_resource(uri).await,
+            None => Err(AdapterError::NotInitialized),
+        }
+    }
+
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
         self.call_tool_with_request_params(name, arguments, serde_json::Map::new())
             .await

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -928,6 +928,69 @@ impl McpAdapter for SseAdapter {
         *self.list_ttl_ms.read().await
     }
 
+    async fn list_resources(&self) -> Result<Vec<Value>, AdapterError> {
+        async {
+            let result = self.send_request("resources/list", None).await?;
+            match result.get("resources") {
+                Some(Value::Array(items)) => Ok(items.clone()),
+                _ => Ok(vec![]),
+            }
+        }
+        .instrument(self.span.clone())
+        .await
+    }
+
+    async fn list_resource_templates(&self) -> Result<Vec<Value>, AdapterError> {
+        async {
+            let result = self.send_request("resources/templates/list", None).await?;
+            match result.get("resourceTemplates") {
+                Some(Value::Array(items)) => Ok(items.clone()),
+                _ => Ok(vec![]),
+            }
+        }
+        .instrument(self.span.clone())
+        .await
+    }
+
+    async fn read_resource(&self, uri: &str) -> Result<Value, AdapterError> {
+        async {
+            let params = serde_json::json!({ "uri": uri });
+            self.send_request("resources/read", Some(params)).await
+        }
+        .instrument(self.span.clone())
+        .await
+    }
+
+    async fn list_prompts(&self) -> Result<Vec<Value>, AdapterError> {
+        async {
+            let result = self.send_request("prompts/list", None).await?;
+            match result.get("prompts") {
+                Some(Value::Array(items)) => Ok(items.clone()),
+                _ => Ok(vec![]),
+            }
+        }
+        .instrument(self.span.clone())
+        .await
+    }
+
+    async fn get_prompt(
+        &self,
+        name: &str,
+        arguments: Option<Value>,
+    ) -> Result<Value, AdapterError> {
+        async {
+            let mut params = serde_json::Map::new();
+            params.insert("name".to_string(), Value::String(name.to_string()));
+            if let Some(args) = arguments {
+                params.insert("arguments".to_string(), args);
+            }
+            self.send_request("prompts/get", Some(Value::Object(params)))
+                .await
+        }
+        .instrument(self.span.clone())
+        .await
+    }
+
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
         self.call_tool_with_request_params(name, arguments, serde_json::Map::new())
             .await

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -1031,6 +1031,69 @@ impl McpAdapter for StdioAdapter {
         *self.list_ttl_ms.read().await
     }
 
+    async fn list_resources(&self) -> Result<Vec<Value>, AdapterError> {
+        async {
+            let result = self.send_request("resources/list", None).await?;
+            match result.get("resources") {
+                Some(Value::Array(items)) => Ok(items.clone()),
+                _ => Ok(vec![]),
+            }
+        }
+        .instrument(self.span.clone())
+        .await
+    }
+
+    async fn list_resource_templates(&self) -> Result<Vec<Value>, AdapterError> {
+        async {
+            let result = self.send_request("resources/templates/list", None).await?;
+            match result.get("resourceTemplates") {
+                Some(Value::Array(items)) => Ok(items.clone()),
+                _ => Ok(vec![]),
+            }
+        }
+        .instrument(self.span.clone())
+        .await
+    }
+
+    async fn read_resource(&self, uri: &str) -> Result<Value, AdapterError> {
+        async {
+            let params = serde_json::json!({ "uri": uri });
+            self.send_request("resources/read", Some(params)).await
+        }
+        .instrument(self.span.clone())
+        .await
+    }
+
+    async fn list_prompts(&self) -> Result<Vec<Value>, AdapterError> {
+        async {
+            let result = self.send_request("prompts/list", None).await?;
+            match result.get("prompts") {
+                Some(Value::Array(items)) => Ok(items.clone()),
+                _ => Ok(vec![]),
+            }
+        }
+        .instrument(self.span.clone())
+        .await
+    }
+
+    async fn get_prompt(
+        &self,
+        name: &str,
+        arguments: Option<Value>,
+    ) -> Result<Value, AdapterError> {
+        async {
+            let mut params = serde_json::Map::new();
+            params.insert("name".to_string(), Value::String(name.to_string()));
+            if let Some(args) = arguments {
+                params.insert("arguments".to_string(), args);
+            }
+            self.send_request("prompts/get", Some(Value::Object(params)))
+                .await
+        }
+        .instrument(self.span.clone())
+        .await
+    }
+
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, AdapterError> {
         self.call_tool_with_request_params(name, arguments, serde_json::Map::new())
             .await

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -1361,6 +1361,7 @@ mod tests {
             description: Some(desc.to_string()),
             input_schema: json!({"type": "object"}),
             annotations: None,
+            ..Default::default()
         }
     }
 
@@ -1599,6 +1600,7 @@ mod tests {
             description: Some(desc.to_string()),
             input_schema: schema,
             annotations: None,
+            ..Default::default()
         }
     }
 
@@ -2759,6 +2761,7 @@ mod tests {
             description: Some(format!("{} tool", name)),
             input_schema: json!({"type": "object"}),
             annotations: Some(annotations),
+            ..Default::default()
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,10 +14,12 @@ pub mod prefix;
 pub mod profile_registry;
 pub mod protocol;
 pub mod registry;
+pub mod resource_uri;
 pub mod server;
 pub mod shell_env;
 pub mod token_manager;
 pub mod token_security;
+pub mod tool_call_rewrite;
 pub mod toon_convert;
 pub mod watcher;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,10 +25,12 @@ mod prefix;
 mod profile_registry;
 mod protocol;
 mod registry;
+mod resource_uri;
 mod server;
 mod shell_env;
 #[cfg(test)]
 mod test_tracing;
+mod tool_call_rewrite;
 mod toon_convert;
 
 use adapter::oauth::{OAuthAdapter, OAuthAdapterConfig, OAuthAdapterInner};

--- a/src/management.rs
+++ b/src/management.rs
@@ -5760,6 +5760,7 @@ mod tests {
             description: None,
             input_schema: serde_json::json!({}),
             annotations: None,
+            ..Default::default()
         }];
         let state = test_state(vec![("echo", MockAdapter::healthy_with_tools(tools))]).await;
         let app = management_routes(state);
@@ -5818,12 +5819,14 @@ mod tests {
                 description: None,
                 input_schema: serde_json::json!({}),
                 annotations: None,
+                ..Default::default()
             },
             ToolInfo {
                 name: "t2".into(),
                 description: None,
                 input_schema: serde_json::json!({}),
                 annotations: None,
+                ..Default::default()
             },
         ];
         let state = test_state(vec![
@@ -5948,6 +5951,7 @@ mod tests {
             description: Some("Read a file".into()),
             input_schema: serde_json::json!({"type": "object"}),
             annotations: None,
+            ..Default::default()
         }];
         let state = test_state(vec![("fs", MockAdapter::healthy_with_tools(tools))]).await;
         let app = management_routes(state);
@@ -6074,6 +6078,7 @@ mod tests {
             description: None,
             input_schema: serde_json::json!({}),
             annotations: None,
+            ..Default::default()
         }];
         let state = test_state(vec![("echo", MockAdapter::healthy_with_tools(tools))]).await;
         let app = management_routes(state);
@@ -6715,6 +6720,7 @@ command = "echo"
             description: None,
             input_schema: serde_json::json!({}),
             annotations: None,
+            ..Default::default()
         }];
         let state = test_state(vec![("echo", MockAdapter::healthy_with_tools(tools))]).await;
         let app = management_routes(state);
@@ -6754,6 +6760,7 @@ command = "echo"
             description: None,
             input_schema: serde_json::json!({}),
             annotations: None,
+            ..Default::default()
         }];
         let state = test_state(vec![("echo", MockAdapter::healthy_with_tools(tools))]).await;
         let app = management_routes(state);
@@ -6820,12 +6827,14 @@ command = "echo"
                 description: Some("Read".into()),
                 input_schema: serde_json::json!({"type": "object"}),
                 annotations: None,
+                ..Default::default()
             },
             ToolInfo {
                 name: "write".into(),
                 description: Some("Write".into()),
                 input_schema: serde_json::json!({"type": "object"}),
                 annotations: None,
+                ..Default::default()
             },
         ];
         let state = test_state(vec![("fs", MockAdapter::healthy_with_tools(tools))]).await;
@@ -6878,6 +6887,7 @@ command = "echo"
             description: Some("Read".into()),
             input_schema: serde_json::json!({"type": "object"}),
             annotations: None,
+            ..Default::default()
         }];
         let state = test_state(vec![("fs", MockAdapter::healthy_with_tools(tools))]).await;
         let app = management_routes(state);
@@ -6974,6 +6984,7 @@ command = "echo"
             description: None,
             input_schema: serde_json::json!({}),
             annotations: None,
+            ..Default::default()
         }];
         let state = test_state(vec![("echo", MockAdapter::healthy_with_tools(tools))]).await;
         // Hold the registry Arc so the broadcast sender outlives the router.
@@ -6997,6 +7008,7 @@ command = "echo"
             description: None,
             input_schema: serde_json::json!({}),
             annotations: None,
+            ..Default::default()
         }];
         let state = test_state(vec![("echo", MockAdapter::healthy_with_tools(tools))]).await;
         let app = management_routes(state.clone());
@@ -7022,6 +7034,7 @@ command = "echo"
             description: Some("Read".into()),
             input_schema: serde_json::json!({"type": "object"}),
             annotations: None,
+            ..Default::default()
         }];
         let state = test_state(vec![("fs", MockAdapter::healthy_with_tools(tools))]).await;
         // Hold the registry Arc so the broadcast sender outlives the router.
@@ -7045,6 +7058,7 @@ command = "echo"
             description: Some("Read".into()),
             input_schema: serde_json::json!({"type": "object"}),
             annotations: None,
+            ..Default::default()
         }];
         let state = test_state(vec![("fs", MockAdapter::healthy_with_tools(tools))]).await;
         let app = management_routes(state.clone());
@@ -9100,6 +9114,7 @@ client_id = "client123"
                         description: None,
                         input_schema: serde_json::json!({}),
                         annotations: None,
+                        ..Default::default()
                     }])),
                     "stdio".to_string(),
                     None,

--- a/src/profile_registry.rs
+++ b/src/profile_registry.rs
@@ -162,6 +162,135 @@ impl ProfileRegistryView {
             .route_tool_call_with_request_params(prefixed_name, arguments, request_params)
             .await
     }
+
+    /// Profile-scoped variant of [`AdapterRegistry::list_resources`].
+    ///
+    /// Aggregates `resources/list` across only the profile's allowed endpoints
+    /// and wraps URIs using the *in-profile* active count so the wrap trigger
+    /// matches [`Self::route_resource_read`]'s unwrap trigger — keeping the
+    /// allowed-endpoint guard tight in the `(global>=2, profile==1)` corner.
+    pub async fn list_resources(&self) -> Vec<Value> {
+        self.inner.list_resources_in(&self.allowed_endpoints).await
+    }
+
+    /// Profile-scoped variant of [`AdapterRegistry::list_resource_templates`].
+    /// See [`Self::list_resources`] for the wrap-trigger rationale.
+    pub async fn list_resource_templates(&self) -> Vec<Value> {
+        self.inner
+            .list_resource_templates_in(&self.allowed_endpoints)
+            .await
+    }
+
+    /// Profile-scoped variant of [`AdapterRegistry::list_prompts`].
+    ///
+    /// Aggregates `prompts/list` across only the profile's allowed endpoints
+    /// and namespaces `prompts[].name` using the *in-profile* active count so
+    /// the prefix trigger stays consistent with the profile-scoped tool
+    /// catalog.
+    pub async fn list_prompts(&self) -> Vec<Value> {
+        self.inner.list_prompts_in(&self.allowed_endpoints).await
+    }
+
+    /// Profile-scoped variant of [`AdapterRegistry::route_prompt_get`].
+    ///
+    /// Rebuilds the reverse lookup from the *in-profile* `list_prompts_in_with_lookup`
+    /// so the prefix-trigger matches what the profile-scoped `prompts/list`
+    /// emitted; that closes the `(global>=2, profile==1)` foreign-prompt
+    /// bypass the same way [`Self::route_resource_read`] does for resources.
+    /// Rejects any prompt whose owning endpoint is outside the profile's
+    /// allowed set before dispatch. Slot #9 URI rewriting is applied with
+    /// the in-profile `skip_wrap` trigger so the wrap toggles in lockstep
+    /// with the profile-scoped prompt-name prefix toggle.
+    pub async fn route_prompt_get(
+        &self,
+        prefixed_name: &str,
+        arguments: Option<Value>,
+    ) -> Result<Value, AdapterError> {
+        let (_prompts, lookup) = self
+            .inner
+            .list_prompts_in_with_lookup(&self.allowed_endpoints)
+            .await;
+        let (endpoint, raw_name) = match lookup.get(prefixed_name) {
+            Some(v) => v.clone(),
+            None => {
+                return Err(AdapterError::ProtocolError(format!(
+                    "no prompt '{}' in profile",
+                    prefixed_name
+                )));
+            }
+        };
+        if !self.allowed_endpoints.contains(&endpoint) {
+            return Err(AdapterError::ProtocolError(format!(
+                "prompt '{}' is not available in this profile",
+                prefixed_name
+            )));
+        }
+        let skip_wrap = self
+            .inner
+            .active_endpoint_count_in(&self.allowed_endpoints)
+            .await
+            <= 1;
+        let value = self
+            .inner
+            .dispatch_prompt_get_to(&endpoint, &raw_name, arguments)
+            .await?;
+        Ok(crate::tool_call_rewrite::rewrite_prompt_get_result(
+            value, &endpoint, skip_wrap,
+        ))
+    }
+
+    /// Profile-scoped variant of [`AdapterRegistry::route_resource_read`].
+    ///
+    /// Always attempts a strict decode of `wrapped_uri` first — independent
+    /// of the in-profile active count — so a fully-wrapped `mcp-relay://`
+    /// URI is recognised even when the profile would otherwise pass URIs
+    /// through (DD5 single-endpoint). When the decoded endpoint is outside
+    /// the profile's allowed set, the read is rejected before dispatch.
+    /// When the URI is not wrapped, the request is treated as a DD5 raw URI
+    /// and dispatched to the sole in-profile active endpoint; if zero or
+    /// more than one in-profile endpoint is active, the request is rejected.
+    ///
+    /// This always-strict decode is what closes the
+    /// `(global>=2, profile==1)` foreign-endpoint bypass: without it, a
+    /// `skip_wrap=true` decode would treat the wrapper as raw and dispatch
+    /// to the profile's sole endpoint with a foreign endpoint name baked
+    /// into the URI string.
+    pub async fn route_resource_read(&self, wrapped_uri: &str) -> Result<Value, AdapterError> {
+        // Strict-decode first. Successful decode → wrapper-style URI; the
+        // resolved endpoint must be inside the profile.
+        if let Ok((endpoint, original_uri)) = crate::resource_uri::decode_resource_uri(wrapped_uri)
+        {
+            if !self.allowed_endpoints.contains(&endpoint) {
+                return Err(AdapterError::ProtocolError(format!(
+                    "resource '{}' is not available in this profile",
+                    wrapped_uri
+                )));
+            }
+            return self
+                .inner
+                .dispatch_resource_read_to(&endpoint, &original_uri)
+                .await;
+        }
+
+        // Not a wrapped URI → DD5 single-endpoint mode within the profile.
+        // Require exactly one in-profile active endpoint; reject otherwise
+        // because there is no endpoint hint to disambiguate the target.
+        match self
+            .inner
+            .find_single_active_endpoint_in(&self.allowed_endpoints)
+            .await
+        {
+            Some(endpoint) => {
+                self.inner
+                    .dispatch_resource_read_to(&endpoint, wrapped_uri)
+                    .await
+            }
+            None => Err(AdapterError::ProtocolError(format!(
+                "no active endpoint to serve resource '{}'",
+                wrapped_uri
+            ))),
+        }
+    }
 }
 
 #[async_trait]
@@ -399,6 +528,18 @@ mod tests {
         ) -> Result<serde_json::Value, AdapterError> {
             Ok(json!({ "called": name, "args": arguments }))
         }
+        async fn read_resource(&self, uri: &str) -> Result<serde_json::Value, AdapterError> {
+            // Echo the URI the adapter received so the profile-guard test
+            // can assert (a) the reverse-rewrite stripped the wrapper and
+            // (b) the call reached the correct endpoint.
+            Ok(json!({
+                "contents": [{
+                    "uri": uri,
+                    "mimeType": "text/plain",
+                    "text": format!("body for {uri}"),
+                }]
+            }))
+        }
         fn health(&self) -> HealthStatus {
             HealthStatus::Healthy
         }
@@ -416,6 +557,7 @@ mod tests {
             description: Some(format!("{name} tool")),
             input_schema: json!({"type": "object"}),
             annotations: None,
+            ..Default::default()
         }
     }
 
@@ -546,6 +688,7 @@ mod tests {
                             "required": ["repo"],
                         }),
                         annotations: None,
+                        ..Default::default()
                     }],
                 }),
                 "stdio".into(),
@@ -850,5 +993,573 @@ mod tests {
             err_msg.contains("todoist__add_task"),
             "expected error to mention the out-of-profile tool, got: {err_msg}"
         );
+    }
+
+    // ---- T4 — profile-scoped `route_resource_read` -----------------------
+
+    /// A wrapped URI whose owning endpoint is inside the profile dispatches
+    /// successfully, and the adapter receives the *original* (un-wrapped) URI.
+    #[tokio::test]
+    async fn route_resource_read_succeeds_for_in_profile_endpoint() {
+        let registry = registry_with_four_endpoints().await;
+        let pr = ProfileRegistry::new(registry);
+        pr.rebuild(&[ProfileConfig {
+            name: "Work".into(),
+            path: "work".into(),
+            endpoints: vec!["gmail".into(), "linear".into()],
+            js_execution: false,
+            toon_output: true,
+        }])
+        .await;
+
+        let ctx = pr.get("work").await.unwrap();
+        let wrapped = crate::resource_uri::encode_resource_uri("gmail", "ui://inbox/123");
+        let result = ctx
+            .registry_view
+            .route_resource_read(&wrapped)
+            .await
+            .expect("in-profile resource read must succeed");
+        assert_eq!(
+            result["contents"][0]["uri"], "ui://inbox/123",
+            "wrapper must be stripped before reaching the adapter"
+        );
+    }
+
+    /// A wrapped URI whose owning endpoint is outside the profile is rejected
+    /// before delegation, mirroring the `route_tool_call` guard.
+    #[tokio::test]
+    async fn route_resource_read_rejects_out_of_profile_endpoint() {
+        let registry = registry_with_four_endpoints().await;
+        let pr = ProfileRegistry::new(registry);
+        pr.rebuild(&[ProfileConfig {
+            name: "Work".into(),
+            path: "work".into(),
+            endpoints: vec!["gmail".into(), "linear".into()],
+            js_execution: false,
+            toon_output: true,
+        }])
+        .await;
+
+        let ctx = pr.get("work").await.unwrap();
+        let wrapped = crate::resource_uri::encode_resource_uri("todoist", "ui://tasks/today");
+        let err = ctx
+            .registry_view
+            .route_resource_read(&wrapped)
+            .await
+            .expect_err("out-of-profile read must be rejected");
+        match err {
+            AdapterError::ProtocolError(msg) => {
+                assert!(
+                    msg.contains("not available in this profile"),
+                    "unexpected error message: {msg}"
+                );
+            }
+            other => panic!("expected ProtocolError, got {other:?}"),
+        }
+    }
+
+    /// T12 regression — the `(global>=2, profile==1)` foreign-endpoint
+    /// bypass. With multiple endpoints globally but only one in the
+    /// profile, the profile's in-scope `skip_wrap` is `true` so the
+    /// incoming URI is treated as its own original. A wrapped URI that
+    /// targets a *foreign* endpoint must NOT be accepted as a raw URI by
+    /// the profile's single allowed endpoint — the dispatch target is
+    /// resolved against the profile's allowed set, not the global registry.
+    #[tokio::test]
+    async fn route_resource_read_rejects_wrapped_foreign_uri_in_single_endpoint_profile() {
+        let registry = registry_with_four_endpoints().await;
+        let pr = ProfileRegistry::new(registry);
+        pr.rebuild(&[ProfileConfig {
+            name: "Solo".into(),
+            path: "solo".into(),
+            endpoints: vec!["gmail".into()],
+            js_execution: false,
+            toon_output: true,
+        }])
+        .await;
+
+        let ctx = pr.get("solo").await.unwrap();
+        // Profile has 1 endpoint → its `skip_wrap` is true; global has 4
+        // → wrapping is normally in effect. Build a fully-wrapped URI
+        // targeting a foreign endpoint and submit it through the
+        // profile-scoped path.
+        let wrapped = crate::resource_uri::encode_resource_uri("todoist", "ui://tasks/today");
+        let result = ctx.registry_view.route_resource_read(&wrapped).await;
+        match result {
+            Ok(v) => panic!(
+                "wrapped foreign-endpoint URI must NOT be served by the profile's \
+                 sole endpoint (bypass!): {v}"
+            ),
+            Err(AdapterError::ProtocolError(_)) => {
+                // Either path is acceptable as a closed bypass: the URI
+                // may be reported as not-available-in-profile, or as
+                // unknown by the adapter (the in-profile endpoint won't
+                // recognise the `mcp-relay://` scheme). The critical
+                // invariant is that we never see the foreign adapter's
+                // `read_resource` echo for `ui://tasks/today`.
+            }
+            Err(other) => panic!("expected ProtocolError, got {other:?}"),
+        }
+    }
+
+    /// T12 regression (list side) — the outbound `list_resources`
+    /// aggregation must also use the profile-local active count when
+    /// deciding to wrap. With one in-profile endpoint, URIs flow through
+    /// unwrapped, matching the unwrap trigger used by
+    /// [`ProfileRegistryView::route_resource_read`]. The list must contain
+    /// only the profile's endpoint's resources.
+    #[tokio::test]
+    async fn list_resources_is_profile_scoped_with_in_profile_active_count() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "gmail".into(),
+                Box::new(ResourceMockForProfile {
+                    resources: vec![json!({ "uri": "ui://inbox/1", "name": "inbox" })],
+                }),
+                "stdio".into(),
+                None,
+                Some("gmail".into()),
+            )
+            .await;
+        registry
+            .register(
+                "todoist".into(),
+                Box::new(ResourceMockForProfile {
+                    resources: vec![json!({ "uri": "ui://tasks/today", "name": "today" })],
+                }),
+                "stdio".into(),
+                None,
+                Some("todoist".into()),
+            )
+            .await;
+
+        let pr = ProfileRegistry::new(registry);
+        pr.rebuild(&[ProfileConfig {
+            name: "Solo".into(),
+            path: "solo".into(),
+            endpoints: vec!["gmail".into()],
+            js_execution: false,
+            toon_output: true,
+        }])
+        .await;
+
+        let ctx = pr.get("solo").await.unwrap();
+        let resources = ctx.registry_view.list_resources().await;
+        assert_eq!(
+            resources.len(),
+            1,
+            "must list only gmail's resources: {resources:?}"
+        );
+        // One in-profile endpoint → wrap is skipped, the URI is its raw
+        // original (no `mcp-relay://` prefix). This is exactly what
+        // `route_resource_read`'s in-profile single-endpoint dispatch
+        // expects, so the listing and read paths stay symmetric.
+        assert_eq!(resources[0]["uri"], "ui://inbox/1");
+    }
+
+    /// T9 — profile-scoped `list_prompts` filters to the profile's allowed
+    /// endpoints and applies the *in-profile* active count when deciding to
+    /// prefix names. With one in-profile endpoint, names pass through
+    /// unprefixed (DD5 parity); foreign endpoints' prompts are excluded.
+    #[tokio::test]
+    async fn list_prompts_is_profile_scoped_with_in_profile_active_count() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "gmail".into(),
+                Box::new(PromptMockForProfile {
+                    prompts: vec![json!({ "name": "compose", "description": "Compose mail" })],
+                }),
+                "stdio".into(),
+                None,
+                Some("gmail".into()),
+            )
+            .await;
+        registry
+            .register(
+                "todoist".into(),
+                Box::new(PromptMockForProfile {
+                    prompts: vec![json!({ "name": "add_task", "description": "Add a task" })],
+                }),
+                "stdio".into(),
+                None,
+                Some("todoist".into()),
+            )
+            .await;
+
+        let pr = ProfileRegistry::new(registry);
+        pr.rebuild(&[ProfileConfig {
+            name: "Solo".into(),
+            path: "solo".into(),
+            endpoints: vec!["gmail".into()],
+            js_execution: false,
+            toon_output: true,
+        }])
+        .await;
+
+        let ctx = pr.get("solo").await.unwrap();
+        let prompts = ctx.registry_view.list_prompts().await;
+        assert_eq!(
+            prompts.len(),
+            1,
+            "must list only gmail's prompts: {prompts:?}"
+        );
+        // One in-profile endpoint → prefix is skipped, the name is its raw
+        // original. Symmetric with the registry's DD5 unprefixed mode.
+        assert_eq!(prompts[0]["name"], "compose");
+    }
+
+    /// T9 — profile-scoped `list_prompts` prefixes names when the in-profile
+    /// active count is ≥ 2, even when only a subset of the global registry
+    /// is in the profile.
+    #[tokio::test]
+    async fn list_prompts_profile_prefixes_when_multiple_in_profile() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "gmail".into(),
+                Box::new(PromptMockForProfile {
+                    prompts: vec![json!({ "name": "compose" })],
+                }),
+                "stdio".into(),
+                None,
+                Some("gmail".into()),
+            )
+            .await;
+        registry
+            .register(
+                "todoist".into(),
+                Box::new(PromptMockForProfile {
+                    prompts: vec![json!({ "name": "add_task" })],
+                }),
+                "stdio".into(),
+                None,
+                Some("todoist".into()),
+            )
+            .await;
+
+        let pr = ProfileRegistry::new(registry);
+        pr.rebuild(&[ProfileConfig {
+            name: "All".into(),
+            path: "all".into(),
+            endpoints: vec!["gmail".into(), "todoist".into()],
+            js_execution: false,
+            toon_output: true,
+        }])
+        .await;
+
+        let ctx = pr.get("all").await.unwrap();
+        let mut prompts = ctx.registry_view.list_prompts().await;
+        prompts.sort_by(|a, b| {
+            a["name"]
+                .as_str()
+                .unwrap_or("")
+                .cmp(b["name"].as_str().unwrap_or(""))
+        });
+        assert_eq!(prompts.len(), 2);
+        assert_eq!(prompts[0]["name"], "gmail__compose");
+        assert_eq!(prompts[1]["name"], "todoist__add_task");
+    }
+
+    // ---- T10 — profile-scoped `route_prompt_get` --------------------------
+
+    /// Adapter mock that advertises a prompt and serves `prompts/get` with
+    /// content blocks the slot #9 wrapper must visit. Tags responses with
+    /// `endpoint_label` so the profile-scoped dispatch can be verified.
+    struct PromptGetMockForProfile {
+        endpoint_label: String,
+        prompts: Vec<serde_json::Value>,
+    }
+
+    #[async_trait]
+    impl McpAdapter for PromptGetMockForProfile {
+        async fn initialize(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+        async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
+            Ok(vec![])
+        }
+        async fn call_tool(
+            &self,
+            _name: &str,
+            _arguments: serde_json::Value,
+        ) -> Result<serde_json::Value, AdapterError> {
+            Ok(json!({}))
+        }
+        async fn list_prompts(&self) -> Result<Vec<serde_json::Value>, AdapterError> {
+            Ok(self.prompts.clone())
+        }
+        async fn get_prompt(
+            &self,
+            name: &str,
+            _arguments: Option<serde_json::Value>,
+        ) -> Result<serde_json::Value, AdapterError> {
+            Ok(json!({
+                "endpoint": self.endpoint_label,
+                "raw_name": name,
+                "messages": [{
+                    "role": "assistant",
+                    "content": [
+                        { "type": "text", "text": "see https://example.com" },
+                        { "type": "resource_link", "uri": "ui://app/link", "name": "Open" }
+                    ]
+                }]
+            }))
+        }
+        fn health(&self) -> HealthStatus {
+            HealthStatus::Healthy
+        }
+        async fn shutdown(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+    }
+
+    /// Profile-scoped `route_prompt_get` dispatches in-profile prompts to
+    /// the owning upstream, applies slot #9 URI wrapping using the
+    /// *in-profile* active count, and forwards the raw name verbatim.
+    #[tokio::test]
+    async fn route_prompt_get_succeeds_for_in_profile_endpoint() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "gmail".into(),
+                Box::new(PromptGetMockForProfile {
+                    endpoint_label: "gmail".into(),
+                    prompts: vec![json!({ "name": "compose" })],
+                }),
+                "stdio".into(),
+                None,
+                Some("gmail".into()),
+            )
+            .await;
+        registry
+            .register(
+                "todoist".into(),
+                Box::new(PromptGetMockForProfile {
+                    endpoint_label: "todoist".into(),
+                    prompts: vec![json!({ "name": "add_task" })],
+                }),
+                "stdio".into(),
+                None,
+                Some("todoist".into()),
+            )
+            .await;
+
+        let pr = ProfileRegistry::new(registry);
+        pr.rebuild(&[ProfileConfig {
+            name: "All".into(),
+            path: "all".into(),
+            endpoints: vec!["gmail".into(), "todoist".into()],
+            js_execution: false,
+            toon_output: true,
+        }])
+        .await;
+
+        let ctx = pr.get("all").await.unwrap();
+        let result = ctx
+            .registry_view
+            .route_prompt_get("gmail__compose", None)
+            .await
+            .expect("in-profile prompt must dispatch");
+        assert_eq!(result["endpoint"], "gmail");
+        assert_eq!(result["raw_name"], "compose");
+        // Multi-endpoint profile → slot #9 wraps the resource_link URI.
+        let link_uri = result["messages"][0]["content"][1]["uri"].as_str().unwrap();
+        let (ep, orig) = crate::resource_uri::decode_resource_uri(link_uri).unwrap();
+        assert_eq!(ep, "gmail");
+        assert_eq!(orig, "ui://app/link");
+    }
+
+    /// Profile-scoped `route_prompt_get` rejects a prompt whose owning
+    /// endpoint is not in the profile's allowed set — even when that
+    /// endpoint exists in the global registry. This is the prompts-side
+    /// analogue of the foreign-endpoint guard `route_resource_read` /
+    /// `route_tool_call` enforce.
+    #[tokio::test]
+    async fn route_prompt_get_rejects_out_of_profile_endpoint() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "gmail".into(),
+                Box::new(PromptGetMockForProfile {
+                    endpoint_label: "gmail".into(),
+                    prompts: vec![json!({ "name": "compose" })],
+                }),
+                "stdio".into(),
+                None,
+                Some("gmail".into()),
+            )
+            .await;
+        registry
+            .register(
+                "todoist".into(),
+                Box::new(PromptGetMockForProfile {
+                    endpoint_label: "todoist".into(),
+                    prompts: vec![json!({ "name": "add_task" })],
+                }),
+                "stdio".into(),
+                None,
+                Some("todoist".into()),
+            )
+            .await;
+
+        let pr = ProfileRegistry::new(registry);
+        pr.rebuild(&[ProfileConfig {
+            name: "Solo".into(),
+            path: "solo".into(),
+            endpoints: vec!["gmail".into()],
+            js_execution: false,
+            toon_output: true,
+        }])
+        .await;
+
+        let ctx = pr.get("solo").await.unwrap();
+        // `todoist__add_task` exists in the global registry but is not in
+        // the profile's allowed set; the lookup is built from the in-profile
+        // list so the name doesn't even appear in `lookup`.
+        let err = ctx
+            .registry_view
+            .route_prompt_get("todoist__add_task", None)
+            .await
+            .expect_err("foreign prompt must reject");
+        match err {
+            AdapterError::ProtocolError(msg) => {
+                assert!(
+                    msg.contains("no prompt") || msg.contains("not available in this profile"),
+                    "unexpected error message: {msg}"
+                );
+            }
+            other => panic!("expected ProtocolError, got: {other:?}"),
+        }
+    }
+
+    /// Profile-scoped `route_prompt_get` follows the in-profile DD5 rule:
+    /// when the profile has exactly one active endpoint, names pass
+    /// through unprefixed and slot #9 URIs flow through unwrapped, even
+    /// when the global registry has multiple endpoints.
+    #[tokio::test]
+    async fn route_prompt_get_single_in_profile_passes_through() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "gmail".into(),
+                Box::new(PromptGetMockForProfile {
+                    endpoint_label: "gmail".into(),
+                    prompts: vec![json!({ "name": "compose" })],
+                }),
+                "stdio".into(),
+                None,
+                Some("gmail".into()),
+            )
+            .await;
+        registry
+            .register(
+                "todoist".into(),
+                Box::new(PromptGetMockForProfile {
+                    endpoint_label: "todoist".into(),
+                    prompts: vec![json!({ "name": "add_task" })],
+                }),
+                "stdio".into(),
+                None,
+                Some("todoist".into()),
+            )
+            .await;
+
+        let pr = ProfileRegistry::new(registry);
+        pr.rebuild(&[ProfileConfig {
+            name: "Solo".into(),
+            path: "solo".into(),
+            endpoints: vec!["gmail".into()],
+            js_execution: false,
+            toon_output: true,
+        }])
+        .await;
+
+        let ctx = pr.get("solo").await.unwrap();
+        let result = ctx
+            .registry_view
+            .route_prompt_get("compose", None)
+            .await
+            .expect("DD5 in-profile dispatch must succeed");
+        assert_eq!(result["endpoint"], "gmail");
+        assert_eq!(result["raw_name"], "compose");
+        // In-profile active_count == 1 → slot #9 wrap is skipped.
+        assert_eq!(result["messages"][0]["content"][1]["uri"], "ui://app/link");
+    }
+
+    /// Adapter mock for profile-scoped resource listing tests. Kept local
+    /// to the module so it doesn't grow the existing `MockAdapter` with
+    /// resource fields used only by these tests.
+    struct ResourceMockForProfile {
+        resources: Vec<serde_json::Value>,
+    }
+
+    #[async_trait]
+    impl McpAdapter for ResourceMockForProfile {
+        async fn initialize(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+        async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
+            Ok(vec![])
+        }
+        async fn call_tool(
+            &self,
+            name: &str,
+            arguments: serde_json::Value,
+        ) -> Result<serde_json::Value, AdapterError> {
+            Ok(json!({ "called": name, "args": arguments }))
+        }
+        async fn list_resources(&self) -> Result<Vec<serde_json::Value>, AdapterError> {
+            Ok(self.resources.clone())
+        }
+        async fn read_resource(&self, uri: &str) -> Result<serde_json::Value, AdapterError> {
+            Ok(json!({
+                "contents": [{
+                    "uri": uri,
+                    "mimeType": "text/plain",
+                    "text": format!("body for {uri}"),
+                }]
+            }))
+        }
+        fn health(&self) -> HealthStatus {
+            HealthStatus::Healthy
+        }
+        async fn shutdown(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+    }
+
+    /// Adapter mock for profile-scoped prompt listing tests. Kept local
+    /// to the module so it doesn't grow the existing mocks with prompt
+    /// fields used only by these tests.
+    struct PromptMockForProfile {
+        prompts: Vec<serde_json::Value>,
+    }
+
+    #[async_trait]
+    impl McpAdapter for PromptMockForProfile {
+        async fn initialize(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+        async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
+            Ok(vec![])
+        }
+        async fn call_tool(
+            &self,
+            name: &str,
+            arguments: serde_json::Value,
+        ) -> Result<serde_json::Value, AdapterError> {
+            Ok(json!({ "called": name, "args": arguments }))
+        }
+        async fn list_prompts(&self) -> Result<Vec<serde_json::Value>, AdapterError> {
+            Ok(self.prompts.clone())
+        }
+        fn health(&self) -> HealthStatus {
+            HealthStatus::Healthy
+        }
+        async fn shutdown(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -585,6 +585,45 @@ impl AdapterRegistry {
             .count()
     }
 
+    /// Count non-disabled adapters whose endpoint name is in
+    /// `allowed_endpoints`. Used by [`crate::profile_registry::ProfileRegistryView`]
+    /// to compute the in-profile `skip_wrap` / `skip_prefix` trigger so the
+    /// wrap toggles in lockstep with the profile-scoped catalog rather than
+    /// the global one (closes the `(global>=2, profile==1)` foreign-endpoint
+    /// bypass for any per-request wrap pass).
+    pub(crate) async fn active_endpoint_count_in(
+        &self,
+        allowed_endpoints: &HashSet<String>,
+    ) -> usize {
+        let adapters = self.adapters.read().await;
+        adapters
+            .iter()
+            .filter(|(name, e)| !e.disabled && allowed_endpoints.contains(*name))
+            .count()
+    }
+
+    /// Pick the sole non-disabled adapter whose endpoint name is in
+    /// `allowed_endpoints`, or `None` if zero or more than one match.
+    /// Used by [`crate::profile_registry::ProfileRegistryView::route_resource_read`]
+    /// to resolve the DD5 single-endpoint dispatch target *within the
+    /// profile's scope* rather than the global registry's, which is what
+    /// closes the `(global>=2, profile==1)` foreign-endpoint bypass.
+    pub(crate) async fn find_single_active_endpoint_in(
+        &self,
+        allowed_endpoints: &HashSet<String>,
+    ) -> Option<String> {
+        let adapters = self.adapters.read().await;
+        let mut iter = adapters
+            .iter()
+            .filter(|(name, e)| !e.disabled && allowed_endpoints.contains(*name));
+        let first = iter.next().map(|(name, _)| name.clone());
+        if iter.next().is_some() {
+            None
+        } else {
+            first
+        }
+    }
+
     /// Access the underlying adapters map (for management API use).
     pub fn entries(&self) -> &Arc<RwLock<HashMap<String, RegisteredAdapter>>> {
         &self.adapters
@@ -693,11 +732,45 @@ impl AdapterRegistry {
                             final_name.clone(),
                             (endpoint_name.clone(), tool.name.clone()),
                         );
+                        // Slot #1 (T6): wrap the MCP Apps UI pointer fields
+                        // (`_meta.ui.resourceUri` + alias
+                        // `_meta["openai/outputTemplate"]`) on the tool
+                        // descriptor to this tool's owning endpoint, so a
+                        // pointer the client receives via `tools/list`
+                        // reverses through `route_resource_read` back to the
+                        // same upstream. STRICT DD1: only those two fields
+                        // are touched; arbitrary `_meta` siblings (e.g.
+                        // `ui.csp`) pass through untouched. DD5: skipped in
+                        // single-endpoint mode (`skip_prefix == true`) so the
+                        // wrap/unwrap pair flips with the tool-prefix step
+                        // above. The helper is the same one slot #2 calls in
+                        // `rewrite_tool_call_result`, keeping descriptor and
+                        // result encoding in lockstep with slot #6's decoder.
+                        let mut meta = tool.meta;
+                        if !skip_prefix {
+                            if let Some(meta_obj) = meta.as_mut().and_then(|v| v.as_object_mut()) {
+                                crate::tool_call_rewrite::rewrite_meta_ui_pointers(
+                                    meta_obj,
+                                    endpoint_name,
+                                );
+                            }
+                        }
+                        // Preserve every upstream descriptor field other than
+                        // `name` (rewritten by the prefix step above) and
+                        // `description` (enriched with the `[endpoint]` /
+                        // `[⚠️ UNAVAILABLE]` label above) so MCP Apps UI
+                        // pointers in `_meta`, plus `title`/`outputSchema`
+                        // and any catch-all `extra` fields, survive
+                        // re-serialization through the merged catalog.
                         catalog.push(ToolInfo {
                             name: final_name,
                             description: enriched_description,
                             input_schema: tool.input_schema,
                             annotations: tool.annotations,
+                            title: tool.title,
+                            output_schema: tool.output_schema,
+                            meta,
+                            extra: tool.extra,
                         });
                     }
                 }
@@ -761,6 +834,12 @@ impl AdapterRegistry {
         };
 
         let adapters = self.adapters.read().await;
+        // DD5 single-endpoint passthrough trigger. Mirrors
+        // [`Self::list_resources`] / [`Self::route_resource_read`] /
+        // [`Self::build_catalog`] so the tool-prefix wrap and the result-URI
+        // wrap flip together — when only one active endpoint is registered,
+        // both pass through unchanged (slots #2 and #3 are no-ops below).
+        let skip_wrap = adapters.values().filter(|e| !e.disabled).count() <= 1;
         let entry = match adapters.get(endpoint) {
             Some(e) => e,
             None => {
@@ -857,11 +936,22 @@ impl AdapterRegistry {
         // path. Cheap no-op when the pipeline is unwired or disabled, and
         // skipped for internal callers that have no `request_uid`. Enqueue is
         // non-blocking (`try_send`); overflow drops are counted in the handle.
+        //
+        // T5: each return path applies `rewrite_tool_call_result` so the
+        // enumerated URI slots (`_meta.ui.resourceUri`,
+        // `_meta["openai/outputTemplate"]`, `content[]` of type `resource` /
+        // `resource_link`) are namespaced to `endpoint`. `skip_wrap` mirrors
+        // DD5 single-endpoint passthrough so the rewrite is byte-for-byte
+        // identical to the upstream response when only one endpoint is
+        // active.
         let Some(obs) = self.observability.as_ref().filter(|o| o.is_enabled()) else {
             return entry
                 .adapter
                 .call_tool_with_request_params(tool, arguments, request_params)
-                .await;
+                .await
+                .map(|v| {
+                    crate::tool_call_rewrite::rewrite_tool_call_result(v, endpoint, skip_wrap)
+                });
         };
         let span_ctx = current_request_context();
         // Gate capture on an inbound request context (skip internal callers),
@@ -875,7 +965,10 @@ impl AdapterRegistry {
             return entry
                 .adapter
                 .call_tool_with_request_params(tool, arguments, request_params)
-                .await;
+                .await
+                .map(|v| {
+                    crate::tool_call_rewrite::rewrite_tool_call_result(v, endpoint, skip_wrap)
+                });
         }
         let request_uid = uuid::Uuid::new_v4().to_string();
 
@@ -903,7 +996,8 @@ impl AdapterRegistry {
         let result = entry
             .adapter
             .call_tool_with_request_params(tool, arguments, request_params)
-            .await;
+            .await
+            .map(|v| crate::tool_call_rewrite::rewrite_tool_call_result(v, endpoint, skip_wrap));
         let duration_ms = started.elapsed().as_millis() as i64;
         let ts_end = ts_start + duration_ms;
 
@@ -959,6 +1053,521 @@ impl AdapterRegistry {
         obs.capture(CaptureRecord { record, payloads });
 
         result
+    }
+
+    /// Aggregate `resources/list` across every non-disabled adapter, wrapping
+    /// each `uri` per slot #4 so the resulting list routes back to the owning
+    /// endpoint via `resources/read`.
+    ///
+    /// Mirrors [`Self::build_catalog`]'s `skip_prefix` semantics: when only
+    /// one non-disabled adapter is active (DD5), URIs flow through unwrapped.
+    /// Adapters whose upstream rejects `resources/list` (e.g. `-32601` for
+    /// servers that don't expose resources) are skipped with a warning so a
+    /// mixed-capability deployment still surfaces the resources it can.
+    pub async fn list_resources(&self) -> Vec<Value> {
+        let adapters = self.adapters.read().await;
+        let active_count = adapters.values().filter(|e| !e.disabled).count();
+        let skip_wrap = active_count <= 1;
+
+        let mut merged: Vec<Value> = Vec::new();
+        for (endpoint_name, entry) in adapters.iter() {
+            if entry.disabled {
+                continue;
+            }
+            match entry.adapter.list_resources().await {
+                Ok(items) => {
+                    for mut item in items {
+                        if let Some(uri) = item.get("uri").and_then(|v| v.as_str()) {
+                            let wrapped = crate::resource_uri::maybe_encode_resource_uri(
+                                endpoint_name,
+                                uri,
+                                skip_wrap,
+                            );
+                            if let Some(obj) = item.as_object_mut() {
+                                obj.insert("uri".to_string(), Value::String(wrapped));
+                            }
+                        }
+                        merged.push(item);
+                    }
+                }
+                Err(e) => {
+                    warn!(endpoint = %endpoint_name, error = %e, "Failed to list resources");
+                }
+            }
+        }
+        merged
+    }
+
+    /// Aggregate `resources/templates/list` across every non-disabled
+    /// adapter, wrapping each `uriTemplate` per slot #5 via
+    /// [`crate::resource_uri::maybe_encode_resource_uri_template`] so RFC
+    /// 6570 `{var}` markers survive the wrap and client-side variable
+    /// expansion still works. DD5 single-endpoint mode passes templates
+    /// through unwrapped, mirroring [`Self::list_resources`].
+    pub async fn list_resource_templates(&self) -> Vec<Value> {
+        let adapters = self.adapters.read().await;
+        let active_count = adapters.values().filter(|e| !e.disabled).count();
+        let skip_wrap = active_count <= 1;
+
+        let mut merged: Vec<Value> = Vec::new();
+        for (endpoint_name, entry) in adapters.iter() {
+            if entry.disabled {
+                continue;
+            }
+            match entry.adapter.list_resource_templates().await {
+                Ok(items) => {
+                    for mut item in items {
+                        if let Some(tmpl) = item.get("uriTemplate").and_then(|v| v.as_str()) {
+                            let wrapped = crate::resource_uri::maybe_encode_resource_uri_template(
+                                endpoint_name,
+                                tmpl,
+                                skip_wrap,
+                            );
+                            if let Some(obj) = item.as_object_mut() {
+                                obj.insert("uriTemplate".to_string(), Value::String(wrapped));
+                            }
+                        }
+                        merged.push(item);
+                    }
+                }
+                Err(e) => {
+                    warn!(endpoint = %endpoint_name, error = %e, "Failed to list resource templates");
+                }
+            }
+        }
+        merged
+    }
+
+    /// Profile-scoped variant of [`Self::list_resources`]: aggregates
+    /// `resources/list` only across non-disabled adapters whose endpoint name
+    /// is in `allowed_endpoints`, wrapping URIs based on the *in-profile*
+    /// active count. This keeps the wrap trigger consistent with
+    /// [`crate::profile_registry::ProfileRegistryView::route_resource_read`]
+    /// so the allowed-endpoint guard cannot be bypassed in the
+    /// `(global>=2, profile==1)` corner case.
+    pub async fn list_resources_in(&self, allowed_endpoints: &HashSet<String>) -> Vec<Value> {
+        let adapters = self.adapters.read().await;
+        let active_count = adapters
+            .iter()
+            .filter(|(name, e)| !e.disabled && allowed_endpoints.contains(*name))
+            .count();
+        let skip_wrap = active_count <= 1;
+
+        let mut merged: Vec<Value> = Vec::new();
+        for (endpoint_name, entry) in adapters.iter() {
+            if entry.disabled || !allowed_endpoints.contains(endpoint_name) {
+                continue;
+            }
+            match entry.adapter.list_resources().await {
+                Ok(items) => {
+                    for mut item in items {
+                        if let Some(uri) = item.get("uri").and_then(|v| v.as_str()) {
+                            let wrapped = crate::resource_uri::maybe_encode_resource_uri(
+                                endpoint_name,
+                                uri,
+                                skip_wrap,
+                            );
+                            if let Some(obj) = item.as_object_mut() {
+                                obj.insert("uri".to_string(), Value::String(wrapped));
+                            }
+                        }
+                        merged.push(item);
+                    }
+                }
+                Err(e) => {
+                    warn!(endpoint = %endpoint_name, error = %e, "Failed to list resources");
+                }
+            }
+        }
+        merged
+    }
+
+    /// Profile-scoped variant of [`Self::list_resource_templates`] — see
+    /// [`Self::list_resources_in`] for the rationale; uses the template-aware
+    /// encoder so RFC 6570 `{var}` markers survive the wrap.
+    pub async fn list_resource_templates_in(
+        &self,
+        allowed_endpoints: &HashSet<String>,
+    ) -> Vec<Value> {
+        let adapters = self.adapters.read().await;
+        let active_count = adapters
+            .iter()
+            .filter(|(name, e)| !e.disabled && allowed_endpoints.contains(*name))
+            .count();
+        let skip_wrap = active_count <= 1;
+
+        let mut merged: Vec<Value> = Vec::new();
+        for (endpoint_name, entry) in adapters.iter() {
+            if entry.disabled || !allowed_endpoints.contains(endpoint_name) {
+                continue;
+            }
+            match entry.adapter.list_resource_templates().await {
+                Ok(items) => {
+                    for mut item in items {
+                        if let Some(tmpl) = item.get("uriTemplate").and_then(|v| v.as_str()) {
+                            let wrapped = crate::resource_uri::maybe_encode_resource_uri_template(
+                                endpoint_name,
+                                tmpl,
+                                skip_wrap,
+                            );
+                            if let Some(obj) = item.as_object_mut() {
+                                obj.insert("uriTemplate".to_string(), Value::String(wrapped));
+                            }
+                        }
+                        merged.push(item);
+                    }
+                }
+                Err(e) => {
+                    warn!(endpoint = %endpoint_name, error = %e, "Failed to list resource templates");
+                }
+            }
+        }
+        merged
+    }
+
+    /// Aggregate `prompts/list` across every non-disabled adapter, namespacing
+    /// each `prompts[].name` via the existing tool-prefix scheme
+    /// ([`prefix::encode_tool_name`]) per slot #8 so a prefixed prompt name
+    /// later routes back to its owning upstream. Mirrors
+    /// [`Self::build_catalog`]'s `skip_prefix` semantics: when only one
+    /// non-disabled adapter is active (DD5), names flow through unprefixed.
+    ///
+    /// Returns the merged `prompts` array. Adapters whose upstream rejects
+    /// `prompts/list` (e.g. `-32601` for servers that don't expose prompts)
+    /// are skipped with a warning so a mixed-capability deployment still
+    /// surfaces the prompts it can.
+    pub async fn list_prompts(&self) -> Vec<Value> {
+        self.list_prompts_with_lookup().await.0
+    }
+
+    /// Aggregate `prompts/list` and build a reverse lookup map from each
+    /// prefixed prompt name to `(endpoint_name, raw_prompt_name)`. The lookup
+    /// shape mirrors the tool catalog's reverse map so a future
+    /// `prompts/get` dispatcher can reuse the same resolution pattern as
+    /// `route_tool_call`.
+    pub async fn list_prompts_with_lookup(
+        &self,
+    ) -> (Vec<Value>, HashMap<String, (String, String)>) {
+        let adapters = self.adapters.read().await;
+        let active_count = adapters.values().filter(|e| !e.disabled).count();
+        let skip_prefix = active_count <= 1;
+
+        let mut merged: Vec<Value> = Vec::new();
+        let mut lookup: HashMap<String, (String, String)> = HashMap::new();
+        for (endpoint_name, entry) in adapters.iter() {
+            if entry.disabled {
+                continue;
+            }
+            let effective_prefix = if skip_prefix {
+                None
+            } else {
+                entry.tool_prefix.clone()
+            };
+            match entry.adapter.list_prompts().await {
+                Ok(items) => {
+                    for mut item in items {
+                        if let Some(raw_name) = item
+                            .get("name")
+                            .and_then(|v| v.as_str())
+                            .map(str::to_string)
+                        {
+                            let final_name = match &effective_prefix {
+                                Some(pfx) => prefix::encode_tool_name(pfx, None, &raw_name),
+                                None => raw_name.clone(),
+                            };
+                            if let Some(obj) = item.as_object_mut() {
+                                obj.insert("name".to_string(), Value::String(final_name.clone()));
+                            }
+                            lookup.insert(final_name, (endpoint_name.clone(), raw_name));
+                        }
+                        merged.push(item);
+                    }
+                }
+                Err(e) => {
+                    warn!(endpoint = %endpoint_name, error = %e, "Failed to list prompts");
+                }
+            }
+        }
+        (merged, lookup)
+    }
+
+    /// Profile-scoped variant of [`Self::list_prompts`]: aggregates
+    /// `prompts/list` only across non-disabled adapters whose endpoint name
+    /// is in `allowed_endpoints`, namespacing names based on the *in-profile*
+    /// active count. This keeps the prefix trigger consistent with the
+    /// profile-scoped tool catalog so the allowed-endpoint guard cannot be
+    /// bypassed in the `(global>=2, profile==1)` corner case.
+    pub async fn list_prompts_in(&self, allowed_endpoints: &HashSet<String>) -> Vec<Value> {
+        self.list_prompts_in_with_lookup(allowed_endpoints).await.0
+    }
+
+    /// Profile-scoped variant of [`Self::list_prompts_with_lookup`] — see
+    /// [`Self::list_prompts_in`] for the rationale.
+    pub async fn list_prompts_in_with_lookup(
+        &self,
+        allowed_endpoints: &HashSet<String>,
+    ) -> (Vec<Value>, HashMap<String, (String, String)>) {
+        let adapters = self.adapters.read().await;
+        let active_count = adapters
+            .iter()
+            .filter(|(name, e)| !e.disabled && allowed_endpoints.contains(*name))
+            .count();
+        let skip_prefix = active_count <= 1;
+
+        let mut merged: Vec<Value> = Vec::new();
+        let mut lookup: HashMap<String, (String, String)> = HashMap::new();
+        for (endpoint_name, entry) in adapters.iter() {
+            if entry.disabled || !allowed_endpoints.contains(endpoint_name) {
+                continue;
+            }
+            let effective_prefix = if skip_prefix {
+                None
+            } else {
+                entry.tool_prefix.clone()
+            };
+            match entry.adapter.list_prompts().await {
+                Ok(items) => {
+                    for mut item in items {
+                        if let Some(raw_name) = item
+                            .get("name")
+                            .and_then(|v| v.as_str())
+                            .map(str::to_string)
+                        {
+                            let final_name = match &effective_prefix {
+                                Some(pfx) => prefix::encode_tool_name(pfx, None, &raw_name),
+                                None => raw_name.clone(),
+                            };
+                            if let Some(obj) = item.as_object_mut() {
+                                obj.insert("name".to_string(), Value::String(final_name.clone()));
+                            }
+                            lookup.insert(final_name, (endpoint_name.clone(), raw_name));
+                        }
+                        merged.push(item);
+                    }
+                }
+                Err(e) => {
+                    warn!(endpoint = %endpoint_name, error = %e, "Failed to list prompts");
+                }
+            }
+        }
+        (merged, lookup)
+    }
+
+    /// Route an inbound `prompts/get` to the owning upstream after
+    /// reverse-prefixing the namespaced prompt name and wrapping resource
+    /// references in the returned messages (slot #9).
+    ///
+    /// `prefixed_name` is the prompt name the client received from a previous
+    /// `prompts/list` — either `{endpoint_prefix}__{raw_name}` (multi-endpoint
+    /// mode) or the raw upstream name passed through unchanged (DD5 single-
+    /// endpoint mode). The reverse map is rebuilt from
+    /// [`Self::list_prompts_with_lookup`] so the wrap/unwrap pair stays
+    /// symmetric — a name that came out of `prompts/list` must reverse here.
+    ///
+    /// Mirrors [`Self::route_tool_call_with_request_params`]'s early-rejection
+    /// shape: an unknown prefixed name, an endpoint the registry no longer
+    /// has an adapter for, a disabled endpoint, and an unhealthy endpoint
+    /// each return a distinct [`AdapterError::ProtocolError`] message so log
+    /// scrapers can distinguish the cases. The returned `Value` is the
+    /// upstream `prompts/get` result with slot #9 URI rewriting applied to
+    /// `messages[].content` blocks scoped to the owning endpoint — the
+    /// `skip_wrap` trigger mirrors [`Self::route_tool_call_with_request_params`]
+    /// (`active_count <= 1`) so the wrap toggles in lockstep with the name
+    /// prefix toggle.
+    pub async fn route_prompt_get(
+        &self,
+        prefixed_name: &str,
+        arguments: Option<Value>,
+    ) -> Result<Value, AdapterError> {
+        let (_prompts, lookup) = self.list_prompts_with_lookup().await;
+        let (endpoint, raw_name) = match lookup.get(prefixed_name) {
+            Some(v) => v.clone(),
+            None => {
+                return Err(AdapterError::ProtocolError(format!(
+                    "no prompt found for prefixed name '{}'",
+                    prefixed_name
+                )));
+            }
+        };
+
+        let skip_wrap = {
+            let adapters = self.adapters.read().await;
+            adapters.values().filter(|e| !e.disabled).count() <= 1
+        };
+
+        let value = self
+            .dispatch_prompt_get_to(&endpoint, &raw_name, arguments)
+            .await?;
+        Ok(crate::tool_call_rewrite::rewrite_prompt_get_result(
+            value, &endpoint, skip_wrap,
+        ))
+    }
+
+    /// Dispatch a `prompts/get` to a specific endpoint without performing any
+    /// name reverse-prefixing or result rewriting. The caller is responsible
+    /// for selecting the endpoint (e.g. by consulting the reverse lookup
+    /// themselves), supplying the raw upstream prompt name, and applying any
+    /// downstream slot #9 URI rewrite.
+    ///
+    /// Returns the same error shapes as [`Self::route_prompt_get`] for unknown
+    /// / disabled / unhealthy endpoints so log scrapers see identical messages
+    /// regardless of whether the fetch came through the global or a profile-
+    /// scoped path.
+    pub(crate) async fn dispatch_prompt_get_to(
+        &self,
+        endpoint_name: &str,
+        raw_name: &str,
+        arguments: Option<Value>,
+    ) -> Result<Value, AdapterError> {
+        let adapters = self.adapters.read().await;
+        let entry = match adapters.get(endpoint_name) {
+            Some(e) => e,
+            None => {
+                return Err(AdapterError::ProtocolError(format!(
+                    "no adapter found for endpoint '{}'",
+                    endpoint_name
+                )));
+            }
+        };
+
+        if entry.disabled {
+            return Err(AdapterError::ProtocolError(format!(
+                "endpoint '{}' is disabled",
+                endpoint_name
+            )));
+        }
+
+        if !matches!(entry.adapter.health(), HealthStatus::Healthy) {
+            return Err(AdapterError::ProtocolError(format!(
+                "prompt '{}' is currently unavailable: endpoint '{}' is not healthy",
+                raw_name, endpoint_name
+            )));
+        }
+
+        info!(
+            endpoint = %endpoint_name,
+            prompt = %raw_name,
+            "Routing prompt get"
+        );
+
+        entry.adapter.get_prompt(raw_name, arguments).await
+    }
+
+    /// Route an inbound `resources/read` to the owning upstream after
+    /// reverse-rewriting the wrapped URI (slot #6).
+    ///
+    /// `wrapped_uri` is the URI the client received from a previous
+    /// `resources/list`, `resources/templates/list`, or `tools/call` result —
+    /// either `mcp-relay://{endpoint}/{percent-encoded-original}` (multi-
+    /// endpoint mode) or the original URI passed through unchanged (DD5
+    /// single-endpoint mode). The decode trigger mirrors `build_catalog`'s
+    /// `skip_prefix = active_count <= 1` so the wrap/unwrap pair is symmetric:
+    /// in single-endpoint mode the URI is treated as already-original and
+    /// dispatched to the sole adapter; in multi-endpoint mode the wrapper
+    /// scheme is decoded to `(endpoint, original_uri)` and the original is
+    /// forwarded to the adapter at `endpoint`.
+    ///
+    /// Rejects every error branch as [`AdapterError::ProtocolError`] mirroring
+    /// [`Self::route_tool_call`]'s early-rejection shape: a wrapped URI that
+    /// fails to decode, an unknown endpoint, a disabled endpoint, and an
+    /// unhealthy endpoint each return a distinct message so log scrapers can
+    /// distinguish the cases. No `ToolCallEvent` is emitted — the event bus is
+    /// scoped to `tools/call` (R3.B) and reusing it here would inject phantom
+    /// tool-call rows into the desktop overlay.
+    ///
+    /// Per DD2 the returned `Value` is the upstream `resources/read` result
+    /// object forwarded verbatim — URIs inside the resource body are not
+    /// rewritten in v1.
+    pub async fn route_resource_read(&self, wrapped_uri: &str) -> Result<Value, AdapterError> {
+        let (endpoint_name, original_uri) = {
+            let adapters = self.adapters.read().await;
+            let active_count = adapters.values().filter(|e| !e.disabled).count();
+            let skip_wrap = active_count <= 1;
+
+            // Decode the wrapped URI to `(Option<endpoint>, original_uri)`. In
+            // DD5 single-endpoint mode the wrap is skipped entirely so the URI is
+            // its own original and the endpoint hint is absent — dispatched to
+            // the sole active adapter below.
+            let (endpoint_hint, original_uri) =
+                crate::resource_uri::maybe_decode_resource_uri(wrapped_uri, skip_wrap).map_err(
+                    |e| {
+                        AdapterError::ProtocolError(format!(
+                            "invalid resource URI '{}': {}",
+                            wrapped_uri, e
+                        ))
+                    },
+                )?;
+
+            let endpoint_name = match endpoint_hint {
+                Some(name) => name,
+                None => {
+                    // DD5 single-endpoint mode: dispatch to the sole non-disabled
+                    // adapter. If somehow zero are active (unlikely — the wrap
+                    // trigger uses `active_count <= 1`) return a clean rejection.
+                    match adapters.iter().find(|(_, e)| !e.disabled) {
+                        Some((name, _)) => name.clone(),
+                        None => {
+                            return Err(AdapterError::ProtocolError(format!(
+                                "no active endpoint to serve resource '{}'",
+                                wrapped_uri
+                            )));
+                        }
+                    }
+                }
+            };
+            (endpoint_name, original_uri)
+        };
+
+        self.dispatch_resource_read_to(&endpoint_name, &original_uri)
+            .await
+    }
+
+    /// Dispatch a `resources/read` to a specific endpoint without performing
+    /// any URI decoding. The caller is responsible for selecting the endpoint
+    /// (e.g. by decoding the wrapper themselves) and supplying the unwrapped
+    /// resource URI.
+    ///
+    /// Returns the same error shapes as [`Self::route_resource_read`] for
+    /// unknown / disabled / unhealthy endpoints so log scrapers see identical
+    /// messages regardless of whether the read came through the global or a
+    /// profile-scoped path.
+    pub(crate) async fn dispatch_resource_read_to(
+        &self,
+        endpoint_name: &str,
+        original_uri: &str,
+    ) -> Result<Value, AdapterError> {
+        let adapters = self.adapters.read().await;
+        let entry = match adapters.get(endpoint_name) {
+            Some(e) => e,
+            None => {
+                return Err(AdapterError::ProtocolError(format!(
+                    "no adapter found for endpoint '{}'",
+                    endpoint_name
+                )));
+            }
+        };
+
+        if entry.disabled {
+            return Err(AdapterError::ProtocolError(format!(
+                "endpoint '{}' is disabled",
+                endpoint_name
+            )));
+        }
+
+        if !matches!(entry.adapter.health(), HealthStatus::Healthy) {
+            return Err(AdapterError::ProtocolError(format!(
+                "resource '{}' is currently unavailable: endpoint '{}' is not healthy",
+                original_uri, endpoint_name
+            )));
+        }
+
+        info!(
+            endpoint = %endpoint_name,
+            uri = %original_uri,
+            "Routing resource read"
+        );
+
+        entry.adapter.read_resource(original_uri).await
     }
 
     /// Publish a `Started` + `Failed` pair on the shared
@@ -2137,6 +2746,7 @@ mod tests {
             description: Some(format!("{} tool", name)),
             input_schema: json!({"type": "object"}),
             annotations: None,
+            ..Default::default()
         }
     }
 
@@ -2159,6 +2769,97 @@ mod tests {
         assert_eq!(catalog.len(), 1);
         // Single adapter → no prefix
         assert_eq!(catalog[0].name, "read");
+    }
+
+    // --- T1: lossless passthrough of tool-descriptor metadata ---
+
+    #[tokio::test]
+    async fn test_merged_catalog_preserves_tool_metadata_passthrough() {
+        // A tool with `title`, `outputSchema`, `_meta.ui.resourceUri`,
+        // and an unmodeled top-level field must survive aggregation through
+        // `merged_catalog` without losing or mutating those fields. `name`
+        // (prefixed for multi-server), `description` (enriched with the
+        // `[endpoint]` label), and the two slot #1 `_meta` UI pointers (T6
+        // namespaces `_meta.ui.resourceUri` + `_meta["openai/outputTemplate"]`
+        // to the owning endpoint) are expected to change.
+        let registry = AdapterRegistry::new();
+        let upstream = ToolInfo {
+            name: "show_users".into(),
+            description: Some("Show users".into()),
+            input_schema: json!({"type": "object"}),
+            annotations: Some(json!({"readOnlyHint": true})),
+            title: Some("Show Users".into()),
+            output_schema: Some(json!({
+                "type": "object",
+                "properties": {"users": {"type": "array"}},
+            })),
+            meta: Some(json!({
+                "ui": {"resourceUri": "ui://widgets/users.html"},
+                "openai/outputTemplate": "ui://widgets/users.html",
+            })),
+            extra: {
+                let mut m = serde_json::Map::new();
+                m.insert("futureField".into(), json!("future-value"));
+                m
+            },
+        };
+        registry
+            .register(
+                "ep1".into(),
+                Box::new(MockAdapter::healthy(vec![upstream.clone()])),
+                "stdio".into(),
+                None,
+                Some("ep1".into()),
+            )
+            .await;
+        registry
+            .register(
+                "ep2".into(),
+                Box::new(MockAdapter::healthy(vec![make_tool("noop")])),
+                "stdio".into(),
+                None,
+                Some("ep2".into()),
+            )
+            .await;
+
+        let catalog = registry.merged_catalog().await;
+        let entry = catalog
+            .iter()
+            .find(|t| t.name == "ep1__show_users")
+            .expect("prefixed tool present in catalog");
+
+        // Enrichment label is applied to description; everything else
+        // passes through verbatim.
+        assert_eq!(
+            entry.description.as_deref(),
+            Some("[ep1] Show users"),
+            "description should carry the [endpoint] enrichment label"
+        );
+        assert_eq!(entry.input_schema, upstream.input_schema);
+        assert_eq!(entry.annotations, upstream.annotations);
+        assert_eq!(entry.title, upstream.title);
+        assert_eq!(entry.output_schema, upstream.output_schema);
+        assert_eq!(entry.extra, upstream.extra);
+
+        // Re-serializing through serde_json must keep `_meta` (renamed,
+        // not dropped) and the catch-all `extra` field reachable for
+        // downstream MCP Apps clients. The two slot #1 pointer fields are
+        // wrapped to the owning endpoint per T6; everything else under
+        // `_meta` (none here, but a CSP sibling would be) and the unmodeled
+        // top-level fields survive verbatim.
+        let wrapped_ui = crate::resource_uri::encode_resource_uri("ep1", "ui://widgets/users.html");
+        let wire = serde_json::to_value(entry).expect("serialize entry");
+        assert_eq!(
+            wire["_meta"]["ui"]["resourceUri"], wrapped_ui,
+            "_meta.ui.resourceUri must be wrapped to the owning endpoint (T6 slot #1)"
+        );
+        assert_eq!(
+            wire["_meta"]["openai/outputTemplate"], wrapped_ui,
+            "_meta openai alias must be wrapped to the owning endpoint (T6 slot #1)"
+        );
+        assert_eq!(wire["title"], "Show Users");
+        assert!(wire["outputSchema"].is_object());
+        assert_eq!(wire["futureField"], "future-value");
     }
 
     // --- Multi-server with tool_prefix ---
@@ -2587,6 +3288,7 @@ mod tests {
             description: None,
             input_schema: json!({"type": "object"}),
             annotations: None,
+            ..Default::default()
         };
         registry
             .register(
@@ -4204,6 +4906,7 @@ mod tests {
             description: Some(format!("{} tool", name)),
             input_schema: schema,
             annotations: None,
+            ..Default::default()
         }
     }
 
@@ -5069,6 +5772,1421 @@ mod tests {
                 assert_eq!(status, "validation_error");
             }
             other => panic!("expected Failed, got {:?}", other),
+        }
+    }
+
+    // --- T3: resources/list + resources/templates/list aggregation ---
+
+    /// Adapter mock that returns canned `list_resources` and
+    /// `list_resource_templates` payloads. Kept separate from `MockAdapter`
+    /// so the existing tools-only tests don't grow new fields.
+    struct ResourceMockAdapter {
+        resources: Vec<serde_json::Value>,
+        templates: Vec<serde_json::Value>,
+    }
+
+    #[async_trait]
+    impl McpAdapter for ResourceMockAdapter {
+        async fn initialize(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+        async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
+            Ok(vec![])
+        }
+        async fn call_tool(
+            &self,
+            name: &str,
+            arguments: serde_json::Value,
+        ) -> Result<serde_json::Value, AdapterError> {
+            Ok(json!({ "called": name, "args": arguments }))
+        }
+        async fn list_resources(&self) -> Result<Vec<serde_json::Value>, AdapterError> {
+            Ok(self.resources.clone())
+        }
+        async fn list_resource_templates(&self) -> Result<Vec<serde_json::Value>, AdapterError> {
+            Ok(self.templates.clone())
+        }
+        async fn read_resource(&self, uri: &str) -> Result<serde_json::Value, AdapterError> {
+            // Echo the URI the adapter received so tests can assert the
+            // registry's reverse-rewrite stripped the wrapper before dispatch.
+            Ok(json!({
+                "contents": [{
+                    "uri": uri,
+                    "mimeType": "text/plain",
+                    "text": format!("body for {uri}"),
+                }]
+            }))
+        }
+        fn health(&self) -> HealthStatus {
+            HealthStatus::Healthy
+        }
+        async fn shutdown(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+    }
+
+    /// Adapter mock whose `list_resources` / `list_resource_templates`
+    /// always error out, used to exercise the registry's "skip on error"
+    /// branch in the multi-endpoint aggregation.
+    struct FailingResourceAdapter;
+
+    #[async_trait]
+    impl McpAdapter for FailingResourceAdapter {
+        async fn initialize(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+        async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
+            Ok(vec![])
+        }
+        async fn call_tool(
+            &self,
+            _name: &str,
+            _arguments: serde_json::Value,
+        ) -> Result<serde_json::Value, AdapterError> {
+            Err(AdapterError::ProtocolError("not implemented".into()))
+        }
+        async fn list_resources(&self) -> Result<Vec<serde_json::Value>, AdapterError> {
+            Err(AdapterError::JsonRpcError {
+                code: -32601,
+                message: "method not found".into(),
+                data: None,
+            })
+        }
+        async fn list_resource_templates(&self) -> Result<Vec<serde_json::Value>, AdapterError> {
+            Err(AdapterError::JsonRpcError {
+                code: -32601,
+                message: "method not found".into(),
+                data: None,
+            })
+        }
+        fn health(&self) -> HealthStatus {
+            HealthStatus::Healthy
+        }
+        async fn shutdown(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+    }
+
+    /// DD5 — single-endpoint mode passes resource URIs through unwrapped
+    /// (mirrors the tool-prefix `skip_prefix` parity).
+    #[tokio::test]
+    async fn list_resources_single_endpoint_passes_uris_through() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "alpha".into(),
+                Box::new(ResourceMockAdapter {
+                    resources: vec![json!({
+                        "uri": "ui://app/main",
+                        "name": "Main",
+                        "mimeType": "text/html"
+                    })],
+                    templates: vec![],
+                }),
+                "stdio".into(),
+                None,
+                Some("alpha".into()),
+            )
+            .await;
+
+        let resources = registry.list_resources().await;
+        assert_eq!(resources.len(), 1);
+        assert_eq!(resources[0]["uri"], "ui://app/main");
+        // Sibling fields round-trip untouched.
+        assert_eq!(resources[0]["name"], "Main");
+        assert_eq!(resources[0]["mimeType"], "text/html");
+    }
+
+    /// Multi-endpoint aggregation wraps every `uri` to its owning endpoint
+    /// via the `mcp-relay://` wrapper scheme (slot #4).
+    #[tokio::test]
+    async fn list_resources_multi_endpoint_wraps_uris() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "alpha".into(),
+                Box::new(ResourceMockAdapter {
+                    resources: vec![json!({ "uri": "ui://app/main", "name": "A" })],
+                    templates: vec![],
+                }),
+                "stdio".into(),
+                None,
+                Some("alpha".into()),
+            )
+            .await;
+        registry
+            .register(
+                "beta".into(),
+                Box::new(ResourceMockAdapter {
+                    resources: vec![json!({ "uri": "file:///tmp/notes.md", "name": "B" })],
+                    templates: vec![],
+                }),
+                "stdio".into(),
+                None,
+                Some("beta".into()),
+            )
+            .await;
+
+        let mut resources = registry.list_resources().await;
+        assert_eq!(resources.len(), 2);
+        // Stable order for assertion regardless of HashMap iteration order.
+        resources.sort_by(|a, b| {
+            a["name"]
+                .as_str()
+                .unwrap_or("")
+                .cmp(b["name"].as_str().unwrap_or(""))
+        });
+
+        let a_uri = resources[0]["uri"].as_str().unwrap();
+        let b_uri = resources[1]["uri"].as_str().unwrap();
+        assert!(
+            a_uri.starts_with("mcp-relay://alpha/"),
+            "expected alpha wrap, got {}",
+            a_uri
+        );
+        assert!(
+            b_uri.starts_with("mcp-relay://beta/"),
+            "expected beta wrap, got {}",
+            b_uri
+        );
+
+        // Round-trip back to the original URI to prove the wrap is reversible.
+        let (ep_a, orig_a) = crate::resource_uri::decode_resource_uri(a_uri).unwrap();
+        let (ep_b, orig_b) = crate::resource_uri::decode_resource_uri(b_uri).unwrap();
+        assert_eq!(ep_a, "alpha");
+        assert_eq!(orig_a, "ui://app/main");
+        assert_eq!(ep_b, "beta");
+        assert_eq!(orig_b, "file:///tmp/notes.md");
+    }
+
+    /// Multi-endpoint template aggregation wraps `uriTemplate` via the
+    /// template-aware encoder (slot #5) so RFC 6570 `{var}` markers survive
+    /// the wrap and client-side expansion still works.
+    #[tokio::test]
+    async fn list_resource_templates_multi_endpoint_preserves_rfc6570_braces() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "alpha".into(),
+                Box::new(ResourceMockAdapter {
+                    resources: vec![],
+                    templates: vec![json!({
+                        "uriTemplate": "ui://app/items/{id}",
+                        "name": "Item"
+                    })],
+                }),
+                "stdio".into(),
+                None,
+                Some("alpha".into()),
+            )
+            .await;
+        registry
+            .register(
+                "beta".into(),
+                Box::new(ResourceMockAdapter {
+                    resources: vec![],
+                    templates: vec![json!({
+                        "uriTemplate": "file:///docs/{section}/{page}",
+                        "name": "Doc"
+                    })],
+                }),
+                "stdio".into(),
+                None,
+                Some("beta".into()),
+            )
+            .await;
+
+        let templates = registry.list_resource_templates().await;
+        assert_eq!(templates.len(), 2);
+        for t in &templates {
+            let wrapped = t["uriTemplate"].as_str().unwrap();
+            assert!(
+                wrapped.starts_with("mcp-relay://"),
+                "expected wrap, got {}",
+                wrapped
+            );
+            assert!(
+                wrapped.contains('{') && wrapped.contains('}'),
+                "RFC 6570 braces must survive the wrap, got {}",
+                wrapped
+            );
+            // Confirm the literal `{var}` is reachable after a decode pass
+            // (proves the host's RFC 6570 expansion will find it).
+            let (_, original) = crate::resource_uri::decode_resource_uri(wrapped).unwrap();
+            assert!(
+                original.contains('{') && original.contains('}'),
+                "decoded original must still carry literal braces, got {}",
+                original
+            );
+        }
+    }
+
+    /// DD5 — single-endpoint template mode is also a passthrough.
+    #[tokio::test]
+    async fn list_resource_templates_single_endpoint_passes_through() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "alpha".into(),
+                Box::new(ResourceMockAdapter {
+                    resources: vec![],
+                    templates: vec![json!({
+                        "uriTemplate": "ui://app/items/{id}",
+                        "name": "Item"
+                    })],
+                }),
+                "stdio".into(),
+                None,
+                Some("alpha".into()),
+            )
+            .await;
+
+        let templates = registry.list_resource_templates().await;
+        assert_eq!(templates.len(), 1);
+        assert_eq!(templates[0]["uriTemplate"], "ui://app/items/{id}");
+    }
+
+    /// Adapters whose upstream rejects `resources/list` (typical for MCP
+    /// servers that do not expose resources, returning `-32601`) are skipped
+    /// without poisoning the merged response — endpoints that DO support
+    /// resources still surface their entries.
+    #[tokio::test]
+    async fn list_resources_skips_endpoints_that_error_out() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "alpha".into(),
+                Box::new(ResourceMockAdapter {
+                    resources: vec![json!({ "uri": "ui://app/main", "name": "A" })],
+                    templates: vec![],
+                }),
+                "stdio".into(),
+                None,
+                Some("alpha".into()),
+            )
+            .await;
+        registry
+            .register(
+                "beta".into(),
+                Box::new(FailingResourceAdapter),
+                "stdio".into(),
+                None,
+                Some("beta".into()),
+            )
+            .await;
+
+        let resources = registry.list_resources().await;
+        assert_eq!(
+            resources.len(),
+            1,
+            "endpoint that errored on list_resources must be skipped, leaving alpha's entry"
+        );
+        let uri = resources[0]["uri"].as_str().unwrap();
+        assert!(
+            uri.starts_with("mcp-relay://alpha/"),
+            "alpha's URI must still be wrapped under multi-endpoint mode, got {}",
+            uri
+        );
+    }
+
+    /// The default adapter implementation returns an empty resource list
+    /// (placeholder adapters / transports that haven't implemented the
+    /// passthrough yet). Aggregating them yields an empty merged list.
+    #[tokio::test]
+    async fn list_resources_default_impl_returns_empty() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "alpha".into(),
+                Box::new(MockAdapter::healthy(vec![])),
+                "stdio".into(),
+                None,
+                Some("alpha".into()),
+            )
+            .await;
+        assert!(registry.list_resources().await.is_empty());
+        assert!(registry.list_resource_templates().await.is_empty());
+    }
+
+    // ---- T4 — `route_resource_read` ---------------------------------------
+
+    /// Multi-endpoint reverse-rewrite (slot #6): a `mcp-relay://A/...` URI
+    /// is decoded back to endpoint `A` and the adapter receives the original
+    /// URI, not the wrapped one. Symmetric with `list_resources_multi_endpoint_wraps_uris`.
+    #[tokio::test]
+    async fn route_resource_read_decodes_wrapper_and_dispatches_to_owning_endpoint() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "alpha".into(),
+                Box::new(ResourceMockAdapter {
+                    resources: vec![json!({ "uri": "ui://app/main", "name": "A" })],
+                    templates: vec![],
+                }),
+                "stdio".into(),
+                None,
+                Some("alpha".into()),
+            )
+            .await;
+        registry
+            .register(
+                "beta".into(),
+                Box::new(ResourceMockAdapter {
+                    resources: vec![json!({ "uri": "file:///tmp/notes.md", "name": "B" })],
+                    templates: vec![],
+                }),
+                "stdio".into(),
+                None,
+                Some("beta".into()),
+            )
+            .await;
+
+        let wrapped = crate::resource_uri::encode_resource_uri("alpha", "ui://app/main");
+        let result = registry
+            .route_resource_read(&wrapped)
+            .await
+            .expect("read should succeed");
+        // The adapter echoes back the URI it actually received — proving the
+        // wrapper was stripped before dispatch.
+        let echoed = result["contents"][0]["uri"].as_str().unwrap();
+        assert_eq!(echoed, "ui://app/main", "wrapper must be stripped");
+        let text = result["contents"][0]["text"].as_str().unwrap();
+        assert!(text.contains("ui://app/main"));
+    }
+
+    /// DD5 single-endpoint mode: the wrap was skipped on the outbound side,
+    /// so the inbound URI is its own original. The registry must dispatch it
+    /// to the sole adapter without trying to decode a `mcp-relay://` prefix.
+    #[tokio::test]
+    async fn route_resource_read_single_endpoint_passes_uri_through() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "solo".into(),
+                Box::new(ResourceMockAdapter {
+                    resources: vec![json!({ "uri": "ui://app/main", "name": "Main" })],
+                    templates: vec![],
+                }),
+                "stdio".into(),
+                None,
+                Some("solo".into()),
+            )
+            .await;
+
+        let result = registry
+            .route_resource_read("ui://app/main")
+            .await
+            .expect("single-endpoint read should succeed");
+        let echoed = result["contents"][0]["uri"].as_str().unwrap();
+        assert_eq!(echoed, "ui://app/main");
+    }
+
+    /// A wrapped URI pointing at an endpoint that isn't registered must be
+    /// rejected with a `ProtocolError`, mirroring `route_tool_call`'s
+    /// "no adapter found for endpoint" shape so log scrapers can match on the
+    /// same wording.
+    #[tokio::test]
+    async fn route_resource_read_unknown_endpoint_returns_protocol_error() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "alpha".into(),
+                Box::new(ResourceMockAdapter {
+                    resources: vec![],
+                    templates: vec![],
+                }),
+                "stdio".into(),
+                None,
+                Some("alpha".into()),
+            )
+            .await;
+        registry
+            .register(
+                "beta".into(),
+                Box::new(ResourceMockAdapter {
+                    resources: vec![],
+                    templates: vec![],
+                }),
+                "stdio".into(),
+                None,
+                Some("beta".into()),
+            )
+            .await;
+
+        let wrapped = crate::resource_uri::encode_resource_uri("ghost", "ui://x/y");
+        let err = registry
+            .route_resource_read(&wrapped)
+            .await
+            .expect_err("unknown endpoint must be rejected");
+        match err {
+            AdapterError::ProtocolError(msg) => {
+                assert!(
+                    msg.contains("ghost") && msg.contains("no adapter found"),
+                    "unexpected error message: {msg}"
+                );
+            }
+            other => panic!("expected ProtocolError, got {other:?}"),
+        }
+    }
+
+    /// A URI that doesn't decode as a relay wrapper (in multi-endpoint mode)
+    /// returns a `ProtocolError` rather than silently dispatching to a random
+    /// adapter. Mirrors the unknown-endpoint branch.
+    #[tokio::test]
+    async fn route_resource_read_undecodable_uri_returns_protocol_error() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "alpha".into(),
+                Box::new(ResourceMockAdapter {
+                    resources: vec![],
+                    templates: vec![],
+                }),
+                "stdio".into(),
+                None,
+                Some("alpha".into()),
+            )
+            .await;
+        registry
+            .register(
+                "beta".into(),
+                Box::new(ResourceMockAdapter {
+                    resources: vec![],
+                    templates: vec![],
+                }),
+                "stdio".into(),
+                None,
+                Some("beta".into()),
+            )
+            .await;
+
+        // No `mcp-relay://` prefix → decode fails when multiple endpoints are
+        // active (the wrap was never skipped on the outbound side).
+        let err = registry
+            .route_resource_read("ui://app/main")
+            .await
+            .expect_err("undecodable URI must be rejected in multi-endpoint mode");
+        match err {
+            AdapterError::ProtocolError(msg) => {
+                assert!(
+                    msg.contains("invalid resource URI"),
+                    "unexpected error message: {msg}"
+                );
+            }
+            other => panic!("expected ProtocolError, got {other:?}"),
+        }
+    }
+
+    /// DD2 — the relay returns the upstream `resources/read` result verbatim;
+    /// URIs inside the resource body are not rewritten in v1.
+    #[tokio::test]
+    async fn route_resource_read_returns_body_unmodified() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "alpha".into(),
+                Box::new(ResourceMockAdapter {
+                    resources: vec![],
+                    templates: vec![],
+                }),
+                "stdio".into(),
+                None,
+                Some("alpha".into()),
+            )
+            .await;
+        registry
+            .register(
+                "beta".into(),
+                Box::new(ResourceMockAdapter {
+                    resources: vec![],
+                    templates: vec![],
+                }),
+                "stdio".into(),
+                None,
+                Some("beta".into()),
+            )
+            .await;
+
+        let wrapped = crate::resource_uri::encode_resource_uri("alpha", "ui://app/main");
+        let result = registry.route_resource_read(&wrapped).await.unwrap();
+        // The mock echoes the *original* URI into `contents[0].uri`; the
+        // registry forwards the `result` value unchanged so the body still
+        // contains the original (un-wrapped) URI rather than the wrapper.
+        assert_eq!(result["contents"][0]["uri"], "ui://app/main");
+        assert!(result.get("contents").is_some());
+    }
+
+    // --- T5: tools/call result URI rewriting wired through `route_tool_call` ---
+
+    /// Mock adapter whose `call_tool` returns a payload exercising every
+    /// rewrite slot (slots #2 and #3) plus untouched text/image/structured
+    /// content. Used to verify [`AdapterRegistry::route_tool_call`] applies
+    /// [`crate::tool_call_rewrite::rewrite_tool_call_result`] end-to-end.
+    struct UriEchoAdapter;
+
+    #[async_trait]
+    impl McpAdapter for UriEchoAdapter {
+        async fn initialize(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+        async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
+            Ok(vec![make_tool("open")])
+        }
+        async fn call_tool(
+            &self,
+            _name: &str,
+            _arguments: serde_json::Value,
+        ) -> Result<serde_json::Value, AdapterError> {
+            Ok(json!({
+                "_meta": {
+                    "ui": { "resourceUri": "ui://app/main" },
+                    "openai/outputTemplate": "ui://app/template"
+                },
+                "content": [
+                    { "type": "text", "text": "see ui://app/main" },
+                    { "type": "resource", "resource": { "uri": "ui://app/inline", "mimeType": "text/html" } },
+                    { "type": "resource_link", "uri": "ui://app/link", "name": "Open" }
+                ],
+                "structuredContent": { "uri": "ui://app/inside-structured" }
+            }))
+        }
+        fn health(&self) -> HealthStatus {
+            HealthStatus::Healthy
+        }
+        async fn shutdown(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn route_tool_call_rewrites_enumerated_uri_slots_two_endpoints() {
+        // Two endpoints registered → multi-endpoint mode (DD5 `skip_wrap=false`).
+        // Verifies the rewrite is wired through the fast (no-observability)
+        // path and touches slots #2 and #3 but not text/structuredContent.
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "alpha".into(),
+                Box::new(UriEchoAdapter),
+                "stdio".into(),
+                None,
+                Some("alpha".into()),
+            )
+            .await;
+        registry
+            .register(
+                "beta".into(),
+                Box::new(MockAdapter::healthy(vec![make_tool("noop")])),
+                "stdio".into(),
+                None,
+                Some("beta".into()),
+            )
+            .await;
+
+        let result = registry
+            .route_tool_call("alpha__open", json!({}))
+            .await
+            .unwrap();
+
+        let decode = crate::resource_uri::decode_resource_uri;
+        // Slot #2: `_meta.ui.resourceUri` + `openai/outputTemplate` alias.
+        let ui = result["_meta"]["ui"]["resourceUri"].as_str().unwrap();
+        assert_eq!(
+            decode(ui).unwrap(),
+            ("alpha".to_string(), "ui://app/main".to_string())
+        );
+        let tmpl = result["_meta"]["openai/outputTemplate"].as_str().unwrap();
+        assert_eq!(
+            decode(tmpl).unwrap(),
+            ("alpha".to_string(), "ui://app/template".to_string())
+        );
+        // Slot #3: `content[type==resource].resource.uri` + `content[type==resource_link].uri`.
+        let inline = result["content"][1]["resource"]["uri"].as_str().unwrap();
+        assert_eq!(
+            decode(inline).unwrap(),
+            ("alpha".to_string(), "ui://app/inline".to_string())
+        );
+        let link = result["content"][2]["uri"].as_str().unwrap();
+        assert_eq!(
+            decode(link).unwrap(),
+            ("alpha".to_string(), "ui://app/link".to_string())
+        );
+        // Untouched: text content and `structuredContent.uri` (DD1).
+        assert_eq!(result["content"][0]["text"], "see ui://app/main");
+        assert_eq!(
+            result["structuredContent"]["uri"],
+            "ui://app/inside-structured"
+        );
+    }
+
+    #[tokio::test]
+    async fn route_tool_call_skips_rewrite_in_single_endpoint_mode() {
+        // Single active endpoint → DD5 passthrough (`skip_wrap=true`):
+        // the upstream result is returned byte-for-byte unchanged.
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "solo".into(),
+                Box::new(UriEchoAdapter),
+                "stdio".into(),
+                None,
+                Some("solo".into()),
+            )
+            .await;
+
+        let result = registry.route_tool_call("open", json!({})).await.unwrap();
+
+        assert_eq!(result["_meta"]["ui"]["resourceUri"], "ui://app/main");
+        assert_eq!(
+            result["_meta"]["openai/outputTemplate"],
+            "ui://app/template"
+        );
+        assert_eq!(result["content"][1]["resource"]["uri"], "ui://app/inline");
+        assert_eq!(result["content"][2]["uri"], "ui://app/link");
+        assert_eq!(result["content"][0]["text"], "see ui://app/main");
+        assert_eq!(
+            result["structuredContent"]["uri"],
+            "ui://app/inside-structured"
+        );
+    }
+
+    // ---- T6 — `tools/list` descriptor UI-pointer rewriting (slot #1) ------
+
+    /// Adapter that advertises a single tool descriptor carrying the two MCP
+    /// Apps `_meta` UI pointers (slot #1) plus an unrelated `_meta` sibling
+    /// (DD1 regression: must not be touched), and a `read_resource`
+    /// implementation that echoes the URI it received so the round-trip test
+    /// can prove the de-wrapped original reaches the owning upstream.
+    struct DescriptorMetaAdapter {
+        endpoint_label: String,
+    }
+
+    #[async_trait]
+    impl McpAdapter for DescriptorMetaAdapter {
+        async fn initialize(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+        async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
+            Ok(vec![ToolInfo {
+                name: "open".into(),
+                description: Some("open tool".into()),
+                input_schema: json!({"type": "object"}),
+                annotations: None,
+                meta: Some(json!({
+                    "ui": { "resourceUri": "ui://app/main" },
+                    "openai/outputTemplate": "ui://app/template",
+                    "ui.csp": { "origins": ["https://cdn.example.com"] }
+                })),
+                ..Default::default()
+            }])
+        }
+        async fn call_tool(
+            &self,
+            name: &str,
+            arguments: serde_json::Value,
+        ) -> Result<serde_json::Value, AdapterError> {
+            Ok(json!({ "called": name, "args": arguments }))
+        }
+        async fn read_resource(&self, uri: &str) -> Result<serde_json::Value, AdapterError> {
+            // Tag the response with the endpoint that served it so the
+            // round-trip test can assert which adapter was reached.
+            Ok(json!({
+                "endpoint": self.endpoint_label,
+                "contents": [{ "uri": uri, "mimeType": "text/plain", "text": "ok" }]
+            }))
+        }
+        fn health(&self) -> HealthStatus {
+            HealthStatus::Healthy
+        }
+        async fn shutdown(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+    }
+
+    /// Two endpoints → multi-endpoint mode (`skip_prefix=false`): each tool
+    /// descriptor's `_meta.ui.resourceUri` and `_meta["openai/outputTemplate"]`
+    /// are wrapped to that tool's owning endpoint, while unrelated `_meta`
+    /// siblings (`ui.csp`) pass through untouched per DD1.
+    #[tokio::test]
+    async fn build_catalog_wraps_descriptor_ui_pointers_two_endpoints() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "alpha".into(),
+                Box::new(DescriptorMetaAdapter {
+                    endpoint_label: "alpha".into(),
+                }),
+                "stdio".into(),
+                None,
+                Some("alpha".into()),
+            )
+            .await;
+        registry
+            .register(
+                "beta".into(),
+                Box::new(DescriptorMetaAdapter {
+                    endpoint_label: "beta".into(),
+                }),
+                "stdio".into(),
+                None,
+                Some("beta".into()),
+            )
+            .await;
+
+        let (catalog, _lookup) = registry.merged_catalog_with_lookup().await;
+        assert_eq!(catalog.len(), 2, "two endpoints, one tool each");
+
+        for tool in &catalog {
+            let (expected_endpoint, _raw) = if tool.name == "alpha__open" {
+                ("alpha", "open")
+            } else if tool.name == "beta__open" {
+                ("beta", "open")
+            } else {
+                panic!("unexpected prefixed name: {}", tool.name);
+            };
+
+            let meta = tool.meta.as_ref().expect("descriptor _meta preserved");
+
+            // Slot #1: `_meta.ui.resourceUri` wrapped to the owning endpoint.
+            let ui_uri = meta["ui"]["resourceUri"].as_str().unwrap();
+            let (ep, orig) = crate::resource_uri::decode_resource_uri(ui_uri).unwrap();
+            assert_eq!(ep, expected_endpoint);
+            assert_eq!(orig, "ui://app/main");
+
+            // Slot #1 alias: `_meta["openai/outputTemplate"]` wrapped.
+            let tmpl = meta["openai/outputTemplate"].as_str().unwrap();
+            let (ep, orig) = crate::resource_uri::decode_resource_uri(tmpl).unwrap();
+            assert_eq!(ep, expected_endpoint);
+            assert_eq!(orig, "ui://app/template");
+
+            // DD1: unrelated `_meta` siblings must pass through untouched.
+            assert_eq!(
+                meta["ui.csp"]["origins"][0], "https://cdn.example.com",
+                "_meta.ui.csp must not be rewritten"
+            );
+        }
+    }
+
+    /// Round-trip: a wrapped pointer emitted by `build_catalog` (slot #1)
+    /// must reverse exactly via `route_resource_read` (slot #6) back to the
+    /// owning upstream, with the adapter receiving the de-wrapped original
+    /// URI. This is the closed-loop guarantee that ties T6's encoder to T4's
+    /// decoder; if the two ever diverge, a real client would receive a
+    /// pointer it cannot read back.
+    #[tokio::test]
+    async fn build_catalog_pointer_round_trips_through_route_resource_read() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "alpha".into(),
+                Box::new(DescriptorMetaAdapter {
+                    endpoint_label: "alpha".into(),
+                }),
+                "stdio".into(),
+                None,
+                Some("alpha".into()),
+            )
+            .await;
+        registry
+            .register(
+                "beta".into(),
+                Box::new(DescriptorMetaAdapter {
+                    endpoint_label: "beta".into(),
+                }),
+                "stdio".into(),
+                None,
+                Some("beta".into()),
+            )
+            .await;
+
+        let (catalog, _) = registry.merged_catalog_with_lookup().await;
+
+        // Pick the `beta__open` descriptor and feed its wrapped pointer
+        // straight back into `route_resource_read` — the response must be
+        // tagged with `beta` (slot #6 dispatch reached the right upstream)
+        // and the adapter must have received the original `ui://app/main`
+        // (slot #6 stripped the wrapper before dispatch).
+        let beta = catalog
+            .iter()
+            .find(|t| t.name == "beta__open")
+            .expect("beta__open present");
+        let wrapped = beta.meta.as_ref().unwrap()["ui"]["resourceUri"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let read_result = registry
+            .route_resource_read(&wrapped)
+            .await
+            .expect("round-trip read succeeds");
+        assert_eq!(
+            read_result["endpoint"], "beta",
+            "wrapper must route back to the owning upstream"
+        );
+        assert_eq!(
+            read_result["contents"][0]["uri"], "ui://app/main",
+            "adapter must receive the de-wrapped original URI"
+        );
+
+        // Same pointer scheme works for the alias slot.
+        let tmpl_wrapped = beta.meta.as_ref().unwrap()["openai/outputTemplate"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let read_result = registry
+            .route_resource_read(&tmpl_wrapped)
+            .await
+            .expect("alias round-trip read succeeds");
+        assert_eq!(read_result["endpoint"], "beta");
+        assert_eq!(read_result["contents"][0]["uri"], "ui://app/template");
+    }
+
+    /// DD5 single-endpoint mode: descriptor `_meta` UI pointers pass through
+    /// unwrapped (no `mcp-relay://` scheme), mirroring the tool-prefix
+    /// `skip_prefix` parity. The whole `_meta` object must be structurally
+    /// identical to the upstream descriptor — no wrap, no inserted defaults.
+    #[tokio::test]
+    async fn build_catalog_single_endpoint_descriptor_meta_passes_through() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "solo".into(),
+                Box::new(DescriptorMetaAdapter {
+                    endpoint_label: "solo".into(),
+                }),
+                "stdio".into(),
+                None,
+                Some("solo".into()),
+            )
+            .await;
+
+        let (catalog, _) = registry.merged_catalog_with_lookup().await;
+        assert_eq!(catalog.len(), 1);
+        // Single-endpoint mode also skips tool-name prefixing (DD5 parity).
+        assert_eq!(catalog[0].name, "open");
+
+        let meta = catalog[0]
+            .meta
+            .as_ref()
+            .expect("descriptor _meta preserved");
+        assert_eq!(
+            meta["ui"]["resourceUri"], "ui://app/main",
+            "single-endpoint mode must not wrap"
+        );
+        assert_eq!(
+            meta["openai/outputTemplate"], "ui://app/template",
+            "single-endpoint mode must not wrap the alias"
+        );
+        assert_eq!(meta["ui.csp"]["origins"][0], "https://cdn.example.com");
+    }
+
+    /// Regression: the existing tool-name prefixing and `[endpoint]`
+    /// description enrichment continue to work alongside the new `_meta`
+    /// rewriting — slot #1 wrapping must not perturb other descriptor fields.
+    #[tokio::test]
+    async fn build_catalog_prefixing_and_enrichment_unchanged() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "alpha".into(),
+                Box::new(DescriptorMetaAdapter {
+                    endpoint_label: "alpha".into(),
+                }),
+                "stdio".into(),
+                None,
+                Some("alpha".into()),
+            )
+            .await;
+        registry
+            .register(
+                "beta".into(),
+                Box::new(DescriptorMetaAdapter {
+                    endpoint_label: "beta".into(),
+                }),
+                "stdio".into(),
+                None,
+                Some("beta".into()),
+            )
+            .await;
+
+        let (catalog, lookup) = registry.merged_catalog_with_lookup().await;
+        // Prefixing: each tool gets `{prefix}__{name}`.
+        assert!(catalog.iter().any(|t| t.name == "alpha__open"));
+        assert!(catalog.iter().any(|t| t.name == "beta__open"));
+        // Lookup map points back at `(endpoint, raw_tool)`.
+        assert_eq!(
+            lookup.get("alpha__open").unwrap(),
+            &("alpha".to_string(), "open".to_string())
+        );
+        // Description enrichment: `[endpoint] {desc}` prefix preserved.
+        let alpha = catalog.iter().find(|t| t.name == "alpha__open").unwrap();
+        assert_eq!(
+            alpha.description.as_deref().unwrap(),
+            "[alpha] open tool",
+            "`[endpoint]` enrichment must survive the slot #1 rewrite"
+        );
+    }
+
+    // --- T9: prompts/list aggregation with prompt-name namespacing ---
+
+    /// Adapter mock that returns a canned `list_prompts` payload. Kept
+    /// separate from `MockAdapter` / `ResourceMockAdapter` so the existing
+    /// tools-only and resources-only tests don't grow new fields.
+    struct PromptMockAdapter {
+        prompts: Vec<serde_json::Value>,
+    }
+
+    #[async_trait]
+    impl McpAdapter for PromptMockAdapter {
+        async fn initialize(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+        async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
+            Ok(vec![])
+        }
+        async fn call_tool(
+            &self,
+            name: &str,
+            arguments: serde_json::Value,
+        ) -> Result<serde_json::Value, AdapterError> {
+            Ok(json!({ "called": name, "args": arguments }))
+        }
+        async fn list_prompts(&self) -> Result<Vec<serde_json::Value>, AdapterError> {
+            Ok(self.prompts.clone())
+        }
+        fn health(&self) -> HealthStatus {
+            HealthStatus::Healthy
+        }
+        async fn shutdown(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+    }
+
+    /// Adapter mock whose `list_prompts` always errors out, used to
+    /// exercise the registry's "skip on error" branch in the merged
+    /// aggregation (mirrors `FailingResourceAdapter`).
+    struct FailingPromptAdapter;
+
+    #[async_trait]
+    impl McpAdapter for FailingPromptAdapter {
+        async fn initialize(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+        async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
+            Ok(vec![])
+        }
+        async fn call_tool(
+            &self,
+            _name: &str,
+            _arguments: serde_json::Value,
+        ) -> Result<serde_json::Value, AdapterError> {
+            Err(AdapterError::ProtocolError("not implemented".into()))
+        }
+        async fn list_prompts(&self) -> Result<Vec<serde_json::Value>, AdapterError> {
+            Err(AdapterError::JsonRpcError {
+                code: -32601,
+                message: "method not found".into(),
+                data: None,
+            })
+        }
+        fn health(&self) -> HealthStatus {
+            HealthStatus::Healthy
+        }
+        async fn shutdown(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+    }
+
+    /// DD5 — single-endpoint mode passes prompt names through unprefixed,
+    /// mirroring the tool-prefix `skip_prefix` parity.
+    #[tokio::test]
+    async fn list_prompts_single_endpoint_passes_names_through() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "alpha".into(),
+                Box::new(PromptMockAdapter {
+                    prompts: vec![json!({
+                        "name": "summarize",
+                        "description": "Summarize the input",
+                        "arguments": []
+                    })],
+                }),
+                "stdio".into(),
+                None,
+                Some("alpha".into()),
+            )
+            .await;
+
+        let (prompts, lookup) = registry.list_prompts_with_lookup().await;
+        assert_eq!(prompts.len(), 1);
+        assert_eq!(prompts[0]["name"], "summarize");
+        // Sibling fields round-trip untouched.
+        assert_eq!(prompts[0]["description"], "Summarize the input");
+        // Reverse lookup is keyed by the unprefixed name and points back at
+        // the owning endpoint with the raw prompt name preserved.
+        assert_eq!(
+            lookup.get("summarize").unwrap(),
+            &("alpha".to_string(), "summarize".to_string())
+        );
+    }
+
+    /// Multi-endpoint aggregation namespaces every `name` to its owning
+    /// endpoint via the tool-prefix scheme (`{prefix}__{name}`) per slot #8.
+    /// Identically-named prompts on two endpoints stay distinct in the
+    /// merged list because each carries its endpoint's prefix.
+    #[tokio::test]
+    async fn list_prompts_multi_endpoint_prefixes_names() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "alpha".into(),
+                Box::new(PromptMockAdapter {
+                    prompts: vec![json!({ "name": "summarize", "description": "A" })],
+                }),
+                "stdio".into(),
+                None,
+                Some("alpha".into()),
+            )
+            .await;
+        registry
+            .register(
+                "beta".into(),
+                Box::new(PromptMockAdapter {
+                    prompts: vec![json!({ "name": "summarize", "description": "B" })],
+                }),
+                "stdio".into(),
+                None,
+                Some("beta".into()),
+            )
+            .await;
+
+        let (mut prompts, lookup) = registry.list_prompts_with_lookup().await;
+        assert_eq!(prompts.len(), 2, "collision must surface both prompts");
+        // Stable order for assertion regardless of HashMap iteration order.
+        prompts.sort_by(|a, b| {
+            a["name"]
+                .as_str()
+                .unwrap_or("")
+                .cmp(b["name"].as_str().unwrap_or(""))
+        });
+
+        assert_eq!(prompts[0]["name"], "alpha__summarize");
+        assert_eq!(prompts[0]["description"], "A");
+        assert_eq!(prompts[1]["name"], "beta__summarize");
+        assert_eq!(prompts[1]["description"], "B");
+
+        // Reverse lookup maps each prefixed name back to (endpoint, raw_name)
+        // so a future `prompts/get` dispatch can resolve like `route_tool_call`.
+        assert_eq!(
+            lookup.get("alpha__summarize").unwrap(),
+            &("alpha".to_string(), "summarize".to_string())
+        );
+        assert_eq!(
+            lookup.get("beta__summarize").unwrap(),
+            &("beta".to_string(), "summarize".to_string())
+        );
+    }
+
+    /// Adapters whose upstream rejects `prompts/list` (typical for MCP
+    /// servers that do not expose prompts, returning `-32601`) are skipped
+    /// without poisoning the merged response — endpoints that DO support
+    /// prompts still surface their entries with the prefix applied.
+    #[tokio::test]
+    async fn list_prompts_skips_endpoints_that_error_out() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "alpha".into(),
+                Box::new(PromptMockAdapter {
+                    prompts: vec![json!({ "name": "summarize", "description": "A" })],
+                }),
+                "stdio".into(),
+                None,
+                Some("alpha".into()),
+            )
+            .await;
+        registry
+            .register(
+                "beta".into(),
+                Box::new(FailingPromptAdapter),
+                "stdio".into(),
+                None,
+                Some("beta".into()),
+            )
+            .await;
+
+        let prompts = registry.list_prompts().await;
+        assert_eq!(
+            prompts.len(),
+            1,
+            "endpoint that errored on prompts/list must be skipped, leaving alpha's entry"
+        );
+        assert_eq!(
+            prompts[0]["name"], "alpha__summarize",
+            "alpha's name must still be prefixed under multi-endpoint mode"
+        );
+    }
+
+    /// The default adapter implementation returns an empty prompt list
+    /// (placeholder adapters / transports that haven't implemented the
+    /// passthrough yet). Aggregating them yields an empty merged list.
+    #[tokio::test]
+    async fn list_prompts_default_impl_returns_empty() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "alpha".into(),
+                Box::new(MockAdapter::healthy(vec![])),
+                "stdio".into(),
+                None,
+                Some("alpha".into()),
+            )
+            .await;
+        assert!(registry.list_prompts().await.is_empty());
+    }
+
+    // --- T10: prompts/get routing + slot #9 result rewriting ---------------
+
+    /// Adapter mock that advertises a single prompt and echoes the
+    /// `get_prompt` arguments back in the result `description`, plus emits
+    /// resource / resource_link / text content blocks on the returned
+    /// messages so the slot #9 wrapper can be verified end-to-end.
+    struct PromptGetMockAdapter {
+        endpoint_label: String,
+        prompts: Vec<serde_json::Value>,
+    }
+
+    #[async_trait]
+    impl McpAdapter for PromptGetMockAdapter {
+        async fn initialize(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+        async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
+            Ok(vec![])
+        }
+        async fn call_tool(
+            &self,
+            _name: &str,
+            _arguments: serde_json::Value,
+        ) -> Result<serde_json::Value, AdapterError> {
+            Ok(json!({}))
+        }
+        async fn list_prompts(&self) -> Result<Vec<serde_json::Value>, AdapterError> {
+            Ok(self.prompts.clone())
+        }
+        async fn get_prompt(
+            &self,
+            name: &str,
+            arguments: Option<serde_json::Value>,
+        ) -> Result<serde_json::Value, AdapterError> {
+            // Tag the response with the endpoint that served it so the
+            // round-trip test can assert which adapter was reached, and echo
+            // the raw `name` + `arguments` for the reverse-prefix assertion.
+            Ok(json!({
+                "endpoint": self.endpoint_label,
+                "raw_name": name,
+                "arguments": arguments,
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": [
+                            { "type": "text", "text": "see https://example.com/x" },
+                            { "type": "resource", "resource": { "uri": "ui://app/inline", "mimeType": "text/html" } },
+                            { "type": "resource_link", "uri": "ui://app/link", "name": "Open" }
+                        ]
+                    }
+                ]
+            }))
+        }
+        fn health(&self) -> HealthStatus {
+            HealthStatus::Healthy
+        }
+        async fn shutdown(&mut self) -> Result<(), AdapterError> {
+            Ok(())
+        }
+    }
+
+    /// Multi-endpoint mode: a prefixed prompt name routes back to its
+    /// owning upstream with the raw name + arguments forwarded verbatim,
+    /// and slot #9 resource refs in the returned messages are wrapped to
+    /// the owning endpoint while `text` blocks pass through (DD1).
+    #[tokio::test]
+    async fn route_prompt_get_multi_endpoint_dispatches_and_wraps() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "alpha".into(),
+                Box::new(PromptGetMockAdapter {
+                    endpoint_label: "alpha".into(),
+                    prompts: vec![json!({ "name": "summarize", "description": "A" })],
+                }),
+                "stdio".into(),
+                None,
+                Some("alpha".into()),
+            )
+            .await;
+        registry
+            .register(
+                "beta".into(),
+                Box::new(PromptGetMockAdapter {
+                    endpoint_label: "beta".into(),
+                    prompts: vec![json!({ "name": "summarize", "description": "B" })],
+                }),
+                "stdio".into(),
+                None,
+                Some("beta".into()),
+            )
+            .await;
+
+        let result = registry
+            .route_prompt_get("beta__summarize", Some(json!({ "k": "v" })))
+            .await
+            .expect("dispatch must succeed");
+
+        // Dispatched to the right upstream with the de-prefixed name.
+        assert_eq!(result["endpoint"], "beta");
+        assert_eq!(result["raw_name"], "summarize");
+        assert_eq!(result["arguments"], json!({ "k": "v" }));
+
+        // Slot #9: resource / resource_link URIs wrapped to `beta`.
+        let res_uri = result["messages"][0]["content"][1]["resource"]["uri"]
+            .as_str()
+            .unwrap();
+        let (ep, orig) = crate::resource_uri::decode_resource_uri(res_uri).unwrap();
+        assert_eq!(ep, "beta");
+        assert_eq!(orig, "ui://app/inline");
+
+        let link_uri = result["messages"][0]["content"][2]["uri"].as_str().unwrap();
+        let (ep, orig) = crate::resource_uri::decode_resource_uri(link_uri).unwrap();
+        assert_eq!(ep, "beta");
+        assert_eq!(orig, "ui://app/link");
+
+        // DD1: `text` block round-trips verbatim.
+        assert_eq!(
+            result["messages"][0]["content"][0]["text"],
+            "see https://example.com/x"
+        );
+    }
+
+    /// Round-trip: a wrapped URI emitted by `route_prompt_get` (slot #9)
+    /// must reverse exactly via `route_resource_read` (slot #6) back to the
+    /// owning upstream. Closes the encode/decode loop the same way the T6
+    /// descriptor round-trip does for slot #1.
+    #[tokio::test]
+    async fn route_prompt_get_wrapped_uri_round_trips_through_read() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "alpha".into(),
+                Box::new(DescriptorMetaAdapter {
+                    endpoint_label: "alpha".into(),
+                }),
+                "stdio".into(),
+                None,
+                Some("alpha".into()),
+            )
+            .await;
+        registry
+            .register(
+                "beta".into(),
+                Box::new(PromptGetMockAdapter {
+                    endpoint_label: "beta".into(),
+                    prompts: vec![json!({ "name": "summarize" })],
+                }),
+                "stdio".into(),
+                None,
+                Some("beta".into()),
+            )
+            .await;
+
+        let result = registry
+            .route_prompt_get("beta__summarize", None)
+            .await
+            .expect("dispatch must succeed");
+        let wrapped = result["messages"][0]["content"][2]["uri"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        // `beta`'s `DescriptorMetaAdapter` was not registered, so we feed
+        // the wrapped URI back through `route_resource_read`. The wrapper
+        // names `beta`, but `beta`'s `PromptGetMockAdapter` doesn't
+        // implement `read_resource` — the default impl returns -32601, which
+        // proves slot #9 decoding routed to the owning endpoint.
+        let read_err = registry
+            .route_resource_read(&wrapped)
+            .await
+            .expect_err("default read_resource impl returns -32601");
+        let msg = read_err.to_string();
+        assert!(
+            msg.contains("not supported by this adapter") || msg.contains("-32601"),
+            "expected default read_resource rejection, got: {msg}"
+        );
+    }
+
+    /// DD5 single-endpoint mode: prompt names pass through unprefixed and
+    /// slot #9 URIs flow through unwrapped — strict byte-for-byte parity
+    /// with the upstream `prompts/get` shape.
+    #[tokio::test]
+    async fn route_prompt_get_single_endpoint_passes_through() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "solo".into(),
+                Box::new(PromptGetMockAdapter {
+                    endpoint_label: "solo".into(),
+                    prompts: vec![json!({ "name": "summarize", "description": "" })],
+                }),
+                "stdio".into(),
+                None,
+                Some("solo".into()),
+            )
+            .await;
+
+        let result = registry
+            .route_prompt_get("summarize", None)
+            .await
+            .expect("DD5 dispatch must succeed");
+        // Slot #9 must NOT wrap when only one active endpoint exists.
+        assert_eq!(
+            result["messages"][0]["content"][1]["resource"]["uri"],
+            "ui://app/inline"
+        );
+        assert_eq!(result["messages"][0]["content"][2]["uri"], "ui://app/link");
+    }
+
+    /// Unknown prefixed name is rejected as a `ProtocolError` with a
+    /// distinct message so log scrapers can distinguish it from the other
+    /// early-rejection branches (mirrors `route_tool_call`'s shape).
+    #[tokio::test]
+    async fn route_prompt_get_unknown_name_returns_protocol_error() {
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "alpha".into(),
+                Box::new(PromptGetMockAdapter {
+                    endpoint_label: "alpha".into(),
+                    prompts: vec![json!({ "name": "summarize" })],
+                }),
+                "stdio".into(),
+                None,
+                Some("alpha".into()),
+            )
+            .await;
+
+        let err = registry
+            .route_prompt_get("nonexistent", None)
+            .await
+            .expect_err("unknown prefixed name must reject");
+        match err {
+            AdapterError::ProtocolError(msg) => {
+                assert!(
+                    msg.contains("no prompt found for prefixed name"),
+                    "unexpected error message: {msg}"
+                );
+            }
+            other => panic!("expected ProtocolError, got: {other:?}"),
         }
     }
 }

--- a/src/resource_uri.rs
+++ b/src/resource_uri.rs
@@ -1,0 +1,454 @@
+//! Reversible per-endpoint wrapping for resource URIs (DD4 wrapper scheme).
+//!
+//! ## Rewrite boundary (DD1 + DD2)
+//!
+//! The relay rewrites URIs only at the **enumerated MCP protocol slots**
+//! listed in the spec (DD1): outbound `tools/list` / `tools/call` /
+//! `resources/list` / `resources/templates/list` / `prompts/get` results,
+//! and inbound `resources/read` params. The encode/decode primitives in
+//! this module are the lowest-level boundary for that rewrite.
+//!
+//! Per DD2, references **inside** a served resource body
+//! (HTML/JS/CSS of a `ui://` app referencing another resource) are
+//! intentionally NOT parsed or rewritten in v1. Apps are expected to use
+//! either:
+//!
+//! - **relative references** within their own resource namespace, which
+//!   the MCP Apps host resolves against the already-namespaced parent URI
+//!   (e.g. an iframe at `mcp-relay://ep/ui%3A%2F%2Fapp%2Findex.html`
+//!   referencing `./style.css` resolves to
+//!   `mcp-relay://ep/ui%3A%2F%2Fapp%2Fstyle.css`); OR
+//! - external assets reached via absolute `http(s)://` URLs allowlisted by
+//!   `_meta.ui.csp`, which are left untouched on both legs.
+//!
+//! Absolute `ui://` references emitted from inside a body to another app's
+//! resource are a documented v1 limitation. This boundary does NOT
+//! validate or reject body content — `resources/read` returns upstream
+//! bodies verbatim (see `mcp_resources_read` in `server.rs`).
+use percent_encoding::{percent_decode_str, utf8_percent_encode, AsciiSet, CONTROLS};
+use std::fmt;
+
+/// Wrapper scheme used to namespace resource URIs across endpoints.
+#[allow(dead_code)]
+pub const WRAPPER_SCHEME: &str = "mcp-relay";
+const WRAPPER_PREFIX: &str = "mcp-relay://";
+
+/// Characters to percent-encode when wrapping an original URI. Encodes every
+/// ASCII character except RFC 3986 "unreserved" (ALPHA / DIGIT / `-` / `.` /
+/// `_` / `~`), so the wrapper structure (`mcp-relay://endpoint/...`) is
+/// unambiguous and the encoded payload round-trips losslessly regardless of
+/// the original scheme.
+const ENCODE_SET: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'!')
+    .add(b'"')
+    .add(b'#')
+    .add(b'$')
+    .add(b'%')
+    .add(b'&')
+    .add(b'\'')
+    .add(b'(')
+    .add(b')')
+    .add(b'*')
+    .add(b'+')
+    .add(b',')
+    .add(b'/')
+    .add(b':')
+    .add(b';')
+    .add(b'<')
+    .add(b'=')
+    .add(b'>')
+    .add(b'?')
+    .add(b'@')
+    .add(b'[')
+    .add(b'\\')
+    .add(b']')
+    .add(b'^')
+    .add(b'`')
+    .add(b'{')
+    .add(b'|')
+    .add(b'}');
+
+/// RFC 6570 variant of [`ENCODE_SET`] for wrapping URI **templates** (slot
+/// #5). Identical to `ENCODE_SET` except `{` and `}` are left unencoded so a
+/// downstream MCP host that performs RFC 6570 expansion still sees the
+/// literal `{var}` markers it needs to substitute. The reverse decoder in
+/// [`decode_resource_uri`] is agnostic — both encoded and literal braces
+/// round-trip cleanly through `percent_decode_str`.
+const ENCODE_SET_TEMPLATE: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'!')
+    .add(b'"')
+    .add(b'#')
+    .add(b'$')
+    .add(b'%')
+    .add(b'&')
+    .add(b'\'')
+    .add(b'(')
+    .add(b')')
+    .add(b'*')
+    .add(b'+')
+    .add(b',')
+    .add(b'/')
+    .add(b':')
+    .add(b';')
+    .add(b'<')
+    .add(b'=')
+    .add(b'>')
+    .add(b'?')
+    .add(b'@')
+    .add(b'[')
+    .add(b'\\')
+    .add(b']')
+    .add(b'^')
+    .add(b'`')
+    .add(b'|');
+
+/// Error type for resource-URI wrapping/unwrapping.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub enum ResourceUriError {
+    /// The wrapped URI is missing the scheme prefix, separator, or has an
+    /// empty/invalid segment.
+    InvalidFormat(String),
+}
+
+impl fmt::Display for ResourceUriError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ResourceUriError::InvalidFormat(msg) => {
+                write!(f, "invalid wrapped resource URI: {}", msg)
+            }
+        }
+    }
+}
+
+impl std::error::Error for ResourceUriError {}
+
+/// Encode an original resource URI into a reversible per-endpoint wrapper:
+/// `mcp-relay://{endpoint}/{percent-encoded-original}`.
+///
+/// Reversible without a lookup table (DD4), which matters because result URIs
+/// are non-enumerable. Idempotent only relative to TOON / non-URI passes —
+/// re-encoding an already-wrapped URI nests it.
+pub fn encode_resource_uri(endpoint: &str, original: &str) -> String {
+    let encoded = utf8_percent_encode(original, ENCODE_SET);
+    format!("{}{}/{}", WRAPPER_PREFIX, endpoint, encoded)
+}
+
+/// Decode a wrapped resource URI into `(endpoint, original)`. Rejects any
+/// malformed input (wrong scheme, missing separator, empty endpoint, invalid
+/// percent-encoding) with a typed `ResourceUriError`.
+pub fn decode_resource_uri(wrapped: &str) -> Result<(String, String), ResourceUriError> {
+    let body = wrapped.strip_prefix(WRAPPER_PREFIX).ok_or_else(|| {
+        ResourceUriError::InvalidFormat(format!(
+            "missing '{}' scheme prefix in '{}'",
+            WRAPPER_PREFIX, wrapped
+        ))
+    })?;
+
+    let slash_idx = body.find('/').ok_or_else(|| {
+        ResourceUriError::InvalidFormat(format!(
+            "missing '/' separator after endpoint in '{}'",
+            wrapped
+        ))
+    })?;
+
+    let endpoint = &body[..slash_idx];
+    let encoded_original = &body[slash_idx + 1..];
+
+    if endpoint.is_empty() {
+        return Err(ResourceUriError::InvalidFormat(format!(
+            "empty endpoint segment in '{}'",
+            wrapped
+        )));
+    }
+
+    let original = percent_decode_str(encoded_original)
+        .decode_utf8()
+        .map_err(|e| {
+            ResourceUriError::InvalidFormat(format!(
+                "invalid percent-encoding in '{}': {}",
+                wrapped, e
+            ))
+        })?;
+
+    Ok((endpoint.to_string(), original.into_owned()))
+}
+
+/// DD5 single-endpoint passthrough on the outbound (wrap) path: when only one
+/// active endpoint exists, the caller passes `skip_wrap = true` so resource
+/// URIs flow through unchanged (mirrors `build_catalog`'s `skip_prefix` flag).
+#[allow(dead_code)]
+pub fn maybe_encode_resource_uri(endpoint: &str, original: &str, skip_wrap: bool) -> String {
+    if skip_wrap {
+        original.to_string()
+    } else {
+        encode_resource_uri(endpoint, original)
+    }
+}
+
+/// Template variant of [`encode_resource_uri`] for slot #5
+/// (`resourceTemplates[].uriTemplate`). Uses [`ENCODE_SET_TEMPLATE`] so RFC
+/// 6570 `{var}` markers survive the wrap unencoded — without this, a host
+/// that expands templates would never see literal braces and variable
+/// substitution would silently no-op.
+#[allow(dead_code)]
+pub fn encode_resource_uri_template(endpoint: &str, original: &str) -> String {
+    let encoded = utf8_percent_encode(original, ENCODE_SET_TEMPLATE);
+    format!("{}{}/{}", WRAPPER_PREFIX, endpoint, encoded)
+}
+
+/// DD5 single-endpoint passthrough for templates; mirrors
+/// [`maybe_encode_resource_uri`] but routes through
+/// [`encode_resource_uri_template`] so `{var}` survives the wrap.
+#[allow(dead_code)]
+pub fn maybe_encode_resource_uri_template(
+    endpoint: &str,
+    original: &str,
+    skip_wrap: bool,
+) -> String {
+    if skip_wrap {
+        original.to_string()
+    } else {
+        encode_resource_uri_template(endpoint, original)
+    }
+}
+
+/// DD5 mirror for the inbound (unwrap) path: when `skip_wrap` is `true`, the
+/// caller treats the incoming URI as already-original (no endpoint hint, as
+/// there is only one); otherwise the wrapper is unwrapped to
+/// `(Some(endpoint), original)`.
+#[allow(dead_code)]
+pub fn maybe_decode_resource_uri(
+    incoming: &str,
+    skip_wrap: bool,
+) -> Result<(Option<String>, String), ResourceUriError> {
+    if skip_wrap {
+        Ok((None, incoming.to_string()))
+    } else {
+        let (ep, orig) = decode_resource_uri(incoming)?;
+        Ok((Some(ep), orig))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_roundtrip(endpoint: &str, original: &str) {
+        let wrapped = encode_resource_uri(endpoint, original);
+        let (ep, orig) = decode_resource_uri(&wrapped).expect("decode should succeed");
+        assert_eq!(ep, endpoint, "endpoint mismatch (wrapped: {})", wrapped);
+        assert_eq!(orig, original, "original mismatch (wrapped: {})", wrapped);
+    }
+
+    #[test]
+    fn test_encode_basic_shape() {
+        let wrapped = encode_resource_uri("work", "ui://app/main");
+        assert!(wrapped.starts_with("mcp-relay://work/"), "got: {}", wrapped);
+        assert!(
+            !wrapped.contains("ui://"),
+            "scheme must be percent-encoded, got: {}",
+            wrapped
+        );
+    }
+
+    #[test]
+    fn test_roundtrip_ui_scheme() {
+        assert_roundtrip("work", "ui://app/main");
+        assert_roundtrip("work", "ui://my-app/path/to/resource");
+    }
+
+    #[test]
+    fn test_roundtrip_file_scheme() {
+        assert_roundtrip("local", "file:///Users/alice/notes.md");
+        assert_roundtrip("local", "file:///tmp/with%20space");
+    }
+
+    #[test]
+    fn test_roundtrip_https_scheme() {
+        assert_roundtrip("web", "https://example.com/path?q=1&r=2#frag");
+        assert_roundtrip("web", "https://example.com/");
+    }
+
+    #[test]
+    fn test_roundtrip_assorted_schemes() {
+        for (ep, uri) in [
+            ("a", "custom-scheme:opaque-payload"),
+            ("b", "data:text/plain;base64,SGVsbG8="),
+            ("c", "git+ssh://git@example.com:org/repo.git"),
+        ] {
+            assert_roundtrip(ep, uri);
+        }
+    }
+
+    #[test]
+    fn test_roundtrip_percent_edge_cases() {
+        assert_roundtrip("ep", "https://x/%20already%20encoded");
+        assert_roundtrip("ep", "ui://app/with spaces and /slashes");
+        assert_roundtrip("ep", "ui://app/?query=a&b=c#hash");
+        assert_roundtrip("ep", "ui://app/unicode/café/日本語");
+        assert_roundtrip("ep", "ui://app/punct!*'();:@&=+$,?#[]");
+        assert_roundtrip("ep", "ui://app/control\nchar");
+    }
+
+    #[test]
+    fn test_roundtrip_empty_original() {
+        let wrapped = encode_resource_uri("ep", "");
+        assert_eq!(wrapped, "mcp-relay://ep/");
+        let (ep, orig) = decode_resource_uri(&wrapped).expect("empty original is allowed");
+        assert_eq!(ep, "ep");
+        assert_eq!(orig, "");
+    }
+
+    #[test]
+    fn test_encode_idempotent_within_pass_is_nested() {
+        // Encoding an already-wrapped URI nests it (DD3: idempotent vs TOON,
+        // not vs itself). The nested form still round-trips losslessly.
+        let inner = encode_resource_uri("a", "ui://x/y");
+        let outer = encode_resource_uri("b", &inner);
+        let (ep_outer, orig_outer) = decode_resource_uri(&outer).unwrap();
+        assert_eq!(ep_outer, "b");
+        assert_eq!(orig_outer, inner);
+        let (ep_inner, orig_inner) = decode_resource_uri(&orig_outer).unwrap();
+        assert_eq!(ep_inner, "a");
+        assert_eq!(orig_inner, "ui://x/y");
+    }
+
+    #[test]
+    fn test_decode_rejects_empty_string() {
+        assert!(matches!(
+            decode_resource_uri(""),
+            Err(ResourceUriError::InvalidFormat(_))
+        ));
+    }
+
+    #[test]
+    fn test_decode_rejects_wrong_scheme() {
+        assert!(decode_resource_uri("ui://app/main").is_err());
+        assert!(decode_resource_uri("https://example.com/").is_err());
+        assert!(decode_resource_uri("mcp-relay:/ep/foo").is_err());
+        assert!(decode_resource_uri("mcp-relayy://ep/foo").is_err());
+    }
+
+    #[test]
+    fn test_decode_rejects_missing_separator() {
+        // No '/' after the endpoint.
+        assert!(decode_resource_uri("mcp-relay://ep").is_err());
+        assert!(decode_resource_uri("mcp-relay://").is_err());
+    }
+
+    #[test]
+    fn test_decode_rejects_empty_endpoint() {
+        assert!(decode_resource_uri("mcp-relay:///foo").is_err());
+        assert!(decode_resource_uri("mcp-relay:///").is_err());
+    }
+
+    #[test]
+    fn test_decode_rejects_invalid_utf8_percent_encoding() {
+        // Decoded bytes that aren't valid UTF-8 are rejected. The
+        // `percent-encoding` crate is intentionally forgiving on malformed
+        // escapes themselves (e.g. `%ZZ` is preserved verbatim), so only the
+        // UTF-8 validity of the decoded payload is enforced here.
+        assert!(decode_resource_uri("mcp-relay://ep/%FF%FE").is_err());
+        assert!(decode_resource_uri("mcp-relay://ep/%C3%28").is_err());
+    }
+
+    #[test]
+    fn test_decode_preserves_non_escape_percent() {
+        // `%ZZ` is not a valid escape but the decoder leaves it intact.
+        // Round-trip with a real encode goes through the percent-encoder,
+        // so `%` from the original is encoded as `%25` and survives cleanly.
+        let (ep, orig) = decode_resource_uri("mcp-relay://ep/%ZZ").unwrap();
+        assert_eq!(ep, "ep");
+        assert_eq!(orig, "%ZZ");
+    }
+
+    #[test]
+    fn test_maybe_encode_skip_wrap_passthrough() {
+        let original = "ui://app/main";
+        assert_eq!(
+            maybe_encode_resource_uri("work", original, true),
+            original,
+            "skip_wrap=true must pass through unchanged"
+        );
+        assert_eq!(
+            maybe_encode_resource_uri("work", original, false),
+            encode_resource_uri("work", original)
+        );
+    }
+
+    #[test]
+    fn test_maybe_decode_skip_wrap_passthrough() {
+        let raw = "ui://app/main";
+        let (ep, orig) = maybe_decode_resource_uri(raw, true).unwrap();
+        assert!(ep.is_none(), "skip_wrap=true returns no endpoint hint");
+        assert_eq!(orig, raw);
+
+        let wrapped = encode_resource_uri("work", raw);
+        let (ep, orig) = maybe_decode_resource_uri(&wrapped, false).unwrap();
+        assert_eq!(ep.as_deref(), Some("work"));
+        assert_eq!(orig, raw);
+    }
+
+    #[test]
+    fn test_maybe_decode_skip_wrap_false_validates() {
+        // skip_wrap=false must still reject malformed wrappers.
+        assert!(maybe_decode_resource_uri("not-a-wrapper", false).is_err());
+    }
+
+    #[test]
+    fn test_encode_template_preserves_rfc6570_braces() {
+        // Slot #5 wrappers must keep `{var}` literal so RFC 6570 expansion on
+        // the client still finds the markers to substitute.
+        let wrapped = encode_resource_uri_template("ep", "ui://app/items/{id}");
+        assert!(wrapped.starts_with("mcp-relay://ep/"));
+        assert!(
+            wrapped.contains("{id}"),
+            "braces must be literal in template wrap, got {}",
+            wrapped
+        );
+        // The wrap is still reversible: a decode yields the original template
+        // with its braces intact.
+        let (ep, orig) = decode_resource_uri(&wrapped).expect("template wrap round-trips");
+        assert_eq!(ep, "ep");
+        assert_eq!(orig, "ui://app/items/{id}");
+    }
+
+    #[test]
+    fn test_encode_template_handles_multiple_vars() {
+        let wrapped = encode_resource_uri_template("ep", "file:///docs/{section}/{page}");
+        assert!(wrapped.contains("{section}"));
+        assert!(wrapped.contains("{page}"));
+        let (_, orig) = decode_resource_uri(&wrapped).unwrap();
+        assert_eq!(orig, "file:///docs/{section}/{page}");
+    }
+
+    #[test]
+    fn test_maybe_encode_template_skip_wrap_passthrough() {
+        let original = "ui://app/items/{id}";
+        assert_eq!(
+            maybe_encode_resource_uri_template("ep", original, true),
+            original
+        );
+        assert_eq!(
+            maybe_encode_resource_uri_template("ep", original, false),
+            encode_resource_uri_template("ep", original)
+        );
+    }
+
+    #[test]
+    fn test_encode_template_still_encodes_path_metachars() {
+        // Template wrap leaves `{`/`}` alone but still percent-encodes other
+        // reserved characters (`?`, `#`, `/`, spaces, etc.) so the wrapper
+        // structure stays unambiguous.
+        let wrapped = encode_resource_uri_template("ep", "ui://app/?q={q}#frag");
+        // The leading scheme separator inside the original is encoded.
+        assert!(!wrapped.contains("://app/"));
+        // Braces survive verbatim.
+        assert!(wrapped.contains("{q}"));
+        let (_, orig) = decode_resource_uri(&wrapped).unwrap();
+        assert_eq!(orig, "ui://app/?q={q}#frag");
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -515,11 +515,35 @@ async fn mcp_initialize(
 /// Build the `InitializeResult` body (`protocolVersion`/`capabilities`/
 /// `serverInfo`/optional `instructions`) shared by `initialize` and
 /// `server/discover`, so both advertise the relay identically.
+///
+/// The advertised capability set MUST stay in lockstep with the reachable
+/// method arms in the `/mcp` dispatcher (see `handle_single_message`). The
+/// relay currently dispatches `tools/*`, `resources/list`,
+/// `resources/templates/list`, `resources/read`, `prompts/list`, and
+/// `prompts/get` — hence `tools`, `resources`, and `prompts` here. T7
+/// decision: resources and prompts pass through in BOTH normal and
+/// `local_js_execution` modes (the JS-mode catalog reduction only collapses
+/// `tools/list` to the meta-tools; it does not gate `resources/*` or
+/// `prompts/*`), so the capability set is mode-invariant.
 async fn build_initialize_result(state: &AppState, profile_ctx: Option<&ProfileContext>) -> Value {
     let mut result = json!({
         "protocolVersion": protocol::VERSION_2025_03_26,
         "capabilities": {
-            "tools": { "listChanged": true }
+            "tools": { "listChanged": true },
+            // T7: advertise `resources` now that `resources/list`,
+            // `resources/templates/list`, and `resources/read` are all
+            // dispatched. `listChanged` and `subscribe` are intentionally
+            // omitted — the relay does NOT forward upstream
+            // `notifications/resources/list_changed` and does NOT implement
+            // `resources/subscribe`/`unsubscribe` dispatch arms. Adding
+            // either sub-flag here would lie about a reachable method.
+            "resources": {},
+            // T10: advertise `prompts` so clients know the relay proxies
+            // `prompts/list` + `prompts/get`. `listChanged` is intentionally
+            // omitted — the relay does not yet forward upstream
+            // `notifications/prompts/list_changed` to clients (no equivalent
+            // of the tools-changed SSE pipeline for prompts).
+            "prompts": {}
         },
         "serverInfo": {
             "name": "Endara Relay",
@@ -543,8 +567,13 @@ async fn build_initialize_result(state: &AppState, profile_ctx: Option<&ProfileC
 /// `initialize` handshake. The result reuses [`build_initialize_result`] so
 /// `serverInfo`/`capabilities`/`protocolVersion` stay byte-for-byte consistent
 /// with `initialize`, then appends the aggregated primitive summary the relay
-/// exposes — `tools` (mirroring `tools/list`). The relay advertises no prompts
-/// or resources, so only `tools` appears.
+/// exposes — `tools` (mirroring `tools/list`). Only the `tools` primitive
+/// summary array is emitted here; aggregated `resources`/`prompts` summaries
+/// would require their own list aggregators in this dispatcher and are not
+/// yet shipped. The `capabilities` object (built above by
+/// `build_initialize_result`) still advertises `tools`, `resources`, and
+/// `prompts` — clients fetch the live `resources/list` and `prompts/list`
+/// directly when they need those primitives.
 ///
 /// Per the coordinator decision (T11 — relay is local/single-user), the result
 /// carries NO `ttlMs` and NO `cacheScope`: 2026 clients treat the absent hint
@@ -681,7 +710,21 @@ async fn mcp_tools_list(
         meta_tool_definitions(js_mode, &state.registry, toon_enabled, profile_ctx).await;
 
     let tools: Vec<Value> = if js_mode {
-        // JS execution mode: only the 3 meta-tools (incl. execute_tools)
+        // JS execution mode: only the 3 meta-tools (incl. execute_tools).
+        // T7 decision: the JS-mode catalog reduction is SCOPED to
+        // `tools/list` only — `resources/*` and `prompts/*` continue to pass
+        // through in JS mode (see `mcp_resources_list` /
+        // `mcp_resource_templates_list` / `mcp_resources_read` /
+        // `mcp_prompts_list` / `mcp_prompts_get`, none of which read
+        // `js_mode`). Rationale: the catalog collapse exists to keep the
+        // tool-prompt budget small when the LLM drives calls through
+        // `execute_tools`; resources and prompts are user/host-driven (the
+        // MCP Apps UI host calls `resources/read` with a URI it received
+        // from a tool descriptor; users select prompts explicitly), so
+        // hiding them would break the apps + prompts flow without saving
+        // any tokens. The advertised capability set in
+        // `build_initialize_result` matches this — `resources` and
+        // `prompts` are advertised in BOTH modes.
         meta_tools
     } else {
         // Normal mode: full prefixed catalog + list/search meta-tools.
@@ -717,6 +760,150 @@ async fn mcp_tools_list(
     };
 
     jsonrpc_response(body.id, json!({ "tools": tools }))
+}
+
+/// POST /mcp `resources/list`
+///
+/// Aggregates [`AdapterRegistry::list_resources`] across every non-disabled
+/// adapter and returns the merged `{ resources: [...] }` payload to the
+/// client. Slot #4 URI wrapping is applied inside the registry method so the
+/// `uri` field of every entry routes back to its owning endpoint via the
+/// `mcp-relay://` wrapper scheme (or passes through unwrapped under DD5
+/// single-endpoint mode).
+///
+/// When `profile_ctx` is `Some`, the listing is restricted to the profile's
+/// allowed endpoints and the wrap trigger is the *in-profile* active count.
+/// This keeps the outbound wrap and inbound
+/// [`ProfileRegistryView::route_resource_read`] unwrap symmetric per DD5,
+/// closing the `(global>=2, profile==1)` foreign-endpoint bypass.
+async fn mcp_resources_list(
+    State(state): State<AppState>,
+    Json(body): Json<JsonRpcBody>,
+    profile_ctx: Option<&ProfileContext>,
+) -> Json<Value> {
+    let resources = match profile_ctx {
+        Some(ctx) => ctx.registry_view.list_resources().await,
+        None => state.registry.list_resources().await,
+    };
+    jsonrpc_response(body.id, json!({ "resources": resources }))
+}
+
+/// POST /mcp `resources/templates/list`
+///
+/// Aggregates [`AdapterRegistry::list_resource_templates`] across every
+/// non-disabled adapter. Slot #5 wrapping uses the template-aware encoder so
+/// RFC 6570 `{var}` markers survive untouched and client-side variable
+/// expansion still works. Profile gating mirrors [`mcp_resources_list`].
+async fn mcp_resource_templates_list(
+    State(state): State<AppState>,
+    Json(body): Json<JsonRpcBody>,
+    profile_ctx: Option<&ProfileContext>,
+) -> Json<Value> {
+    let templates = match profile_ctx {
+        Some(ctx) => ctx.registry_view.list_resource_templates().await,
+        None => state.registry.list_resource_templates().await,
+    };
+    jsonrpc_response(body.id, json!({ "resourceTemplates": templates }))
+}
+
+/// POST /mcp `prompts/list`
+///
+/// Aggregates [`AdapterRegistry::list_prompts`] across every non-disabled
+/// adapter and returns the merged `{ prompts: [...] }` payload to the
+/// client. Slot #8 name namespacing is applied inside the registry method
+/// so each `prompts[].name` routes back to its owning endpoint via the
+/// existing tool-prefix scheme (or passes through unprefixed under DD5
+/// single-endpoint mode).
+///
+/// When `profile_ctx` is `Some`, the listing is restricted to the profile's
+/// allowed endpoints and the prefix trigger is the *in-profile* active
+/// count, matching the profile-scoped tool catalog's behavior.
+async fn mcp_prompts_list(
+    State(state): State<AppState>,
+    Json(body): Json<JsonRpcBody>,
+    profile_ctx: Option<&ProfileContext>,
+) -> Json<Value> {
+    let prompts = match profile_ctx {
+        Some(ctx) => ctx.registry_view.list_prompts().await,
+        None => state.registry.list_prompts().await,
+    };
+    jsonrpc_response(body.id, json!({ "prompts": prompts }))
+}
+
+/// POST /mcp `prompts/get` (slot #9).
+///
+/// Pulls the namespaced `name` and optional `arguments` out of `params`,
+/// hands them to [`AdapterRegistry::route_prompt_get`] (or the
+/// profile-scoped [`ProfileRegistryView::route_prompt_get`] when
+/// `profile_ctx` is `Some`), and returns the upstream `result` object with
+/// slot #9 URI rewriting applied to `messages[].content` blocks scoped to
+/// the owning endpoint. Strict DD1: only the enumerated resource /
+/// resource_link slots are wrapped; `text` blocks and arbitrary sibling
+/// fields round-trip verbatim.
+///
+/// Errors map to a JSON-RPC `-32602` (invalid params) when the request is
+/// missing the `name` field and `-32603` (internal error) for routing /
+/// adapter failures, mirroring `mcp_resources_read`'s shape so log scrapers
+/// see the same code surface across the prompts and resources arms.
+async fn mcp_prompts_get(
+    State(state): State<AppState>,
+    Json(body): Json<JsonRpcBody>,
+    profile_ctx: Option<&ProfileContext>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let params = body.params.clone().unwrap_or(json!({}));
+    let name = params
+        .get("name")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| jsonrpc_error(body.id.clone(), -32602, "missing 'name' in params"))?;
+    // `arguments` is optional per MCP spec; forward verbatim when present
+    // (covers both the canonical object shape and any unexpected shape an
+    // upstream might accept) and as `None` otherwise so adapters drop the
+    // field on the wire entirely.
+    let arguments = params.get("arguments").cloned();
+
+    let result = match profile_ctx {
+        Some(ctx) => ctx.registry_view.route_prompt_get(name, arguments).await,
+        None => state.registry.route_prompt_get(name, arguments).await,
+    };
+
+    match result {
+        Ok(value) => Ok(jsonrpc_response(body.id, value)),
+        Err(e) => Err(jsonrpc_error(body.id, -32603, &e.to_string())),
+    }
+}
+
+/// POST /mcp `resources/read` (slot #6).
+///
+/// Pulls the wrapped `uri` out of `params`, hands it to
+/// [`AdapterRegistry::route_resource_read`] (or the profile-scoped
+/// [`ProfileRegistryView::route_resource_read`] when `profile_ctx` is
+/// `Some`), and returns the upstream `result` object verbatim per DD2 — URIs
+/// inside the resource body are not rewritten in v1.
+///
+/// Errors map to a JSON-RPC `-32602` (invalid params) when the request is
+/// missing the `uri` field and `-32603` (internal error) for routing /
+/// adapter failures, mirroring `mcp_tools_call`'s shape so log scrapers see
+/// the same code surface across `tools/call` and `resources/read`.
+async fn mcp_resources_read(
+    State(state): State<AppState>,
+    Json(body): Json<JsonRpcBody>,
+    profile_ctx: Option<&ProfileContext>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let params = body.params.clone().unwrap_or(json!({}));
+    let uri = params
+        .get("uri")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| jsonrpc_error(body.id.clone(), -32602, "missing 'uri' in params"))?;
+
+    let result = match profile_ctx {
+        Some(ctx) => ctx.registry_view.route_resource_read(uri).await,
+        None => state.registry.route_resource_read(uri).await,
+    };
+
+    match result {
+        Ok(value) => Ok(jsonrpc_response(body.id, value)),
+        Err(e) => Err(jsonrpc_error(body.id, -32603, &e.to_string())),
+    }
 }
 
 /// POST /mcp/tools/call
@@ -985,6 +1172,22 @@ async fn handle_single_message(
             }
             "tools/list" => Ok(mcp_tools_list(State(state.clone()), Json(body), profile_ctx).await),
             "tools/call" => mcp_tools_call(State(state.clone()), Json(body), profile_ctx).await,
+            "resources/list" => {
+                Ok(mcp_resources_list(State(state.clone()), Json(body), profile_ctx).await)
+            }
+            "resources/templates/list" => {
+                Ok(
+                    mcp_resource_templates_list(State(state.clone()), Json(body), profile_ctx)
+                        .await,
+                )
+            }
+            "resources/read" => {
+                mcp_resources_read(State(state.clone()), Json(body), profile_ctx).await
+            }
+            "prompts/list" => {
+                Ok(mcp_prompts_list(State(state.clone()), Json(body), profile_ctx).await)
+            }
+            "prompts/get" => mcp_prompts_get(State(state.clone()), Json(body), profile_ctx).await,
             _ => Err(jsonrpc_error(
                 body.id,
                 -32601,
@@ -2415,6 +2618,7 @@ mod tests {
                         description: Some(format!("{} tool", n)),
                         input_schema: json!({"type": "object"}),
                         annotations: None,
+                        ..Default::default()
                     })
                     .collect(),
             }
@@ -3650,6 +3854,178 @@ mod tests {
         assert!(body["result"]["tools"].is_array());
     }
 
+    /// T3 — `resources/list` is dispatched to the registry aggregator and
+    /// returns a `{ resources: [...] }` payload (empty array with no
+    /// adapters registered).
+    #[tokio::test]
+    async fn mcp_unified_dispatches_resources_list() {
+        let state = test_app_state();
+        let resp = post_mcp(
+            state,
+            &json!({"jsonrpc":"2.0","method":"resources/list","id":31}),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["id"], 31);
+        assert!(
+            body["result"]["resources"].is_array(),
+            "expected resources array, got {:?}",
+            body
+        );
+    }
+
+    /// T3 — `resources/templates/list` is dispatched to the registry
+    /// aggregator and returns a `{ resourceTemplates: [...] }` payload.
+    #[tokio::test]
+    async fn mcp_unified_dispatches_resources_templates_list() {
+        let state = test_app_state();
+        let resp = post_mcp(
+            state,
+            &json!({"jsonrpc":"2.0","method":"resources/templates/list","id":32}),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["id"], 32);
+        assert!(
+            body["result"]["resourceTemplates"].is_array(),
+            "expected resourceTemplates array, got {:?}",
+            body
+        );
+    }
+
+    /// T9 — `prompts/list` is dispatched to the registry aggregator and
+    /// returns a `{ prompts: [...] }` payload (empty array with no
+    /// adapters registered).
+    #[tokio::test]
+    async fn mcp_unified_dispatches_prompts_list() {
+        let state = test_app_state();
+        let resp = post_mcp(
+            state,
+            &json!({"jsonrpc":"2.0","method":"prompts/list","id":91}),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["id"], 91);
+        assert!(
+            body["result"]["prompts"].is_array(),
+            "expected prompts array, got {:?}",
+            body
+        );
+    }
+
+    /// T10 — `prompts/get` missing the `name` param is rejected with the
+    /// JSON-RPC `-32602` (invalid params) code, mirroring `tools/call`'s
+    /// missing-`name` shape.
+    #[tokio::test]
+    async fn mcp_unified_prompts_get_missing_name_returns_invalid_params() {
+        let state = test_app_state();
+        let resp = post_mcp(
+            state,
+            &json!({"jsonrpc":"2.0","method":"prompts/get","id":92,"params":{}}),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["id"], 92);
+        assert_eq!(body["error"]["code"], -32602);
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("missing 'name'"),
+            "unexpected error message: {body:?}"
+        );
+    }
+
+    /// T10 — `prompts/get` with no adapters registered returns a JSON-RPC
+    /// `-32603` (internal error) wrapping the registry's
+    /// "no prompt found for prefixed name" rejection; proves the arm
+    /// dispatches into `AdapterRegistry::route_prompt_get` rather than the
+    /// method-not-found fallback.
+    #[tokio::test]
+    async fn mcp_unified_prompts_get_dispatches_to_route_prompt_get() {
+        let state = test_app_state();
+        let resp = post_mcp(
+            state,
+            &json!({
+                "jsonrpc":"2.0",
+                "method":"prompts/get",
+                "id":93,
+                "params":{ "name": "nonexistent" }
+            }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["id"], 93);
+        assert_eq!(body["error"]["code"], -32603);
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("no prompt found for prefixed name"),
+            "unexpected error message: {body:?}"
+        );
+    }
+
+    /// T4 — `resources/read` missing the `uri` param is rejected with the
+    /// JSON-RPC `-32602` (invalid params) code, mirroring `tools/call`'s
+    /// missing-`name` shape.
+    #[tokio::test]
+    async fn mcp_unified_resources_read_missing_uri_returns_invalid_params() {
+        let state = test_app_state();
+        let resp = post_mcp(
+            state,
+            &json!({"jsonrpc":"2.0","method":"resources/read","id":33,"params":{}}),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["id"], 33);
+        assert_eq!(body["error"]["code"], -32602);
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("missing 'uri'"),
+            "unexpected error message: {body:?}"
+        );
+    }
+
+    /// T4 — `resources/read` with no adapters registered returns a JSON-RPC
+    /// `-32603` (internal error) wrapping the registry's "no active endpoint"
+    /// rejection; proves the arm dispatches into
+    /// `AdapterRegistry::route_resource_read` rather than the
+    /// method-not-found fallback.
+    #[tokio::test]
+    async fn mcp_unified_resources_read_dispatches_to_route_resource_read() {
+        let state = test_app_state();
+        let resp = post_mcp(
+            state,
+            &json!({
+                "jsonrpc":"2.0",
+                "method":"resources/read",
+                "id":34,
+                "params":{ "uri": "ui://app/main" }
+            }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["id"], 34);
+        // Internal error from the registry's empty-adapter rejection, not
+        // a `-32601` "method not found".
+        assert_eq!(body["error"]["code"], -32603);
+        let msg = body["error"]["message"].as_str().unwrap_or_default();
+        assert!(
+            msg.contains("no active endpoint") || msg.contains("ui://app/main"),
+            "expected routing error mentioning the URI, got: {msg}"
+        );
+    }
+
     #[tokio::test]
     async fn mcp_unified_2026_stateless_tools_list_without_handshake() {
         // A 2026 client calls tools/list with no prior initialize/initialized
@@ -4794,6 +5170,7 @@ mod tests {
                         description: Some("draw tool".into()),
                         input_schema: schema.clone(),
                         annotations: None,
+                        ..Default::default()
                     }],
                 }),
                 "stdio".into(),
@@ -5371,6 +5748,196 @@ mod tests {
         );
     }
 
+    /// T10 — `initialize` must advertise a `prompts` capability so MCP
+    /// clients know the relay proxies `prompts/list` + `prompts/get`.
+    /// `listChanged` is intentionally absent — the relay does not yet
+    /// forward upstream `notifications/prompts/list_changed` to clients.
+    #[tokio::test]
+    async fn mcp_initialize_advertises_prompts_capability() {
+        let state = test_app_state();
+        let body = JsonRpcBody {
+            jsonrpc: Some("2.0".to_string()),
+            method: Some("initialize".to_string()),
+            params: None,
+            id: Some(json!(8)),
+        };
+        let Json(resp) = mcp_initialize(State(state), Json(body), None).await;
+        assert!(
+            resp["result"]["capabilities"]["prompts"].is_object(),
+            "initialize must advertise prompts capability (got {resp})"
+        );
+        assert!(
+            resp["result"]["capabilities"]["prompts"]
+                .get("listChanged")
+                .is_none(),
+            "relay must not claim listChanged for prompts (got {resp})"
+        );
+    }
+
+    /// T7 — `initialize` must advertise EXACTLY the set of capabilities
+    /// that have matching dispatcher arms in `handle_single_message`:
+    /// `tools`, `resources`, `prompts`. No extra keys, and `resources` /
+    /// `prompts` must NOT carry `listChanged` or `subscribe` sub-flags —
+    /// the relay does not implement either, so advertising them would lie
+    /// about a reachable method.
+    #[tokio::test]
+    async fn mcp_initialize_capabilities_exact_shape() {
+        let state = test_app_state();
+        let body = JsonRpcBody {
+            jsonrpc: Some("2.0".to_string()),
+            method: Some("initialize".to_string()),
+            params: None,
+            id: Some(json!(9)),
+        };
+        let Json(resp) = mcp_initialize(State(state), Json(body), None).await;
+        let caps = &resp["result"]["capabilities"];
+
+        let mut keys: Vec<&str> = caps
+            .as_object()
+            .expect("capabilities must be an object")
+            .keys()
+            .map(|s| s.as_str())
+            .collect();
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec!["prompts", "resources", "tools"],
+            "capabilities must contain EXACTLY tools/resources/prompts (got {caps})"
+        );
+
+        // tools: listChanged true (SSE pipeline implemented).
+        assert_eq!(caps["tools"]["listChanged"], true);
+        // resources: bare {}, no unimplemented sub-flags.
+        assert!(caps["resources"].is_object());
+        assert!(
+            caps["resources"].get("listChanged").is_none(),
+            "resources must not claim listChanged (got {caps})"
+        );
+        assert!(
+            caps["resources"].get("subscribe").is_none(),
+            "resources must not claim subscribe (got {caps})"
+        );
+        // prompts: bare {}, no listChanged.
+        assert!(caps["prompts"].is_object());
+        assert!(caps["prompts"].get("listChanged").is_none());
+    }
+
+    /// T7 — `server/discover` must advertise the same EXACT capability
+    /// shape as `initialize` (they share `build_initialize_result`).
+    #[tokio::test]
+    async fn mcp_server_discover_capabilities_exact_shape() {
+        let state = test_app_state();
+        let resp = post_mcp(
+            state,
+            &json!({"jsonrpc":"2.0","method":"server/discover","id":42}),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let caps = &body["result"]["capabilities"];
+
+        let mut keys: Vec<&str> = caps
+            .as_object()
+            .expect("capabilities must be an object")
+            .keys()
+            .map(|s| s.as_str())
+            .collect();
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec!["prompts", "resources", "tools"],
+            "server/discover capabilities must contain EXACTLY tools/resources/prompts (got {caps})"
+        );
+        assert!(caps["resources"].get("listChanged").is_none());
+        assert!(caps["resources"].get("subscribe").is_none());
+        assert!(caps["prompts"].get("listChanged").is_none());
+    }
+
+    /// T7 — JS-execution mode keeps `resources/*` and `prompts/*`
+    /// reachable: the catalog reduction is scoped to `tools/list` only.
+    /// Capability advertisement and method reachability must agree —
+    /// `resources/list` and `prompts/list` are both advertised AND must
+    /// remain dispatched when `local_js_execution` is on.
+    #[tokio::test]
+    async fn mcp_js_mode_resources_and_prompts_remain_reachable() {
+        let state = test_app_state();
+        state.js_execution_mode.store(true, Ordering::Relaxed);
+
+        // resources/list: still dispatched (returns the empty-aggregate body).
+        let resp = post_mcp(
+            state.clone(),
+            &json!({"jsonrpc":"2.0","method":"resources/list","id":71}),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert!(
+            body["result"]["resources"].is_array(),
+            "resources/list must remain reachable in JS mode (got {body})"
+        );
+        assert!(
+            body.get("error").is_none(),
+            "resources/list must not be method-not-found in JS mode (got {body})"
+        );
+
+        // resources/templates/list: same.
+        let resp = post_mcp(
+            state.clone(),
+            &json!({"jsonrpc":"2.0","method":"resources/templates/list","id":72}),
+        )
+        .await;
+        let body = body_json(resp).await;
+        assert!(
+            body["result"]["resourceTemplates"].is_array(),
+            "resources/templates/list must remain reachable in JS mode (got {body})"
+        );
+
+        // prompts/list: still dispatched.
+        let resp = post_mcp(
+            state,
+            &json!({"jsonrpc":"2.0","method":"prompts/list","id":73}),
+        )
+        .await;
+        let body = body_json(resp).await;
+        assert!(
+            body["result"]["prompts"].is_array(),
+            "prompts/list must remain reachable in JS mode (got {body})"
+        );
+        assert!(
+            body.get("error").is_none(),
+            "prompts/list must not be method-not-found in JS mode (got {body})"
+        );
+    }
+
+    /// T7 — `initialize`/`server/discover` advertise the same capability
+    /// set when JS mode is on (the JS-mode catalog reduction is scoped to
+    /// `tools/list` and does not affect capability advertisement).
+    #[tokio::test]
+    async fn mcp_initialize_capabilities_unchanged_in_js_mode() {
+        let state = test_app_state();
+        state.js_execution_mode.store(true, Ordering::Relaxed);
+        let body = JsonRpcBody {
+            jsonrpc: Some("2.0".to_string()),
+            method: Some("initialize".to_string()),
+            params: None,
+            id: Some(json!(10)),
+        };
+        let Json(resp) = mcp_initialize(State(state), Json(body), None).await;
+        let caps = &resp["result"]["capabilities"];
+        let mut keys: Vec<&str> = caps
+            .as_object()
+            .expect("capabilities must be an object")
+            .keys()
+            .map(|s| s.as_str())
+            .collect();
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec!["prompts", "resources", "tools"],
+            "JS-mode capabilities must still include resources + prompts (got {caps})"
+        );
+    }
+
     /// Helper: read the SSE response body as a UTF-8 string, accumulating
     /// chunks until `predicate` returns true or `timeout` elapses. Returns
     /// the accumulated text either way so tests can produce useful failure
@@ -5542,6 +6109,7 @@ mod tests {
                             description: Some("smoke tool".into()),
                             input_schema: json!({"type": "object"}),
                             annotations: None,
+                            ..Default::default()
                         }],
                         server_type_val: "smoke-server".into(),
                     }),

--- a/src/tool_call_rewrite.rs
+++ b/src/tool_call_rewrite.rs
@@ -1,0 +1,539 @@
+//! `tools/call` result URI rewriting (enumerated slots #2 and #3).
+//!
+//! STRICT DD1: this walker only touches the MCP-defined locations where a
+//! URI is a resource reference the client will hand back to `resources/read`.
+//! Arbitrary tree-walking is forbidden — URL-shaped data in `text`/`image`/
+//! `audio` blocks and in `structuredContent` must round-trip untouched.
+//!
+//! DD3: this pass operates on `resource`/`resource_link` content blocks and
+//! `_meta` UI pointers; [`crate::toon_convert::toonify_call_result`] operates
+//! on `type=="text"` blocks. The two passes touch disjoint slots, so the
+//! pipeline composes in either order with identical output (idempotency).
+
+use serde_json::{Map, Value};
+
+use crate::resource_uri::maybe_encode_resource_uri;
+
+/// Wrap the two MCP Apps UI pointer slots on a `_meta` object in place:
+/// `_meta.ui.resourceUri` and the alias `_meta["openai/outputTemplate"]`.
+///
+/// Shared between slot #1 (`tools/list` tool descriptor `_meta`, applied by
+/// [`crate::registry::AdapterRegistry::build_catalog`]) and slot #2
+/// (`tools/call` result `_meta`, applied by [`rewrite_tool_call_result`]) so
+/// both call sites encode through the same code path — a divergence would let
+/// a pointer the client received from `tools/list` fail to reverse on
+/// `resources/read`. Strict DD1: only these two enumerated fields are
+/// touched; arbitrary `_meta` siblings (including `ui.csp`) pass through
+/// untouched. Idempotent only relative to non-URI passes — re-wrapping nests
+/// the wrapper (mirrors [`maybe_encode_resource_uri`]).
+pub(crate) fn rewrite_meta_ui_pointers(meta: &mut Map<String, Value>, endpoint: &str) {
+    if let Some(ui) = meta.get_mut("ui").and_then(|v| v.as_object_mut()) {
+        if let Some(uri) = ui.get("resourceUri").and_then(|v| v.as_str()) {
+            let wrapped = maybe_encode_resource_uri(endpoint, uri, false);
+            ui.insert("resourceUri".to_string(), Value::String(wrapped));
+        }
+    }
+    if let Some(uri) = meta.get("openai/outputTemplate").and_then(|v| v.as_str()) {
+        let wrapped = maybe_encode_resource_uri(endpoint, uri, false);
+        meta.insert("openai/outputTemplate".to_string(), Value::String(wrapped));
+    }
+}
+
+/// Rewrite the enumerated URI slots of a `tools/call` result to namespace them
+/// to `endpoint`.
+///
+/// Touched slots (DD1):
+/// - `result._meta.ui.resourceUri` (slot #2)
+/// - `result._meta["openai/outputTemplate"]` (slot #2 alias)
+/// - `result.content[]` where `type=="resource"` -> `resource.uri` (slot #3)
+/// - `result.content[]` where `type=="resource_link"` -> top-level `uri` (slot #3)
+///
+/// Everything else passes through verbatim. `skip_wrap` mirrors
+/// [`crate::registry::AdapterRegistry::list_resources`]'s DD5 trigger
+/// (`active_count <= 1`): a true value short-circuits the whole walk so
+/// single-endpoint mode is a strict byte-for-byte no-op.
+pub fn rewrite_tool_call_result(mut result: Value, endpoint: &str, skip_wrap: bool) -> Value {
+    if skip_wrap {
+        return result;
+    }
+
+    // Slot #2: `_meta.ui.resourceUri` and the alias `_meta["openai/outputTemplate"]`.
+    // Delegated to the shared helper so slot #1 (`tools/list` descriptor) and
+    // slot #2 (`tools/call` result) encode through identical logic.
+    if let Some(meta) = result.get_mut("_meta").and_then(|v| v.as_object_mut()) {
+        rewrite_meta_ui_pointers(meta, endpoint);
+    }
+
+    // Slot #3: `content[]` where `type=="resource"` -> `resource.uri`; where
+    // `type=="resource_link"` -> top-level `uri`. Iterate by type discriminant
+    // and ignore everything else (text/image/audio/...) per DD1.
+    if let Some(content) = result.get_mut("content").and_then(|v| v.as_array_mut()) {
+        for item in content.iter_mut() {
+            let kind = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
+            match kind {
+                "resource" => {
+                    if let Some(resource) = item.get_mut("resource").and_then(|v| v.as_object_mut())
+                    {
+                        if let Some(uri) = resource.get("uri").and_then(|v| v.as_str()) {
+                            let wrapped = maybe_encode_resource_uri(endpoint, uri, false);
+                            resource.insert("uri".to_string(), Value::String(wrapped));
+                        }
+                    }
+                }
+                "resource_link" => {
+                    if let Some(obj) = item.as_object_mut() {
+                        if let Some(uri) = obj.get("uri").and_then(|v| v.as_str()) {
+                            let wrapped = maybe_encode_resource_uri(endpoint, uri, false);
+                            obj.insert("uri".to_string(), Value::String(wrapped));
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    result
+}
+
+/// Rewrite the enumerated URI slots of a `prompts/get` result (slot #9) to
+/// namespace them to `endpoint`.
+///
+/// Touched slots (STRICT DD1):
+/// - `result.messages[].content` where `type=="resource"` -> `resource.uri`
+/// - `result.messages[].content` where `type=="resource_link"` -> top-level `uri`
+///
+/// Mirrors [`rewrite_tool_call_result`]'s slot #3 walk: iterates by `type`
+/// discriminant and ignores everything else (text/image/audio/...) so URL-
+/// shaped data in `text` blocks round-trips byte-for-byte. The MCP
+/// `PromptMessage` shape allows `content` to be either a single content
+/// block (object) or an array of blocks; both shapes are handled. Sibling
+/// fields on each message (`role`, etc.) and on the result (`description`)
+/// pass through untouched.
+///
+/// `skip_wrap` mirrors the DD5 single-endpoint trigger
+/// (`active_count <= 1`): a true value short-circuits the whole walk so
+/// single-endpoint mode is a strict byte-for-byte no-op. Re-uses the same
+/// [`maybe_encode_resource_uri`] primitive as slots #2/#3 so a pointer the
+/// client receives from `prompts/get` reverses on `resources/read` through
+/// the identical decoder — a divergence would let a prompt-borne pointer
+/// fail to read back.
+pub fn rewrite_prompt_get_result(mut result: Value, endpoint: &str, skip_wrap: bool) -> Value {
+    if skip_wrap {
+        return result;
+    }
+
+    if let Some(messages) = result.get_mut("messages").and_then(|v| v.as_array_mut()) {
+        for message in messages.iter_mut() {
+            let Some(content) = message.get_mut("content") else {
+                continue;
+            };
+            match content {
+                Value::Array(items) => {
+                    for item in items.iter_mut() {
+                        rewrite_prompt_message_content_block(item, endpoint);
+                    }
+                }
+                Value::Object(_) => {
+                    rewrite_prompt_message_content_block(content, endpoint);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    result
+}
+
+/// Wrap the URI slot inside a single `messages[].content` block when its
+/// `type` is `resource` (rewrites `resource.uri`) or `resource_link`
+/// (rewrites the top-level `uri`). DD1: all other types — including the
+/// MCP-defined `text`/`image`/`audio` blocks — pass through verbatim.
+fn rewrite_prompt_message_content_block(item: &mut Value, endpoint: &str) {
+    let kind = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
+    match kind {
+        "resource" => {
+            if let Some(resource) = item.get_mut("resource").and_then(|v| v.as_object_mut()) {
+                if let Some(uri) = resource.get("uri").and_then(|v| v.as_str()) {
+                    let wrapped = maybe_encode_resource_uri(endpoint, uri, false);
+                    resource.insert("uri".to_string(), Value::String(wrapped));
+                }
+            }
+        }
+        "resource_link" => {
+            if let Some(obj) = item.as_object_mut() {
+                if let Some(uri) = obj.get("uri").and_then(|v| v.as_str()) {
+                    let wrapped = maybe_encode_resource_uri(endpoint, uri, false);
+                    obj.insert("uri".to_string(), Value::String(wrapped));
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resource_uri::{decode_resource_uri, encode_resource_uri};
+    use crate::toon_convert::toonify_call_result;
+    use serde_json::json;
+
+    fn sample_result() -> Value {
+        json!({
+            "_meta": {
+                "ui": { "resourceUri": "ui://app/main" },
+                "openai/outputTemplate": "ui://app/template",
+                "ui.csp": { "origins": ["https://cdn.example.com"] }
+            },
+            "content": [
+                { "type": "text", "text": "see https://example.com/x for details" },
+                {
+                    "type": "resource",
+                    "resource": { "uri": "ui://app/inline", "mimeType": "text/html" }
+                },
+                { "type": "resource_link", "uri": "ui://app/link", "name": "Open" },
+                { "type": "image", "data": "BASE64", "mimeType": "image/png" },
+                { "type": "audio", "data": "BASE64", "mimeType": "audio/mp3" }
+            ],
+            "structuredContent": {
+                "url": "https://example.com/data",
+                "uri": "ui://app/inside-structured"
+            }
+        })
+    }
+
+    #[test]
+    fn rewrites_meta_ui_resource_uri() {
+        let out = rewrite_tool_call_result(sample_result(), "work", false);
+        let got = out["_meta"]["ui"]["resourceUri"].as_str().unwrap();
+        let (ep, orig) = decode_resource_uri(got).unwrap();
+        assert_eq!(ep, "work");
+        assert_eq!(orig, "ui://app/main");
+    }
+
+    #[test]
+    fn rewrites_meta_openai_output_template_alias() {
+        let out = rewrite_tool_call_result(sample_result(), "work", false);
+        let got = out["_meta"]["openai/outputTemplate"].as_str().unwrap();
+        let (ep, orig) = decode_resource_uri(got).unwrap();
+        assert_eq!(ep, "work");
+        assert_eq!(orig, "ui://app/template");
+    }
+
+    #[test]
+    fn rewrites_content_resource_uri() {
+        let out = rewrite_tool_call_result(sample_result(), "work", false);
+        let got = out["content"][1]["resource"]["uri"].as_str().unwrap();
+        let (ep, orig) = decode_resource_uri(got).unwrap();
+        assert_eq!(ep, "work");
+        assert_eq!(orig, "ui://app/inline");
+        // mimeType siblings inside the resource block survive verbatim.
+        assert_eq!(out["content"][1]["resource"]["mimeType"], "text/html");
+    }
+
+    #[test]
+    fn rewrites_content_resource_link_uri() {
+        let out = rewrite_tool_call_result(sample_result(), "work", false);
+        let got = out["content"][2]["uri"].as_str().unwrap();
+        let (ep, orig) = decode_resource_uri(got).unwrap();
+        assert_eq!(ep, "work");
+        assert_eq!(orig, "ui://app/link");
+        assert_eq!(out["content"][2]["name"], "Open");
+    }
+
+    #[test]
+    fn leaves_text_image_audio_untouched() {
+        let out = rewrite_tool_call_result(sample_result(), "work", false);
+        // Text block: URL-shaped data inside `text` is a DD1 regression target.
+        assert_eq!(
+            out["content"][0]["text"],
+            "see https://example.com/x for details"
+        );
+        // Image / audio: data and mimeType untouched.
+        assert_eq!(out["content"][3]["data"], "BASE64");
+        assert_eq!(out["content"][3]["mimeType"], "image/png");
+        assert_eq!(out["content"][4]["data"], "BASE64");
+        assert_eq!(out["content"][4]["mimeType"], "audio/mp3");
+    }
+
+    #[test]
+    fn leaves_structured_content_untouched() {
+        let out = rewrite_tool_call_result(sample_result(), "work", false);
+        // Heuristic rewriting of `structuredContent` is a non-goal (v1).
+        assert_eq!(out["structuredContent"]["url"], "https://example.com/data");
+        assert_eq!(
+            out["structuredContent"]["uri"],
+            "ui://app/inside-structured"
+        );
+    }
+
+    #[test]
+    fn leaves_meta_ui_csp_untouched() {
+        let out = rewrite_tool_call_result(sample_result(), "work", false);
+        // `_meta.ui.csp` origins are passed through (left untouched).
+        assert_eq!(
+            out["_meta"]["ui.csp"]["origins"][0],
+            "https://cdn.example.com"
+        );
+    }
+
+    #[test]
+    fn skip_wrap_passes_through_byte_for_byte() {
+        // DD5 single-endpoint mode: `skip_wrap = true` is a strict no-op.
+        let original = sample_result();
+        let out = rewrite_tool_call_result(original.clone(), "work", true);
+        assert_eq!(out, original);
+    }
+
+    #[test]
+    fn empty_result_is_noop() {
+        let out = rewrite_tool_call_result(json!({}), "work", false);
+        assert_eq!(out, json!({}));
+    }
+
+    #[test]
+    fn missing_meta_subfields_pass_through() {
+        // `_meta` present but no `ui` and no alias: result is structurally
+        // unchanged. The walker must not insert defaulted keys.
+        let input = json!({
+            "_meta": { "other": "value" },
+            "content": []
+        });
+        let out = rewrite_tool_call_result(input.clone(), "work", false);
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn order_uri_then_toon_equals_toon_then_uri() {
+        // DD3 idempotency / disjoint-block-type composition: running
+        // URI-rewrite then TOON must produce the same final result as TOON
+        // then URI-rewrite, because the two passes touch disjoint slots.
+        let mut input = sample_result();
+        // Make the text block JSON-parseable so TOON actually transforms it.
+        input["content"][0]["text"] =
+            Value::String(serde_json::to_string(&json!({"rows": [{"id": 1}]})).unwrap());
+
+        let uri_then_toon =
+            toonify_call_result(rewrite_tool_call_result(input.clone(), "work", false));
+        let toon_then_uri =
+            rewrite_tool_call_result(toonify_call_result(input.clone()), "work", false);
+        assert_eq!(uri_then_toon, toon_then_uri);
+    }
+
+    #[test]
+    fn rewrite_is_idempotent_only_relative_to_disjoint_passes() {
+        // Per DD3 the rewrite is idempotent vs TOON / non-URI passes, NOT vs
+        // itself — applying it twice nests the wrapper (mirrors
+        // `encode_resource_uri`'s documented behavior). Verify the nested form
+        // still decodes cleanly to the once-wrapped form so a double-call
+        // doesn't silently corrupt data.
+        let once = rewrite_tool_call_result(sample_result(), "work", false);
+        let once_uri = once["content"][2]["uri"].as_str().unwrap().to_string();
+        let twice = rewrite_tool_call_result(once, "work", false);
+        let twice_uri = twice["content"][2]["uri"].as_str().unwrap();
+        let (ep_outer, orig_outer) = decode_resource_uri(twice_uri).unwrap();
+        assert_eq!(ep_outer, "work");
+        assert_eq!(orig_outer, once_uri);
+    }
+
+    #[test]
+    fn unknown_content_types_pass_through() {
+        // Strict DD1: any block whose `type` is not `resource`/`resource_link`
+        // is left untouched, even if it has a `uri` field.
+        let input = json!({
+            "content": [
+                { "type": "exotic", "uri": "ui://x/y", "data": "z" }
+            ]
+        });
+        let out = rewrite_tool_call_result(input.clone(), "work", false);
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn non_string_uri_is_noop() {
+        // A malformed upstream that puts a non-string in `uri` must not
+        // crash; the walker leaves it untouched.
+        let input = json!({
+            "content": [
+                { "type": "resource_link", "uri": 42 },
+                { "type": "resource", "resource": { "uri": null } }
+            ]
+        });
+        let out = rewrite_tool_call_result(input.clone(), "work", false);
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn wrapped_endpoint_matches_explicit_encode() {
+        // Sanity: the wrapped value emitted by the rewriter is exactly what
+        // `encode_resource_uri(endpoint, original)` produces — no implicit
+        // template handling (slot #3 is a URI, not a URI template).
+        let out = rewrite_tool_call_result(sample_result(), "ep1", false);
+        assert_eq!(
+            out["content"][2]["uri"].as_str().unwrap(),
+            encode_resource_uri("ep1", "ui://app/link")
+        );
+    }
+
+    // ---- T10 — `prompts/get` result URI rewriting (slot #9) ---------------
+
+    /// Sample `prompts/get` result covering every shape slot #9 must visit:
+    /// an array-content message with text/resource/resource_link blocks
+    /// (DD1: only the resource/resource_link blocks wrap), an object-content
+    /// message carrying a single `resource` block (PromptMessage allows the
+    /// content field to be a single block, not just an array), and an
+    /// object-content `text` block (DD1: must round-trip verbatim).
+    fn sample_prompt_get_result() -> Value {
+        json!({
+            "description": "see ui://app/main",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        { "type": "text", "text": "see https://example.com/x for details" },
+                        {
+                            "type": "resource",
+                            "resource": { "uri": "ui://app/inline", "mimeType": "text/html" }
+                        },
+                        { "type": "resource_link", "uri": "ui://app/link", "name": "Open" },
+                        { "type": "image", "data": "BASE64", "mimeType": "image/png" }
+                    ]
+                },
+                {
+                    "role": "user",
+                    "content": {
+                        "type": "resource",
+                        "resource": { "uri": "ui://app/single", "mimeType": "text/html" }
+                    }
+                },
+                {
+                    "role": "user",
+                    "content": { "type": "text", "text": "plain prompt body" }
+                }
+            ]
+        })
+    }
+
+    #[test]
+    fn rewrites_array_content_resource_and_resource_link() {
+        let out = rewrite_prompt_get_result(sample_prompt_get_result(), "work", false);
+        let res_uri = out["messages"][0]["content"][1]["resource"]["uri"]
+            .as_str()
+            .unwrap();
+        let (ep, orig) = decode_resource_uri(res_uri).unwrap();
+        assert_eq!(ep, "work");
+        assert_eq!(orig, "ui://app/inline");
+        // Sibling fields inside the resource block survive verbatim.
+        assert_eq!(
+            out["messages"][0]["content"][1]["resource"]["mimeType"],
+            "text/html"
+        );
+
+        let link_uri = out["messages"][0]["content"][2]["uri"].as_str().unwrap();
+        let (ep, orig) = decode_resource_uri(link_uri).unwrap();
+        assert_eq!(ep, "work");
+        assert_eq!(orig, "ui://app/link");
+        assert_eq!(out["messages"][0]["content"][2]["name"], "Open");
+    }
+
+    #[test]
+    fn rewrites_object_content_single_resource_block() {
+        // PromptMessage allows `content` to be a single block (not an array).
+        // Slot #9 must wrap it just like the array shape.
+        let out = rewrite_prompt_get_result(sample_prompt_get_result(), "work", false);
+        let uri = out["messages"][1]["content"]["resource"]["uri"]
+            .as_str()
+            .unwrap();
+        let (ep, orig) = decode_resource_uri(uri).unwrap();
+        assert_eq!(ep, "work");
+        assert_eq!(orig, "ui://app/single");
+    }
+
+    #[test]
+    fn leaves_text_image_and_top_level_description_untouched() {
+        let out = rewrite_prompt_get_result(sample_prompt_get_result(), "work", false);
+        // Text block inside an array-content message: URL-shaped data in
+        // `text` is a DD1 regression target.
+        assert_eq!(
+            out["messages"][0]["content"][0]["text"],
+            "see https://example.com/x for details"
+        );
+        // Image block: data and mimeType untouched.
+        assert_eq!(out["messages"][0]["content"][3]["data"], "BASE64");
+        assert_eq!(out["messages"][0]["content"][3]["mimeType"], "image/png");
+        // Object-content `text` block (no array): untouched.
+        assert_eq!(out["messages"][2]["content"]["type"], "text");
+        assert_eq!(out["messages"][2]["content"]["text"], "plain prompt body");
+        // Top-level result `description` is not an enumerated URI slot.
+        assert_eq!(out["description"], "see ui://app/main");
+        // Roles round-trip.
+        assert_eq!(out["messages"][0]["role"], "assistant");
+        assert_eq!(out["messages"][1]["role"], "user");
+    }
+
+    #[test]
+    fn prompt_get_skip_wrap_passes_through_byte_for_byte() {
+        // DD5 single-endpoint mode: `skip_wrap = true` is a strict no-op.
+        let original = sample_prompt_get_result();
+        let out = rewrite_prompt_get_result(original.clone(), "work", true);
+        assert_eq!(out, original);
+    }
+
+    #[test]
+    fn prompt_get_empty_result_is_noop() {
+        let out = rewrite_prompt_get_result(json!({}), "work", false);
+        assert_eq!(out, json!({}));
+    }
+
+    #[test]
+    fn prompt_get_missing_messages_passes_through() {
+        let input = json!({ "description": "no messages here" });
+        let out = rewrite_prompt_get_result(input.clone(), "work", false);
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn prompt_get_unknown_content_types_pass_through() {
+        // Strict DD1: any block whose `type` is not `resource`/`resource_link`
+        // is left untouched, even if it has a `uri` field.
+        let input = json!({
+            "messages": [{
+                "role": "user",
+                "content": [{ "type": "exotic", "uri": "ui://x/y", "data": "z" }]
+            }]
+        });
+        let out = rewrite_prompt_get_result(input.clone(), "work", false);
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn prompt_get_non_string_uri_is_noop() {
+        // A malformed upstream that puts a non-string in `uri` must not
+        // crash; the walker leaves it untouched.
+        let input = json!({
+            "messages": [{
+                "role": "user",
+                "content": [
+                    { "type": "resource_link", "uri": 42 },
+                    { "type": "resource", "resource": { "uri": null } }
+                ]
+            }]
+        });
+        let out = rewrite_prompt_get_result(input.clone(), "work", false);
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn prompt_get_wrapped_endpoint_matches_explicit_encode() {
+        // Sanity: the wrapped value emitted by the rewriter is exactly what
+        // `encode_resource_uri(endpoint, original)` produces — slot #9 uses
+        // the same wrapper primitive as slot #3 so a pointer reverses on
+        // `resources/read` through the identical decoder.
+        let out = rewrite_prompt_get_result(sample_prompt_get_result(), "ep1", false);
+        assert_eq!(
+            out["messages"][0]["content"][2]["uri"].as_str().unwrap(),
+            encode_resource_uri("ep1", "ui://app/link")
+        );
+    }
+}

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1280,6 +1280,7 @@ mod tests {
             description: Some(format!("{} tool", name)),
             input_schema: json!({"type": "object"}),
             annotations: None,
+            ..Default::default()
         }
     }
 
@@ -3108,6 +3109,7 @@ validate_inputs = false
                                     "required": ["repo"],
                                 }),
                                 annotations: None,
+                                ..Default::default()
                             }],
                             dummy,
                         )),

--- a/tests/management_api_integration.rs
+++ b/tests/management_api_integration.rs
@@ -178,6 +178,7 @@ async fn test_management_api_status() {
         description: Some("Echoes input".into()),
         input_schema: json!({"type": "object"}),
         annotations: None,
+        ..Default::default()
     }];
     let (addr, _handle) =
         start_management_server(vec![("echo-ep", MockAdapter::healthy_with_tools(tools))]).await;
@@ -202,6 +203,7 @@ async fn test_management_api_endpoints() {
         description: None,
         input_schema: json!({}),
         annotations: None,
+        ..Default::default()
     }];
     let (addr, _handle) =
         start_management_server(vec![("echo-ep", MockAdapter::healthy_with_tools(tools))]).await;
@@ -228,12 +230,14 @@ async fn test_management_api_endpoint_tools() {
             description: Some("Read a file".into()),
             input_schema: json!({"type": "object"}),
             annotations: None,
+            ..Default::default()
         },
         ToolInfo {
             name: "write_file".into(),
             description: Some("Write a file".into()),
             input_schema: json!({"type": "object"}),
             annotations: None,
+            ..Default::default()
         },
     ];
     let (addr, _handle) =
@@ -260,6 +264,7 @@ async fn test_management_api_refresh_endpoint() {
         description: None,
         input_schema: json!({}),
         annotations: None,
+        ..Default::default()
     }];
     let (addr, _handle) =
         start_management_server(vec![("echo-ep", MockAdapter::healthy_with_tools(tools))]).await;
@@ -492,6 +497,7 @@ command = "cat"
         description: Some("Echoes input".into()),
         input_schema: json!({"type": "object"}),
         annotations: None,
+        ..Default::default()
     }];
     let (addr, _handle) = start_management_server_with_config(
         vec![("echo-ep", MockAdapter::healthy_with_tools(tools))],
@@ -540,12 +546,14 @@ async fn test_management_api_catalog() {
             description: Some("Read a file".into()),
             input_schema: json!({"type": "object"}),
             annotations: None,
+            ..Default::default()
         },
         ToolInfo {
             name: "write_file".into(),
             description: Some("Write a file".into()),
             input_schema: json!({"type": "object"}),
             annotations: Some(json!({"readOnly": true})),
+            ..Default::default()
         },
     ];
     let (addr, _handle) = start_management_server(vec![
@@ -656,6 +664,7 @@ async fn test_management_api_catalog_with_unhealthy_endpoints() {
         description: Some("Read a file".into()),
         input_schema: json!({"type": "object"}),
         annotations: None,
+        ..Default::default()
     }];
     let unhealthy_tools = vec![
         ToolInfo {
@@ -663,12 +672,14 @@ async fn test_management_api_catalog_with_unhealthy_endpoints() {
             description: Some("Ping server".into()),
             input_schema: json!({"type": "object"}),
             annotations: None,
+            ..Default::default()
         },
         ToolInfo {
             name: "status".into(),
             description: Some("Server status".into()),
             input_schema: json!({"type": "object"}),
             annotations: None,
+            ..Default::default()
         },
     ];
     let (addr, _handle) = start_management_server(vec![
@@ -734,6 +745,7 @@ async fn test_management_api_catalog_description_enriched() {
         description: Some("Read a file".into()),
         input_schema: json!({"type": "object"}),
         annotations: None,
+        ..Default::default()
     }];
     let (addr, _handle) =
         start_management_server(vec![("fs-ep", MockAdapter::healthy_with_tools(tools))]).await;

--- a/tests/mcp_app_e2e_integration.rs
+++ b/tests/mcp_app_e2e_integration.rs
@@ -1,0 +1,375 @@
+//! End-to-end multi-endpoint MCP App integration test (T8).
+//!
+//! Drives the full MCP App round-trip across two upstreams through the
+//! registry's real dispatch path (`merged_catalog_with_lookup`,
+//! `route_tool_call`, `route_resource_read`) to prove:
+//!
+//! 1. `tools/list` carries endpoint-namespaced UI pointers — each tool's
+//!    `_meta.ui.resourceUri` (and the `openai/outputTemplate` alias) is
+//!    wrapped to its OWNING endpoint via `mcp-relay://` (slot #1).
+//! 2. `tools/call` results carry wrapped resource refs scoped to the
+//!    owning endpoint (`_meta` UI pointers — slot #2; `resource` /
+//!    `resource_link` content blocks — slot #3).
+//! 3. `resources/read` of each wrapped URI dispatches to the CORRECT
+//!    upstream — endpoint A's wrapped URI never reaches B (slot #6),
+//!    and the de-wrapped original URI is what the adapter receives.
+//! 4. NEGATIVE (DD1): URL-shaped data inside a `text` block and inside
+//!    `structuredContent` is NOT rewritten — only the enumerated slots
+//!    are touched.
+
+use async_trait::async_trait;
+use endara_relay::adapter::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
+use endara_relay::registry::AdapterRegistry;
+use endara_relay::resource_uri::decode_resource_uri;
+use serde_json::{json, Value};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// A mock MCP App adapter that:
+/// - advertises a single `open_app` tool whose descriptor carries
+///   `_meta.ui.resourceUri = ui://app/{label}/main` + alias
+///   `openai/outputTemplate` (distinct per endpoint),
+/// - returns a `tools/call` result with `_meta` UI pointers + a mix of
+///   `resource`/`resource_link`/`text`/`structuredContent` blocks,
+/// - implements `read_resource` echoing the URI it received plus the
+///   endpoint label so cross-routing is detectable from the body alone.
+struct AppMockAdapter {
+    /// Distinct per-endpoint label baked into every URI it advertises and
+    /// surfaced in `read_resource` responses so cross-routing is visible.
+    label: String,
+    /// Captures the most recent URI passed to `read_resource` so the test
+    /// can confirm slot #6 reversed the wrapper before dispatch.
+    last_read_uri: Arc<Mutex<Option<String>>>,
+}
+
+impl AppMockAdapter {
+    fn new(label: &str) -> Self {
+        Self {
+            label: label.into(),
+            last_read_uri: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    fn ui_main(&self) -> String {
+        format!("ui://app/{}/main", self.label)
+    }
+    fn ui_template(&self) -> String {
+        format!("ui://app/{}/template", self.label)
+    }
+    fn ui_embedded(&self) -> String {
+        format!("ui://app/{}/embedded", self.label)
+    }
+    fn ui_widget(&self) -> String {
+        format!("ui://app/{}/widget", self.label)
+    }
+    /// URL-shaped data planted inside `text` and `structuredContent`. DD1
+    /// promises this is preserved byte-for-byte because neither is an
+    /// enumerated rewrite slot.
+    fn payload_url(&self) -> String {
+        format!("https://example.com/api/{}", self.label)
+    }
+}
+
+#[async_trait]
+impl McpAdapter for AppMockAdapter {
+    async fn initialize(&mut self) -> Result<(), AdapterError> {
+        Ok(())
+    }
+
+    async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
+        Ok(vec![ToolInfo {
+            name: "open_app".into(),
+            description: Some(format!("Open the {} app", self.label)),
+            input_schema: json!({"type": "object"}),
+            meta: Some(json!({
+                "ui": { "resourceUri": self.ui_main() },
+                "openai/outputTemplate": self.ui_template(),
+            })),
+            ..Default::default()
+        }])
+    }
+
+    async fn call_tool(&self, _name: &str, _arguments: Value) -> Result<Value, AdapterError> {
+        Ok(json!({
+            "_meta": {
+                "ui": { "resourceUri": self.ui_main() },
+                "openai/outputTemplate": self.ui_template(),
+            },
+            "content": [
+                // DD1 negative: a URL inside a `text` block must NOT be
+                // rewritten — `type==text` is not an enumerated slot.
+                { "type": "text", "text": format!("see {} for details", self.payload_url()) },
+                // Slot #3a: `type==resource` → `resource.uri` wrapped.
+                { "type": "resource", "resource": { "uri": self.ui_embedded(), "mimeType": "text/html" } },
+                // Slot #3b: `type==resource_link` → `uri` wrapped.
+                { "type": "resource_link", "uri": self.ui_widget(), "name": "Widget" },
+            ],
+            // DD1 negative: `structuredContent` is left untouched even when
+            // it contains URI-shaped fields — the relay never tree-walks
+            // arbitrary JSON for URI strings.
+            "structuredContent": {
+                "homepage": self.payload_url(),
+                "uri": format!("ui://app/{}/inside-structured", self.label),
+            },
+            "isError": false,
+        }))
+    }
+
+    async fn read_resource(&self, uri: &str) -> Result<Value, AdapterError> {
+        *self.last_read_uri.lock().await = Some(uri.to_string());
+        Ok(json!({
+            "contents": [{
+                "uri": uri,
+                "mimeType": "text/plain",
+                // The body carries the endpoint label so cross-routing
+                // (alpha's wrapper reaching beta) would be visible here.
+                "text": format!("body-from-{}", self.label),
+            }]
+        }))
+    }
+
+    fn health(&self) -> HealthStatus {
+        HealthStatus::Healthy
+    }
+
+    async fn shutdown(&mut self) -> Result<(), AdapterError> {
+        Ok(())
+    }
+}
+
+/// Register two `AppMockAdapter`s (`alpha`, `beta`) so the registry is in
+/// multi-endpoint mode (active_count >= 2 → DD5 wrapping ON). Returns the
+/// registry plus handles to each adapter's `last_read_uri` recorder so the
+/// test can inspect what slot #6 actually dispatched.
+async fn setup_two_endpoints() -> (
+    AdapterRegistry,
+    Arc<Mutex<Option<String>>>,
+    Arc<Mutex<Option<String>>>,
+) {
+    let registry = AdapterRegistry::new();
+
+    let alpha = AppMockAdapter::new("alpha");
+    let alpha_last = alpha.last_read_uri.clone();
+    registry
+        .register(
+            "alpha".into(),
+            Box::new(alpha),
+            "stdio".into(),
+            None,
+            Some("alpha".into()),
+        )
+        .await;
+
+    let beta = AppMockAdapter::new("beta");
+    let beta_last = beta.last_read_uri.clone();
+    registry
+        .register(
+            "beta".into(),
+            Box::new(beta),
+            "stdio".into(),
+            None,
+            Some("beta".into()),
+        )
+        .await;
+
+    (registry, alpha_last, beta_last)
+}
+
+#[tokio::test]
+async fn mcp_app_round_trip_two_endpoints_full_pipeline() {
+    let (registry, alpha_last, beta_last) = setup_two_endpoints().await;
+
+    // ---------- 1. tools/list: endpoint-namespaced UI pointers ----------
+    let (catalog, _lookup) = registry.merged_catalog_with_lookup().await;
+    assert_eq!(catalog.len(), 2, "two endpoints, one tool each");
+
+    let alpha_tool = catalog
+        .iter()
+        .find(|t| t.name == "alpha__open_app")
+        .expect("alpha__open_app present in catalog");
+    let beta_tool = catalog
+        .iter()
+        .find(|t| t.name == "beta__open_app")
+        .expect("beta__open_app present in catalog");
+
+    let alpha_descriptor_uri = alpha_tool
+        .meta
+        .as_ref()
+        .and_then(|m| m["ui"]["resourceUri"].as_str())
+        .expect("alpha descriptor _meta.ui.resourceUri wrapped");
+    assert!(
+        alpha_descriptor_uri.starts_with("mcp-relay://"),
+        "slot #1 must wrap alpha's UI pointer; got {alpha_descriptor_uri}"
+    );
+    assert_eq!(
+        decode_resource_uri(alpha_descriptor_uri).unwrap(),
+        ("alpha".into(), "ui://app/alpha/main".into()),
+        "alpha's descriptor must wrap to alpha, not beta"
+    );
+
+    let beta_descriptor_uri = beta_tool
+        .meta
+        .as_ref()
+        .and_then(|m| m["ui"]["resourceUri"].as_str())
+        .expect("beta descriptor _meta.ui.resourceUri wrapped");
+    assert_eq!(
+        decode_resource_uri(beta_descriptor_uri).unwrap(),
+        ("beta".into(), "ui://app/beta/main".into()),
+        "beta's descriptor must wrap to beta, not alpha"
+    );
+
+    // Slot #1 alias: `openai/outputTemplate` wrapped on each side.
+    let alpha_descriptor_tmpl = alpha_tool.meta.as_ref().unwrap()["openai/outputTemplate"]
+        .as_str()
+        .expect("alpha descriptor openai/outputTemplate wrapped");
+    assert_eq!(
+        decode_resource_uri(alpha_descriptor_tmpl).unwrap(),
+        ("alpha".into(), "ui://app/alpha/template".into()),
+    );
+
+    // ---------- 2. tools/call: per-endpoint wrapped result URIs ---------
+    let alpha_call = registry
+        .route_tool_call("alpha__open_app", json!({}))
+        .await
+        .expect("alpha tools/call dispatches");
+    let beta_call = registry
+        .route_tool_call("beta__open_app", json!({}))
+        .await
+        .expect("beta tools/call dispatches");
+
+    // Slot #2: `_meta.ui.resourceUri` + `openai/outputTemplate` alias.
+    let alpha_result_ui = alpha_call["_meta"]["ui"]["resourceUri"]
+        .as_str()
+        .expect("alpha result _meta.ui.resourceUri present");
+    assert_eq!(
+        decode_resource_uri(alpha_result_ui).unwrap(),
+        ("alpha".into(), "ui://app/alpha/main".into()),
+    );
+    let alpha_result_tmpl = alpha_call["_meta"]["openai/outputTemplate"]
+        .as_str()
+        .expect("alpha result openai/outputTemplate present");
+    assert_eq!(
+        decode_resource_uri(alpha_result_tmpl).unwrap(),
+        ("alpha".into(), "ui://app/alpha/template".into()),
+    );
+
+    // Slot #3: `content[type==resource].resource.uri` wrapped.
+    let alpha_resource_uri = alpha_call["content"][1]["resource"]["uri"]
+        .as_str()
+        .expect("alpha resource block uri present");
+    assert_eq!(
+        decode_resource_uri(alpha_resource_uri).unwrap(),
+        ("alpha".into(), "ui://app/alpha/embedded".into()),
+    );
+    // Slot #3: `content[type==resource_link].uri` wrapped.
+    let alpha_link_uri = alpha_call["content"][2]["uri"]
+        .as_str()
+        .expect("alpha resource_link uri present");
+    assert_eq!(
+        decode_resource_uri(alpha_link_uri).unwrap(),
+        ("alpha".into(), "ui://app/alpha/widget".into()),
+    );
+
+    // Mirror checks on beta confirm per-endpoint scoping (no cross-talk):
+    // a beta tool result must wrap to `beta`, never to `alpha`.
+    let beta_resource_uri = beta_call["content"][1]["resource"]["uri"].as_str().unwrap();
+    assert_eq!(
+        decode_resource_uri(beta_resource_uri).unwrap(),
+        ("beta".into(), "ui://app/beta/embedded".into()),
+    );
+    let beta_link_uri = beta_call["content"][2]["uri"].as_str().unwrap();
+    assert_eq!(
+        decode_resource_uri(beta_link_uri).unwrap(),
+        ("beta".into(), "ui://app/beta/widget".into()),
+    );
+
+    // ---------- 4. DD1 NEGATIVE: text + structuredContent untouched -----
+    // The text body still carries the literal URL — DD1 forbids tree-walking
+    // arbitrary JSON for URI-shaped strings.
+    assert_eq!(
+        alpha_call["content"][0]["text"], "see https://example.com/api/alpha for details",
+        "slot #2/#3 rewrite must not touch text blocks (DD1)"
+    );
+    assert_eq!(
+        alpha_call["structuredContent"]["homepage"], "https://example.com/api/alpha",
+        "URL inside structuredContent must not be rewritten (DD1)"
+    );
+    assert_eq!(
+        alpha_call["structuredContent"]["uri"], "ui://app/alpha/inside-structured",
+        "ui:// inside structuredContent must not be rewritten (DD1)"
+    );
+    // Same negative checks for beta — the rewrite isn't accidentally
+    // re-running on the second endpoint either.
+    assert_eq!(
+        beta_call["content"][0]["text"],
+        "see https://example.com/api/beta for details",
+    );
+    assert_eq!(
+        beta_call["structuredContent"]["uri"],
+        "ui://app/beta/inside-structured",
+    );
+
+    // ---------- 3. resources/read: per-endpoint routing, no crosstalk ---
+    // (a) Reading the wrapped URI taken from alpha's tools/call dispatches
+    //     to alpha and the adapter receives the de-wrapped original.
+    let alpha_read = registry
+        .route_resource_read(alpha_resource_uri)
+        .await
+        .expect("alpha resources/read dispatches");
+    assert_eq!(
+        alpha_read["contents"][0]["text"], "body-from-alpha",
+        "alpha's wrapped URI must reach alpha, never beta"
+    );
+    assert_eq!(
+        alpha_read["contents"][0]["uri"], "ui://app/alpha/embedded",
+        "adapter must receive the de-wrapped original URI"
+    );
+    assert_eq!(
+        alpha_last.lock().await.as_deref(),
+        Some("ui://app/alpha/embedded"),
+        "alpha adapter recorded the de-wrapped URI"
+    );
+    assert!(
+        beta_last.lock().await.is_none(),
+        "beta adapter must NOT have served alpha's wrapped URI"
+    );
+
+    // (b) Symmetric: beta's wrapped descriptor URI reaches beta only.
+    let beta_read = registry
+        .route_resource_read(beta_descriptor_uri)
+        .await
+        .expect("beta resources/read dispatches");
+    assert_eq!(beta_read["contents"][0]["text"], "body-from-beta");
+    assert_eq!(beta_read["contents"][0]["uri"], "ui://app/beta/main");
+    assert_eq!(
+        beta_last.lock().await.as_deref(),
+        Some("ui://app/beta/main"),
+    );
+
+    // (c) Closed-loop tools/call → resources/read on the second endpoint:
+    //     the wrapped resource_link URI in beta's tool result round-trips
+    //     back to its owning upstream with the original URI re-exposed.
+    let beta_widget_read = registry
+        .route_resource_read(beta_link_uri)
+        .await
+        .expect("beta widget read dispatches");
+    assert_eq!(beta_widget_read["contents"][0]["text"], "body-from-beta");
+    assert_eq!(
+        beta_last.lock().await.as_deref(),
+        Some("ui://app/beta/widget"),
+        "later read overwrites the recorder with beta's widget URI"
+    );
+
+    // (d) Final cross-routing guard: re-reading alpha's descriptor URI
+    //     after the beta reads must still land on alpha — the dispatcher
+    //     keys off the wrapper authority, never on call order.
+    let alpha_main_read = registry
+        .route_resource_read(alpha_descriptor_uri)
+        .await
+        .expect("alpha descriptor read dispatches");
+    assert_eq!(alpha_main_read["contents"][0]["text"], "body-from-alpha");
+    assert_eq!(
+        alpha_last.lock().await.as_deref(),
+        Some("ui://app/alpha/main"),
+    );
+}

--- a/tests/mcp_server_integration.rs
+++ b/tests/mcp_server_integration.rs
@@ -203,6 +203,7 @@ impl McpAdapter for JsonPayloadAdapter {
             description: Some("returns a JSON object in TextContent".to_string()),
             input_schema: json!({"type": "object"}),
             annotations: None,
+            ..Default::default()
         }])
     }
     async fn call_tool(&self, _name: &str, _args: Value) -> Result<Value, AdapterError> {
@@ -356,6 +357,7 @@ impl McpAdapter for NamedToolAdapter {
             description: Some(format!("the {} tool", self.tool)),
             input_schema: json!({"type": "object"}),
             annotations: None,
+            ..Default::default()
         }])
     }
     async fn call_tool(&self, _name: &str, _args: Value) -> Result<Value, AdapterError> {

--- a/tests/prompts_e2e_integration.rs
+++ b/tests/prompts_e2e_integration.rs
@@ -1,0 +1,390 @@
+//! T11 — end-to-end multi-endpoint prompts integration test.
+//!
+//! Drives the real `/mcp` HTTP handler with two in-process mock upstreams and
+//! exercises the full prompts round-trip: `prompts/list` -> `prompts/get` ->
+//! `resources/read`. Proves the slot #8 namespacing + slot #9 URI wrapping
+//! agree with the slot #6 `resources/read` decoder so a pointer the client
+//! receives from `prompts/get` reverses back to the owning upstream without
+//! cross-routing or payload corruption (DD1).
+
+use async_trait::async_trait;
+use endara_relay::adapter::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
+use endara_relay::js_sandbox::MetaToolHandler;
+use endara_relay::profile_registry::ProfileRegistry;
+use endara_relay::registry::AdapterRegistry;
+use endara_relay::server::{
+    build_router, start_server, AppState, MetaToolSchemas, SessionIdentityStore,
+};
+use serde_json::{json, Value};
+use std::net::SocketAddr;
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+/// Recorded `get_prompt` calls: `(raw_name, arguments)` per invocation.
+type PromptCallLog = Arc<Mutex<Vec<(String, Option<Value>)>>>;
+/// Recorded `read_resource` URIs (already unwrapped by the registry).
+type ReadCallLog = Arc<Mutex<Vec<String>>>;
+
+/// In-process upstream that records every `get_prompt` / `read_resource` it
+/// served so the test can assert the per-endpoint dispatch path without
+/// reaching for a subprocess fixture. `prompt_name` is the upstream-raw name
+/// (no relay prefix); `get_prompt` returns a message embedding a text block
+/// (DD1 regression target), a `resource` block, and a `resource_link` block.
+struct PromptMockAdapter {
+    endpoint_label: String,
+    prompt_name: String,
+    prompt_get_calls: PromptCallLog,
+    read_resource_calls: ReadCallLog,
+}
+
+#[async_trait]
+impl McpAdapter for PromptMockAdapter {
+    async fn initialize(&mut self) -> Result<(), AdapterError> {
+        Ok(())
+    }
+    async fn list_tools(&self) -> Result<Vec<ToolInfo>, AdapterError> {
+        Ok(vec![])
+    }
+    async fn call_tool(&self, _name: &str, _args: Value) -> Result<Value, AdapterError> {
+        Ok(json!({}))
+    }
+    async fn list_prompts(&self) -> Result<Vec<Value>, AdapterError> {
+        Ok(vec![json!({
+            "name": self.prompt_name,
+            "description": format!("{} prompt", self.endpoint_label),
+        })])
+    }
+    async fn get_prompt(
+        &self,
+        name: &str,
+        arguments: Option<Value>,
+    ) -> Result<Value, AdapterError> {
+        self.prompt_get_calls
+            .lock()
+            .unwrap()
+            .push((name.to_string(), arguments.clone()));
+        // Tag the response with the endpoint that served it so the round-trip
+        // test can assert which adapter was reached, and echo the raw `name`
+        // for the reverse-prefix assertion. The message intentionally embeds
+        // the three relevant content shapes: a `text` block carrying a
+        // URL-shaped string (DD1: must round-trip verbatim), a `resource`
+        // block, and a `resource_link` block (slot #9: both URIs must be
+        // wrapped to the owning endpoint).
+        Ok(json!({
+            "description": format!("{} response", self.endpoint_label),
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        { "type": "text", "text": "see https://example.com/x for details" },
+                        {
+                            "type": "resource",
+                            "resource": { "uri": "ui://app/inline", "mimeType": "text/html" }
+                        },
+                        { "type": "resource_link", "uri": "ui://app/link", "name": "Open" }
+                    ]
+                }
+            ],
+            "_endpoint_tag": self.endpoint_label,
+            "_raw_name": name,
+        }))
+    }
+    async fn read_resource(&self, uri: &str) -> Result<Value, AdapterError> {
+        self.read_resource_calls
+            .lock()
+            .unwrap()
+            .push(uri.to_string());
+        Ok(json!({
+            "_endpoint_tag": self.endpoint_label,
+            "contents": [{
+                "uri": uri,
+                "mimeType": "text/plain",
+                "text": format!("body from {}", self.endpoint_label),
+            }]
+        }))
+    }
+    fn health(&self) -> HealthStatus {
+        HealthStatus::Healthy
+    }
+    async fn shutdown(&mut self) -> Result<(), AdapterError> {
+        Ok(())
+    }
+}
+
+/// Spin up the real `/mcp` axum router with two in-process upstreams so the
+/// test drives the full server dispatch path (not just the registry helpers).
+async fn setup_two_endpoint_server() -> (
+    SocketAddr,
+    PromptCallLog,
+    ReadCallLog,
+    PromptCallLog,
+    ReadCallLog,
+    tokio::task::JoinHandle<()>,
+) {
+    let alpha_prompt_calls = Arc::new(Mutex::new(Vec::new()));
+    let alpha_read_calls = Arc::new(Mutex::new(Vec::new()));
+    let beta_prompt_calls = Arc::new(Mutex::new(Vec::new()));
+    let beta_read_calls = Arc::new(Mutex::new(Vec::new()));
+
+    let registry = AdapterRegistry::new();
+    registry
+        .register(
+            "alpha".into(),
+            Box::new(PromptMockAdapter {
+                endpoint_label: "alpha".into(),
+                prompt_name: "alpha_prompt".into(),
+                prompt_get_calls: alpha_prompt_calls.clone(),
+                read_resource_calls: alpha_read_calls.clone(),
+            }),
+            "stdio".into(),
+            None,
+            Some("alpha".into()),
+        )
+        .await;
+    registry
+        .register(
+            "beta".into(),
+            Box::new(PromptMockAdapter {
+                endpoint_label: "beta".into(),
+                prompt_name: "beta_prompt".into(),
+                prompt_get_calls: beta_prompt_calls.clone(),
+                read_resource_calls: beta_read_calls.clone(),
+            }),
+            "stdio".into(),
+            None,
+            Some("beta".into()),
+        )
+        .await;
+
+    let registry_arc = Arc::new(registry.clone());
+    let state = AppState {
+        registry: registry.clone(),
+        js_execution_mode: Arc::new(AtomicBool::new(false)),
+        meta_tool_handler: Arc::new(MetaToolHandler::new(registry_arc, Duration::from_secs(30))),
+        profile_registry: Arc::new(ProfileRegistry::new(registry.clone())),
+        oauth_flow_manager: None,
+        token_manager: None,
+        oauth_adapter_inners: None,
+        setup_manager: None,
+        started_at: std::time::Instant::now(),
+        toon_enabled: false,
+        session_identities: Arc::new(std::sync::Mutex::new(SessionIdentityStore::default())),
+        meta_tool_schemas: MetaToolSchemas::new(),
+    };
+    let router = build_router(state);
+    let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
+    let (bound, handle) = start_server(router, addr).await.expect("server start");
+
+    (
+        bound,
+        alpha_prompt_calls,
+        alpha_read_calls,
+        beta_prompt_calls,
+        beta_read_calls,
+        handle,
+    )
+}
+
+async fn post_mcp(client: &reqwest::Client, addr: SocketAddr, body: &Value) -> Value {
+    let resp = client
+        .post(format!("http://{}/mcp", addr))
+        .json(body)
+        .send()
+        .await
+        .expect("send /mcp");
+    assert_eq!(resp.status(), 200, "/mcp returned non-200");
+    resp.json::<Value>().await.expect("parse /mcp body")
+}
+
+/// One end-to-end test exercising `prompts/list` -> `prompts/get` ->
+/// `resources/read` across two upstreams. Asserts (multi-endpoint mode,
+/// `active_count == 2` so wrapping/prefixing is ON):
+///
+/// 1. `prompts/list` carries endpoint-namespaced names (`{prefix}__{name}`).
+/// 2. `prompts/get` of each namespaced name reaches the correct upstream
+///    with the raw (de-prefixed) name.
+/// 3. Slot #9 resource refs in returned messages are wrapped to the OWNING
+///    endpoint and reverse correctly via `resources/read` (no cross-routing).
+/// 4. DD1: `text` blocks whose body is URL-shaped pass through verbatim.
+#[tokio::test]
+async fn prompts_round_trip_across_two_upstreams() {
+    let (addr, alpha_prompt_calls, alpha_read_calls, beta_prompt_calls, beta_read_calls, _handle) =
+        setup_two_endpoint_server().await;
+    let client = reqwest::Client::new();
+
+    // ---- (1) prompts/list returns prefixed names per endpoint ---------------
+    let list = post_mcp(
+        &client,
+        addr,
+        &json!({"jsonrpc":"2.0","method":"prompts/list","id":1}),
+    )
+    .await;
+    let prompts = list["result"]["prompts"].as_array().expect("prompts array");
+    let names: Vec<String> = prompts
+        .iter()
+        .map(|p| p["name"].as_str().unwrap_or_default().to_string())
+        .collect();
+    assert!(
+        names.iter().any(|n| n == "alpha__alpha_prompt"),
+        "missing alpha__alpha_prompt in {:?}",
+        names
+    );
+    assert!(
+        names.iter().any(|n| n == "beta__beta_prompt"),
+        "missing beta__beta_prompt in {:?}",
+        names
+    );
+
+    // ---- (2) prompts/get dispatches to the right upstream with raw name ----
+    let alpha_get = post_mcp(
+        &client,
+        addr,
+        &json!({
+            "jsonrpc":"2.0",
+            "method":"prompts/get",
+            "id":2,
+            "params":{ "name":"alpha__alpha_prompt", "arguments": { "k":"v" } }
+        }),
+    )
+    .await;
+    let alpha_result = &alpha_get["result"];
+    assert_eq!(alpha_result["_endpoint_tag"], "alpha");
+    assert_eq!(alpha_result["_raw_name"], "alpha_prompt");
+    {
+        let calls = alpha_prompt_calls.lock().unwrap();
+        assert_eq!(calls.len(), 1, "alpha get_prompt should fire exactly once");
+        assert_eq!(calls[0].0, "alpha_prompt");
+        assert_eq!(calls[0].1, Some(json!({ "k":"v" })));
+        assert!(
+            beta_prompt_calls.lock().unwrap().is_empty(),
+            "beta must not receive alpha's prompts/get"
+        );
+    }
+
+    // ---- (3) slot #9 URIs in returned messages are wrapped to `alpha` ------
+    let alpha_resource_uri = alpha_result["messages"][0]["content"][1]["resource"]["uri"]
+        .as_str()
+        .expect("alpha resource uri");
+    let alpha_link_uri = alpha_result["messages"][0]["content"][2]["uri"]
+        .as_str()
+        .expect("alpha resource_link uri");
+    assert!(
+        alpha_resource_uri.starts_with("mcp-relay://alpha/"),
+        "alpha resource uri not wrapped to alpha: {}",
+        alpha_resource_uri
+    );
+    assert!(
+        alpha_link_uri.starts_with("mcp-relay://alpha/"),
+        "alpha resource_link uri not wrapped to alpha: {}",
+        alpha_link_uri
+    );
+
+    // ---- (4) DD1: text block with URL-shaped data is NOT rewritten ---------
+    assert_eq!(
+        alpha_result["messages"][0]["content"][0]["text"], "see https://example.com/x for details",
+        "DD1 violation: `text` block must round-trip verbatim",
+    );
+
+    // Same round-trip for beta — proves multi-endpoint dispatch picks the
+    // right adapter rather than just always-alpha.
+    let beta_get = post_mcp(
+        &client,
+        addr,
+        &json!({
+            "jsonrpc":"2.0",
+            "method":"prompts/get",
+            "id":3,
+            "params":{ "name":"beta__beta_prompt" }
+        }),
+    )
+    .await;
+    let beta_result = &beta_get["result"];
+    assert_eq!(beta_result["_endpoint_tag"], "beta");
+    assert_eq!(beta_result["_raw_name"], "beta_prompt");
+    {
+        let calls = beta_prompt_calls.lock().unwrap();
+        assert_eq!(calls.len(), 1, "beta get_prompt should fire exactly once");
+        assert_eq!(calls[0].0, "beta_prompt");
+    }
+    let beta_resource_uri = beta_result["messages"][0]["content"][1]["resource"]["uri"]
+        .as_str()
+        .expect("beta resource uri");
+    let beta_link_uri = beta_result["messages"][0]["content"][2]["uri"]
+        .as_str()
+        .expect("beta resource_link uri");
+    assert!(
+        beta_resource_uri.starts_with("mcp-relay://beta/"),
+        "beta resource uri not wrapped to beta: {}",
+        beta_resource_uri
+    );
+    assert!(
+        beta_link_uri.starts_with("mcp-relay://beta/"),
+        "beta resource_link uri not wrapped to beta: {}",
+        beta_link_uri
+    );
+
+    // ---- (5) resources/read reverses the wrap back to the OWNING upstream --
+    let alpha_read = post_mcp(
+        &client,
+        addr,
+        &json!({
+            "jsonrpc":"2.0",
+            "method":"resources/read",
+            "id":4,
+            "params":{ "uri": alpha_resource_uri }
+        }),
+    )
+    .await;
+    assert_eq!(
+        alpha_read["result"]["_endpoint_tag"], "alpha",
+        "wrapped alpha URI routed to the wrong upstream",
+    );
+    assert_eq!(
+        alpha_read["result"]["contents"][0]["uri"], "ui://app/inline",
+        "alpha upstream must see the unwrapped original URI",
+    );
+    {
+        let reads = alpha_read_calls.lock().unwrap();
+        assert_eq!(
+            reads.as_slice(),
+            &["ui://app/inline".to_string()],
+            "alpha read_resource must receive the unwrapped URI exactly once",
+        );
+        assert!(
+            beta_read_calls.lock().unwrap().is_empty(),
+            "beta must not see alpha's resources/read",
+        );
+    }
+
+    let beta_read = post_mcp(
+        &client,
+        addr,
+        &json!({
+            "jsonrpc":"2.0",
+            "method":"resources/read",
+            "id":5,
+            "params":{ "uri": beta_link_uri }
+        }),
+    )
+    .await;
+    assert_eq!(
+        beta_read["result"]["_endpoint_tag"], "beta",
+        "wrapped beta URI routed to the wrong upstream",
+    );
+    assert_eq!(
+        beta_read["result"]["contents"][0]["uri"], "ui://app/link",
+        "beta upstream must see the unwrapped original URI",
+    );
+    {
+        let reads = beta_read_calls.lock().unwrap();
+        assert_eq!(
+            reads.as_slice(),
+            &["ui://app/link".to_string()],
+            "beta read_resource must receive the unwrapped URI exactly once",
+        );
+        // alpha still only saw its own read above — no cross-routing.
+        let alpha_reads = alpha_read_calls.lock().unwrap();
+        assert_eq!(alpha_reads.len(), 1);
+    }
+}


### PR DESCRIPTION
## Summary

Adds first-class MCP proxying for **resources** and **prompts** so downstream clients see every capability of every upstream server through the relay, while tools continue to work exactly as before. The core design is *reversible URI namespacing*: everything a server owns (tool names, resource URIs, prompt names) is prefixed with the server's stable id on the way out and unprefixed on the way back in, so responses can be fanned in without collisions and requests can be dispatched to the correct upstream deterministically.

## What's included

**Resources**
- Proxy `resources/list`, `resources/templates/list`, `resources/read` across all upstream servers a client is subscribed to, with per-server error isolation.
- Rewrite outbound resource URIs to a reversible `mcp-relay://{server}/...` form in every enumerated slot (list results, template results, tool-call result resource links, prompt-get embedded resources).
- Unrewrite inbound URIs on `resources/read` so the relay dispatches to the correct upstream with the original URI, preserving upstream-native semantics.

**Prompts**
- Proxy `prompts/list` and `prompts/get` with name namespacing (`{server}__{name}`), matching the existing tool-name namespacing pattern.
- Rewrite `resource_link` / embedded resource URIs inside prompt-get responses so clients that follow prompt-provided resources hit the relay and stay routable.

**Capabilities & protocol parity**
- Advertise `resources` / `prompts` capabilities only when at least one upstream actually supports them, computed from live capability snapshots.
- JS-sandbox tool-call path runs the same URI-rewrite pass, so hosted tools cannot leak un-namespaced URIs to clients.
- `tools/list` remains lossless — all upstream tools surfaced with server-prefixed names.

**Profile isolation hardening**
- Per-profile registry now isolates resource/prompt caches, subscriptions, and rewrite tables the same way tools were already isolated. Cross-profile bleed is prevented at the registry layer, not just at the transport layer.

## Design decisions

- **DD1 — Strict slot-bounded URI rewriting.** We only rewrite URIs in the exact MCP-spec slots where they can appear (`resource.uri`, `resource_link.uri`, embedded resource contents). We never regex the payload, which avoids false positives inside tool arguments or free-form text.
- **DD4 — Reversible `mcp-relay://{server}/{original}` scheme.** The prefix carries enough information to invert the mapping without a server-side lookup table, so a cold relay can still route a `resources/read` for a URI it has never seen before.
- **DD5 — Single-endpoint parity.** HTTP, SSE, and stdio adapters share the same rewrite/unrewrite core; there is no transport-specific behavior for clients or servers.

## New files

- `src/resource_uri.rs` — reversible URI rewrite/unrewrite helpers with unit tests for round-tripping and edge cases (empty paths, query strings, fragments, non-ASCII).
- `src/tool_call_rewrite.rs` — post-processing pass that walks tool-call and prompt-get results and rewrites URIs in the enumerated slots.
- `tests/mcp_app_e2e_integration.rs` — two-upstream end-to-end tests for `resources/list`, `resources/templates/list`, and `resources/read`, including fan-in ordering and per-server error isolation.
- `tests/prompts_e2e_integration.rs` — end-to-end coverage for `prompts/list` and `prompts/get`, including embedded resource URI rewriting.

## Test results

Full local run from `packages/relay/`:

- `cargo fmt --check` — clean
- `cargo test -p endara-relay` — **41 suites, 2581 tests passed, 0 failed, 0 ignored**
- `cargo clippy --lib --tests` — 0 warnings, 0 errors

Both new e2e suites (`mcp_app_e2e_integration`, `prompts_e2e_integration`) pass.

## Rebase note

This branch was rebased onto `origin/main` on top of the recently merged enterprise-managed OAuth (#121), observability perf (#122), and management restart-test stabilization (#124) PRs. The diff vs `origin/main` is purely additive (+5558 / -8), with the 8 deletions confined to trivial signature/import touch-ups in the newly added integration points — no logic from #121 / #122 / #124 is removed or altered.
