### PR TITLE
feat(oauth): EMA slice 3 — per-endpoint resource creds, org lifecycle + server_type log-flood guards (END-19)

### DIFF
--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use reqwest::Client;
 use serde_json::{json, Value};
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use tokio::sync::{broadcast, Mutex, Notify, RwLock};
@@ -75,6 +75,13 @@ pub struct HttpAdapter {
     /// body with this span so events carry `endpoint`/`transport` (and
     /// `server_type` once the MCP handshake completes).
     span: tracing::Span,
+    /// Once-guard for the span's `server_type` field. `Span::record` appends
+    /// each write to the span's field list, so recording on every
+    /// [`Self::initialize`] call (e.g. across reconnects) grows the
+    /// `endpoint{…}` header without bound. This flag is flipped the first
+    /// time a non-empty `server_type` is written so subsequent handshakes
+    /// skip the record call.
+    server_type_recorded: AtomicBool,
     /// Broadcast emitter for `notifications/tools/list_changed` events
     /// observed from the upstream server. Ticks come from two sources:
     ///
@@ -205,6 +212,7 @@ impl HttpAdapter {
             upstream_server_name: Arc::new(RwLock::new(None)),
             activity_log: Arc::new(RwLock::new(RingBuffer::new(1000))),
             span,
+            server_type_recorded: AtomicBool::new(false),
             tools_changed_tx,
             listener_handle: Arc::new(Mutex::new(None)),
             shutdown_notify: Arc::new(Notify::new()),
@@ -255,6 +263,7 @@ impl HttpAdapter {
             upstream_server_name: Arc::new(RwLock::new(None)),
             activity_log: Arc::new(RwLock::new(RingBuffer::new(1000))),
             span,
+            server_type_recorded: AtomicBool::new(false),
             tools_changed_tx,
             listener_handle: Arc::new(Mutex::new(None)),
             shutdown_notify: Arc::new(Notify::new()),
@@ -266,6 +275,24 @@ impl HttpAdapter {
             upstream_dialect: Arc::new(RwLock::new(ProtocolVersion::V2025_03_26)),
             list_ttl_ms: Arc::new(RwLock::new(None)),
         }
+    }
+
+    /// Record `server_type` on the per-endpoint span at most once. `Span::record`
+    /// appends each write to the span's field list, so recording on every
+    /// [`Self::initialize`] call (e.g. across HTTP/SSE reconnects) grows the
+    /// `endpoint{…}` header without bound. The guard flips the first time a
+    /// non-empty name is written so subsequent handshakes are a no-op.
+    fn record_server_type_once(&self, name: &str) {
+        if !self.server_type_recorded.swap(true, Ordering::Relaxed) {
+            self.span
+                .record("server_type", tracing::field::display(name));
+        }
+    }
+
+    /// Test-only accessor for the `server_type` once-guard state.
+    #[cfg(test)]
+    pub(crate) fn server_type_recorded_flag(&self) -> bool {
+        self.server_type_recorded.load(Ordering::Relaxed)
     }
 
     /// Install the given event-bus handle (Arc-cloned) on this adapter,
@@ -904,8 +931,7 @@ impl HttpAdapter {
 
         info!(url = %self.config.url, raw_name = %raw_name, sanitized = %sanitized, effective = ?effective, "MCP server reported serverInfo.name");
         if let Some(ref name) = effective {
-            self.span
-                .record("server_type", tracing::field::display(name));
+            self.record_server_type_once(name);
         }
         *self.server_type.write().await = effective;
         *self.upstream_server_name.write().await = Some(upstream_stripped);
@@ -1403,6 +1429,26 @@ mod tests {
     fn test_http_adapter_initial_health() {
         let adapter = HttpAdapter::new(HttpConfig::new("http://localhost:8080/mcp"));
         assert_eq!(adapter.health(), HealthStatus::Stopped);
+    }
+
+    /// Repeated `initialize` calls (standalone HTTP/SSE reconnects) must NOT
+    /// re-append `server_type` to the per-endpoint span's field list. The
+    /// once-guard flips on the first record and short-circuits every later
+    /// call, preventing unbounded `endpoint{…}` log-header growth.
+    #[test]
+    fn record_server_type_once_guards_repeated_calls() {
+        let adapter = HttpAdapter::new(HttpConfig::new("http://localhost:8080/mcp"));
+        assert!(!adapter.server_type_recorded_flag());
+
+        adapter.record_server_type_once("some-server");
+        assert!(adapter.server_type_recorded_flag());
+
+        // Second and subsequent calls (e.g. after a reconnect re-runs
+        // initialize) must NOT re-record — the guard has already flipped,
+        // so this is a no-op.
+        adapter.record_server_type_once("some-server");
+        adapter.record_server_type_once("other-name");
+        assert!(adapter.server_type_recorded_flag());
     }
 
     #[tokio::test]

--- a/src/adapter/oauth/jit.rs
+++ b/src/adapter/oauth/jit.rs
@@ -401,6 +401,7 @@ impl JitInterceptor {
                     client_secret_expires_at: resolved.client_secret_expires_at,
                     registered_at: now_secs(),
                     issuer: Some(disc.issuer.clone()),
+                    ..Default::default()
                 };
                 if let Err(e) = tm.save_dcr(endpoint_name, &creds).await {
                     warn!(error = %e, "failed to persist JIT client credentials");

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -19,6 +19,7 @@ use async_trait::async_trait;
 use reqwest::Client;
 use serde_json::Value;
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use tokio::sync::{broadcast, Mutex, RwLock};
@@ -80,6 +81,31 @@ pub struct EmaConfig {
     /// in the IdP authorize URL and every EMA token leg. `None` keeps the legs
     /// on the hosted CIMD `client_id` ([`ENDARA_CLIENT_METADATA_URL`]).
     pub client_id: Option<String>,
+    /// Optional pre-registered org `client_secret` (confidential IdP client).
+    /// Loaded from the `{org}.dcr.json` credential store at adapter init and
+    /// sent on the IdP-facing legs (RFC 8693 token-exchange Step 2 and the IdP
+    /// `refresh_token` grant) so confidential clients authenticate with
+    /// `client_secret_post`. `None` keeps the legs on the public/PKCE flow.
+    /// **Never** presented at the resource AS (Step 3 stays a public client).
+    pub client_secret: Option<String>,
+    /// Optional **resource** `client_id` presented at the MAS in Step 3
+    /// (RFC 7523 ID-JAG redemption). Distinct from `client_id`, which is the
+    /// requesting client used for SSO / the Step 2 exchange. Per-resource, so
+    /// R3 loads it from the *endpoint* DCR store (`{name}.dcr.json`) rather than
+    /// the org record. `None` keeps Step 3 identifying as the requesting
+    /// `client_id` (org id, else the hosted CIMD `client_id`).
+    pub resource_client_id: Option<String>,
+    /// Optional **resource** `client_secret` paired with `resource_client_id`,
+    /// presented via `client_secret_post` at the MAS in Step 3. Never sent on
+    /// the IdP-facing legs and never substituted by the requesting
+    /// `client_secret` (R1): when `None`, Step 3 sends no secret at the MAS.
+    pub resource_client_secret: Option<String>,
+    /// Optional resource scopes (space-delimited) configured for this endpoint
+    /// (R2). Threaded verbatim onto the Step 2 exchange and Step 3 redemption,
+    /// and composed with `openid`/`offline_access` for the SSO authorize URL and
+    /// the IdP `refresh_token` grant via [`crate::oauth::ema::compose_idp_scope`].
+    /// `None` keeps the historical scopes (regression-safe).
+    pub resource_scope: Option<String>,
 }
 
 /// SSO kick-off wiring for an EMA endpoint: the shared OAuth flow manager and
@@ -224,6 +250,13 @@ pub struct OAuthAdapterInner {
     /// The most recent EMA IdP authorize URL composed when the chain surfaced a
     /// re-SSO-required state. Surfaced to callers/desktop and asserted by tests.
     pending_authorize_url: RwLock<Option<String>>,
+    /// Once-guard for the span's `server_type` field. `Span::record` appends
+    /// each write to the span's field list, so recording on every
+    /// [`Self::apply_tokens`] (e.g. across token refreshes) grows the
+    /// `endpoint{…}` header without bound. This flag is flipped the first
+    /// time a non-empty `server_type` is written so subsequent applies skip
+    /// the record call.
+    server_type_recorded: AtomicBool,
 }
 
 impl OAuthAdapterInner {
@@ -277,6 +310,24 @@ impl OAuthAdapterInner {
             reason = %reason,
             "OAuth state transition"
         );
+    }
+
+    /// Record `server_type` on the per-endpoint span at most once. `Span::record`
+    /// appends each write to the span's field list, so recording on every
+    /// [`Self::apply_tokens`] call (e.g. across token refreshes) grows the
+    /// `endpoint{…}` header without bound. The guard flips the first time a
+    /// non-empty name is written so subsequent applies are a no-op.
+    fn record_server_type_once(&self, name: &str) {
+        if !self.server_type_recorded.swap(true, Ordering::Relaxed) {
+            self.span
+                .record("server_type", tracing::field::display(name));
+        }
+    }
+
+    /// Test-only accessor for the `server_type` once-guard state.
+    #[cfg(test)]
+    pub(crate) fn server_type_recorded_flag(&self) -> bool {
+        self.server_type_recorded.load(Ordering::Relaxed)
     }
 
     /// Resolve the URL that the next token-refresh POST should target.
@@ -479,8 +530,12 @@ impl OAuthAdapterInner {
             &ema.as_issuer,
             &ema.as_token_endpoint,
             &ema.resource,
+            ema.resource_scope.as_deref(),
             self.config.allow_insecure_oauth,
             ema.client_id.as_deref(),
+            ema.client_secret.as_deref(),
+            ema.resource_client_id.as_deref(),
+            ema.resource_client_secret.as_deref(),
         )
         .await
         {
@@ -521,9 +576,11 @@ impl OAuthAdapterInner {
     /// register the pending IdP flow via [`OAuthFlowManager::start_idp_flow`]
     /// (which tags the flow with `idp_issuer` so the `/oauth/callback` handler
     /// persists the returned ID Token as `IdpCredentials`). The requested scope
-    /// is `openid offline_access` (M1) so the IdP returns a refresh token the
-    /// EMA chain can later use to re-mint ID Tokens silently. Returns `None`
-    /// when the adapter was built without EMA SSO wiring (e.g. unit tests).
+    /// is composed via [`ema::compose_idp_scope`] (R2): always `openid` and
+    /// `offline_access` (M1) so the IdP returns a refresh token the EMA chain can
+    /// later use to re-mint ID Tokens silently, plus any configured resource
+    /// scopes. Returns `None` when the adapter was built without EMA SSO wiring
+    /// (e.g. unit tests).
     async fn compose_idp_authorize_url(&self) -> Option<String> {
         let ema = self.config.ema.as_ref()?;
         let sso = self.ema_sso.as_ref()?;
@@ -565,6 +622,7 @@ impl OAuthAdapterInner {
         } else {
             '?'
         };
+        let scope = ema::compose_idp_scope(ema.resource_scope.as_deref(), true);
         let authorize_url = format!(
             "{}{}response_type=code&client_id={}&redirect_uri={}&state={}&code_challenge={}&code_challenge_method=S256&scope={}",
             ema.idp_authorization_endpoint,
@@ -573,12 +631,13 @@ impl OAuthAdapterInner {
             form_urlencode(&redirect_uri),
             form_urlencode(&state_param),
             form_urlencode(&code_challenge),
-            form_urlencode("openid offline_access"),
+            form_urlencode(&scope),
         );
         info!(
             endpoint = %self.config.endpoint_name,
             idp_issuer = %ema.idp_issuer,
-            "EMA IdP SSO authorize URL composed (scope=openid offline_access)"
+            scope = %scope,
+            "EMA IdP SSO authorize URL composed"
         );
         Some(authorize_url)
     }
@@ -806,8 +865,7 @@ impl OAuthAdapterInner {
                 // OAuth span so subsequent events render with the resolved
                 // name in the `endpoint:` header.
                 if let Some(name) = adapter.server_type() {
-                    self.span
-                        .record("server_type", tracing::field::display(&name));
+                    self.record_server_type_once(&name);
                 }
                 // Reflect the freshly initialized inner adapter's health
                 // immediately so health() reports Healthy without waiting for
@@ -1104,6 +1162,7 @@ impl OAuthAdapter {
                 event_bus: Arc::new(OnceLock::new()),
                 ema_sso,
                 pending_authorize_url: RwLock::new(None),
+                server_type_recorded: AtomicBool::new(false),
             }),
         }
     }
@@ -1504,6 +1563,10 @@ mod tests {
                 as_token_endpoint: format!("{}/as/token", resource),
                 resource: resource.to_string(),
                 client_id: None,
+                client_secret: None,
+                resource_client_id: None,
+                resource_client_secret: None,
+                resource_scope: None,
             }),
         }
     }
@@ -3365,5 +3428,26 @@ mod tests {
                 server.abort();
             });
         });
+    }
+
+    /// Repeated `apply_tokens` calls (token refresh, reconnect) must NOT
+    /// re-append `server_type` to the per-endpoint span's field list. The
+    /// once-guard flips on the first record and short-circuits every later
+    /// call, preventing unbounded `endpoint{…}` log-header growth.
+    #[test]
+    fn record_server_type_once_guards_repeated_calls() {
+        let adapter = make_adapter(make_config());
+        let inner = adapter.shared_inner();
+        assert!(!inner.server_type_recorded_flag());
+
+        inner.record_server_type_once("some-server");
+        assert!(inner.server_type_recorded_flag());
+
+        // Second and subsequent calls (e.g. after a token refresh rebuilds
+        // the inner adapter) must NOT re-record — the guard has already
+        // flipped, so this is a no-op.
+        inner.record_server_type_once("some-server");
+        inner.record_server_type_once("other-name");
+        assert!(inner.server_type_recorded_flag());
     }
 }

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use reqwest::Client;
 use serde_json::{json, Value};
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use tokio::sync::{broadcast, Mutex, Notify, RwLock};
@@ -157,6 +157,15 @@ pub struct SseAdapter {
     /// body with this span so events carry `endpoint`/`transport` (and
     /// `server_type` once the MCP handshake completes).
     span: tracing::Span,
+    /// Once-guard for the span's `server_type` field. `Span::record` appends
+    /// each write to the span's field list, so recording on every
+    /// [`Self::initialize`] call (e.g. across SSE reconnects) grows the
+    /// `endpoint{…}` header without bound. This flag is flipped the first
+    /// time a non-empty `server_type` is written so subsequent handshakes
+    /// skip the record call. `Arc`-wrapped because [`SseAdapter`] is
+    /// `Clone`d into the reconnect supervisor task and each clone must
+    /// share the same guard.
+    server_type_recorded: Arc<AtomicBool>,
     /// Shared typed event bus for the desktop overlay's SSE stream. See
     /// the matching field on [`super::stdio::StdioAdapter`].
     event_bus: Arc<OnceLock<ToolCallEventBus>>,
@@ -230,6 +239,7 @@ impl SseAdapter {
             shutdown_notify: Arc::new(Notify::new()),
             tools_changed_tx,
             span,
+            server_type_recorded: Arc::new(AtomicBool::new(false)),
             event_bus: Arc::new(OnceLock::new()),
             tool_annotations_cache: Arc::new(RwLock::new(HashMap::new())),
             upstream_dialect: Arc::new(RwLock::new(ProtocolVersion::V2024_11_05)),
@@ -239,6 +249,24 @@ impl SseAdapter {
 
     fn next_id(&self) -> u64 {
         self.request_id.fetch_add(1, Ordering::SeqCst)
+    }
+
+    /// Record `server_type` on the per-endpoint span at most once. `Span::record`
+    /// appends each write to the span's field list, so recording on every
+    /// [`Self::initialize`] call (e.g. across SSE reconnects) grows the
+    /// `endpoint{…}` header without bound. The guard flips the first time a
+    /// non-empty name is written so subsequent handshakes are a no-op.
+    fn record_server_type_once(&self, name: &str) {
+        if !self.server_type_recorded.swap(true, Ordering::Relaxed) {
+            self.span
+                .record("server_type", tracing::field::display(name));
+        }
+    }
+
+    /// Test-only accessor for the `server_type` once-guard state.
+    #[cfg(test)]
+    pub(crate) fn server_type_recorded_flag(&self) -> bool {
+        self.server_type_recorded.load(Ordering::Relaxed)
     }
 
     /// Record the upstream server's negotiated [`ProtocolVersion`]. Populated
@@ -711,8 +739,7 @@ impl SseAdapter {
 
         debug!(url = %self.config.url, raw_name = %raw_name, sanitized = %sanitized, effective = ?effective, "MCP server reported serverInfo.name");
         if let Some(ref name) = effective {
-            self.span
-                .record("server_type", tracing::field::display(name));
+            self.record_server_type_once(name);
         }
         *self.server_type.write().await = effective;
         *self.upstream_server_name.write().await = Some(upstream_stripped);
@@ -1200,6 +1227,26 @@ mod tests {
         tracker.record_failure();
         tracker.reset();
         assert_eq!(tracker.backoff_duration(), Duration::from_secs(1));
+    }
+
+    /// Repeated `initialize` calls (SSE reconnects re-run the handshake) must
+    /// NOT re-append `server_type` to the per-endpoint span's field list. The
+    /// once-guard flips on the first record and short-circuits every later
+    /// call, preventing unbounded `endpoint{…}` log-header growth.
+    #[test]
+    fn record_server_type_once_guards_repeated_calls() {
+        let adapter = SseAdapter::new(SseConfig::new("http://localhost:8080/sse"));
+        assert!(!adapter.server_type_recorded_flag());
+
+        adapter.record_server_type_once("some-server");
+        assert!(adapter.server_type_recorded_flag());
+
+        // Second and subsequent calls (e.g. after a reconnect re-runs
+        // initialize) must NOT re-record — the guard has already flipped,
+        // so this is a no-op.
+        adapter.record_server_type_once("some-server");
+        adapter.record_server_type_once("other-name");
+        assert!(adapter.server_type_recorded_flag());
     }
 
     // -----------------------------------------------------------------

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::process::Stdio;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
@@ -355,6 +355,13 @@ pub struct StdioAdapter {
     /// body with this span so events carry `endpoint`/`transport` (and
     /// `server_type` once the MCP handshake completes).
     span: tracing::Span,
+    /// Once-guard for the span's `server_type` field. `Span::record` appends
+    /// each write to the span's field list, so recording on every
+    /// [`Self::initialize`] call (e.g. across stdio respawns) grows the
+    /// `endpoint{…}` header without bound. This flag is flipped the first
+    /// time a non-empty `server_type` is written so subsequent handshakes
+    /// skip the record call.
+    server_type_recorded: AtomicBool,
     /// Shared typed event bus for the desktop overlay's SSE stream. Set
     /// once by [`Self::set_event_bus`] from `main.rs`/`watcher.rs` after
     /// construction; `None` keeps `call_tool` silent (no events published)
@@ -422,6 +429,7 @@ impl StdioAdapter {
             upstream_server_name: Arc::new(RwLock::new(None)),
             tools_changed_tx,
             span,
+            server_type_recorded: AtomicBool::new(false),
             event_bus: Arc::new(OnceLock::new()),
             tool_annotations_cache: Arc::new(RwLock::new(HashMap::new())),
             container: Arc::new(Mutex::new(None)),
@@ -437,6 +445,24 @@ impl StdioAdapter {
 
     fn next_id(&self) -> u64 {
         self.request_id.fetch_add(1, Ordering::SeqCst)
+    }
+
+    /// Record `server_type` on the per-endpoint span at most once. `Span::record`
+    /// appends each write to the span's field list, so recording on every
+    /// [`Self::initialize`] call (e.g. across stdio respawns) grows the
+    /// `endpoint{…}` header without bound. The guard flips the first time a
+    /// non-empty name is written so subsequent handshakes are a no-op.
+    fn record_server_type_once(&self, name: &str) {
+        if !self.server_type_recorded.swap(true, Ordering::Relaxed) {
+            self.span
+                .record("server_type", tracing::field::display(name));
+        }
+    }
+
+    /// Test-only accessor for the `server_type` once-guard state.
+    #[cfg(test)]
+    pub(crate) fn server_type_recorded_flag(&self) -> bool {
+        self.server_type_recorded.load(Ordering::Relaxed)
     }
 
     /// Record the upstream server's negotiated [`ProtocolVersion`]. Populated
@@ -902,8 +928,7 @@ impl StdioAdapter {
 
         info!(raw_name = %raw_name, sanitized = %sanitized, effective = ?effective, "MCP server reported serverInfo.name");
         if let Some(ref name) = effective {
-            self.span
-                .record("server_type", tracing::field::display(name));
+            self.record_server_type_once(name);
         }
         *self.server_type.write().await = effective;
         *self.upstream_server_name.write().await = Some(upstream_stripped);
@@ -1385,6 +1410,26 @@ mod tests {
         tracker.record_crash();
         tracker.reset();
         assert_eq!(tracker.backoff_duration(), Duration::from_secs(1));
+    }
+
+    /// Repeated `initialize` calls (stdio respawns re-run the handshake) must
+    /// NOT re-append `server_type` to the per-endpoint span's field list. The
+    /// once-guard flips on the first record and short-circuits every later
+    /// call, preventing unbounded `endpoint{…}` log-header growth.
+    #[test]
+    fn record_server_type_once_guards_repeated_calls() {
+        let adapter = StdioAdapter::new(StdioConfig::default());
+        assert!(!adapter.server_type_recorded_flag());
+
+        adapter.record_server_type_once("some-server");
+        assert!(adapter.server_type_recorded_flag());
+
+        // Second and subsequent calls (e.g. after a respawn re-runs
+        // initialize) must NOT re-record — the guard has already flipped,
+        // so this is a no-op.
+        adapter.record_server_type_once("some-server");
+        adapter.record_server_type_once("other-name");
+        assert!(adapter.server_type_recorded_flag());
     }
 
     // -----------------------------------------------------------------------

--- a/src/config.rs
+++ b/src/config.rs
@@ -365,6 +365,19 @@ pub struct ConfigOrganization {
 /// [`ConfigError::ValidationError`] / per-endpoint warning through the existing
 /// validation paths instead of a raw TOML parse error, preserving the graceful
 /// per-endpoint loading model.
+///
+/// Client credentials are intentionally **not** modeled here, and the two
+/// credential kinds live at different scopes (never in `config.toml`):
+///   * the requesting `client_secret` is genuinely org-level (the shared
+///     SSO/requesting app) — persisted in `{org}.dcr.json` (0600) keyed by org
+///     name, captured via `POST`/`PUT /api/organizations`.
+///   * the optional EMA **resource** credential pair
+///     (`resource_client_id`/`resource_client_secret`, presented at the MAS in
+///     Step 3) is **per-resource**, so R3 keys it by **endpoint** —  persisted in
+///     `{name}.dcr.json` (0600) and captured via
+///     `POST /api/endpoints/{name}/credentials`, never on the org record.
+///
+/// Both are loaded at adapter init.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct EndpointAuthConfig {
     /// Discriminator for the auth scheme. Only `"ema"` is currently supported.

--- a/src/management.rs
+++ b/src/management.rs
@@ -1070,6 +1070,18 @@ struct EndpointCredentialsRequest {
     #[serde(default)]
     #[allow(dead_code)]
     oauth_server_url: Option<String>,
+    /// Optional EMA **resource** `client_id` presented at the MCP Authorization
+    /// Server in Step 3 (ID-JAG redemption) — R3 re-scoped this pair from the
+    /// org record to the endpoint because it is per-resource. Absent preserves
+    /// the stored value, an empty string clears it, a non-empty value sets it.
+    /// Persisted in `{name}.dcr.json` (0600), never in `config.toml`.
+    #[serde(default)]
+    resource_client_id: Option<String>,
+    /// Optional EMA **resource** `client_secret` paired with `resource_client_id`,
+    /// presented via `client_secret_post` at the MAS in Step 3. Same merge
+    /// semantics; never written to `config.toml` and never returned to the UI.
+    #[serde(default)]
+    resource_client_secret: Option<String>,
 }
 
 /// Response body for GET /api/endpoints/:name/credentials.
@@ -1080,6 +1092,12 @@ struct EndpointCredentialsResponse {
     client_secret_set: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     oauth_server_url: Option<String>,
+    /// The EMA **resource** `client_id` stored per-endpoint (R3); omitted when
+    /// unset. The paired secret is never returned — only its presence via
+    /// `resource_client_secret_set`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resource_client_id: Option<String>,
+    resource_client_secret_set: bool,
     /// Where the credentials surfaced from: "dcr" or "config" or "none".
     source: &'static str,
 }
@@ -1330,6 +1348,7 @@ async fn oauth_start(
                             .unwrap_or_default()
                             .as_secs(),
                         issuer: issuer.clone(),
+                        ..Default::default()
                     };
                     if let Err(e) = tm.save_dcr(&name, &creds).await {
                         warn!(endpoint = %name, error = %e, "Failed to persist DCR credentials");
@@ -1472,6 +1491,7 @@ async fn oauth_credentials(
         // Manually-supplied credentials are user-managed, not bound to a
         // discovered issuer; leave None so they are always reused as-is.
         issuer: None,
+        ..Default::default()
     };
 
     if let Err(e) = tm.save_dcr(&name, &creds).await {
@@ -1488,9 +1508,22 @@ async fn oauth_credentials(
 
 /// POST /api/endpoints/:name/credentials
 ///
-/// Persist caller-supplied OAuth client credentials via `TokenManager` (the
-/// DCR file). Never writes them to `config.toml`. Used by Wave 3a so that
-/// `client_secret` is no longer treated as a static config value.
+/// Persist caller-supplied credentials for an endpoint via `TokenManager` (the
+/// `{name}.dcr.json` DCR file, 0600). Never writes them to `config.toml`.
+///
+/// Two independently-optional credential groups are merged into the single
+/// per-endpoint DCR record so updating one never wipes the other:
+///   * the requesting OAuth `client_id`/`client_secret` (Wave 3a) used by the
+///     endpoint's own OAuth flow;
+///   * the optional EMA **resource** `client_id`/`client_secret` pair (R3),
+///     presented only at the MAS in Step 3. R3 re-scoped this pair from the org
+///     record to the endpoint because it is per-resource.
+///
+/// Merge semantics per field: absent preserves the stored value, an empty
+/// string clears it, a non-empty value sets it. A requesting `client_secret`
+/// requires a `client_id` (existing or supplied) — a secret with no client_id
+/// is rejected with 400. When the merged record holds no credential material
+/// the DCR file is deleted.
 async fn set_endpoint_credentials(
     State(state): State<ManagementState>,
     Path(name): Path<String>,
@@ -1505,14 +1538,6 @@ async fn set_endpoint_credentials(
         }
     }
 
-    let client_id = match body.client_id.as_deref().map(str::trim) {
-        Some(id) if !id.is_empty() => id.to_string(),
-        _ => {
-            return error_response(StatusCode::BAD_REQUEST, "client_id must not be empty", None)
-                .into_response();
-        }
-    };
-
     let Some(ref tm) = state.token_manager else {
         return error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -1522,23 +1547,102 @@ async fn set_endpoint_credentials(
         .into_response();
     };
 
-    let client_secret_set = body
-        .client_secret
-        .as_deref()
-        .map(|s| !s.is_empty())
-        .unwrap_or(false);
+    // Load the existing record so unspecified fields are preserved.
+    let existing = match tm.load_dcr(&name).await {
+        Ok(creds) => creds,
+        Err(e) => {
+            warn!(endpoint = %name, error = %e, "Failed to load endpoint DCR record during credential update");
+            None
+        }
+    };
+
+    // keep (absent) / clear (empty) / set (non-empty) per field.
+    let merge = |action: Option<&str>, current: Option<String>| match action {
+        None => current,
+        Some("") => None,
+        Some(s) => Some(s.to_string()),
+    };
+
+    // client_id is a plain (non-optional) field on the record: absent keeps the
+    // stored id (empty for a resource-only EMA endpoint), a value replaces it.
+    let merged_client_id = match body.client_id.as_deref().map(str::trim) {
+        None => existing
+            .as_ref()
+            .map(|c| c.client_id.clone())
+            .unwrap_or_default(),
+        Some(s) => s.to_string(),
+    };
+    let client_secret = merge(
+        body.client_secret.as_deref().map(str::trim),
+        existing.as_ref().and_then(|c| c.client_secret.clone()),
+    );
+    let resource_client_id = merge(
+        body.resource_client_id.as_deref().map(str::trim),
+        existing.as_ref().and_then(|c| c.resource_client_id.clone()),
+    );
+    let resource_client_secret = merge(
+        body.resource_client_secret.as_deref().map(str::trim),
+        existing
+            .as_ref()
+            .and_then(|c| c.resource_client_secret.clone()),
+    );
+
+    // A requesting secret has no meaning without a client_id to pair it with.
+    if client_secret.is_some() && merged_client_id.is_empty() {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "client_id must not be empty when setting client_secret",
+            None,
+        )
+        .into_response();
+    }
+
+    let client_secret_set = client_secret.is_some();
+    let resource_client_secret_set = resource_client_secret.is_some();
+
+    // Nothing left to persist → remove the DCR record entirely.
+    if merged_client_id.is_empty()
+        && client_secret.is_none()
+        && resource_client_id.is_none()
+        && resource_client_secret.is_none()
+    {
+        if let Err(e) = tm.delete_dcr(&name).await {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to clear credentials",
+                Some(&e.to_string()),
+            )
+            .into_response();
+        }
+        return Json(serde_json::json!({
+            "ok": true,
+            "client_secret_set": false,
+            "resource_client_secret_set": false,
+        }))
+        .into_response();
+    }
 
     let creds = DcrCredentials {
-        client_id,
-        client_secret: body.client_secret.filter(|s| !s.is_empty()),
-        client_secret_expires_at: 0,
-        registered_at: std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs(),
+        client_id: merged_client_id,
+        client_secret,
+        client_secret_expires_at: existing
+            .as_ref()
+            .map(|c| c.client_secret_expires_at)
+            .unwrap_or(0),
+        registered_at: existing
+            .as_ref()
+            .map(|c| c.registered_at)
+            .unwrap_or_else(|| {
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs()
+            }),
         // Manually-supplied credentials are user-managed, not bound to a
-        // discovered issuer; leave None so they are always reused as-is.
-        issuer: None,
+        // discovered issuer; preserve any existing binding but never invent one.
+        issuer: existing.as_ref().and_then(|c| c.issuer.clone()),
+        resource_client_id,
+        resource_client_secret,
     };
 
     if let Err(e) = tm.save_dcr(&name, &creds).await {
@@ -1553,6 +1657,7 @@ async fn set_endpoint_credentials(
     Json(serde_json::json!({
         "ok": true,
         "client_secret_set": client_secret_set,
+        "resource_client_secret_set": resource_client_secret_set,
     }))
     .into_response()
 }
@@ -1582,10 +1687,13 @@ async fn get_endpoint_credentials(
     if let Some(ref tm) = state.token_manager {
         match tm.load_dcr(&name).await {
             Ok(Some(creds)) => {
+                let resource_client_secret_set = creds.resource_client_secret.is_some();
                 return Json(EndpointCredentialsResponse {
-                    client_id: Some(creds.client_id),
+                    client_id: Some(creds.client_id).filter(|s| !s.is_empty()),
                     client_secret_set: creds.client_secret.is_some(),
                     oauth_server_url: cfg_oauth_server_url,
+                    resource_client_id: creds.resource_client_id,
+                    resource_client_secret_set,
                     source: "dcr",
                 })
                 .into_response();
@@ -1609,6 +1717,8 @@ async fn get_endpoint_credentials(
             .map(|s| !s.is_empty())
             .unwrap_or(false),
         oauth_server_url: cfg_oauth_server_url,
+        resource_client_id: None,
+        resource_client_secret_set: false,
         source,
     })
     .into_response()
@@ -2049,11 +2159,14 @@ struct OrgProbeResponse {
 /// Run the discovery → ID-JAG-exchange chain for a single resource and map the
 /// outcome to an [`OrgProbeStatus`]. Persists nothing: a successful exchange's
 /// ID-JAG is discarded and Step 3 (redemption) is never run.
+#[allow(clippy::too_many_arguments)]
 async fn run_org_probe_chain(
     resource: &str,
     idp_token_endpoint: &str,
     id_token: &str,
     allow_insecure: bool,
+    client_id: Option<&str>,
+    client_secret: Option<&str>,
 ) -> (OrgProbeStatus, Option<String>) {
     let resource = resource.trim();
     let chain = async {
@@ -2069,7 +2182,11 @@ async fn run_org_probe_chain(
             id_token,
             &as_issuer,
             resource,
+            // Connectivity probe only: no resource scope is threaded (R2).
+            None,
             allow_insecure,
+            client_id,
+            client_secret,
         )
         .await
         {
@@ -2097,12 +2214,15 @@ async fn run_org_probe_chain(
 }
 
 /// Probe one resource, consulting (and populating) the short-TTL cache.
+#[allow(clippy::too_many_arguments)]
 async fn probe_one_resource(
     org: String,
     resource: String,
     idp_token_endpoint: String,
     id_token: String,
     allow_insecure: bool,
+    client_id: Option<String>,
+    client_secret: Option<String>,
 ) -> OrgProbeResult {
     let key = (org, resource.clone());
 
@@ -2119,8 +2239,15 @@ async fn probe_one_resource(
         }
     }
 
-    let (status, server_as_issuer) =
-        run_org_probe_chain(&resource, &idp_token_endpoint, &id_token, allow_insecure).await;
+    let (status, server_as_issuer) = run_org_probe_chain(
+        &resource,
+        &idp_token_endpoint,
+        &id_token,
+        allow_insecure,
+        client_id.as_deref(),
+        client_secret.as_deref(),
+    )
+    .await;
 
     if let Ok(mut cache) = ORG_PROBE_CACHE.write() {
         cache.insert(
@@ -2159,7 +2286,7 @@ async fn probe_organization(
     Json(body): Json<OrgProbeRequest>,
 ) -> impl IntoResponse {
     // Resolve the org's IdP issuer (and the insecure-loopback policy) from config.
-    let (idp_issuer, allow_insecure) = {
+    let (idp_issuer, org_client_id, allow_insecure) = {
         let config = state.config.read().await;
         let Some(found) = config.organizations.iter().find(|o| o.name == org) else {
             return error_response(
@@ -2171,6 +2298,12 @@ async fn probe_organization(
         };
         (
             found.idp.clone(),
+            found
+                .client_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string),
             config.relay.allow_insecure_oauth.unwrap_or(false),
         )
     };
@@ -2228,15 +2361,44 @@ async fn probe_organization(
 
     let id_token = creds.id_token;
 
+    // Confidential-client support: load the optional org `client_secret` from
+    // the secure credential store (`{org}.dcr.json`) and thread it into the
+    // probe's RFC 8693 Step 2 exchange so confidential clients authenticate
+    // with `client_secret_post`. Only honour the stored secret when the DCR
+    // `client_id` matches the resolved org `client_id`; otherwise treat the
+    // secret as stale and fall back to the public flow. The probe never runs
+    // Step 3 so no resource-AS leg is involved.
+    let org_client_secret = match org_client_id.as_deref() {
+        Some(cid) => match token_manager.load_dcr(&org).await {
+            Ok(Some(dcr)) if dcr.client_id == cid => dcr.client_secret,
+            Ok(_) => None,
+            Err(e) => {
+                warn!(organization = %org, error = %e, "Failed to load org DCR credentials; probing as public client");
+                None
+            }
+        },
+        None => None,
+    };
+
     use futures_util::stream::StreamExt;
     let results: Vec<OrgProbeResult> =
         futures_util::stream::iter(body.resources.into_iter().map(|resource| {
             let org = org.clone();
             let idp_token_endpoint = idp_token_endpoint.clone();
             let id_token = id_token.clone();
+            let client_id = org_client_id.clone();
+            let client_secret = org_client_secret.clone();
             async move {
-                probe_one_resource(org, resource, idp_token_endpoint, id_token, allow_insecure)
-                    .await
+                probe_one_resource(
+                    org,
+                    resource,
+                    idp_token_endpoint,
+                    id_token,
+                    allow_insecure,
+                    client_id,
+                    client_secret,
+                )
+                .await
             }
         }))
         .buffered(ORG_PROBE_CONCURRENCY)
@@ -2478,6 +2640,7 @@ async fn oauth_setup(
                         ClientRegistration::Manual => None,
                         _ => Some(issuer.clone()),
                     },
+                    ..Default::default()
                 };
                 if let Err(e) = tm.save_dcr(&body.name, &creds).await {
                     warn!(endpoint = %body.name, error = %e, "Failed to persist client credentials");
@@ -2654,6 +2817,7 @@ async fn oauth_setup_credentials(
                 .as_secs(),
             // Manually-supplied credentials are user-managed; not issuer-bound.
             issuer: None,
+            ..Default::default()
         };
         if let Err(e) = tm.save_dcr(&name, &creds).await {
             warn!(endpoint = %name, error = %e, "Failed to persist manual credentials");
@@ -4693,7 +4857,10 @@ pub fn management_routes(state: ManagementState) -> Router {
             "/api/organizations",
             get(list_organizations).post(create_organization),
         )
-        .route("/api/organizations/{org}", delete(delete_organization))
+        .route(
+            "/api/organizations/{org}",
+            delete(delete_organization).put(update_organization),
+        )
         .route(
             "/api/organizations/{org}/reauthenticate",
             post(reauthenticate_organization),
@@ -4728,6 +4895,45 @@ struct CreateOrganizationRequest {
     /// and is persisted on the org; when omitted the relay falls back to CIMD/DCR.
     #[serde(default)]
     client_id: Option<String>,
+    /// Optional pre-registered OAuth `client_secret` for confidential IdP clients
+    /// that require the authorization-code → token exchange (and later EMA legs)
+    /// to authenticate with `client_secret_post`. Persisted in the secure
+    /// credential store keyed by org name (`{org}.dcr.json`, 0600); never
+    /// written to `config.toml` and never returned to the UI.
+    #[serde(default)]
+    client_secret: Option<String>,
+}
+
+/// Request body for `PUT /api/organizations/{org}`.
+///
+/// Every field is optional — omitted fields preserve the current value.
+/// `client_id` and `client_secret` use an empty string (`""`) as the explicit
+/// "clear" signal so callers can distinguish "keep" (absent) from "remove"
+/// (present-and-empty) without a serde absent-vs-null dance.
+#[derive(Deserialize)]
+struct UpdateOrganizationRequest {
+    /// New display name. When supplied and different from the path segment the
+    /// org is renamed (and pooled IdP credentials are purged — see handler).
+    #[serde(default)]
+    name: Option<String>,
+    /// New provider template id (`okta`, `entra`, `google`, `ping`, `custom`).
+    #[serde(default)]
+    provider: Option<String>,
+    /// New slug for templated providers (Okta subdomain, Entra tenant, …).
+    #[serde(default)]
+    slug: Option<String>,
+    /// New full issuer URL for `provider = "custom"`.
+    #[serde(default)]
+    idp: Option<String>,
+    /// New explicit `client_id`. Empty string clears the persisted id so the
+    /// next resolution falls back to CIMD/DCR. Identity-affecting — see handler.
+    #[serde(default)]
+    client_id: Option<String>,
+    /// New confidential-client `client_secret`. Empty string deletes the
+    /// stored secret (org returns to public/PKCE behaviour). Never written to
+    /// `config.toml`; persisted at `{org}.dcr.json` (0600).
+    #[serde(default)]
+    client_secret: Option<String>,
 }
 
 /// One organization entry returned by `GET /api/organizations`.
@@ -4857,6 +5063,7 @@ async fn compose_org_sso_url(
     issuer: &str,
     disc: &crate::oauth::discovery::DiscoveryResult,
     client_id: &str,
+    client_secret: Option<&str>,
 ) -> String {
     let pkce = PkceChallenge::generate();
     let code_challenge = pkce.code_challenge.clone();
@@ -4867,7 +5074,7 @@ async fn compose_org_sso_url(
             org_name,
             &disc.token_endpoint,
             client_id,
-            None,
+            client_secret,
             pkce,
             &redirect_uri,
             Some(issuer),
@@ -5085,6 +5292,46 @@ async fn create_organization(
     }
     state.config.write().await.organizations = orgs;
 
+    // Confidential-client support: persist an optional requesting `client_secret`
+    // in the secure credential store keyed by org name (`{org}.dcr.json`, 0600).
+    // It is never written to `config.toml` or returned to the UI. When omitted,
+    // no DCR file is written and the public/PKCE behaviour is preserved
+    // byte-for-byte. The stored `client_id` is the resolved id used for the
+    // authorize URL so the auth-code exchange (and later EMA legs) present a
+    // consistent (client_id, client_secret) pair. The EMA **resource** credential
+    // pair is per-resource and lives on the endpoint DCR record (R3), captured via
+    // POST /api/endpoints/{name}/credentials, never on the org record.
+    let trimmed_secret = body
+        .client_secret
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    if let Some(tm) = state.token_manager.as_ref() {
+        if trimmed_secret.is_some() {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            let creds = DcrCredentials {
+                client_id: resolved_client_id.clone(),
+                client_secret: trimmed_secret.map(str::to_string),
+                client_secret_expires_at: 0,
+                registered_at: now,
+                issuer: Some(issuer.clone()),
+                ..Default::default()
+            };
+            if let Err(e) = tm.save_dcr(&name, &creds).await {
+                warn!(organization = %name, error = %e, "Failed to persist org credentials to DCR store");
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "failed to persist client secret",
+                    Some(&e.to_string()),
+                )
+                .into_response();
+            }
+        }
+    }
+
     let authorize_url = compose_org_sso_url(
         flow_mgr,
         state.relay_port,
@@ -5092,6 +5339,7 @@ async fn create_organization(
         &issuer,
         &disc,
         &resolved_client_id,
+        trimmed_secret,
     )
     .await;
 
@@ -5107,6 +5355,340 @@ async fn create_organization(
         }),
     )
         .into_response()
+}
+
+/// PUT /api/organizations/{org}
+///
+/// Updates an existing organization's `name`, `provider`/`slug`/`idp`,
+/// `client_id`, and/or `client_secret`. Body fields are all optional —
+/// omitted fields preserve the current value; `client_id` / `client_secret`
+/// use an empty string to mean "clear" (see [`UpdateOrganizationRequest`]).
+///
+/// **Credential invalidation strategy (chosen: purge + require re-auth).**
+/// Identity-affecting changes — rename, issuer change (via provider/slug/idp),
+/// or `client_id` change — purge the pooled IdP credentials at both the old
+/// and new keys via [`TokenManager::delete_idp`] so the next use forces a
+/// fresh SSO. A rename also purges the cached DCR at the old name (the file
+/// is keyed by org name); the user must re-supply `client_secret` in this
+/// same call (or a follow-up call) to restore confidential-client behaviour.
+/// The "purge + require re-auth" choice is explicitly allowed by the slice
+/// spec (rename can either rekey OR purge — purge is simpler and consistent
+/// with how issuer/client_id changes invalidate the auth state already).
+///
+/// `client_secret` round-trips through the secure store (`{org}.dcr.json`,
+/// 0600) and is never written to `config.toml`; an empty-string secret
+/// deletes the stored entry.
+///
+/// **Returns:** when an identity-affecting change occurred the response
+/// mirrors [`OrganizationSsoResponse`] (the caller must re-run SSO with the
+/// returned `authorize_url`); otherwise it mirrors [`OrganizationResponse`]
+/// with the refreshed metadata + current auth status. Unknown org → 404.
+async fn update_organization(
+    State(state): State<ManagementState>,
+    Path(org): Path<String>,
+    Json(body): Json<UpdateOrganizationRequest>,
+) -> impl IntoResponse {
+    let Some(ref flow_mgr) = state.oauth_flow_manager else {
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "OAuth not configured",
+            None,
+        )
+        .into_response();
+    };
+    let Some(ref config_path) = state.config_path else {
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "config_path not configured",
+            None,
+        )
+        .into_response();
+    };
+
+    // Look up the existing org; capture snapshot for diffing.
+    let (current, allow_insecure, orgs_before) = {
+        let config = state.config.read().await;
+        let Some(found) = config.organizations.iter().find(|o| o.name == org).cloned() else {
+            return error_response(
+                StatusCode::NOT_FOUND,
+                "organization not found",
+                Some(&format!("No organization named '{org}'.")),
+            )
+            .into_response();
+        };
+        (
+            found,
+            config.relay.allow_insecure_oauth.unwrap_or(false),
+            config.organizations.clone(),
+        )
+    };
+
+    // Resolve effective field values: present-and-non-empty → use; absent → keep.
+    let new_name = body
+        .name
+        .as_ref()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| current.name.clone());
+    let new_provider = body
+        .provider
+        .as_ref()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| current.provider.clone());
+
+    // Reject duplicate name on rename.
+    if new_name != current.name && orgs_before.iter().any(|o| o.name == new_name) {
+        return error_response(
+            StatusCode::CONFLICT,
+            "organization_exists",
+            Some(&format!(
+                "An organization named '{new_name}' already exists. Use a different name."
+            )),
+        )
+        .into_response();
+    }
+
+    // Resolve effective issuer: rebuild from provider+slug, take pasted custom,
+    // or keep the current org.idp when neither side moved.
+    let issuer_in_body = body.slug.is_some() || body.idp.is_some();
+    let provider_changed = new_provider != current.provider;
+    let new_issuer = if provider_changed || issuer_in_body {
+        if new_provider == "custom" {
+            match body
+                .idp
+                .as_ref()
+                .map(|s| s.trim())
+                .filter(|s| !s.is_empty())
+            {
+                Some(idp) => idp.to_string(),
+                None if !provider_changed => current.idp.clone(),
+                None => {
+                    return error_response(
+                        StatusCode::BAD_REQUEST,
+                        "missing_idp",
+                        Some("provider 'custom' requires a full 'idp' issuer URL."),
+                    )
+                    .into_response();
+                }
+            }
+        } else {
+            let Some(provider) = crate::oauth::idp_providers::find_provider(&new_provider) else {
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    "unknown_provider",
+                    Some(&format!(
+                        "Unknown provider '{}'. Use GET /api/idp-providers to list templates.",
+                        new_provider
+                    )),
+                )
+                .into_response();
+            };
+            match provider.build_issuer(body.slug.as_deref()) {
+                Ok(issuer) => issuer,
+                Err(e) => {
+                    return error_response(StatusCode::BAD_REQUEST, "invalid_slug", Some(&e))
+                        .into_response();
+                }
+            }
+        }
+    } else {
+        current.idp.clone()
+    };
+
+    // Effective explicit client_id: empty string clears, non-empty sets,
+    // absent preserves the persisted org.client_id.
+    let effective_explicit_client_id: Option<String> = match body.client_id.as_ref() {
+        Some(s) if s.trim().is_empty() => None,
+        Some(s) => Some(s.trim().to_string()),
+        None => current.client_id.clone(),
+    };
+
+    // Always re-validate the issuer + re-resolve the client (matches create /
+    // reauth) so the persisted client_id and any new authorize URL stay
+    // coherent with what the IdP currently advertises.
+    let disc = match validate_org_issuer(&new_issuer, allow_insecure).await {
+        Ok(d) => d,
+        Err(resp) => return resp,
+    };
+    let redirect_uri = format!("http://127.0.0.1:{}/oauth/callback", state.relay_port);
+    let (resolved_client_id, registration) = match resolve_org_client(
+        effective_explicit_client_id.as_deref(),
+        &disc,
+        &redirect_uri,
+        &new_name,
+        allow_insecure,
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+    let persisted_client_id = match registration {
+        ClientRegistration::Cimd => None,
+        _ => Some(resolved_client_id.clone()),
+    };
+
+    let name_changed = new_name != current.name;
+    let issuer_changed = new_issuer != current.idp;
+    let client_id_changed = persisted_client_id != current.client_id;
+    let identity_changed = name_changed || issuer_changed || client_id_changed;
+
+    // Persist the updated org list to config.toml + in-memory.
+    let updated_org = crate::config::ConfigOrganization {
+        name: new_name.clone(),
+        provider: new_provider.clone(),
+        idp: new_issuer.clone(),
+        client_id: persisted_client_id.clone(),
+    };
+    let mut orgs = orgs_before.clone();
+    for o in orgs.iter_mut() {
+        if o.name == current.name {
+            *o = updated_org.clone();
+            break;
+        }
+    }
+    let resolved = crate::config::expand_tilde(config_path);
+    if let Err((status, msg, detail)) = write_organizations_to_disk(&resolved, &orgs) {
+        return error_response(status, msg, Some(&detail)).into_response();
+    }
+    state.config.write().await.organizations = orgs;
+
+    // Credential invalidation. Pooled IdP credentials are keyed by org name
+    // and bound to (issuer, client_id), so any rename / issuer / client_id
+    // change makes the cached entry meaningless — purge at both old and new
+    // names so a stale entry on either side cannot be picked up next call.
+    // DCR cached state is keyed by org name and binds (client_id, secret) to
+    // an issuer; purge the old-name DCR on rename and the same-name DCR when
+    // issuer/client_id moved so a subsequent secret save lands cleanly.
+    if let Some(ref tm) = state.token_manager {
+        if identity_changed {
+            if let Err(e) = tm.delete_idp(&current.name).await {
+                warn!(organization = %current.name, error = %e, "Failed to purge old IdP credentials during update");
+            }
+            if name_changed {
+                if let Err(e) = tm.delete_idp(&new_name).await {
+                    warn!(organization = %new_name, error = %e, "Failed to purge new IdP credentials during update");
+                }
+                if let Err(e) = tm.delete_dcr(&current.name).await {
+                    warn!(organization = %current.name, error = %e, "Failed to purge old DCR record during update");
+                }
+            }
+            if !name_changed && (issuer_changed || client_id_changed) {
+                if let Err(e) = tm.delete_dcr(&new_name).await {
+                    warn!(organization = %new_name, error = %e, "Failed to purge stale DCR record during update");
+                }
+            }
+        }
+    }
+
+    // Apply an explicit requesting `client_secret` override to the single
+    // `{org}.dcr.json` record: absent in the body preserves the stored value,
+    // an empty string clears it, a non-empty value sets it. When cleared the
+    // DCR file is deleted (back to public/PKCE). The EMA **resource** credential
+    // pair is per-resource and lives on the endpoint DCR record (R3), captured
+    // via POST /api/endpoints/{name}/credentials, never on the org record.
+    if let Some(action) = body.client_secret.as_deref().map(str::trim) {
+        if let Some(tm) = state.token_manager.as_ref() {
+            let client_secret = match action {
+                "" => None,
+                s => Some(s.to_string()),
+            };
+            if client_secret.is_none() {
+                if let Err(e) = tm.delete_dcr(&new_name).await {
+                    warn!(organization = %new_name, error = %e, "Failed to clear org credentials from DCR store");
+                    return error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "failed to clear client secret",
+                        Some(&e.to_string()),
+                    )
+                    .into_response();
+                }
+            } else {
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs();
+                let creds = DcrCredentials {
+                    client_id: resolved_client_id.clone(),
+                    client_secret,
+                    client_secret_expires_at: 0,
+                    registered_at: now,
+                    issuer: Some(new_issuer.clone()),
+                    ..Default::default()
+                };
+                if let Err(e) = tm.save_dcr(&new_name, &creds).await {
+                    warn!(organization = %new_name, error = %e, "Failed to persist updated org credentials to DCR store");
+                    return error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "failed to persist client secret",
+                        Some(&e.to_string()),
+                    )
+                    .into_response();
+                }
+            }
+        }
+    }
+
+    // Build the response. Identity changes require fresh SSO → return an
+    // authorize URL just like create / reauthenticate. Otherwise return the
+    // refreshed org metadata with the live auth status.
+    if identity_changed {
+        // Load any freshly-stored secret so the pending flow carries it.
+        let client_secret = match state.token_manager.as_ref() {
+            Some(tm) => match tm.load_dcr(&new_name).await {
+                Ok(Some(creds)) if creds.client_id == resolved_client_id => creds.client_secret,
+                _ => None,
+            },
+            None => None,
+        };
+        let authorize_url = compose_org_sso_url(
+            flow_mgr,
+            state.relay_port,
+            &new_name,
+            &new_issuer,
+            &disc,
+            &resolved_client_id,
+            client_secret.as_deref(),
+        )
+        .await;
+        info!(
+            organization = %new_name,
+            previous_name = %current.name,
+            "Organization updated; identity changed, re-authentication required",
+        );
+        return Json(OrganizationSsoResponse {
+            name: new_name,
+            provider: new_provider,
+            idp: new_issuer,
+            authorize_url,
+        })
+        .into_response();
+    }
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let authenticated = if let Some(ref tm) = state.token_manager {
+        match tm.load_idp(&new_name).await {
+            Ok(Some(creds)) => {
+                let id_valid = creds.id_token_expires_at.map(|e| e > now).unwrap_or(true);
+                id_valid || creds.refresh_token.is_some()
+            }
+            _ => false,
+        }
+    } else {
+        false
+    };
+    info!(organization = %new_name, "Organization updated; credentials preserved");
+    Json(OrganizationResponse {
+        name: new_name,
+        provider: new_provider,
+        idp: new_issuer,
+        authenticated,
+    })
+    .into_response()
 }
 
 /// GET /api/organizations
@@ -5245,6 +5827,22 @@ async fn reauthenticate_organization(
         Err(resp) => return resp,
     };
 
+    // Load the optional confidential-client secret from the secure credential
+    // store (`{org}.dcr.json`); when present the auth-code exchange in
+    // `/oauth/callback` will include `client_secret` in the form body. Missing
+    // DCR / load failure / no secret → public/PKCE flow (existing behaviour).
+    let client_secret = match state.token_manager.as_ref() {
+        Some(tm) => match tm.load_dcr(&org).await {
+            Ok(Some(creds)) if creds.client_id == resolved_client_id => creds.client_secret,
+            Ok(_) => None,
+            Err(e) => {
+                warn!(organization = %org, error = %e, "Failed to load org DCR credentials; continuing as public client");
+                None
+            }
+        },
+        None => None,
+    };
+
     let authorize_url = compose_org_sso_url(
         flow_mgr,
         state.relay_port,
@@ -5252,6 +5850,7 @@ async fn reauthenticate_organization(
         &issuer,
         &disc,
         &resolved_client_id,
+        client_secret.as_deref(),
     )
     .await;
 
@@ -8156,6 +8755,7 @@ command = "echo"
                 client_secret_expires_at: 0,
                 registered_at: 1_700_000_000,
                 issuer: None,
+                ..Default::default()
             },
         )
         .await
@@ -8200,6 +8800,195 @@ command = "echo"
         assert_eq!(body["client_secret_set"], true);
         assert_eq!(body["source"], "config");
         assert!(body.get("client_secret").is_none());
+    }
+
+    /// R3: the optional EMA **resource** credential pair is captured + persisted
+    /// **per-endpoint** in `{name}.dcr.json` via POST
+    /// /api/endpoints/{name}/credentials, with absent=keep / empty=clear /
+    /// non-empty=set semantics. A resource-only update (no requesting client_id)
+    /// is allowed, and each field merges independently.
+    #[tokio::test]
+    async fn endpoint_credentials_resource_pair_persist_and_merge() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (state, tm) = test_state_with_token_manager("ep1", tmp.path(), None, None).await;
+        let app = management_routes(state);
+
+        // 1. SET — resource-only update (no requesting client_id) is allowed.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/api/endpoints/ep1/credentials")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "resource_client_id": "res-client",
+                            "resource_client_secret": "res-secret",
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let creds = tm
+            .load_dcr("ep1")
+            .await
+            .unwrap()
+            .expect("endpoint DCR should exist after set");
+        assert_eq!(creds.resource_client_id.as_deref(), Some("res-client"));
+        assert_eq!(creds.resource_client_secret.as_deref(), Some("res-secret"));
+        // Resource-only: no requesting client_id/secret was supplied.
+        assert!(creds.client_id.is_empty());
+        assert!(creds.client_secret.is_none());
+
+        // 2. Update ONLY the resource secret — resource id preserved.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/api/endpoints/ep1/credentials")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"resource_client_secret": "res-secret-v2"}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let creds = tm.load_dcr("ep1").await.unwrap().unwrap();
+        assert_eq!(
+            creds.resource_client_id.as_deref(),
+            Some("res-client"),
+            "resource_client_id must survive a resource-secret update"
+        );
+        assert_eq!(
+            creds.resource_client_secret.as_deref(),
+            Some("res-secret-v2")
+        );
+
+        // 3. Add requesting client_id + secret — resource pair preserved.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/api/endpoints/ep1/credentials")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "client_id": "req-client",
+                            "client_secret": "req-secret",
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let creds = tm.load_dcr("ep1").await.unwrap().unwrap();
+        assert_eq!(creds.client_id, "req-client");
+        assert_eq!(creds.client_secret.as_deref(), Some("req-secret"));
+        assert_eq!(
+            creds.resource_client_id.as_deref(),
+            Some("res-client"),
+            "resource pair must survive a requesting-cred update"
+        );
+        assert_eq!(
+            creds.resource_client_secret.as_deref(),
+            Some("res-secret-v2")
+        );
+
+        // 4. Clear ONLY the resource secret — everything else kept.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/api/endpoints/ep1/credentials")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"resource_client_secret": ""}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let creds = tm.load_dcr("ep1").await.unwrap().unwrap();
+        assert_eq!(creds.client_id, "req-client");
+        assert_eq!(creds.client_secret.as_deref(), Some("req-secret"));
+        assert_eq!(creds.resource_client_id.as_deref(), Some("res-client"));
+        assert!(
+            creds.resource_client_secret.is_none(),
+            "resource_client_secret must be cleared by an empty string"
+        );
+
+        // 5. GET surfaces the resource id + secret-set flag (never the secret).
+        let _ = app
+            .clone()
+            .oneshot(
+                Request::post("/api/endpoints/ep1/credentials")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"resource_client_secret": "res-secret-v3"}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::get("/api/endpoints/ep1/credentials")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["resource_client_id"], "res-client");
+        assert_eq!(body["resource_client_secret_set"], true);
+        assert!(body.get("resource_client_secret").is_none());
+    }
+
+    /// R3: clearing the last remaining credential removes the per-endpoint DCR
+    /// record entirely (back to the no-credential state).
+    #[tokio::test]
+    async fn endpoint_credentials_clearing_last_removes_dcr() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (state, tm) = test_state_with_token_manager("ep1", tmp.path(), None, None).await;
+        let app = management_routes(state);
+        // Seed a resource-only record.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/api/endpoints/ep1/credentials")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"resource_client_id": "res-client"}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(tm.load_dcr("ep1").await.unwrap().is_some());
+        // Clear it — the record should be removed.
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/ep1/credentials")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"resource_client_id": ""}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(
+            tm.load_dcr("ep1").await.unwrap().is_none(),
+            "DCR file should be removed when the last credential is cleared"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -8635,6 +9424,7 @@ command = "echo"
             client_secret_expires_at: 0,
             registered_at: 0,
             issuer: None,
+            ..Default::default()
         };
         token_manager.save_dcr("ep1", &creds).await.unwrap();
 
@@ -8697,6 +9487,7 @@ command = "echo"
             client_secret_expires_at: 0,
             registered_at: 0,
             issuer: None,
+            ..Default::default()
         };
         token_manager.save_dcr("ep1", &creds).await.unwrap();
 
@@ -10718,5 +11509,651 @@ client_id = "client123"
             config.read().await.organizations.is_empty(),
             "org must not be persisted when client_id is unresolvable"
         );
+    }
+
+    /// Confidential client: an org created with `client_secret` persists the
+    /// secret to the secure credential store (`{org}.dcr.json`), NEVER to
+    /// `config.toml`, and the composed SSO flow carries the secret so the
+    /// auth-code exchange in `/oauth/callback` authenticates with it.
+    #[tokio::test]
+    async fn create_organization_with_client_secret_persists_dcr_and_threads_flow_secret() {
+        let (base_url, _server) = spawn_mock_as(org_well_known_router()).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_orgs(tmp.path(), true).await;
+        let flow_mgr = state.oauth_flow_manager.clone().unwrap();
+        let token_manager = state.token_manager.clone().unwrap();
+        let config = state.config.clone();
+        let config_path = state.config_path.clone().unwrap();
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::post("/api/organizations")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "name": "Acme Corp",
+                            "provider": "custom",
+                            "idp": base_url,
+                            "client_id": "explicit-okta-client",
+                            "client_secret": "super-secret-value",
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let body = body_json(resp).await;
+        let authorize_url = body["authorize_url"].as_str().unwrap();
+
+        // The DCR file must hold the resolved client_id + the secret.
+        let loaded = token_manager
+            .load_dcr("Acme Corp")
+            .await
+            .unwrap()
+            .expect("DCR credentials should be persisted for the org");
+        assert_eq!(loaded.client_id, "explicit-okta-client");
+        assert_eq!(loaded.client_secret.as_deref(), Some("super-secret-value"));
+        assert_eq!(loaded.issuer.as_deref(), Some(base_url.as_str()));
+
+        // config.toml must NOT contain the secret (only public org fields).
+        let disk = std::fs::read_to_string(&config_path).unwrap();
+        assert!(
+            !disk.contains("super-secret-value"),
+            "client_secret must never be written to config.toml; got: {disk}"
+        );
+        assert!(!disk.contains("client_secret"));
+        let orgs = config.read().await.organizations.clone();
+        assert_eq!(orgs.len(), 1);
+        assert_eq!(orgs[0].client_id.as_deref(), Some("explicit-okta-client"));
+
+        // The pending flow registered with the OAuthFlowManager must carry the
+        // secret so /oauth/callback includes it in the form body.
+        let state_param = extract_state_param(authorize_url);
+        let flow = flow_mgr
+            .consume_flow(&state_param)
+            .await
+            .expect("pending IdP flow was registered");
+        assert_eq!(flow.client_id, "explicit-okta-client");
+        assert_eq!(
+            flow.client_secret.as_deref(),
+            Some("super-secret-value"),
+            "create_organization must thread client_secret into the pending flow"
+        );
+    }
+
+    /// Public/PKCE org: omitting `client_secret` MUST keep the existing
+    /// behaviour byte-for-byte — no DCR file is written and the pending flow
+    /// carries no secret.
+    #[tokio::test]
+    async fn create_organization_without_client_secret_keeps_public_pkce_behaviour() {
+        let (base_url, _server) = spawn_mock_as(org_well_known_router()).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_orgs(tmp.path(), true).await;
+        let flow_mgr = state.oauth_flow_manager.clone().unwrap();
+        let token_manager = state.token_manager.clone().unwrap();
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::post("/api/organizations")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "name": "Acme Corp",
+                            "provider": "custom",
+                            "idp": base_url,
+                            "client_id": "explicit-okta-client",
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let body = body_json(resp).await;
+        let authorize_url = body["authorize_url"].as_str().unwrap();
+
+        assert!(
+            token_manager.load_dcr("Acme Corp").await.unwrap().is_none(),
+            "no DCR file should be written when client_secret is omitted"
+        );
+
+        let state_param = extract_state_param(authorize_url);
+        let flow = flow_mgr
+            .consume_flow(&state_param)
+            .await
+            .expect("pending IdP flow was registered");
+        assert!(
+            flow.client_secret.is_none(),
+            "public/PKCE flow must not carry a client_secret; got {:?}",
+            flow.client_secret
+        );
+    }
+
+    /// Re-authenticate threads the previously-stored client_secret into the
+    /// pending flow so the second authorize → token exchange uses it just like
+    /// the first one.
+    #[tokio::test]
+    async fn reauthenticate_organization_threads_stored_client_secret() {
+        let (base_url, _server) = spawn_mock_as(org_well_known_router()).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_orgs(tmp.path(), true).await;
+        let flow_mgr = state.oauth_flow_manager.clone().unwrap();
+        let token_manager = state.token_manager.clone().unwrap();
+
+        // Seed the org config + DCR store as if creation had captured a secret.
+        state.config.write().await.organizations = vec![crate::config::ConfigOrganization {
+            name: "Acme Corp".to_string(),
+            provider: "custom".to_string(),
+            idp: base_url.clone(),
+            client_id: Some("explicit-okta-client".to_string()),
+        }];
+        token_manager
+            .save_dcr(
+                "Acme Corp",
+                &DcrCredentials {
+                    client_id: "explicit-okta-client".to_string(),
+                    client_secret: Some("super-secret-value".to_string()),
+                    client_secret_expires_at: 0,
+                    registered_at: 0,
+                    issuer: Some(base_url.clone()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/organizations/Acme%20Corp/reauthenticate")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let authorize_url = body["authorize_url"].as_str().unwrap();
+
+        let state_param = extract_state_param(authorize_url);
+        let flow = flow_mgr
+            .consume_flow(&state_param)
+            .await
+            .expect("pending IdP flow was registered on reauth");
+        assert_eq!(flow.client_id, "explicit-okta-client");
+        assert_eq!(
+            flow.client_secret.as_deref(),
+            Some("super-secret-value"),
+            "reauthenticate must load and thread the stored client_secret"
+        );
+    }
+
+    /// PUT against an unknown org returns 404 and leaves config untouched.
+    #[tokio::test]
+    async fn update_organization_missing_returns_404() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_orgs(tmp.path(), true).await;
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::put("/api/organizations/ghost")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::json!({"name": "ghost"}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// Field-level update with no identity change (provider/idp/client_id all
+    /// match the existing org) returns the refreshed org metadata WITHOUT an
+    /// authorize_url and preserves pooled IdP credentials.
+    #[tokio::test]
+    async fn update_organization_no_identity_change_preserves_creds_and_returns_org() {
+        let (base_url, _server) = spawn_mock_as(org_well_known_router()).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_orgs(tmp.path(), true).await;
+        let tm = state.token_manager.clone().unwrap();
+        state.config.write().await.organizations = vec![crate::config::ConfigOrganization {
+            name: "Acme Corp".to_string(),
+            provider: "custom".to_string(),
+            idp: base_url.clone(),
+            client_id: None,
+        }];
+        tm.save_idp(
+            "Acme Corp",
+            &crate::token_manager::IdpCredentials {
+                idp_issuer: base_url.clone(),
+                id_token: "id-tok".to_string(),
+                refresh_token: Some("refresh-tok".to_string()),
+                id_token_expires_at: None,
+                obtained_at: 0,
+            },
+        )
+        .await
+        .unwrap();
+        let app = management_routes(state);
+
+        // Send a PUT with an empty body — everything preserved.
+        let resp = app
+            .oneshot(
+                Request::put("/api/organizations/Acme%20Corp")
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert!(
+            body.get("authorize_url").is_none(),
+            "no authorize_url should be returned when identity is unchanged; got: {body}"
+        );
+        assert_eq!(body["name"], "Acme Corp");
+        assert_eq!(body["authenticated"], true);
+        // IdP credentials must still be present.
+        assert!(tm.load_idp("Acme Corp").await.unwrap().is_some());
+    }
+
+    /// Changing the issuer (provider/slug/idp) purges pooled IdP credentials
+    /// so the org flips back to "Sign-in required", and the response carries
+    /// a fresh authorize URL pointing at the NEW issuer.
+    #[tokio::test]
+    async fn update_organization_issuer_change_purges_pooled_credentials() {
+        let (old_base_url, _old_server) = spawn_mock_as(org_well_known_router()).await;
+        let (new_base_url, _new_server) = spawn_mock_as(org_well_known_router()).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_orgs(tmp.path(), true).await;
+        let tm = state.token_manager.clone().unwrap();
+        let config = state.config.clone();
+        let config_path = state.config_path.clone().unwrap();
+        state.config.write().await.organizations = vec![crate::config::ConfigOrganization {
+            name: "Acme Corp".to_string(),
+            provider: "custom".to_string(),
+            idp: old_base_url.clone(),
+            client_id: None,
+        }];
+        tm.save_idp(
+            "Acme Corp",
+            &crate::token_manager::IdpCredentials {
+                idp_issuer: old_base_url.clone(),
+                id_token: "id-tok".to_string(),
+                refresh_token: Some("refresh-tok".to_string()),
+                id_token_expires_at: None,
+                obtained_at: 0,
+            },
+        )
+        .await
+        .unwrap();
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::put("/api/organizations/Acme%20Corp")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "provider": "custom",
+                            "idp": new_base_url,
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["idp"], new_base_url);
+        let authorize_url = body["authorize_url"]
+            .as_str()
+            .expect("issuer change must return an authorize_url since pooled creds were purged");
+        assert!(
+            authorize_url.starts_with(&format!("{new_base_url}/authorize?")),
+            "authorize_url should target the NEW issuer, got: {authorize_url}"
+        );
+
+        // Pooled IdP credentials must be gone — status flips to "Sign-in required".
+        assert!(tm.load_idp("Acme Corp").await.unwrap().is_none());
+        // config.toml + in-memory both reflect the new issuer.
+        let orgs = config.read().await.organizations.clone();
+        assert_eq!(orgs[0].idp, new_base_url);
+        let disk = std::fs::read_to_string(&config_path).unwrap();
+        assert!(disk.contains(&new_base_url));
+        assert!(!disk.contains(&old_base_url));
+    }
+
+    /// Changing the explicit `client_id` purges pooled IdP credentials and
+    /// the stale DCR record, then persists the new id.
+    #[tokio::test]
+    async fn update_organization_client_id_change_purges_pooled_credentials() {
+        let (base_url, _server) = spawn_mock_as(org_well_known_router()).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_orgs(tmp.path(), true).await;
+        let tm = state.token_manager.clone().unwrap();
+        let config = state.config.clone();
+        state.config.write().await.organizations = vec![crate::config::ConfigOrganization {
+            name: "Acme Corp".to_string(),
+            provider: "custom".to_string(),
+            idp: base_url.clone(),
+            client_id: Some("old-client".to_string()),
+        }];
+        tm.save_idp(
+            "Acme Corp",
+            &crate::token_manager::IdpCredentials {
+                idp_issuer: base_url.clone(),
+                id_token: "id-tok".to_string(),
+                refresh_token: Some("refresh-tok".to_string()),
+                id_token_expires_at: None,
+                obtained_at: 0,
+            },
+        )
+        .await
+        .unwrap();
+        tm.save_dcr(
+            "Acme Corp",
+            &DcrCredentials {
+                client_id: "old-client".to_string(),
+                client_secret: Some("old-secret".to_string()),
+                client_secret_expires_at: 0,
+                registered_at: 0,
+                issuer: Some(base_url.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::put("/api/organizations/Acme%20Corp")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"client_id": "new-client"}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let authorize_url = body["authorize_url"]
+            .as_str()
+            .expect("client_id change must return an authorize_url");
+        assert!(
+            authorize_url.contains("client_id=new-client"),
+            "authorize_url should carry the new client_id, got: {authorize_url}"
+        );
+
+        assert!(tm.load_idp("Acme Corp").await.unwrap().is_none());
+        // The stale DCR (bound to the old client_id) must be purged.
+        assert!(tm.load_dcr("Acme Corp").await.unwrap().is_none());
+        let orgs = config.read().await.organizations.clone();
+        assert_eq!(orgs[0].client_id.as_deref(), Some("new-client"));
+    }
+
+    /// `client_secret` lifecycle: set on a public/PKCE org, replace it, then
+    /// clear it. The DCR file is created, overwritten, then deleted; the
+    /// config.toml is never touched.
+    #[tokio::test]
+    async fn update_organization_client_secret_set_replace_clear() {
+        let (base_url, _server) = spawn_mock_as(org_well_known_router()).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_orgs(tmp.path(), true).await;
+        let tm = state.token_manager.clone().unwrap();
+        let config_path = state.config_path.clone().unwrap();
+        state.config.write().await.organizations = vec![crate::config::ConfigOrganization {
+            name: "Acme Corp".to_string(),
+            provider: "custom".to_string(),
+            idp: base_url.clone(),
+            client_id: Some("explicit-okta-client".to_string()),
+        }];
+        let app = management_routes(state);
+
+        // 1. SET — supply a secret on an org that had none.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::put("/api/organizations/Acme%20Corp")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"client_secret": "secret-v1"}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let creds = tm
+            .load_dcr("Acme Corp")
+            .await
+            .unwrap()
+            .expect("DCR file should exist after secret set");
+        assert_eq!(creds.client_id, "explicit-okta-client");
+        assert_eq!(creds.client_secret.as_deref(), Some("secret-v1"));
+        assert_eq!(creds.issuer.as_deref(), Some(base_url.as_str()));
+        let disk = std::fs::read_to_string(&config_path).unwrap();
+        assert!(!disk.contains("secret-v1"));
+        assert!(!disk.contains("client_secret"));
+
+        // 2. REPLACE — overwrite with a new secret.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::put("/api/organizations/Acme%20Corp")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"client_secret": "secret-v2"}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let creds = tm
+            .load_dcr("Acme Corp")
+            .await
+            .unwrap()
+            .expect("DCR file still present after replace");
+        assert_eq!(creds.client_secret.as_deref(), Some("secret-v2"));
+        let disk = std::fs::read_to_string(&config_path).unwrap();
+        assert!(!disk.contains("secret-v1"));
+        assert!(!disk.contains("secret-v2"));
+
+        // 3. CLEAR — empty string deletes the DCR record.
+        let resp = app
+            .oneshot(
+                Request::put("/api/organizations/Acme%20Corp")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"client_secret": ""}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(
+            tm.load_dcr("Acme Corp").await.unwrap().is_none(),
+            "DCR file should be removed when client_secret is explicitly cleared"
+        );
+    }
+
+    /// R3: the org route still captures the requesting `client_secret`, but the
+    /// EMA **resource** credential pair has moved to the endpoint (R3/D2) — any
+    /// resource fields posted to `/api/organizations` are now ignored and never
+    /// land in `{org}.dcr.json`.
+    #[tokio::test]
+    async fn update_organization_ignores_resource_creds_keeps_requesting_secret() {
+        let (base_url, _server) = spawn_mock_as(org_well_known_router()).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_orgs(tmp.path(), true).await;
+        let tm = state.token_manager.clone().unwrap();
+        let config_path = state.config_path.clone().unwrap();
+        state.config.write().await.organizations = vec![crate::config::ConfigOrganization {
+            name: "Acme Corp".to_string(),
+            provider: "custom".to_string(),
+            idp: base_url.clone(),
+            client_id: Some("explicit-okta-client".to_string()),
+        }];
+        let app = management_routes(state);
+
+        // Supply the requesting secret AND (now-ignored) resource fields.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::put("/api/organizations/Acme%20Corp")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "client_secret": "req-secret",
+                            "resource_client_id": "res-client",
+                            "resource_client_secret": "res-secret",
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let creds = tm
+            .load_dcr("Acme Corp")
+            .await
+            .unwrap()
+            .expect("DCR file should exist after set");
+        assert_eq!(creds.client_secret.as_deref(), Some("req-secret"));
+        assert!(
+            creds.resource_client_id.is_none(),
+            "org route must not persist a resource_client_id (moved to endpoint)"
+        );
+        assert!(
+            creds.resource_client_secret.is_none(),
+            "org route must not persist a resource_client_secret (moved to endpoint)"
+        );
+        // Secrets never leak into config.toml.
+        let disk = std::fs::read_to_string(&config_path).unwrap();
+        assert!(!disk.contains("req-secret"));
+        assert!(!disk.contains("res-secret"));
+    }
+
+    /// Rename purges pooled credentials at both keys and removes the old DCR,
+    /// returning an authorize_url so the user re-runs SSO under the new name.
+    #[tokio::test]
+    async fn update_organization_rename_purges_credentials_at_both_keys() {
+        let (base_url, _server) = spawn_mock_as(org_well_known_router()).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_orgs(tmp.path(), true).await;
+        let tm = state.token_manager.clone().unwrap();
+        let config = state.config.clone();
+        state.config.write().await.organizations = vec![crate::config::ConfigOrganization {
+            name: "Acme Corp".to_string(),
+            provider: "custom".to_string(),
+            idp: base_url.clone(),
+            client_id: None,
+        }];
+        tm.save_idp(
+            "Acme Corp",
+            &crate::token_manager::IdpCredentials {
+                idp_issuer: base_url.clone(),
+                id_token: "id-tok".to_string(),
+                refresh_token: Some("refresh-tok".to_string()),
+                id_token_expires_at: None,
+                obtained_at: 0,
+            },
+        )
+        .await
+        .unwrap();
+        tm.save_dcr(
+            "Acme Corp",
+            &DcrCredentials {
+                client_id: "old-client".to_string(),
+                client_secret: Some("old-secret".to_string()),
+                client_secret_expires_at: 0,
+                registered_at: 0,
+                issuer: Some(base_url.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::put("/api/organizations/Acme%20Corp")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"name": "Acme Inc"}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["name"], "Acme Inc");
+        assert!(
+            body.get("authorize_url").is_some(),
+            "rename must return a fresh authorize_url; got: {body}"
+        );
+
+        // Both the old and new IdP keys must be empty; the old DCR must be gone.
+        assert!(tm.load_idp("Acme Corp").await.unwrap().is_none());
+        assert!(tm.load_idp("Acme Inc").await.unwrap().is_none());
+        assert!(tm.load_dcr("Acme Corp").await.unwrap().is_none());
+
+        let orgs = config.read().await.organizations.clone();
+        assert_eq!(orgs.len(), 1);
+        assert_eq!(orgs[0].name, "Acme Inc");
+    }
+
+    /// Rename onto a name that already exists returns 409 and leaves the org
+    /// list untouched.
+    #[tokio::test]
+    async fn update_organization_rename_conflict_returns_409() {
+        let (base_url, _server) = spawn_mock_as(org_well_known_router()).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_orgs(tmp.path(), true).await;
+        let config = state.config.clone();
+        state.config.write().await.organizations = vec![
+            crate::config::ConfigOrganization {
+                name: "Acme Corp".to_string(),
+                provider: "custom".to_string(),
+                idp: base_url.clone(),
+                client_id: None,
+            },
+            crate::config::ConfigOrganization {
+                name: "Acme Inc".to_string(),
+                provider: "custom".to_string(),
+                idp: base_url.clone(),
+                client_id: None,
+            },
+        ];
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::put("/api/organizations/Acme%20Corp")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"name": "Acme Inc"}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        let orgs = config.read().await.organizations.clone();
+        assert_eq!(orgs.len(), 2);
+        assert!(orgs.iter().any(|o| o.name == "Acme Corp"));
     }
 }

--- a/src/management.rs
+++ b/src/management.rs
@@ -1597,6 +1597,22 @@ async fn set_endpoint_credentials(
         .into_response();
     }
 
+    // Symmetric guard: a resource secret must be paired with a resource client_id.
+    if resource_client_secret.is_some()
+        && resource_client_id
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or("")
+            .is_empty()
+    {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "resource_client_id must not be empty when setting resource_client_secret",
+            None,
+        )
+        .into_response();
+    }
+
     let client_secret_set = client_secret.is_some();
     let resource_client_secret_set = resource_client_secret.is_some();
 
@@ -8709,6 +8725,25 @@ command = "echo"
                     .header("content-type", "application/json")
                     .body(Body::from(
                         serde_json::json!({ "client_secret": "x" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn credentials_endpoint_rejects_missing_resource_client_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (state, _tm) = test_state_with_token_manager("ep1", tmp.path(), None, None).await;
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/ep1/credentials")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "resource_client_secret": "x" }).to_string(),
                     ))
                     .unwrap(),
             )

--- a/src/oauth/ema.rs
+++ b/src/oauth/ema.rs
@@ -34,9 +34,28 @@ const SUBJECT_TOKEN_TYPE_ID_TOKEN: &str = "urn:ietf:params:oauth:token-type:id_t
 const GRANT_TYPE_JWT_BEARER: &str = "urn:ietf:params:oauth:grant-type:jwt-bearer";
 /// OIDC `refresh_token` grant type used to mint a fresh ID Token at the IdP.
 const GRANT_TYPE_REFRESH_TOKEN: &str = "refresh_token";
-/// Scope requested on the IdP refresh grant: `openid` to re-mint an ID Token,
-/// `offline_access` to keep a refresh token.
-const REFRESH_SCOPE: &str = "openid offline_access";
+
+/// Compose the IdP-facing scope (Step-1 SSO authorize + the IdP `refresh_token`
+/// grant) from the resource's *configured* scopes. `openid` is always present so
+/// the IdP mints an ID Token; any configured resource scopes are appended
+/// (deduplicated); and `offline_access` is appended when a refresh token is
+/// desired. With no configured scope this yields the historical
+/// `openid offline_access` (or `openid` when no refresh token is wanted), so
+/// behavior is unchanged for endpoints that configure no scope.
+pub fn compose_idp_scope(resource_scope: Option<&str>, want_offline: bool) -> String {
+    let mut parts: Vec<&str> = vec!["openid"];
+    if let Some(scope) = resource_scope {
+        for tok in scope.split_whitespace() {
+            if !parts.contains(&tok) {
+                parts.push(tok);
+            }
+        }
+    }
+    if want_offline && !parts.contains(&"offline_access") {
+        parts.push("offline_access");
+    }
+    parts.join(" ")
+}
 
 /// Clock-skew buffer (seconds), mirroring `TokenSet::is_valid`.
 const EXP_SKEW_SECS: u64 = 30;
@@ -93,42 +112,93 @@ pub enum EmaError {
 
 /// Build the RFC 8693 token-exchange form body for the ID Token → ID-JAG leg
 /// (M4). Kept pure so the exact wire form can be asserted in isolation.
-fn build_id_jag_exchange_form(id_token: &str, resource_as_issuer: &str, resource: &str) -> String {
-    url::form_urlencoded::Serializer::new(String::new())
-        .append_pair("grant_type", GRANT_TYPE_TOKEN_EXCHANGE)
+///
+/// `client_id` is the IdP client identifier — the org's pre-registered id when
+/// present, else the hosted CIMD `client_id` ([`ENDARA_CLIENT_METADATA_URL`])
+/// when `None`. Okta's token-exchange grant requires this. `client_secret` is
+/// appended only when `Some` (confidential clients); a public client must omit
+/// it. `scope` (the resource's configured scopes) is appended only when `Some`
+/// and non-empty; with `None` the exchange omits `scope` exactly as before
+/// (regression-safe).
+fn build_id_jag_exchange_form(
+    id_token: &str,
+    resource_as_issuer: &str,
+    resource: &str,
+    scope: Option<&str>,
+    client_id: Option<&str>,
+    client_secret: Option<&str>,
+) -> String {
+    let client_id = client_id.unwrap_or(ENDARA_CLIENT_METADATA_URL);
+    let mut ser = url::form_urlencoded::Serializer::new(String::new());
+    ser.append_pair("grant_type", GRANT_TYPE_TOKEN_EXCHANGE)
         .append_pair("requested_token_type", REQUESTED_TOKEN_TYPE_ID_JAG)
         .append_pair("audience", resource_as_issuer)
         .append_pair("resource", resource)
         .append_pair("subject_token", id_token)
-        .append_pair("subject_token_type", SUBJECT_TOKEN_TYPE_ID_TOKEN)
-        .finish()
+        .append_pair("subject_token_type", SUBJECT_TOKEN_TYPE_ID_TOKEN);
+    if let Some(scope) = scope.filter(|s| !s.is_empty()) {
+        ser.append_pair("scope", scope);
+    }
+    ser.append_pair("client_id", client_id);
+    if let Some(secret) = client_secret {
+        ser.append_pair("client_secret", secret);
+    }
+    ser.finish()
 }
 
 /// Build the RFC 7523 jwt-bearer form body for the ID-JAG → access-token leg
-/// (M7). No client secret is sent: the relay is a public client identified by
-/// `client_id` — the org's pre-registered id when present, else the hosted CIMD
-/// `client_id` ([`ENDARA_CLIENT_METADATA_URL`]) when `None`.
-fn build_jwt_bearer_form(id_jag: &str, client_id: Option<&str>) -> String {
+/// (M7). The relay identifies itself via `client_id` — the org's pre-registered
+/// id when present, else the hosted CIMD `client_id`
+/// ([`ENDARA_CLIENT_METADATA_URL`]) when `None`. `client_secret` is appended
+/// only when `Some` (confidential clients authenticating via
+/// `client_secret_post`); a public client must omit it. `scope` carries the
+/// same resource scopes used on the Step 2 exchange and is appended only when
+/// `Some` and non-empty; with `None` the form omits `scope` exactly as before
+/// (regression-safe).
+fn build_jwt_bearer_form(
+    id_jag: &str,
+    scope: Option<&str>,
+    client_id: Option<&str>,
+    client_secret: Option<&str>,
+) -> String {
     let client_id = client_id.unwrap_or(ENDARA_CLIENT_METADATA_URL);
-    url::form_urlencoded::Serializer::new(String::new())
-        .append_pair("grant_type", GRANT_TYPE_JWT_BEARER)
-        .append_pair("assertion", id_jag)
-        .append_pair("client_id", client_id)
-        .finish()
+    let mut ser = url::form_urlencoded::Serializer::new(String::new());
+    ser.append_pair("grant_type", GRANT_TYPE_JWT_BEARER)
+        .append_pair("assertion", id_jag);
+    if let Some(scope) = scope.filter(|s| !s.is_empty()) {
+        ser.append_pair("scope", scope);
+    }
+    ser.append_pair("client_id", client_id);
+    if let Some(secret) = client_secret {
+        ser.append_pair("client_secret", secret);
+    }
+    ser.finish()
 }
 
 /// Build the OIDC `refresh_token` grant body used to mint a fresh ID Token at
 /// the IdP (M9). The relay is a public client identified by `client_id` — the
 /// org's pre-registered id when present, else the hosted CIMD `client_id`
-/// ([`ENDARA_CLIENT_METADATA_URL`]) when `None`; no secret is sent.
-fn build_refresh_token_form(refresh_token: &str, client_id: Option<&str>) -> String {
+/// ([`ENDARA_CLIENT_METADATA_URL`]) when `None`. `client_secret` is appended
+/// only when `Some` (confidential clients); a public client must omit it.
+/// `scope` is the IdP-facing scope composed by [`compose_idp_scope`] — it always
+/// carries `openid` and `offline_access` (so the IdP keeps re-minting ID Tokens
+/// and a refresh token) plus any configured resource scopes.
+fn build_refresh_token_form(
+    refresh_token: &str,
+    client_id: Option<&str>,
+    client_secret: Option<&str>,
+    scope: &str,
+) -> String {
     let client_id = client_id.unwrap_or(ENDARA_CLIENT_METADATA_URL);
-    url::form_urlencoded::Serializer::new(String::new())
-        .append_pair("grant_type", GRANT_TYPE_REFRESH_TOKEN)
+    let mut ser = url::form_urlencoded::Serializer::new(String::new());
+    ser.append_pair("grant_type", GRANT_TYPE_REFRESH_TOKEN)
         .append_pair("refresh_token", refresh_token)
         .append_pair("client_id", client_id)
-        .append_pair("scope", REFRESH_SCOPE)
-        .finish()
+        .append_pair("scope", scope);
+    if let Some(secret) = client_secret {
+        ser.append_pair("client_secret", secret);
+    }
+    ser.finish()
 }
 
 /// Map a non-success IdP token-exchange response to an [`EmaError`] (M5).
@@ -175,16 +245,28 @@ fn now_unix() -> u64 {
 /// ID-JAG JWT (the response `access_token`). The URL is validated through
 /// [`url_guard`] (M11). HTTP 400 `access_denied` maps to a terminal
 /// [`EmaError::AuthorizationDenied`]; other failures stay transport/expiry-class
-/// (M5).
+/// (M5). `scope` carries the resource's configured scopes onto the exchange form
+/// (omitted when `None`).
+#[allow(clippy::too_many_arguments)]
 pub async fn exchange_for_id_jag(
     idp_token_endpoint: &str,
     id_token: &str,
     resource_as_issuer: &str,
     resource: &str,
+    scope: Option<&str>,
     allow_insecure: bool,
+    client_id: Option<&str>,
+    client_secret: Option<&str>,
 ) -> Result<String, EmaError> {
     let client = url_guard::validated_client(idp_token_endpoint, allow_insecure).await?;
-    let form_body = build_id_jag_exchange_form(id_token, resource_as_issuer, resource);
+    let form_body = build_id_jag_exchange_form(
+        id_token,
+        resource_as_issuer,
+        resource,
+        scope,
+        client_id,
+        client_secret,
+    );
 
     let resp = client
         .post(idp_token_endpoint)
@@ -216,16 +298,21 @@ pub async fn exchange_for_id_jag(
 /// resource AS (M7/M8).
 ///
 /// POSTs the jwt-bearer grant to the **resource AS** token endpoint with
-/// `client_id=ENDARA_CLIENT_METADATA_URL` and no secret, then parses the
-/// response into a [`TokenSet`] mirroring the existing OAuth token parsing.
+/// `client_id` (the org's pre-registered id, or the hosted CIMD `client_id`
+/// when `None`). Confidential clients additionally authenticate via
+/// `client_secret_post` when `client_secret` is `Some`; public clients pass
+/// `None`. Parses the response into a [`TokenSet`] mirroring the existing
+/// OAuth token parsing.
 pub async fn redeem_id_jag(
     as_token_endpoint: &str,
     id_jag: &str,
+    scope: Option<&str>,
     allow_insecure: bool,
     client_id: Option<&str>,
+    client_secret: Option<&str>,
 ) -> Result<TokenSet, EmaError> {
     let client = url_guard::validated_client(as_token_endpoint, allow_insecure).await?;
-    let form_body = build_jwt_bearer_form(id_jag, client_id);
+    let form_body = build_jwt_bearer_form(id_jag, scope, client_id, client_secret);
 
     let resp = client
         .post(as_token_endpoint)
@@ -382,15 +469,19 @@ struct RefreshedIdToken {
 /// [`url_guard`], M11) and parses the new `id_token` (+ rotation) from the
 /// response. Any non-success status is surfaced as transport/expiry-class
 /// [`EmaError::TokenEndpoint`]; the caller maps a failed refresh to
-/// [`EmaError::ReauthRequired`].
+/// [`EmaError::ReauthRequired`]. `scope` is the IdP-facing scope composed by
+/// [`compose_idp_scope`] (always `openid offline_access`, plus any configured
+/// resource scopes).
 async fn refresh_idp_token(
     idp_token_endpoint: &str,
     refresh_token: &str,
     allow_insecure: bool,
     client_id: Option<&str>,
+    client_secret: Option<&str>,
+    scope: &str,
 ) -> Result<RefreshedIdToken, EmaError> {
     let client = url_guard::validated_client(idp_token_endpoint, allow_insecure).await?;
-    let form_body = build_refresh_token_form(refresh_token, client_id);
+    let form_body = build_refresh_token_form(refresh_token, client_id, client_secret, scope);
 
     let resp = client
         .post(idp_token_endpoint)
@@ -456,7 +547,10 @@ fn is_subject_token_invalid(err: &EmaError) -> bool {
 
 /// Run the IdP `refresh_token` grant, persist the rotated credentials, and
 /// return the fresh ID Token. A missing refresh token or any grant failure is
-/// surfaced as [`EmaError::ReauthRequired`] (M9: no silent loop).
+/// surfaced as [`EmaError::ReauthRequired`] (M9: no silent loop). `resource_scope`
+/// is the resource's configured scopes; it is composed with `openid` and
+/// `offline_access` via [`compose_idp_scope`] for the refresh grant.
+#[allow(clippy::too_many_arguments)]
 async fn refresh_and_persist_idp_token(
     token_manager: &TokenManager,
     idp_token_endpoint: &str,
@@ -464,6 +558,8 @@ async fn refresh_and_persist_idp_token(
     creds: &IdpCredentials,
     allow_insecure: bool,
     client_id: Option<&str>,
+    client_secret: Option<&str>,
+    resource_scope: Option<&str>,
 ) -> Result<String, EmaError> {
     let refresh_token = creds
         .refresh_token
@@ -472,11 +568,18 @@ async fn refresh_and_persist_idp_token(
             reason: "ID Token expired and no IdP refresh token is stored".to_string(),
         })?;
 
-    let refreshed = refresh_idp_token(idp_token_endpoint, refresh_token, allow_insecure, client_id)
-        .await
-        .map_err(|e| EmaError::ReauthRequired {
-            reason: format!("IdP refresh-token grant failed: {e}"),
-        })?;
+    let refreshed = refresh_idp_token(
+        idp_token_endpoint,
+        refresh_token,
+        allow_insecure,
+        client_id,
+        client_secret,
+        &compose_idp_scope(resource_scope, true),
+    )
+    .await
+    .map_err(|e| EmaError::ReauthRequired {
+        reason: format!("IdP refresh-token grant failed: {e}"),
+    })?;
 
     let new_creds = IdpCredentials {
         idp_issuer: creds.idp_issuer.clone(),
@@ -513,6 +616,22 @@ async fn refresh_and_persist_idp_token(
 ///
 /// `refresh_mutex` is supplied by the caller (the OAuth adapter owns one per
 /// endpoint), mirroring the adapter's existing refresh-coalescing guard.
+///
+/// **Credential routing (R1).** `client_id`/`client_secret` are the *requesting*
+/// client credentials and are used only on the IdP-facing legs (Step 2 exchange
+/// and the IdP `refresh_token` grant). `resource_client_id`/
+/// `resource_client_secret` are the optional *resource* credential presented at
+/// the MAS in Step 3 (`redeem_id_jag`). When no resource credential is
+/// configured, Step 3 reuses the requesting `client_id` (org id, else CIMD) for
+/// identification only and sends **no** `client_secret` — the requesting secret
+/// is never substituted at the MAS.
+///
+/// **Scope alignment (R2).** `resource_scope` carries the resource's configured
+/// scopes. It is threaded onto the Step 2 exchange and the Step 3 redemption
+/// verbatim (omitted when `None`), and composed with `openid`/`offline_access`
+/// via [`compose_idp_scope`] for the IdP `refresh_token` grant. With `None` the
+/// exchange/redemption omit `scope` and the refresh grant falls back to the
+/// historical `openid offline_access` (regression-safe).
 #[allow(clippy::too_many_arguments)]
 pub async fn ensure_access_token(
     token_manager: &TokenManager,
@@ -523,8 +642,12 @@ pub async fn ensure_access_token(
     as_issuer: &str,
     as_token_endpoint: &str,
     resource: &str,
+    resource_scope: Option<&str>,
     allow_insecure: bool,
     client_id: Option<&str>,
+    client_secret: Option<&str>,
+    resource_client_id: Option<&str>,
+    resource_client_secret: Option<&str>,
 ) -> Result<TokenSet, EmaError> {
     // Fast path: a still-valid persisted token needs neither lock nor network.
     if let Some(ts) = load_token(token_manager, endpoint).await? {
@@ -563,6 +686,8 @@ pub async fn ensure_access_token(
             &creds,
             allow_insecure,
             client_id,
+            client_secret,
+            resource_scope,
         )
         .await?;
         refreshed = true;
@@ -575,7 +700,10 @@ pub async fn ensure_access_token(
         &id_token,
         as_issuer,
         resource,
+        resource_scope,
         allow_insecure,
+        client_id,
+        client_secret,
     )
     .await
     {
@@ -588,6 +716,8 @@ pub async fn ensure_access_token(
                 &creds,
                 allow_insecure,
                 client_id,
+                client_secret,
+                resource_scope,
             )
             .await?;
             exchange_for_id_jag(
@@ -595,16 +725,31 @@ pub async fn ensure_access_token(
                 &new_id_token,
                 as_issuer,
                 resource,
+                resource_scope,
                 allow_insecure,
+                client_id,
+                client_secret,
             )
             .await?
         }
         Err(e) => return Err(e),
     };
 
-    // M6 claim validation, then Step 3 (RFC 7523) → access token.
+    // M6 claim validation, then Step 3 (RFC 7523) → access token. Step 3
+    // authenticates at the MAS with the optional **resource** credential, never
+    // the requesting client's secret (R1): the resource `client_id` is used when
+    // set (else the requesting `client_id`/CIMD for identification only) and the
+    // resource secret is sent solely when present.
     validate_id_jag(&id_jag, &idp_issuer, as_issuer, resource)?;
-    let token_set = redeem_id_jag(as_token_endpoint, &id_jag, allow_insecure, client_id).await?;
+    let token_set = redeem_id_jag(
+        as_token_endpoint,
+        &id_jag,
+        resource_scope,
+        allow_insecure,
+        resource_client_id.or(client_id),
+        resource_client_secret,
+    )
+    .await?;
     token_manager
         .save(endpoint, &token_set)
         .await
@@ -633,6 +778,9 @@ mod tests {
     const IDP_ISS: &str = "https://acme.okta.com";
     const AS_ISS: &str = "https://as.example.com";
     const RESOURCE: &str = "https://api.githubcopilot.com/mcp/";
+    /// Historical IdP-facing scope when no resource scope is configured:
+    /// `openid` re-mints an ID Token, `offline_access` keeps a refresh token.
+    const REFRESH_SCOPE: &str = "openid offline_access";
 
     fn parse_form(body: &str) -> HashMap<String, String> {
         url::form_urlencoded::parse(body.as_bytes())
@@ -650,7 +798,7 @@ mod tests {
 
     #[test]
     fn id_jag_exchange_form_has_exact_rfc8693_params() {
-        let body = build_id_jag_exchange_form("the-id-token", AS_ISS, RESOURCE);
+        let body = build_id_jag_exchange_form("the-id-token", AS_ISS, RESOURCE, None, None, None);
         let f = parse_form(&body);
         assert_eq!(
             f.get("grant_type").map(String::as_str),
@@ -670,14 +818,75 @@ mod tests {
             f.get("subject_token_type").map(String::as_str),
             Some("urn:ietf:params:oauth:token-type:id_token")
         );
-        assert_eq!(f.len(), 6, "exactly six params, no extras");
+        // Step 2 now always carries a `client_id` (Okta requires it); `None`
+        // resolves to the hosted CIMD `client_id`, and no secret is sent.
+        assert_eq!(
+            f.get("client_id").map(String::as_str),
+            Some(ENDARA_CLIENT_METADATA_URL)
+        );
+        assert!(
+            !f.contains_key("client_secret"),
+            "public client must not send a secret"
+        );
+        assert_eq!(f.len(), 7, "exactly seven params, no extras");
+    }
+
+    /// An explicit org `client_id` is sent verbatim on the Step 2 token-exchange
+    /// form; `None` keeps the hosted CIMD `client_id`. `client_secret` is
+    /// appended only when `Some` (confidential client).
+    #[test]
+    fn id_jag_exchange_form_client_id_and_secret() {
+        // Public client with an explicit org client_id, no secret.
+        let body = build_id_jag_exchange_form(
+            "the-id-token",
+            AS_ISS,
+            RESOURCE,
+            None,
+            Some("org-okta-client"),
+            None,
+        );
+        let f = parse_form(&body);
+        assert_eq!(
+            f.get("client_id").map(String::as_str),
+            Some("org-okta-client")
+        );
+        assert!(!f.contains_key("client_secret"));
+        assert_eq!(f.len(), 7, "no extras when secret is None");
+
+        // Confidential client with both client_id and client_secret.
+        let body = build_id_jag_exchange_form(
+            "the-id-token",
+            AS_ISS,
+            RESOURCE,
+            None,
+            Some("org-okta-client"),
+            Some("super-secret"),
+        );
+        let f = parse_form(&body);
+        assert_eq!(
+            f.get("client_id").map(String::as_str),
+            Some("org-okta-client")
+        );
+        assert_eq!(
+            f.get("client_secret").map(String::as_str),
+            Some("super-secret")
+        );
+        assert_eq!(f.len(), 8, "exactly eight params when secret is set");
+
+        // `None` client_id falls back to the hosted CIMD URL.
+        let body = build_id_jag_exchange_form("the-id-token", AS_ISS, RESOURCE, None, None, None);
+        let f = parse_form(&body);
+        assert_eq!(
+            f.get("client_id").map(String::as_str),
+            Some(ENDARA_CLIENT_METADATA_URL)
+        );
     }
 
     // ---- M7: jwt-bearer (Step 3) form exactness ------------------------------
 
     #[test]
     fn jwt_bearer_form_has_exact_rfc7523_params_and_no_secret() {
-        let body = build_jwt_bearer_form("the-id-jag", None);
+        let body = build_jwt_bearer_form("the-id-jag", None, None, None);
         let f = parse_form(&body);
         assert_eq!(
             f.get("grant_type").map(String::as_str),
@@ -699,7 +908,8 @@ mod tests {
     /// form; `None` keeps the hosted CIMD `client_id`.
     #[test]
     fn jwt_bearer_form_client_id_some_vs_none() {
-        let with_explicit = build_jwt_bearer_form("the-id-jag", Some("org-okta-client"));
+        let with_explicit =
+            build_jwt_bearer_form("the-id-jag", None, Some("org-okta-client"), None);
         let f = parse_form(&with_explicit);
         assert_eq!(
             f.get("client_id").map(String::as_str),
@@ -708,7 +918,7 @@ mod tests {
         assert!(!f.contains_key("client_secret"));
         assert_eq!(f.len(), 3, "exactly three params, no extras");
 
-        let with_none = build_jwt_bearer_form("the-id-jag", None);
+        let with_none = build_jwt_bearer_form("the-id-jag", None, None, None);
         let f = parse_form(&with_none);
         assert_eq!(
             f.get("client_id").map(String::as_str),
@@ -716,12 +926,47 @@ mod tests {
         );
     }
 
+    /// `client_secret` is appended to the Step 3 jwt-bearer form only when
+    /// `Some`; the rest of the form is unchanged. Public clients (`None`) keep
+    /// the exact three-param wire form.
+    #[test]
+    fn jwt_bearer_form_client_secret_present_vs_absent() {
+        let with_secret = build_jwt_bearer_form(
+            "the-id-jag",
+            None,
+            Some("org-okta-client"),
+            Some("super-secret"),
+        );
+        let f = parse_form(&with_secret);
+        assert_eq!(
+            f.get("grant_type").map(String::as_str),
+            Some("urn:ietf:params:oauth:grant-type:jwt-bearer")
+        );
+        assert_eq!(f.get("assertion").map(String::as_str), Some("the-id-jag"));
+        assert_eq!(
+            f.get("client_id").map(String::as_str),
+            Some("org-okta-client")
+        );
+        assert_eq!(
+            f.get("client_secret").map(String::as_str),
+            Some("super-secret")
+        );
+        assert_eq!(f.len(), 4, "exactly four params when secret is set");
+
+        let without_secret =
+            build_jwt_bearer_form("the-id-jag", None, Some("org-okta-client"), None);
+        let f = parse_form(&without_secret);
+        assert!(!f.contains_key("client_secret"));
+        assert_eq!(f.len(), 3);
+    }
+
     /// An explicit org `client_id` is sent verbatim on the IdP refresh form;
     /// `None` keeps the hosted CIMD `client_id`. `scope` and absence of a secret
-    /// are preserved in both cases.
+    /// are preserved when no secret is supplied.
     #[test]
     fn refresh_token_form_client_id_some_vs_none() {
-        let with_explicit = build_refresh_token_form("the-refresh", Some("org-okta-client"));
+        let with_explicit =
+            build_refresh_token_form("the-refresh", Some("org-okta-client"), None, REFRESH_SCOPE);
         let f = parse_form(&with_explicit);
         assert_eq!(
             f.get("grant_type").map(String::as_str),
@@ -739,13 +984,42 @@ mod tests {
         assert!(!f.contains_key("client_secret"));
         assert_eq!(f.len(), 4, "exactly four params, no extras");
 
-        let with_none = build_refresh_token_form("the-refresh", None);
+        let with_none = build_refresh_token_form("the-refresh", None, None, REFRESH_SCOPE);
         let f = parse_form(&with_none);
         assert_eq!(
             f.get("client_id").map(String::as_str),
             Some(ENDARA_CLIENT_METADATA_URL)
         );
         assert_eq!(f.get("scope").map(String::as_str), Some(REFRESH_SCOPE));
+    }
+
+    /// `client_secret` is appended to the IdP refresh form only when `Some`;
+    /// the rest of the form is unchanged.
+    #[test]
+    fn refresh_token_form_client_secret_present_vs_absent() {
+        let with_secret = build_refresh_token_form(
+            "the-refresh",
+            Some("org-okta-client"),
+            Some("super-secret"),
+            REFRESH_SCOPE,
+        );
+        let f = parse_form(&with_secret);
+        assert_eq!(
+            f.get("client_id").map(String::as_str),
+            Some("org-okta-client")
+        );
+        assert_eq!(
+            f.get("client_secret").map(String::as_str),
+            Some("super-secret")
+        );
+        assert_eq!(f.get("scope").map(String::as_str), Some(REFRESH_SCOPE));
+        assert_eq!(f.len(), 5, "exactly five params when secret is set");
+
+        let without_secret =
+            build_refresh_token_form("the-refresh", Some("org-okta-client"), None, REFRESH_SCOPE);
+        let f = parse_form(&without_secret);
+        assert!(!f.contains_key("client_secret"));
+        assert_eq!(f.len(), 4);
     }
 
     // ---- M6: ID-JAG validation -----------------------------------------------
@@ -758,6 +1032,66 @@ mod tests {
             "sub": "user-123",
             "exp": now_unix() + 600,
         })
+    }
+
+    // ---- R2: resource-scope composition + threading -------------------------
+
+    /// [`compose_idp_scope`] always leads with `openid`, appends configured
+    /// resource scopes (deduplicated), and appends `offline_access` only when a
+    /// refresh token is wanted. With no resource scope it reproduces the
+    /// historical `openid offline_access` (regression-safe).
+    #[test]
+    fn compose_idp_scope_cases() {
+        assert_eq!(compose_idp_scope(None, true), "openid offline_access");
+        assert_eq!(compose_idp_scope(None, false), "openid");
+        assert_eq!(
+            compose_idp_scope(Some("todos.read todos.write"), true),
+            "openid todos.read todos.write offline_access"
+        );
+        assert_eq!(
+            compose_idp_scope(Some("todos.read"), false),
+            "openid todos.read"
+        );
+        // Duplicates (incl. `openid`/`offline_access`) are not repeated.
+        assert_eq!(
+            compose_idp_scope(Some("openid todos.read offline_access todos.read"), true),
+            "openid todos.read offline_access"
+        );
+        // Empty/whitespace resource scope behaves like `None`.
+        assert_eq!(
+            compose_idp_scope(Some("   "), true),
+            "openid offline_access"
+        );
+    }
+
+    /// A configured resource `scope` is appended to the Step 2 exchange and the
+    /// Step 3 jwt-bearer forms; `None`/empty omits `scope` entirely.
+    #[test]
+    fn resource_scope_appended_to_exchange_and_redeem_forms() {
+        let body = build_id_jag_exchange_form(
+            "the-id-token",
+            AS_ISS,
+            RESOURCE,
+            Some("todos.read"),
+            None,
+            None,
+        );
+        let f = parse_form(&body);
+        assert_eq!(f.get("scope").map(String::as_str), Some("todos.read"));
+        assert_eq!(f.len(), 8, "scope adds exactly one param");
+
+        let body = build_jwt_bearer_form("the-id-jag", Some("todos.read"), None, None);
+        let f = parse_form(&body);
+        assert_eq!(f.get("scope").map(String::as_str), Some("todos.read"));
+        assert_eq!(f.len(), 4, "scope adds exactly one param");
+
+        // `None` and empty scope both omit the `scope` param (regression-safe).
+        for empty in [None, Some("")] {
+            let body = build_id_jag_exchange_form("t", AS_ISS, RESOURCE, empty, None, None);
+            assert!(!parse_form(&body).contains_key("scope"));
+            let body = build_jwt_bearer_form("j", empty, None, None);
+            assert!(!parse_form(&body).contains_key("scope"));
+        }
     }
 
     #[test]
@@ -1064,7 +1398,11 @@ mod tests {
             AS_ISS,
             "http://127.0.0.1:1/as/token",
             RESOURCE,
+            None,
             true,
+            None,
+            None,
+            None,
             None,
         )
         .await
@@ -1090,7 +1428,8 @@ mod tests {
         let lock = Mutex::new(());
 
         let ts = ensure_access_token(
-            &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, true, None,
+            &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, None, true, None, None,
+            None, None,
         )
         .await
         .expect("chain must succeed");
@@ -1129,7 +1468,8 @@ mod tests {
         let lock = Mutex::new(());
 
         let ts = ensure_access_token(
-            &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, true, None,
+            &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, None, true, None, None,
+            None, None,
         )
         .await
         .expect("refresh then chain must succeed");
@@ -1174,7 +1514,8 @@ mod tests {
         let lock = Mutex::new(());
 
         let ts = ensure_access_token(
-            &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, true, None,
+            &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, None, true, None, None,
+            None, None,
         )
         .await
         .expect("reactive refresh then retry must succeed");
@@ -1207,7 +1548,8 @@ mod tests {
         let lock = Mutex::new(());
 
         let err = ensure_access_token(
-            &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, true, None,
+            &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, None, true, None, None,
+            None, None,
         )
         .await
         .unwrap_err();
@@ -1238,7 +1580,11 @@ mod tests {
             AS_ISS,
             "http://127.0.0.1:1/as/token",
             RESOURCE,
+            None,
             true,
+            None,
+            None,
+            None,
             None,
         )
         .await
@@ -1265,7 +1611,11 @@ mod tests {
             AS_ISS,
             "http://127.0.0.1:1/as/token",
             RESOURCE,
+            None,
             true,
+            None,
+            None,
+            None,
             None,
         )
         .await
@@ -1300,7 +1650,8 @@ mod tests {
             let as_ep = as_ep.clone();
             handles.push(tokio::spawn(async move {
                 ensure_access_token(
-                    &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, true, None,
+                    &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, None, true,
+                    None, None, None, None,
                 )
                 .await
             }));
@@ -1317,6 +1668,209 @@ mod tests {
         );
         assert_eq!(c.redeem, 1, "coalesced: exactly one Step 3");
         drop(c);
+        server.abort();
+    }
+
+    // ---- R1: requesting vs resource credential routing -----------------------
+
+    /// Captured request forms for the credential-routing tests.
+    #[derive(Clone, Default)]
+    struct CapturedForms {
+        exchange: Arc<std::sync::Mutex<Option<HashMap<String, String>>>>,
+        redeem: Arc<std::sync::Mutex<Option<HashMap<String, String>>>>,
+    }
+
+    /// Spawn a mock token server that records the Step 2 (exchange) and Step 3
+    /// (redeem) request forms so the credential routing can be asserted. The IdP
+    /// endpoint returns a valid ID-JAG; the AS endpoint returns an access token.
+    async fn spawn_capturing_fixture(
+    ) -> (String, String, CapturedForms, tokio::task::JoinHandle<()>) {
+        use axum::extract::State;
+        use axum::http::StatusCode;
+        use axum::response::IntoResponse;
+        use axum::routing::post;
+        use axum::{Json, Router};
+
+        async fn idp_token(
+            State(cap): State<CapturedForms>,
+            body: String,
+        ) -> axum::response::Response {
+            let form: HashMap<String, String> = url::form_urlencoded::parse(body.as_bytes())
+                .into_owned()
+                .collect();
+            *cap.exchange.lock().unwrap() = Some(form);
+            let id_jag = make_jwt(serde_json::json!({
+                "iss": IDP_ISS,
+                "aud": AS_ISS,
+                "resource": RESOURCE,
+                "sub": "user-123",
+                "exp": now_unix() + 600,
+            }));
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({ "access_token": id_jag })),
+            )
+                .into_response()
+        }
+
+        async fn as_token(
+            State(cap): State<CapturedForms>,
+            body: String,
+        ) -> axum::response::Response {
+            let form: HashMap<String, String> = url::form_urlencoded::parse(body.as_bytes())
+                .into_owned()
+                .collect();
+            *cap.redeem.lock().unwrap() = Some(form);
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "access_token": "final-access-token",
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                })),
+            )
+                .into_response()
+        }
+
+        let cap = CapturedForms::default();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let base = format!("http://127.0.0.1:{}", addr.port());
+        let router = Router::new()
+            .route("/idp/token", post(idp_token))
+            .route("/as/token", post(as_token))
+            .with_state(cap.clone());
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        (
+            format!("{base}/idp/token"),
+            format!("{base}/as/token"),
+            cap,
+            handle,
+        )
+    }
+
+    /// Requesting creds authenticate the IdP-facing Step 2 exchange; the
+    /// resource creds authenticate the MAS-facing Step 3 redemption.
+    #[tokio::test]
+    async fn ensure_routes_requesting_creds_to_step2_and_resource_creds_to_step3() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        mgr.save_idp(
+            IDP_ISS,
+            &idp_creds("good-id-token", Some(now_unix() + 3600), None),
+        )
+        .await
+        .unwrap();
+        let (idp_ep, as_ep, cap, server) = spawn_capturing_fixture().await;
+        let lock = Mutex::new(());
+
+        let ts = ensure_access_token(
+            &mgr,
+            &lock,
+            "ep",
+            IDP_ISS,
+            &idp_ep,
+            AS_ISS,
+            &as_ep,
+            RESOURCE,
+            None,
+            true,
+            Some("req-client"),
+            Some("req-secret"),
+            Some("res-client"),
+            Some("res-secret"),
+        )
+        .await
+        .expect("chain must succeed");
+        assert_eq!(ts.access_token, "final-access-token");
+
+        let exchange = cap.exchange.lock().unwrap().clone().expect("Step 2 ran");
+        assert_eq!(
+            exchange.get("client_id").map(String::as_str),
+            Some("req-client"),
+            "Step 2 uses the requesting client_id"
+        );
+        assert_eq!(
+            exchange.get("client_secret").map(String::as_str),
+            Some("req-secret"),
+            "Step 2 uses the requesting secret"
+        );
+
+        let redeem = cap.redeem.lock().unwrap().clone().expect("Step 3 ran");
+        assert_eq!(
+            redeem.get("client_id").map(String::as_str),
+            Some("res-client"),
+            "Step 3 uses the resource client_id"
+        );
+        assert_eq!(
+            redeem.get("client_secret").map(String::as_str),
+            Some("res-secret"),
+            "Step 3 uses the resource secret"
+        );
+        server.abort();
+    }
+
+    /// With no resource credential configured, Step 3 identifies as the
+    /// requesting client_id but sends NO secret — and never the requesting
+    /// secret (R1). Step 2 still authenticates with the requesting confidential
+    /// creds.
+    #[tokio::test]
+    async fn step3_omits_secret_and_never_uses_requesting_secret_when_no_resource_cred() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        mgr.save_idp(
+            IDP_ISS,
+            &idp_creds("good-id-token", Some(now_unix() + 3600), None),
+        )
+        .await
+        .unwrap();
+        let (idp_ep, as_ep, cap, server) = spawn_capturing_fixture().await;
+        let lock = Mutex::new(());
+
+        ensure_access_token(
+            &mgr,
+            &lock,
+            "ep",
+            IDP_ISS,
+            &idp_ep,
+            AS_ISS,
+            &as_ep,
+            RESOURCE,
+            None,
+            true,
+            Some("req-client"),
+            Some("req-secret"),
+            None,
+            None,
+        )
+        .await
+        .expect("chain must succeed");
+
+        let exchange = cap.exchange.lock().unwrap().clone().expect("Step 2 ran");
+        assert_eq!(
+            exchange.get("client_secret").map(String::as_str),
+            Some("req-secret"),
+            "Step 2 still authenticates with the requesting secret"
+        );
+
+        let redeem = cap.redeem.lock().unwrap().clone().expect("Step 3 ran");
+        assert_eq!(
+            redeem.get("client_id").map(String::as_str),
+            Some("req-client"),
+            "Step 3 identifies as the requesting client_id when no resource id is set"
+        );
+        assert!(
+            !redeem.contains_key("client_secret"),
+            "Step 3 must omit client_secret when no resource credential is configured"
+        );
+        assert_ne!(
+            redeem.get("client_secret").map(String::as_str),
+            Some("req-secret"),
+            "Step 3 must never send the requesting secret"
+        );
         server.abort();
     }
 }

--- a/src/token_manager.rs
+++ b/src/token_manager.rs
@@ -43,7 +43,7 @@ impl TokenSet {
 }
 
 /// A set of DCR (Dynamic Client Registration) credentials for a single endpoint.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, PartialEq)]
 pub struct DcrCredentials {
     pub client_id: String,
     pub client_secret: Option<String>,
@@ -58,6 +58,23 @@ pub struct DcrCredentials {
     /// existed (treated as "reuse as-is" for backward compatibility).
     #[serde(default)]
     pub issuer: Option<String>,
+    /// Optional EMA **resource** client id used only at the MCP Authorization
+    /// Server (Step 3, RFC 7523 ID-JAG redemption). Distinct from `client_id`,
+    /// which is the *requesting* client used for SSO / the ID-JAG exchange at
+    /// the IdP. Spec-compliant MASes need no resource credential; xaa.dev/Okta
+    /// style MASes require this per-pairing credential. `None` (the common case)
+    /// keeps Step 3 on the requesting client_id with no secret. This pair is
+    /// **per-resource**, so R3 persists it on the *endpoint* DCR record
+    /// (`{name}.dcr.json`, 0600) — captured via
+    /// `POST /api/endpoints/{name}/credentials` — not the org record. For a
+    /// resource-only EMA endpoint the record's `client_id` is empty.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource_client_id: Option<String>,
+    /// Optional EMA **resource** client secret paired with `resource_client_id`,
+    /// presented via `client_secret_post` at the MAS in Step 3. Never sent on
+    /// the IdP-facing legs and never substituted by the requesting secret.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource_client_secret: Option<String>,
 }
 
 /// Per-IdP credentials captured during EMA Step 1 (IdP SSO). Holds the ID Token
@@ -431,6 +448,7 @@ mod tests {
             client_secret_expires_at: 0,
             registered_at: 1700000000,
             issuer: Some("https://auth.example.com".to_string()),
+            ..Default::default()
         }
     }
 
@@ -537,6 +555,7 @@ mod tests {
             client_secret_expires_at: 0,
             registered_at: 1700000000,
             issuer: None,
+            ..Default::default()
         };
 
         mgr.save_dcr("public-ep", &creds).await.unwrap();

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -865,12 +865,16 @@ fn resolve_ema_idp(
 /// resource AS (issuer + token endpoint). All URLs are routed through
 /// `url_guard` inside the discovery clients. Returns `None` if either discovery
 /// fails so the caller can register a [`FailedAdapter`].
+#[allow(clippy::too_many_arguments)]
 async fn resolve_ema_config(
     ep: &EndpointConfig,
     idp_key: &str,
     idp_issuer: &str,
     resource: &str,
     client_id: Option<&str>,
+    client_secret: Option<&str>,
+    resource_client_id: Option<&str>,
+    resource_client_secret: Option<&str>,
     allow_insecure_oauth: bool,
 ) -> Option<EmaConfig> {
     let idp_disc = match crate::oauth::discovery::discover_authorization_server(
@@ -912,6 +916,23 @@ async fn resolve_ema_config(
         // Org's pre-registered client_id (when set); `None` keeps the EMA legs
         // on the hosted CIMD `client_id`.
         client_id: client_id.map(str::to_string),
+        // Org's pre-registered client_secret (confidential client); `None`
+        // keeps the IdP-facing legs on the public/PKCE flow. The resource AS
+        // leg (Step 3) never uses this value.
+        client_secret: client_secret.map(str::to_string),
+        // Optional resource credential presented at the MAS in Step 3 (R1);
+        // `None` keeps Step 3 identifying as the requesting client_id with no
+        // secret.
+        resource_client_id: resource_client_id.map(str::to_string),
+        resource_client_secret: resource_client_secret.map(str::to_string),
+        // R2: the endpoint's configured resource scopes (space-delimited),
+        // threaded onto the EMA legs. An absent/empty list keeps the historical
+        // scopes (regression-safe).
+        resource_scope: ep
+            .scopes
+            .as_ref()
+            .map(|s| s.join(" "))
+            .filter(|s| !s.is_empty()),
     })
 }
 
@@ -969,12 +990,60 @@ async fn build_ema_adapter(
             .with_server_type_override(ep.server_type_override.clone()),
         );
     }
+    // Load the org DCR record (`{org}.dcr.json`) once for the requesting
+    // `client_secret` used on the IdP-facing legs (RFC 8693 Step 2 + the IdP
+    // refresh grant) so confidential clients authenticate with
+    // `client_secret_post`. Only honoured when the stored `client_id` matches
+    // the resolved org `client_id`; otherwise treated as stale and the legs fall
+    // back to the public flow. This requesting credential is genuinely org-level
+    // (the shared SSO/requesting app) and stays keyed by the org.
+    let dcr = match token_manager.load_dcr(&resolved.idp_key).await {
+        Ok(creds) => creds,
+        Err(e) => {
+            warn!(endpoint = %ep.name, organization = %resolved.idp_key, error = %e, "Failed to load org DCR credentials; continuing as public client");
+            None
+        }
+    };
+    let resolved_client_secret = match (resolved.client_id.as_deref(), dcr.as_ref()) {
+        (Some(org_client_id), Some(creds)) if creds.client_id == org_client_id => {
+            creds.client_secret.clone()
+        }
+        // No org client_id (CIMD/bare-idp END-18) or a stale/mismatched DCR
+        // record: no confidential secret on the IdP-facing legs.
+        _ => None,
+    };
+    // R3: the optional EMA **resource** credential pair (presented at the MAS in
+    // Step 3) is per-resource, so it is loaded from the *endpoint* DCR record
+    // (`{ep.name}.dcr.json`), captured via POST /api/endpoints/{name}/credentials
+    // — NOT from the org record. Loaded independently of the requesting
+    // `client_id` since it is a separate per-pairing credential; Step 3 never
+    // uses the requesting secret. `None` (the common case) keeps Step 3 on the
+    // requesting client_id with no secret. Any resource cred written to the org
+    // record by a pre-R3 build is intentionally ignored (re-enter it on the
+    // endpoint's Config tab).
+    let endpoint_dcr = match token_manager.load_dcr(&ep.name).await {
+        Ok(creds) => creds,
+        Err(e) => {
+            warn!(endpoint = %ep.name, error = %e, "Failed to load endpoint DCR credentials; continuing without a resource credential");
+            None
+        }
+    };
+    let resource_client_id = endpoint_dcr
+        .as_ref()
+        .and_then(|c| c.resource_client_id.clone());
+    let resource_client_secret = endpoint_dcr
+        .as_ref()
+        .and_then(|c| c.resource_client_secret.clone());
+
     let ema = match resolve_ema_config(
         ep,
         &resolved.idp_key,
         &resolved.idp_issuer,
         &resolved.resource,
         resolved.client_id.as_deref(),
+        resolved_client_secret.as_deref(),
+        resource_client_id.as_deref(),
+        resource_client_secret.as_deref(),
         allow_insecure_oauth,
     )
     .await
@@ -2409,6 +2478,7 @@ mod tests {
                 client_secret_expires_at: 0,
                 registered_at: 1_700_000_000,
                 issuer: None,
+                ..Default::default()
             },
         )
         .await

--- a/tests/ema_integration.rs
+++ b/tests/ema_integration.rs
@@ -280,6 +280,10 @@ fn ema_config(urls: &FxUrls) -> OAuthAdapterConfig {
             as_token_endpoint: urls.as_token_endpoint.clone(),
             resource: RESOURCE.to_string(),
             client_id: None,
+            client_secret: None,
+            resource_client_id: None,
+            resource_client_secret: None,
+            resource_scope: None,
         }),
     }
 }


### PR DESCRIPTION
## EMA slice 3 — per-endpoint resource creds, org lifecycle + server_type log-flood guards (END-19)

Refines the Enterprise-Managed Authentication (EMA) chain from the END-19 base PR (#121) with the slice-3 polish, plus a targeted logging fix that landed alongside the same work.

### Highlights

- **Per-endpoint resource credentials** — Step 3 (RFC 7523 ID-JAG redemption at the MAS) now loads a per-endpoint `resource_client_id` / `resource_client_secret` from the endpoint's own `{name}.dcr.json` store. These identify the endpoint at the resource AS and are **never** presented on the IdP-facing legs. New `resource_scope` field is threaded onto Step 2 (RFC 8693 token exchange) and Step 3 verbatim.
- **Org confidential-client secret** — new `client_secret` on `EmaConfig` (from `{org}.dcr.json`) is presented via `client_secret_post` on the IdP-facing legs (Step 2 exchange and IdP `refresh_token` grant) but never at the resource AS. Public/PKCE flow preserved when the secret is absent.
- **Composed IdP scope** — `compose_idp_scope` combines `openid` + `offline_access` (M1) with any configured `resource_scope` so the SSO authorize URL and the IdP `refresh_token` grant carry the full scope set the resource legs need.
- **Org lifecycle & re-auth surfacing** — management, `token_manager`, `watcher`, and the JIT OAuth-adapter path pick up the new fields; the OAuth adapter surfaces re-SSO-required states via `pending_authorize_url` so callers/desktop can prompt the user.
- **End-to-end coverage** — `tests/ema_integration.rs` walks the full three-leg chain with the new per-endpoint credentials and scope wiring.

### server_type log-flood guards

The per-endpoint tracing span records `server_type` via `Span::record` on every `initialize` handshake. Because `Span::record` **appends** each write to the span's field list, reconnects and token refreshes were causing the `endpoint{…}` log header to grow unbounded.

Fixed with an `AtomicBool` once-guard on each transport adapter (`http`, `sse`, `stdio`) and on `OAuthAdapterInner`, wired through a small `record_server_type_once` helper that flips the flag on the first non-empty write and short-circuits every subsequent call. Four regression tests exercise repeated calls (one per adapter).

### Commits

- `fix(logging): guard server_type span-field against duplication on reconnect/refresh`
- `feat(oauth): EMA slice 3 — per-endpoint resource credentials, org lifecycle, ID-JAG chain refinements (END-19)`

### Verification

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 2443 passed / 0 failed

Refs END-19.
