### PR TITLE
test: make restart foreground/background ticks test deterministic

### DIFF
--- a/src/management.rs
+++ b/src/management.rs
@@ -6445,9 +6445,19 @@ mod tests {
                 Some("echo".to_string()),
             )
             .await;
+        // Deliberately use a config with NO endpoints so restart_endpoint's
+        // background task cannot find a matching config entry for "echo" and
+        // therefore takes the in-place `old.initialize()` re-init branch
+        // instead of `watcher::create_adapter` (which would spawn a real
+        // `echo` subprocess and run an MCP handshake that only fails after
+        // an internal timeout, the source of flakiness on loaded CI).
+        // SlowShutdownAdapter::initialize returns Ok(()) instantly, so the
+        // background tick fires deterministically after the 150ms shutdown.
+        let mut cfg = test_config();
+        cfg.endpoints.clear();
         let state = ManagementState {
             registry: Arc::new(registry),
-            config: Arc::new(RwLock::new(test_config())),
+            config: Arc::new(RwLock::new(cfg)),
             start_time: Instant::now(),
             config_path: None,
             oauth_flow_manager: None,
@@ -6484,12 +6494,12 @@ mod tests {
             .expect("foreground tick channel closed");
         assert_eq!(first, "echo", "foreground tick should carry endpoint name");
 
-        // Second tick: background re-init swap completion. Allow generous
-        // time because the slow shutdown must finish before the new adapter
-        // is swapped in, and CI can be slow.
-        let second = tokio::time::timeout(Duration::from_secs(30), rx.recv())
+        // Second tick: background in-place re-init swap completion. Fires
+        // after the 150ms SlowShutdownAdapter shutdown finishes and
+        // `old.initialize()` returns Ok(()) instantly.
+        let second = tokio::time::timeout(Duration::from_secs(5), rx.recv())
             .await
-            .expect("background tick did not arrive within 30s")
+            .expect("background tick did not arrive within 5s")
             .expect("background tick channel closed");
         assert_eq!(second, "echo", "background tick should carry endpoint name");
     }


### PR DESCRIPTION
## Problem

management::tests::restart_endpoint_emits_foreground_and_background_ticks intermittently fails in CI — including inside the merge queue, which ejected #123 — with:

    background tick did not arrive within 30s: Elapsed(())

This persisted even after #124 widened the bound from 5s to 30s. The fact that it still times out at the full 30s proves this is not a tight-timing flake.

## Root cause

The test built ManagementState with test_config(), which contains an "echo" stdio endpoint. That steered restart_endpoint background task onto the rebuild branch (watcher::create_adapter), which spawns a real echo subprocess and runs an MCP initialize handshake. echo is not an MCP server, so the handshake only fails after an internal timeout that is unbounded under loaded CI — delaying the second (background) tools_changed tick past the wait.

## Fix (test-only)

Clear endpoints in the test config so the restart background task finds no matching entry for "echo" and takes the in-place old.initialize() re-init branch instead of the subprocess rebuild path. SlowShutdownAdapter initialize() returns Ok(()) instantly, so the background tick fires deterministically after the 150ms shutdown. Both ticks still fire and still carry the "echo" payload; every behavioral assertion is unchanged. Background-tick timeout tightened back from 30s to 5s. No production code touched.

## Verification

- cargo fmt --check: PASS
- cargo clippy --all-targets -- -D warnings: PASS
- Looped management::tests::restart_endpoint on this branch off latest main: 12/12 PASS, plus 15/15 on the source branch and the implementor 20/20 sequential + 10/10 parallel.
