### PR TITLE
chore: bump version to 0.1.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "endara-relay"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endara-relay"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 description = "Local MCP tool aggregator — aggregate multiple MCP servers behind a single endpoint"
 license = "Apache-2.0"


### PR DESCRIPTION
Post-stable-v0.1.10 base version bump (Scenario 3).

Bumps the committed base version from `0.1.10` to `0.1.11`:

- `Cargo.toml` — package `version` field
- `Cargo.lock` — own-package version line (via `cargo update --workspace`)

No functional changes.
