### PR TITLE
fix(oauth): re-register DCR client instead of reusing stale client_id

### DIFF
--- a/src/adapter/oauth/jit.rs
+++ b/src/adapter/oauth/jit.rs
@@ -401,6 +401,9 @@ impl JitInterceptor {
                     client_secret_expires_at: resolved.client_secret_expires_at,
                     registered_at: now_secs(),
                     issuer: Some(disc.issuer.clone()),
+                    // Only true DCR (RFC 7591) counts as DCR provenance;
+                    // CIMD-resolved clients are never auto-discarded.
+                    registered_via_dcr: matches!(resolved.registration, ClientRegistration::Dcr),
                     ..Default::default()
                 };
                 if let Err(e) = tm.save_dcr(endpoint_name, &creds).await {

--- a/src/adapter/oauth/jit.rs
+++ b/src/adapter/oauth/jit.rs
@@ -338,6 +338,13 @@ impl JitInterceptor {
         // legacy files (which deserialize with `registered_via_dcr = false`)
         // are reused unconditionally — auto-discarding them and re-registering
         // would break the "manual credentials survive" promise.
+        //
+        // A DCR-provenanced record with an empty `client_id` is a
+        // post-self-heal tombstone left by `clear_dcr_requesting_client`
+        // (issuer cleared, resource pair possibly preserved). Its
+        // `issuer == None` would satisfy `dcr_issuer_allows_reuse`, but
+        // the empty id is not a usable requesting client — treat it as
+        // absent so JIT falls through to CIMD / fresh DCR registration.
         let preregistered = if let Some(ref tm) = self.token_manager {
             match tm.load_dcr(endpoint_name).await {
                 Ok(Some(creds)) => {
@@ -345,7 +352,14 @@ impl JitInterceptor {
                         creds.issuer.as_deref(),
                         Some(disc.issuer.as_str()),
                     );
-                    if !creds.registered_via_dcr || issuer_allows_reuse {
+                    let is_dcr_tombstone = creds.registered_via_dcr && creds.client_id.is_empty();
+                    if is_dcr_tombstone {
+                        info!(
+                            endpoint = %endpoint_name,
+                            "DCR post-self-heal tombstone detected; falling through to CIMD/DCR"
+                        );
+                        None
+                    } else if !creds.registered_via_dcr || issuer_allows_reuse {
                         Some((creds.client_id, creds.client_secret))
                     } else {
                         info!(
@@ -854,6 +868,58 @@ mod tests {
     /// authorize URL's `client_id` is the Endara CIMD URL — no DCR is attempted
     /// (the fixture serves no `/register`), and the pending flow carries no
     /// client_secret (public client).
+    /// R3-2: a post-self-heal DCR tombstone (`registered_via_dcr = true`,
+    /// `client_id = ""`, `issuer = None`) must NOT be reused as
+    /// pre-registered credentials — JIT must fall through to fresh DCR
+    /// registration and the resulting authorize URL must carry the newly
+    /// minted client_id, not an empty one.
+    #[tokio::test]
+    async fn intercept_falls_through_to_dcr_when_stored_creds_are_tombstone() {
+        let (base, server) = spawn_oauth_fixture().await;
+        let flow_mgr = Arc::new(OAuthFlowManager::new());
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        // Seed the post-self-heal tombstone shape that
+        // `clear_dcr_requesting_client` leaves on disk.
+        let tombstone = DcrCredentials {
+            client_id: String::new(),
+            client_secret: None,
+            client_secret_expires_at: 0,
+            registered_at: 0,
+            issuer: None,
+            resource_client_id: None,
+            resource_client_secret: None,
+            registered_via_dcr: true,
+        };
+        tm.save_dcr("tombstone-ep", &tombstone).await.unwrap();
+
+        let interceptor = JitInterceptor::new(9400, flow_mgr.clone(), Some(tm.clone()), true);
+
+        let www_authenticate = format!(
+            "Bearer realm=\"Test\", resource_metadata=\"{}/.well-known/oauth-protected-resource\"",
+            base
+        );
+        let resource_url = format!("{}/mcp", base);
+        let authorize_url = interceptor
+            .intercept(&resource_url, &www_authenticate, "tombstone-ep")
+            .await
+            .expect("intercept should fall through to fresh DCR registration");
+
+        let url = Url::parse(&authorize_url).unwrap();
+        let q: std::collections::HashMap<_, _> = url.query_pairs().into_owned().collect();
+        assert_eq!(
+            q.get("client_id").map(String::as_str),
+            Some("jit-client-123"),
+            "tombstone must be treated as absent; fresh DCR client_id must appear in the authorize URL"
+        );
+        // And the DCR file has been rewritten with the fresh id.
+        let stored = tm.load_dcr("tombstone-ep").await.unwrap().unwrap();
+        assert_eq!(stored.client_id, "jit-client-123");
+        assert!(stored.registered_via_dcr);
+
+        server.abort();
+    }
+
     #[tokio::test]
     async fn intercept_uses_cimd_client_id_when_advertised() {
         let (base, server) = spawn_oauth_fixture_cimd().await;

--- a/src/adapter/oauth/jit.rs
+++ b/src/adapter/oauth/jit.rs
@@ -29,7 +29,9 @@ use crate::oauth::client::{self, ClientRegistration, ResolvedClient};
 use crate::oauth::dcr::{self, ClientRegistrationResponse};
 use crate::oauth::discovery::{self, DiscoveryError, DiscoveryResult};
 use crate::oauth::{OAuthFlowManager, PkceChallenge};
-use crate::token_manager::{dcr_issuer_allows_reuse, merge_scopes, DcrCredentials, TokenManager};
+use crate::token_manager::{
+    dcr_issuer_allows_reuse, merge_scopes, DcrCredentials, TokenError, TokenManager,
+};
 use serde_json::{json, Value};
 
 /// A parsed `WWW-Authenticate: Bearer ...` challenge.
@@ -409,23 +411,45 @@ impl JitInterceptor {
         // Persist freshly-resolved credentials (DCR or CIMD) so future refresh /
         // re-auth can find the client_id. Pre-registered creds are already
         // stored; CIMD persists the constant client_id as a public client.
+        //
+        // Use `update_dcr` (compare-and-update under the DCR write lock) so a
+        // concurrent `POST /credentials` write that landed between our
+        // `load_dcr` above and this persist survives, and so any resource_*
+        // pair (operator-set MAS registration; distinct from the requesting
+        // client) already on disk — including one carried by a post-self-heal
+        // tombstone we just resolved through — is preserved. Round-4
+        // finding R4-2.
         if matches!(
             resolved.registration,
             ClientRegistration::Dcr | ClientRegistration::Cimd
         ) {
             if let Some(ref tm) = self.token_manager {
-                let creds = DcrCredentials {
-                    client_id: resolved.client_id.clone(),
-                    client_secret: resolved.client_secret.clone(),
-                    client_secret_expires_at: resolved.client_secret_expires_at,
-                    registered_at: now_secs(),
-                    issuer: Some(disc.issuer.clone()),
-                    // Only true DCR (RFC 7591) counts as DCR provenance;
-                    // CIMD-resolved clients are never auto-discarded.
-                    registered_via_dcr: matches!(resolved.registration, ClientRegistration::Dcr),
-                    ..Default::default()
-                };
-                if let Err(e) = tm.save_dcr(endpoint_name, &creds).await {
+                let new_client_id = resolved.client_id.clone();
+                let new_client_secret = resolved.client_secret.clone();
+                let expires_at = resolved.client_secret_expires_at;
+                let bind_issuer = disc.issuer.clone();
+                let is_dcr = matches!(resolved.registration, ClientRegistration::Dcr);
+                let update_res: Result<Option<DcrCredentials>, TokenError> = tm
+                    .update_dcr(endpoint_name, |current| {
+                        let (resource_client_id, resource_client_secret) = current
+                            .map(|c| (c.resource_client_id, c.resource_client_secret))
+                            .unwrap_or_default();
+                        Ok(Some(DcrCredentials {
+                            client_id: new_client_id.clone(),
+                            client_secret: new_client_secret.clone(),
+                            client_secret_expires_at: expires_at,
+                            registered_at: now_secs(),
+                            issuer: Some(bind_issuer.clone()),
+                            resource_client_id,
+                            resource_client_secret,
+                            // Only true DCR (RFC 7591) counts as DCR
+                            // provenance; CIMD-resolved clients are never
+                            // auto-discarded.
+                            registered_via_dcr: is_dcr,
+                        }))
+                    })
+                    .await;
+                if let Err(e) = update_res {
                     warn!(error = %e, "failed to persist JIT client credentials");
                 }
             }
@@ -916,6 +940,59 @@ mod tests {
         let stored = tm.load_dcr("tombstone-ep").await.unwrap().unwrap();
         assert_eq!(stored.client_id, "jit-client-123");
         assert!(stored.registered_via_dcr);
+
+        server.abort();
+    }
+
+    /// Round-4 finding R4-2: a JIT-driven fresh DCR persist on top of a
+    /// post-self-heal tombstone that already carries an operator-set
+    /// `resource_client_id`/`resource_client_secret` pair must PRESERVE the
+    /// resource pair on the freshly-written record (via `update_dcr`),
+    /// exactly like the interactive re-registration path in `management.rs`.
+    #[tokio::test]
+    async fn intercept_dcr_persist_preserves_resource_pair_on_tombstone() {
+        let (base, server) = spawn_oauth_fixture().await;
+        let flow_mgr = Arc::new(OAuthFlowManager::new());
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        // Post-self-heal tombstone that ALSO carries an operator-set MAS
+        // resource pair — a distinct registration that must survive the
+        // fresh DCR persist.
+        let tombstone = DcrCredentials {
+            client_id: String::new(),
+            client_secret: None,
+            client_secret_expires_at: 0,
+            registered_at: 0,
+            issuer: None,
+            resource_client_id: Some("mas-resource-client".to_string()),
+            resource_client_secret: Some("mas-resource-secret".to_string()),
+            registered_via_dcr: true,
+        };
+        tm.save_dcr("tombstone-mixed-ep", &tombstone).await.unwrap();
+
+        let interceptor = JitInterceptor::new(9400, flow_mgr.clone(), Some(tm.clone()), true);
+        let www_authenticate = format!(
+            "Bearer realm=\"Test\", resource_metadata=\"{}/.well-known/oauth-protected-resource\"",
+            base
+        );
+        let resource_url = format!("{}/mcp", base);
+        let _ = interceptor
+            .intercept(&resource_url, &www_authenticate, "tombstone-mixed-ep")
+            .await
+            .expect("intercept should fall through to fresh DCR registration");
+
+        let stored = tm.load_dcr("tombstone-mixed-ep").await.unwrap().unwrap();
+        assert_eq!(stored.client_id, "jit-client-123");
+        assert!(stored.registered_via_dcr);
+        assert_eq!(
+            stored.resource_client_id.as_deref(),
+            Some("mas-resource-client"),
+            "operator-set MAS resource pair must survive JIT fresh-DCR persist"
+        );
+        assert_eq!(
+            stored.resource_client_secret.as_deref(),
+            Some("mas-resource-secret")
+        );
 
         server.abort();
     }

--- a/src/adapter/oauth/jit.rs
+++ b/src/adapter/oauth/jit.rs
@@ -332,15 +332,20 @@ impl JitInterceptor {
         endpoint_name: &str,
     ) -> Result<ResolvedClient, JitError> {
         // Pre-registered (issuer-bound) stored credentials, validated for reuse.
+        //
+        // The issuer-mismatch discard only fires for DCR-provenanced records
+        // (`registered_via_dcr == true`). Manually-supplied credentials and
+        // legacy files (which deserialize with `registered_via_dcr = false`)
+        // are reused unconditionally — auto-discarding them and re-registering
+        // would break the "manual credentials survive" promise.
         let preregistered = if let Some(ref tm) = self.token_manager {
             match tm.load_dcr(endpoint_name).await {
                 Ok(Some(creds)) => {
-                    // Credential-to-issuer binding: only reuse a stored client_id
-                    // with the SAME authorization server that issued it. If the
-                    // AS issuer changed, discard and fall through (CIMD/DCR).
-                    // Legacy creds with no stored issuer are reused as-is.
-                    if dcr_issuer_allows_reuse(creds.issuer.as_deref(), Some(disc.issuer.as_str()))
-                    {
+                    let issuer_allows_reuse = dcr_issuer_allows_reuse(
+                        creds.issuer.as_deref(),
+                        Some(disc.issuer.as_str()),
+                    );
+                    if !creds.registered_via_dcr || issuer_allows_reuse {
                         Some((creds.client_id, creds.client_secret))
                     } else {
                         info!(

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -409,6 +409,23 @@ impl OAuthAdapterInner {
         }
     }
 
+    /// Snapshot the effective `(client_id, client_secret)` pair under a
+    /// single `client_credentials_override` read guard. Callers must use
+    /// this — not two `effective_client_*` reads — whenever they need both
+    /// halves atomically, because `set_client_credentials` can rotate the
+    /// pair between two separate acquisitions and let a refresh POST an
+    /// old id with a new secret (or vice-versa).
+    pub async fn effective_client_pair(&self) -> (String, Option<String>) {
+        if let Some((id, secret)) = self.client_credentials_override.read().await.as_ref() {
+            (id.clone(), secret.clone())
+        } else {
+            (
+                self.config.client_id.clone(),
+                self.config.client_secret.clone(),
+            )
+        }
+    }
+
     /// Install (or replace) the in-memory client-credentials override.
     ///
     /// Used by the management `/oauth/callback` handler to propagate the
@@ -498,12 +515,21 @@ impl OAuthAdapterInner {
         self.transition_to(OAuthState::Refreshing, "starting token refresh")
             .await;
 
+        // Snapshot the requesting (client_id, client_secret) under a single
+        // `client_credentials_override` read guard so a concurrent
+        // `set_client_credentials` cannot swap the pair between the two
+        // reads and let this refresh POST an old id with a new secret.
+        // The exact posted client_id is threaded into
+        // `handle_invalid_client_if_present` so an eventual `invalid_client`
+        // heal targets the id we actually presented — never one re-read
+        // after the fact.
+        let (posted_client_id, posted_client_secret) = self.effective_client_pair().await;
         let mut form_parts: Vec<(&str, String)> = vec![
             ("grant_type", "refresh_token".to_string()),
             ("refresh_token", refresh_token),
-            ("client_id", self.effective_client_id().await),
+            ("client_id", posted_client_id.clone()),
         ];
-        if let Some(secret) = self.effective_client_secret().await {
+        if let Some(secret) = posted_client_secret {
             form_parts.push(("client_secret", secret));
         }
 
@@ -525,8 +551,15 @@ impl OAuthAdapterInner {
                 Ok(token_set)
             }
             TokenPostOutcome::NotFound { status, body } => {
-                self.handle_refresh_404(&form_body, &initial_url, &correlation_id, status, body)
-                    .await
+                self.handle_refresh_404(
+                    &form_body,
+                    &initial_url,
+                    &correlation_id,
+                    &posted_client_id,
+                    status,
+                    body,
+                )
+                .await
             }
             TokenPostOutcome::HttpError { status, body } => {
                 error!(
@@ -536,7 +569,9 @@ impl OAuthAdapterInner {
                     "Token refresh failed"
                 );
                 self.metrics.inc_refresh_failure();
-                let reason = self.handle_invalid_client_if_present(&body).await;
+                let reason = self
+                    .handle_invalid_client_if_present(&body, &posted_client_id)
+                    .await;
                 self.transition_to(OAuthState::AuthRequired, reason).await;
                 Err(OAuthError::RefreshFailed { status, body })
             }
@@ -571,33 +606,41 @@ impl OAuthAdapterInner {
     /// Inspect an OAuth token-endpoint error body for `invalid_client` (RFC
     /// 6749 §5.2). If the current endpoint's DCR record was minted by the
     /// relay (`registered_via_dcr == true`) AND the stored `client_id` still
-    /// matches the one this refresh presented, atomically clear ONLY the
-    /// requesting `client_id`/`client_secret` pair (via
-    /// [`TokenManager::clear_dcr_requesting_client`]) so the next authorize
-    /// triggers a fresh RFC 7591 registration and returns a distinct
-    /// transition reason. Manually-supplied credentials
+    /// matches `posted_client_id` (the id this refresh actually presented),
+    /// atomically clear ONLY the requesting `client_id`/`client_secret`
+    /// pair (via [`TokenManager::clear_dcr_requesting_client`]) so the next
+    /// authorize triggers a fresh RFC 7591 registration and returns a
+    /// distinct transition reason. Manually-supplied credentials
     /// (`registered_via_dcr == false`), a stored `client_id` that no longer
     /// matches (i.e. a concurrent re-registration replaced the record), and
     /// endpoints with no DCR record are never auto-discarded; the caller
     /// receives the generic `"token refresh failed"` reason. Operator-set
     /// `resource_client_id`/`resource_client_secret` are preserved.
-    async fn handle_invalid_client_if_present(&self, body: &str) -> &'static str {
+    ///
+    /// `posted_client_id` is snapshotted by the caller under the same
+    /// `client_credentials_override` guard as the posted secret, so a
+    /// concurrent `set_client_credentials` cannot cause the self-heal to
+    /// target a different id than the one that actually failed.
+    async fn handle_invalid_client_if_present(
+        &self,
+        body: &str,
+        posted_client_id: &str,
+    ) -> &'static str {
         if !is_invalid_client_error(body) {
             return "token refresh failed";
         }
         let endpoint = &self.config.endpoint_name;
-        let requesting_client_id = self.effective_client_id().await;
         match self.token_manager.load_dcr(endpoint).await {
             Ok(Some(creds)) if creds.registered_via_dcr => {
                 match self
                     .token_manager
-                    .clear_dcr_requesting_client(endpoint, &requesting_client_id)
+                    .clear_dcr_requesting_client(endpoint, posted_client_id)
                     .await
                 {
                     Ok(true) => {
                         info!(
                             endpoint = %endpoint,
-                            client_id = %requesting_client_id,
+                            client_id = %posted_client_id,
                             "Cleared stale DCR requesting client after invalid_client at token endpoint"
                         );
                         "client registration invalidated; re-authorize to re-register"
@@ -605,7 +648,7 @@ impl OAuthAdapterInner {
                     Ok(false) => {
                         info!(
                             endpoint = %endpoint,
-                            failing_client_id = %requesting_client_id,
+                            failing_client_id = %posted_client_id,
                             stored_client_id = %creds.client_id,
                             "invalid_client for stale client_id; a newer registration is already persisted"
                         );
@@ -774,11 +817,19 @@ impl OAuthAdapterInner {
     /// endpoint and the retry succeeds; otherwise returns the original
     /// `RefreshFailed` error (the retry-failure path also transitions to
     /// `AuthRequired`, matching the pre-existing non-2xx behavior).
+    ///
+    /// `posted_client_id` is threaded through so that a retry against the
+    /// rediscovered token endpoint which returns an OAuth error body
+    /// containing `invalid_client` triggers the same self-heal as the
+    /// primary refresh path — otherwise a rediscovered endpoint proving the
+    /// requesting client dead would leave the stale DCR record intact and
+    /// loop.
     async fn handle_refresh_404(
         self: &Arc<Self>,
         form_body: &str,
         initial_url: &str,
         correlation_id: &str,
+        posted_client_id: &str,
         status: reqwest::StatusCode,
         body: String,
     ) -> Result<TokenSet, OAuthError> {
@@ -854,6 +905,27 @@ impl OAuthAdapterInner {
                     "Token refresh successful after rediscovery"
                 );
                 Ok(token_set)
+            }
+            // A rediscovered token endpoint may itself return an OAuth
+            // error body (e.g. `invalid_client` when the AS purged our
+            // registration); run the same self-heal as the primary refresh
+            // path so the rediscovery-and-retry route can also invalidate
+            // stale DCR credentials.
+            TokenPostOutcome::HttpError {
+                status: retry_status,
+                body: retry_body,
+            } => {
+                warn!(
+                    correlation_id = %correlation_id,
+                    %retry_status,
+                    "Token refresh retry after rediscovery failed with HTTP error; returning original 404"
+                );
+                self.metrics.inc_refresh_failure();
+                let reason = self
+                    .handle_invalid_client_if_present(&retry_body, posted_client_id)
+                    .await;
+                self.transition_to(OAuthState::AuthRequired, reason).await;
+                Err(original_err)
             }
             other => {
                 warn!(
@@ -2678,11 +2750,13 @@ mod tests {
 
     /// `invalid_client` (RFC 6749 §5.2) from the token endpoint with a
     /// DCR-registered record whose `client_id` matches the requesting
-    /// client must atomically clear the stale `{name}.dcr.json`, land in
+    /// client must atomically clear the stale requesting pair, land in
     /// `AuthRequired`, and record a distinct transition reason so callers
-    /// surface a re-authorize hint.
+    /// surface a re-authorize hint. The record itself is preserved as a
+    /// stub with `registered_via_dcr = true` so the next authorize prefers
+    /// re-registration over any stale `config.toml` `client_id`.
     #[tokio::test]
-    async fn do_token_refresh_invalid_client_deletes_dcr_registered_record() {
+    async fn do_token_refresh_invalid_client_clears_dcr_registered_record() {
         use crate::token_manager::DcrCredentials;
 
         let (url, server) = spawn_token_server("invalid_client").await;
@@ -2713,9 +2787,16 @@ mod tests {
             result
         );
 
+        let loaded = tm
+            .load_dcr("test")
+            .await
+            .unwrap()
+            .expect("pure-DCR self-heal must retain a stub record so auth-start re-registers");
+        assert_eq!(loaded.client_id, "");
+        assert!(loaded.client_secret.is_none());
         assert!(
-            tm.load_dcr("test").await.unwrap().is_none(),
-            "invalid_client with a matching DCR-registered record must remove {{name}}.dcr.json (no resource_* to preserve)"
+            loaded.registered_via_dcr,
+            "registered_via_dcr must survive so auth-start prefers re-registration over the stale config.toml client_id"
         );
         assert_eq!(
             adapter.inner.state.read().await.clone(),
@@ -2771,7 +2852,10 @@ mod tests {
             .expect("mixed record must persist so the resource pair is retained");
         assert_eq!(loaded.client_id, "");
         assert!(loaded.client_secret.is_none());
-        assert!(!loaded.registered_via_dcr);
+        assert!(
+            loaded.registered_via_dcr,
+            "mixed-record self-heal must retain the DCR provenance flag so auth-start prefers re-registration over the stale config.toml client_id"
+        );
         assert_eq!(loaded.resource_client_id.as_deref(), Some("mas-resource"));
         assert_eq!(
             loaded.resource_client_secret.as_deref(),
@@ -3435,6 +3519,12 @@ mod tests {
 
     /// Shared in/out counters and canned responses for the discovery test
     /// fixture. `None` for any of the metadata fields means "respond 404".
+    ///
+    /// `new_token_error_body`, when set, overrides `new_token_response` and
+    /// causes `/new/token` to respond with HTTP 400 and a raw OAuth error
+    /// body (e.g. `{"error":"invalid_client"}`) — used by the round-2 R6
+    /// regression that exercises `handle_refresh_404`'s retry path
+    /// self-heal.
     #[derive(Clone, Default)]
     struct DiscoveryFixtureOpts {
         new_token_count: Arc<std::sync::atomic::AtomicUsize>,
@@ -3444,6 +3534,7 @@ mod tests {
         pr_metadata: Option<serde_json::Value>,
         as_metadata: Option<serde_json::Value>,
         new_token_response: Option<serde_json::Value>,
+        new_token_error_body: Option<String>,
     }
 
     /// Build a `DiscoveryFixtureOpts` pre-populated with a valid protected-
@@ -3503,6 +3594,7 @@ mod tests {
             pr_metadata: Arc<Option<Value>>,
             as_metadata: Arc<Option<Value>>,
             new_token_response: Arc<Option<Value>>,
+            new_token_error_body: Arc<Option<String>>,
         }
 
         async fn old_token(State(fx): State<Fx>) -> impl IntoResponse {
@@ -3513,6 +3605,9 @@ mod tests {
         async fn new_token(State(fx): State<Fx>) -> impl IntoResponse {
             fx.new_token_count
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if let Some(body) = fx.new_token_error_body.as_ref() {
+                return (StatusCode::BAD_REQUEST, body.clone()).into_response();
+            }
             match fx.new_token_response.as_ref() {
                 Some(v) => (StatusCode::OK, Json(v.clone())).into_response(),
                 None => (StatusCode::NOT_FOUND, "not found").into_response(),
@@ -3543,6 +3638,7 @@ mod tests {
             pr_metadata: Arc::new(opts.pr_metadata),
             as_metadata: Arc::new(opts.as_metadata),
             new_token_response: Arc::new(opts.new_token_response),
+            new_token_error_body: Arc::new(opts.new_token_error_body),
         };
 
         let router = Router::new()
@@ -3794,6 +3890,100 @@ mod tests {
             new_token_count.load(std::sync::atomic::Ordering::SeqCst),
             0,
             "new token endpoint must NOT be POSTed without discovery"
+        );
+
+        server.abort();
+    }
+
+    /// Regression for PR #130 round-2 finding R6: when the primary token
+    /// endpoint returns 404 and OAuth discovery rediscovers a new endpoint,
+    /// but that retried endpoint returns an OAuth error body containing
+    /// `invalid_client`, `handle_refresh_404` must run the same self-heal
+    /// as the primary refresh path — clearing the requesting DCR pair and
+    /// emitting the "client registration invalidated" transition reason
+    /// — otherwise a rediscovery-and-retry route with a purged AS
+    /// registration would leave the stale DCR record intact and loop.
+    #[tokio::test]
+    async fn refresh_404_retry_invalid_client_triggers_self_heal() {
+        use crate::token_manager::DcrCredentials;
+
+        let (listener, base) = reserve_port().await;
+        let mut opts = happy_discovery_opts(&base);
+        opts.new_token_error_body = Some(
+            "{\"error\":\"invalid_client\",\"error_description\":\"unknown client\"}".to_string(),
+        );
+        // Clear the happy-path 200 body so we exercise the 400 branch.
+        opts.new_token_response = None;
+        let new_token_count = opts.new_token_count.clone();
+        let old_token_count = opts.old_token_count.clone();
+        let server = spawn_discovery_fixture_on(listener, opts).await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        tm.save_dcr(
+            "test",
+            &DcrCredentials {
+                client_id: "test-client".to_string(),
+                client_secret: Some("test-secret".to_string()),
+                registered_via_dcr: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let mut config = make_config();
+        config.url = base.clone();
+        config.token_endpoint_url = format!("{}/old/token", base);
+        config.client_secret = Some("test-secret".to_string());
+        config.allow_insecure_oauth = true;
+        let adapter = make_adapter_with_shared_tm(config, tm.clone()).await;
+
+        let result = adapter.inner.do_token_refresh().await;
+        assert!(
+            matches!(result, Err(OAuthError::RefreshFailed { .. })),
+            "expected RefreshFailed after failed retry, got {:?}",
+            result
+        );
+
+        assert_eq!(
+            old_token_count.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "old token endpoint must be hit exactly once"
+        );
+        assert_eq!(
+            new_token_count.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "rediscovered token endpoint must be retried exactly once"
+        );
+
+        // Self-heal must fire even though the failure surfaced through the
+        // rediscovery-and-retry path: the record persists as a stub with
+        // the requesting pair cleared but the DCR provenance flag intact.
+        let loaded = tm
+            .load_dcr("test")
+            .await
+            .unwrap()
+            .expect("post-self-heal stub must persist");
+        assert_eq!(loaded.client_id, "");
+        assert!(loaded.client_secret.is_none());
+        assert!(
+            loaded.registered_via_dcr,
+            "registered_via_dcr must survive so the next authorize re-registers"
+        );
+
+        assert_eq!(
+            adapter.inner.state.read().await.clone(),
+            OAuthState::AuthRequired,
+            "retry-with-invalid_client must still land in AuthRequired"
+        );
+        let history = adapter.inner.transition_history.read().await;
+        assert!(
+            history
+                .iter()
+                .any(|r| r.reason == "client registration invalidated; re-authorize to re-register"),
+            "rediscovery/retry self-heal must emit the same distinct transition reason as the primary refresh path, got: {:?}",
+            history.iter().map(|r| r.reason.clone()).collect::<Vec<_>>()
         );
 
         server.abort();

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -522,32 +522,55 @@ impl OAuthAdapterInner {
 
     /// Inspect an OAuth token-endpoint error body for `invalid_client` (RFC
     /// 6749 §5.2). If the current endpoint's DCR record was minted by the
-    /// relay (`registered_via_dcr == true`), delete the stale record so the
-    /// next authorize triggers a fresh RFC 7591 registration and returns a
-    /// distinct transition reason. Manually-supplied credentials
-    /// (`registered_via_dcr == false`) and endpoints with no DCR record are
-    /// never auto-discarded; the caller receives the generic
-    /// `"token refresh failed"` reason.
+    /// relay (`registered_via_dcr == true`) AND the stored `client_id` still
+    /// matches the one this refresh presented, atomically clear ONLY the
+    /// requesting `client_id`/`client_secret` pair (via
+    /// [`TokenManager::clear_dcr_requesting_client`]) so the next authorize
+    /// triggers a fresh RFC 7591 registration and returns a distinct
+    /// transition reason. Manually-supplied credentials
+    /// (`registered_via_dcr == false`), a stored `client_id` that no longer
+    /// matches (i.e. a concurrent re-registration replaced the record), and
+    /// endpoints with no DCR record are never auto-discarded; the caller
+    /// receives the generic `"token refresh failed"` reason. Operator-set
+    /// `resource_client_id`/`resource_client_secret` are preserved.
     async fn handle_invalid_client_if_present(&self, body: &str) -> &'static str {
         if !is_invalid_client_error(body) {
             return "token refresh failed";
         }
         let endpoint = &self.config.endpoint_name;
+        let requesting_client_id = self.config.client_id.clone();
         match self.token_manager.load_dcr(endpoint).await {
             Ok(Some(creds)) if creds.registered_via_dcr => {
-                if let Err(e) = self.token_manager.delete_dcr(endpoint).await {
-                    error!(
-                        endpoint = %endpoint,
-                        error = %e,
-                        "Failed to delete stale DCR credentials after invalid_client"
-                    );
-                    "token refresh failed"
-                } else {
-                    info!(
-                        endpoint = %endpoint,
-                        "Discarded stale DCR credentials after invalid_client at token endpoint"
-                    );
-                    "client registration invalidated; re-authorize to re-register"
+                match self
+                    .token_manager
+                    .clear_dcr_requesting_client(endpoint, &requesting_client_id)
+                    .await
+                {
+                    Ok(true) => {
+                        info!(
+                            endpoint = %endpoint,
+                            client_id = %requesting_client_id,
+                            "Cleared stale DCR requesting client after invalid_client at token endpoint"
+                        );
+                        "client registration invalidated; re-authorize to re-register"
+                    }
+                    Ok(false) => {
+                        info!(
+                            endpoint = %endpoint,
+                            failing_client_id = %requesting_client_id,
+                            stored_client_id = %creds.client_id,
+                            "invalid_client for stale client_id; a newer registration is already persisted"
+                        );
+                        "token refresh failed"
+                    }
+                    Err(e) => {
+                        error!(
+                            endpoint = %endpoint,
+                            error = %e,
+                            "Failed to clear stale DCR requesting client after invalid_client"
+                        );
+                        "token refresh failed"
+                    }
                 }
             }
             _ => "token refresh failed",
@@ -2499,9 +2522,10 @@ mod tests {
     }
 
     /// `invalid_client` (RFC 6749 §5.2) from the token endpoint with a
-    /// DCR-registered record must delete the stale `{name}.dcr.json`, land
-    /// in `AuthRequired`, and record a distinct transition reason so
-    /// callers surface a re-authorize hint.
+    /// DCR-registered record whose `client_id` matches the requesting
+    /// client must atomically clear the stale `{name}.dcr.json`, land in
+    /// `AuthRequired`, and record a distinct transition reason so callers
+    /// surface a re-authorize hint.
     #[tokio::test]
     async fn do_token_refresh_invalid_client_deletes_dcr_registered_record() {
         use crate::token_manager::DcrCredentials;
@@ -2509,11 +2533,13 @@ mod tests {
         let (url, server) = spawn_token_server("invalid_client").await;
         let tmp = tempfile::tempdir().unwrap();
         let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
-        // Seed a DCR-minted credential record for the endpoint.
+        // Seed a DCR-minted credential record that matches the adapter's
+        // configured `client_id` — that pair is what the refresh POST will
+        // present to the token endpoint.
         tm.save_dcr(
             "test",
             &DcrCredentials {
-                client_id: "dcr-client-123".to_string(),
+                client_id: "test-client".to_string(),
                 registered_via_dcr: true,
                 ..Default::default()
             },
@@ -2534,7 +2560,7 @@ mod tests {
 
         assert!(
             tm.load_dcr("test").await.unwrap().is_none(),
-            "invalid_client with a DCR-registered record must delete {{name}}.dcr.json"
+            "invalid_client with a matching DCR-registered record must remove {{name}}.dcr.json (no resource_* to preserve)"
         );
         assert_eq!(
             adapter.inner.state.read().await.clone(),
@@ -2548,6 +2574,103 @@ mod tests {
                 .any(|r| r.reason == "client registration invalidated; re-authorize to re-register"),
             "expected the distinct invalid_client transition reason, got: {:?}",
             history.iter().map(|r| r.reason.clone()).collect::<Vec<_>>()
+        );
+
+        server.abort();
+    }
+
+    /// A mixed DCR record (the requesting `client_id`/`client_secret` sits
+    /// alongside an operator-set `resource_client_id`/`resource_client_secret`)
+    /// must have its requesting pair cleared on `invalid_client` while the
+    /// resource pair survives — the resource credential is a distinct
+    /// registration used only at the MAS in Step 3.
+    #[tokio::test]
+    async fn do_token_refresh_invalid_client_preserves_resource_pair() {
+        use crate::token_manager::DcrCredentials;
+
+        let (url, server) = spawn_token_server("invalid_client").await;
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let mixed = DcrCredentials {
+            client_id: "test-client".to_string(),
+            client_secret: Some("test-secret".to_string()),
+            client_secret_expires_at: 0,
+            registered_at: 1_700_000_000,
+            issuer: Some("https://as.example.com".to_string()),
+            resource_client_id: Some("mas-resource".to_string()),
+            resource_client_secret: Some("mas-resource-secret".to_string()),
+            registered_via_dcr: true,
+        };
+        tm.save_dcr("test", &mixed).await.unwrap();
+
+        let mut config = make_config();
+        config.token_endpoint_url = url;
+        let adapter = make_adapter_with_shared_tm(config, tm.clone()).await;
+
+        let _ = adapter.inner.do_token_refresh().await;
+
+        let loaded = tm
+            .load_dcr("test")
+            .await
+            .unwrap()
+            .expect("mixed record must persist so the resource pair is retained");
+        assert_eq!(loaded.client_id, "");
+        assert!(loaded.client_secret.is_none());
+        assert!(!loaded.registered_via_dcr);
+        assert_eq!(loaded.resource_client_id.as_deref(), Some("mas-resource"));
+        assert_eq!(
+            loaded.resource_client_secret.as_deref(),
+            Some("mas-resource-secret")
+        );
+
+        server.abort();
+    }
+
+    /// A concurrent re-registration replaces the DCR record with a NEWER
+    /// `client_id` while an in-flight refresh is still using the previous
+    /// one. When that stale refresh eventually returns `invalid_client`,
+    /// the self-heal must not touch the newer record: `invalid_client`
+    /// only proves the presented `client_id` is gone.
+    #[tokio::test]
+    async fn do_token_refresh_invalid_client_leaves_newer_registration_intact() {
+        use crate::token_manager::DcrCredentials;
+
+        let (url, server) = spawn_token_server("invalid_client").await;
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        // Persisted record already carries a NEWER client_id (a concurrent
+        // re-registration succeeded first). The adapter's config still has
+        // the old client_id — that is the one this refresh will present.
+        let newer = DcrCredentials {
+            client_id: "fresh-client".to_string(),
+            client_secret: Some("fresh-secret".to_string()),
+            registered_via_dcr: true,
+            ..Default::default()
+        };
+        tm.save_dcr("test", &newer).await.unwrap();
+
+        let mut config = make_config();
+        config.token_endpoint_url = url;
+        assert_eq!(config.client_id, "test-client");
+        let adapter = make_adapter_with_shared_tm(config, tm.clone()).await;
+
+        let _ = adapter.inner.do_token_refresh().await;
+
+        let loaded = tm
+            .load_dcr("test")
+            .await
+            .unwrap()
+            .expect("newer registration must survive stale invalid_client");
+        assert_eq!(loaded.client_id, "fresh-client");
+        assert_eq!(loaded.client_secret.as_deref(), Some("fresh-secret"));
+        assert!(loaded.registered_via_dcr);
+
+        let history = adapter.inner.transition_history.read().await;
+        assert!(
+            !history
+                .iter()
+                .any(|r| r.reason == "client registration invalidated; re-authorize to re-register"),
+            "stale invalid_client for a superseded client_id must NOT emit the re-register reason"
         );
 
         server.abort();

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -221,6 +221,14 @@ pub struct OAuthAdapterInner {
     /// URL. Cleared only on adapter reconstruction; not persisted to disk
     /// (that is handled separately by the startup-time migration path).
     token_endpoint_override: RwLock<Option<String>>,
+    /// In-memory override of `config.client_id` / `config.client_secret`.
+    /// Populated by the management `/oauth/callback` handler after a
+    /// successful interactive re-authorization that produced a fresh RFC
+    /// 7591 registration, so subsequent proactive refreshes POST the newly
+    /// minted requesting client credentials instead of the stale ones baked
+    /// into `config.toml` at startup. Cleared only on adapter reconstruction;
+    /// not persisted to disk (config-file coherence is handled separately).
+    client_credentials_override: RwLock<Option<(String, Option<String>)>>,
     /// The inner HTTP/SSE adapter that talks to the upstream MCP server.
     inner_adapter: RwLock<Option<HttpAdapter>>,
     /// Token persistence layer.
@@ -373,6 +381,46 @@ impl OAuthAdapterInner {
         *self.token_endpoint_override.write().await = Some(url);
     }
 
+    /// Resolve the `client_id` that the next token-refresh POST should
+    /// present.
+    ///
+    /// Returns the in-memory `client_credentials_override` if a previous
+    /// interactive re-authorization propagated a freshly re-registered
+    /// client, otherwise the immutable `config.client_id` baked in at
+    /// adapter construction. Checked at the top of every refresh attempt
+    /// so subsequent refreshes after a successful re-registration go
+    /// straight to the new `client_id` without needing to rebuild the
+    /// adapter.
+    pub async fn effective_client_id(&self) -> String {
+        if let Some((id, _)) = self.client_credentials_override.read().await.as_ref() {
+            id.clone()
+        } else {
+            self.config.client_id.clone()
+        }
+    }
+
+    /// Resolve the `client_secret` that the next token-refresh POST should
+    /// present, mirroring [`Self::effective_client_id`].
+    pub async fn effective_client_secret(&self) -> Option<String> {
+        if let Some((_, secret)) = self.client_credentials_override.read().await.as_ref() {
+            secret.clone()
+        } else {
+            self.config.client_secret.clone()
+        }
+    }
+
+    /// Install (or replace) the in-memory client-credentials override.
+    ///
+    /// Used by the management `/oauth/callback` handler to propagate the
+    /// requesting `client_id` / `client_secret` freshly minted by an RFC
+    /// 7591 re-registration during an interactive re-authorization, so
+    /// that the next proactive refresh POSTs the new credentials instead
+    /// of the stale ones from startup config. Mirrors
+    /// [`Self::set_token_endpoint_override`].
+    pub async fn set_client_credentials(&self, client_id: String, client_secret: Option<String>) {
+        *self.client_credentials_override.write().await = Some((client_id, client_secret));
+    }
+
     /// Perform a token refresh using the refresh_token grant.
     ///
     /// POSTs to the token endpoint (using `effective_token_endpoint`) with
@@ -453,10 +501,10 @@ impl OAuthAdapterInner {
         let mut form_parts: Vec<(&str, String)> = vec![
             ("grant_type", "refresh_token".to_string()),
             ("refresh_token", refresh_token),
-            ("client_id", self.config.client_id.clone()),
+            ("client_id", self.effective_client_id().await),
         ];
-        if let Some(ref secret) = self.config.client_secret {
-            form_parts.push(("client_secret", secret.clone()));
+        if let Some(secret) = self.effective_client_secret().await {
+            form_parts.push(("client_secret", secret));
         }
 
         let form_body: String = url::form_urlencoded::Serializer::new(String::new())
@@ -538,7 +586,7 @@ impl OAuthAdapterInner {
             return "token refresh failed";
         }
         let endpoint = &self.config.endpoint_name;
-        let requesting_client_id = self.config.client_id.clone();
+        let requesting_client_id = self.effective_client_id().await;
         match self.token_manager.load_dcr(endpoint).await {
             Ok(Some(creds)) if creds.registered_via_dcr => {
                 match self
@@ -1217,6 +1265,7 @@ impl OAuthAdapter {
                 tokens: RwLock::new(None),
                 config,
                 token_endpoint_override: RwLock::new(None),
+                client_credentials_override: RwLock::new(None),
                 inner_adapter: RwLock::new(None),
                 token_manager,
                 http_client: Client::builder()
@@ -1982,6 +2031,112 @@ mod tests {
             adapter.inner.effective_token_endpoint().await,
             "https://oauth2.googleapis.com/v2/token"
         );
+    }
+
+    /// `set_client_credentials` installs an in-memory override that
+    /// supersedes `config.client_id` / `config.client_secret` for every
+    /// subsequent `effective_client_*` read. Mirrors the behaviour of
+    /// `set_token_endpoint_override`.
+    #[tokio::test]
+    async fn set_client_credentials_takes_effect() {
+        let adapter = make_adapter(make_config());
+        assert_eq!(adapter.inner.effective_client_id().await, "test-client");
+        assert!(adapter.inner.effective_client_secret().await.is_none());
+
+        adapter
+            .inner
+            .set_client_credentials("fresh-client".to_string(), Some("fresh-secret".to_string()))
+            .await;
+
+        assert_eq!(adapter.inner.effective_client_id().await, "fresh-client");
+        assert_eq!(
+            adapter.inner.effective_client_secret().await.as_deref(),
+            Some("fresh-secret")
+        );
+
+        // Replacing again overwrites the previous value (idempotent setter).
+        adapter
+            .inner
+            .set_client_credentials("even-fresher".to_string(), None)
+            .await;
+        assert_eq!(adapter.inner.effective_client_id().await, "even-fresher");
+        assert!(adapter.inner.effective_client_secret().await.is_none());
+    }
+
+    /// After `set_client_credentials`, the refresh POST body must carry
+    /// the override `client_id` (and `client_secret` when present) — not
+    /// the stale `config.client_id` / `config.client_secret` baked in at
+    /// adapter construction. Guards Finding 2 of PR #130: without the
+    /// propagation, the next refresh after a DCR re-registration would
+    /// keep POSTing the pre-re-registration client_id and loop through
+    /// the `invalid_client` self-heal.
+    #[tokio::test]
+    async fn refresh_uses_overridden_client_credentials() {
+        use axum::extract::Form;
+        use axum::http::StatusCode;
+        use axum::{response::IntoResponse, routing::post, Router};
+        use std::collections::HashMap;
+        use std::sync::Mutex;
+
+        // Mock token endpoint that captures the last POSTed form and
+        // always returns 401 invalid_client (we only care about the body
+        // this adapter sent, not the response shape).
+        type CapturedForm = Arc<Mutex<Option<HashMap<String, String>>>>;
+        let captured: CapturedForm = Arc::new(Mutex::new(None));
+        let captured_clone = captured.clone();
+        async fn handler(
+            axum::extract::State(cap): axum::extract::State<CapturedForm>,
+            Form(form): Form<HashMap<String, String>>,
+        ) -> impl IntoResponse {
+            *cap.lock().unwrap() = Some(form);
+            (StatusCode::UNAUTHORIZED, "{\"error\":\"invalid_client\"}")
+        }
+        let router = Router::new()
+            .route("/token", post(handler))
+            .with_state(captured_clone);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let url = format!("http://127.0.0.1:{}/token", addr.port());
+
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let mut config = make_config();
+        config.token_endpoint_url = url;
+        // Config baked in at startup carries the STALE credentials.
+        config.client_id = "stale-client".to_string();
+        config.client_secret = Some("stale-secret".to_string());
+        let adapter = make_adapter_with_shared_tm(config, tm.clone()).await;
+
+        // A successful interactive re-authorization propagated the
+        // freshly re-registered credentials into the override.
+        adapter
+            .inner
+            .set_client_credentials("fresh-client".to_string(), Some("fresh-secret".to_string()))
+            .await;
+
+        let _ = adapter.inner.do_token_refresh().await;
+
+        let form = captured
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("refresh POST must have reached the mock token endpoint");
+        assert_eq!(
+            form.get("client_id").map(String::as_str),
+            Some("fresh-client"),
+            "refresh must POST the overridden client_id, not the stale config value"
+        );
+        assert_eq!(
+            form.get("client_secret").map(String::as_str),
+            Some("fresh-secret"),
+            "refresh must POST the overridden client_secret, not the stale config value"
+        );
+
+        server.abort();
     }
 
     #[tokio::test]

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -55,6 +55,22 @@ fn form_urlencode(s: &str) -> String {
 /// against and forces a deliberate review of any future change.
 const REFRESH_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Detect an RFC 6749 §5.2 `invalid_client` token-endpoint error body.
+///
+/// Returns `true` iff `body` parses as JSON with a top-level `"error"` string
+/// exactly equal to `"invalid_client"`. Non-JSON bodies, missing/other error
+/// codes, and non-string `error` values all return `false`, so this sniff is
+/// safe to run on any token-endpoint response body without accidentally
+/// triggering the DCR self-heal on unrelated errors (`invalid_grant`,
+/// `invalid_request`, HTML error pages, etc.).
+pub(crate) fn is_invalid_client_error(body: &str) -> bool {
+    serde_json::from_str::<Value>(body)
+        .ok()
+        .and_then(|v| v.get("error").and_then(|e| e.as_str()).map(str::to_owned))
+        .as_deref()
+        == Some("invalid_client")
+}
+
 /// Resolved Enterprise-Managed Authorization (EMA, END-18) parameters for an
 /// endpoint whose `[endpoints.auth] type = "ema"`. Present on
 /// [`OAuthAdapterConfig::ema`] only for EMA endpoints; `None` leaves the adapter
@@ -472,8 +488,8 @@ impl OAuthAdapterInner {
                     "Token refresh failed"
                 );
                 self.metrics.inc_refresh_failure();
-                self.transition_to(OAuthState::AuthRequired, "token refresh failed")
-                    .await;
+                let reason = self.handle_invalid_client_if_present(&body).await;
+                self.transition_to(OAuthState::AuthRequired, reason).await;
                 Err(OAuthError::RefreshFailed { status, body })
             }
             TokenPostOutcome::Network(e) => {
@@ -501,6 +517,40 @@ impl OAuthAdapterInner {
                 .await;
                 Err(OAuthError::Http(e))
             }
+        }
+    }
+
+    /// Inspect an OAuth token-endpoint error body for `invalid_client` (RFC
+    /// 6749 §5.2). If the current endpoint's DCR record was minted by the
+    /// relay (`registered_via_dcr == true`), delete the stale record so the
+    /// next authorize triggers a fresh RFC 7591 registration and returns a
+    /// distinct transition reason. Manually-supplied credentials
+    /// (`registered_via_dcr == false`) and endpoints with no DCR record are
+    /// never auto-discarded; the caller receives the generic
+    /// `"token refresh failed"` reason.
+    async fn handle_invalid_client_if_present(&self, body: &str) -> &'static str {
+        if !is_invalid_client_error(body) {
+            return "token refresh failed";
+        }
+        let endpoint = &self.config.endpoint_name;
+        match self.token_manager.load_dcr(endpoint).await {
+            Ok(Some(creds)) if creds.registered_via_dcr => {
+                if let Err(e) = self.token_manager.delete_dcr(endpoint).await {
+                    error!(
+                        endpoint = %endpoint,
+                        error = %e,
+                        "Failed to delete stale DCR credentials after invalid_client"
+                    );
+                    "token refresh failed"
+                } else {
+                    info!(
+                        endpoint = %endpoint,
+                        "Discarded stale DCR credentials after invalid_client at token endpoint"
+                    );
+                    "client registration invalidated; re-authorize to re-register"
+                }
+            }
+            _ => "token refresh failed",
         }
     }
 
@@ -2292,10 +2342,14 @@ mod tests {
         async fn malformed() -> impl IntoResponse {
             (StatusCode::OK, "not json")
         }
+        async fn invalid_client() -> impl IntoResponse {
+            (StatusCode::UNAUTHORIZED, "{\"error\":\"invalid_client\"}")
+        }
 
         let router = match mode {
             "400" => Router::new().route("/token", post(bad_request)),
             "malformed" => Router::new().route("/token", post(malformed)),
+            "invalid_client" => Router::new().route("/token", post(invalid_client)),
             other => panic!("unknown spawn_token_server mode: {}", other),
         };
 
@@ -2423,6 +2477,177 @@ mod tests {
         );
 
         server.abort();
+    }
+
+    /// Helper: build an adapter that shares the given `TokenManager` (so the
+    /// test can pre-seed `{endpoint}.dcr.json`) and is pre-loaded with a
+    /// refresh token so `do_token_refresh` reaches the network call.
+    async fn make_adapter_with_shared_tm(
+        config: OAuthAdapterConfig,
+        tm: Arc<TokenManager>,
+    ) -> OAuthAdapter {
+        let adapter = OAuthAdapter::new(config, tm);
+        *adapter.inner.tokens.write().await = Some(TokenSet {
+            access_token: "old-access".to_string(),
+            refresh_token: Some("test-refresh".to_string()),
+            expires_at: None,
+            token_type: "Bearer".to_string(),
+            scope: None,
+            issued_at: None,
+        });
+        adapter
+    }
+
+    /// `invalid_client` (RFC 6749 §5.2) from the token endpoint with a
+    /// DCR-registered record must delete the stale `{name}.dcr.json`, land
+    /// in `AuthRequired`, and record a distinct transition reason so
+    /// callers surface a re-authorize hint.
+    #[tokio::test]
+    async fn do_token_refresh_invalid_client_deletes_dcr_registered_record() {
+        use crate::token_manager::DcrCredentials;
+
+        let (url, server) = spawn_token_server("invalid_client").await;
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        // Seed a DCR-minted credential record for the endpoint.
+        tm.save_dcr(
+            "test",
+            &DcrCredentials {
+                client_id: "dcr-client-123".to_string(),
+                registered_via_dcr: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let mut config = make_config();
+        config.token_endpoint_url = url;
+        let adapter = make_adapter_with_shared_tm(config, tm.clone()).await;
+
+        let result = adapter.inner.do_token_refresh().await;
+        assert!(
+            matches!(result, Err(OAuthError::RefreshFailed { .. })),
+            "expected RefreshFailed, got {:?}",
+            result
+        );
+
+        assert!(
+            tm.load_dcr("test").await.unwrap().is_none(),
+            "invalid_client with a DCR-registered record must delete {{name}}.dcr.json"
+        );
+        assert_eq!(
+            adapter.inner.state.read().await.clone(),
+            OAuthState::AuthRequired,
+            "invalid_client must still land in AuthRequired"
+        );
+        let history = adapter.inner.transition_history.read().await;
+        assert!(
+            history
+                .iter()
+                .any(|r| r.reason == "client registration invalidated; re-authorize to re-register"),
+            "expected the distinct invalid_client transition reason, got: {:?}",
+            history.iter().map(|r| r.reason.clone()).collect::<Vec<_>>()
+        );
+
+        server.abort();
+    }
+
+    /// A manually-supplied credential record (`registered_via_dcr == false`)
+    /// must survive an `invalid_client` at the token endpoint — only
+    /// DCR-minted records are auto-discarded.
+    #[tokio::test]
+    async fn do_token_refresh_invalid_client_preserves_manual_record() {
+        use crate::token_manager::DcrCredentials;
+
+        let (url, server) = spawn_token_server("invalid_client").await;
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        // Seed a manually-supplied credential record (registered_via_dcr = false).
+        let manual = DcrCredentials {
+            client_id: "manual-client-abc".to_string(),
+            registered_via_dcr: false,
+            ..Default::default()
+        };
+        tm.save_dcr("test", &manual).await.unwrap();
+
+        let mut config = make_config();
+        config.token_endpoint_url = url;
+        let adapter = make_adapter_with_shared_tm(config, tm.clone()).await;
+
+        let result = adapter.inner.do_token_refresh().await;
+        assert!(matches!(result, Err(OAuthError::RefreshFailed { .. })));
+
+        let loaded = tm
+            .load_dcr("test")
+            .await
+            .unwrap()
+            .expect("manual credential record must be preserved");
+        assert_eq!(loaded, manual);
+        assert_eq!(
+            adapter.inner.state.read().await.clone(),
+            OAuthState::AuthRequired
+        );
+        let history = adapter.inner.transition_history.read().await;
+        assert!(
+            !history
+                .iter()
+                .any(|r| r.reason == "client registration invalidated; re-authorize to re-register"),
+            "manual credential must NOT trigger the invalid_client re-register reason"
+        );
+
+        server.abort();
+    }
+
+    /// Other OAuth errors (e.g. `invalid_grant`) must never touch a
+    /// DCR-registered credential record — only `invalid_client` triggers
+    /// the self-heal.
+    #[tokio::test]
+    async fn do_token_refresh_invalid_grant_preserves_dcr_registered_record() {
+        use crate::token_manager::DcrCredentials;
+
+        let (url, server) = spawn_token_server("400").await;
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let dcr = DcrCredentials {
+            client_id: "dcr-client-xyz".to_string(),
+            registered_via_dcr: true,
+            ..Default::default()
+        };
+        tm.save_dcr("test", &dcr).await.unwrap();
+
+        let mut config = make_config();
+        config.token_endpoint_url = url;
+        let adapter = make_adapter_with_shared_tm(config, tm.clone()).await;
+
+        let result = adapter.inner.do_token_refresh().await;
+        assert!(matches!(result, Err(OAuthError::RefreshFailed { .. })));
+
+        let loaded = tm
+            .load_dcr("test")
+            .await
+            .unwrap()
+            .expect("invalid_grant must not delete the DCR credential record");
+        assert_eq!(loaded, dcr);
+
+        server.abort();
+    }
+
+    /// The token-body sniff must be strictly `error == "invalid_client"`:
+    /// unrelated JSON shapes and non-JSON bodies must not trigger deletion.
+    #[test]
+    fn is_invalid_client_error_shape_and_negatives() {
+        assert!(is_invalid_client_error("{\"error\":\"invalid_client\"}"));
+        assert!(is_invalid_client_error(
+            "{\"error\":\"invalid_client\",\"error_description\":\"unknown client\"}"
+        ));
+        assert!(!is_invalid_client_error("{\"error\":\"invalid_grant\"}"));
+        assert!(!is_invalid_client_error("{\"error\":\"invalid_request\"}"));
+        assert!(!is_invalid_client_error("{}"));
+        assert!(!is_invalid_client_error(""));
+        assert!(!is_invalid_client_error("not json"));
+        assert!(!is_invalid_client_error("<html>error</html>"));
+        assert!(!is_invalid_client_error("{\"error\":123}"));
     }
 
     /// Wait until the shared call counter reaches `target`. Drives the

--- a/src/main.rs
+++ b/src/main.rs
@@ -882,7 +882,7 @@ async fn main() {
                 let mut ready = 0usize;
                 let mut failed = 0usize;
                 let mut initializing = 0usize;
-                for (_, entry) in entries.iter() {
+                for entry in entries.values() {
                     if entry.disabled {
                         continue;
                     }

--- a/src/management.rs
+++ b/src/management.rs
@@ -1300,8 +1300,17 @@ async fn oauth_start(
     // we just discovered, discard them so resolution falls through to dynamic
     // re-registration (RFC 7591), exactly as if no creds existed. Legacy creds
     // with no stored issuer are reused as-is (backward compatibility).
+    //
+    // Only DCR-provenanced records (`registered_via_dcr == true`) participate
+    // in the issuer-mismatch discard. Manually-supplied credentials and
+    // legacy files (which deserialize with `registered_via_dcr = false`) are
+    // preserved unconditionally — auto-discarding them and then silently
+    // re-registering would break the "manual credentials survive" promise.
     let persisted_dcr = match persisted_dcr {
-        Some(creds) if !dcr_issuer_allows_reuse(creds.issuer.as_deref(), issuer.as_deref()) => {
+        Some(creds)
+            if creds.registered_via_dcr
+                && !dcr_issuer_allows_reuse(creds.issuer.as_deref(), issuer.as_deref()) =>
+        {
             info!(
                 endpoint = %name,
                 stored_issuer = ?creds.issuer,
@@ -10246,6 +10255,275 @@ command = "echo"
         let persisted = token_manager.load_dcr("ep1").await.unwrap().unwrap();
         assert_eq!(persisted.client_id, "fresh-dcr-client");
         assert!(persisted.registered_via_dcr);
+    }
+
+    /// Regression for PR #130 round-2 finding R2: after a token-endpoint
+    /// `invalid_client` self-heal on a pure-DCR record the on-disk record
+    /// keeps `client_id=""` / `client_secret=None` with
+    /// `registered_via_dcr = true` (rather than being deleted outright).
+    /// This test asserts that the next interactive Authorize on an endpoint
+    /// whose `config.toml` still carries the previous DCR `client_id`
+    /// still takes the DCR-provenanced re-registration heal path and
+    /// mints a fresh `client_id` — never falls back to the stale
+    /// config value.
+    #[tokio::test]
+    async fn oauth_start_after_self_heal_reregisters_pure_dcr_stub_ignoring_stale_config_client_id()
+    {
+        async fn well_known(headers: axum::http::HeaderMap) -> Json<Value> {
+            let issuer = mock_issuer(&headers);
+            Json(serde_json::json!({
+                "issuer": issuer,
+                "authorization_endpoint": format!("{issuer}/authorize"),
+                "token_endpoint": format!("{issuer}/token"),
+                "registration_endpoint": format!("{issuer}/register"),
+                "code_challenge_methods_supported": ["S256"],
+            }))
+        }
+        async fn register() -> Json<Value> {
+            Json(serde_json::json!({
+                "client_id": "fresh-dcr-client",
+                "client_secret": "fresh-dcr-secret",
+            }))
+        }
+        let router = Router::new()
+            .route("/.well-known/oauth-authorization-server", get(well_known))
+            .route("/register", post(register));
+        let (base_url, _server) = spawn_mock_as(router).await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let token_manager = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+
+        // Post-self-heal stub: cleared requesting pair, cleared issuer,
+        // provenance flag retained. This is exactly what
+        // `TokenManager::clear_dcr_requesting_client` leaves on disk after
+        // a token-endpoint `invalid_client`.
+        let post_heal = DcrCredentials {
+            client_id: String::new(),
+            client_secret: None,
+            client_secret_expires_at: 0,
+            registered_at: 0,
+            issuer: None,
+            resource_client_id: None,
+            resource_client_secret: None,
+            registered_via_dcr: true,
+        };
+        token_manager.save_dcr("ep1", &post_heal).await.unwrap();
+
+        let (mut state, flow_mgr) = test_state_oauth_start("ep1", &base_url, None);
+        {
+            let mut cfg = state.config.write().await;
+            cfg.endpoints[0].client_id = Some("stale-dcr-client".to_string());
+            cfg.endpoints[0].client_secret = Some("stale-dcr-secret".to_string());
+        }
+        state.token_manager = Some(token_manager.clone());
+
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/ep1/oauth/start")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let authorize_url = body["authorize_url"].as_str().unwrap();
+        let state_param = extract_state_param(authorize_url);
+        let flow = flow_mgr
+            .consume_flow(&state_param)
+            .await
+            .expect("pending flow was registered");
+        assert_eq!(
+            flow.client_id, "fresh-dcr-client",
+            "post-self-heal stub with registered_via_dcr=true must still \
+             drive DCR re-registration; the stale config.toml client_id \
+             must NOT be used"
+        );
+        assert_eq!(flow.client_secret, Some("fresh-dcr-secret".to_string()));
+
+        let persisted = token_manager.load_dcr("ep1").await.unwrap().unwrap();
+        assert_eq!(persisted.client_id, "fresh-dcr-client");
+        assert!(persisted.registered_via_dcr);
+    }
+
+    /// Regression for PR #130 round-2 finding R3: after a token-endpoint
+    /// `invalid_client` self-heal on a MIXED record (requesting pair
+    /// alongside an operator-set MAS resource pair), the on-disk record
+    /// keeps `client_id=""` / `client_secret=None` / `resource_*` intact
+    /// with `registered_via_dcr = true`. The next interactive Authorize
+    /// on an endpoint whose `config.toml` still carries the previous
+    /// DCR `client_id` must take the DCR-provenanced re-registration
+    /// heal path (mint a fresh id) while preserving the resource pair.
+    #[tokio::test]
+    async fn oauth_start_after_self_heal_reregisters_mixed_record_and_preserves_resource_pair() {
+        async fn well_known(headers: axum::http::HeaderMap) -> Json<Value> {
+            let issuer = mock_issuer(&headers);
+            Json(serde_json::json!({
+                "issuer": issuer,
+                "authorization_endpoint": format!("{issuer}/authorize"),
+                "token_endpoint": format!("{issuer}/token"),
+                "registration_endpoint": format!("{issuer}/register"),
+                "code_challenge_methods_supported": ["S256"],
+            }))
+        }
+        async fn register() -> Json<Value> {
+            Json(serde_json::json!({
+                "client_id": "fresh-dcr-client",
+                "client_secret": "fresh-dcr-secret",
+            }))
+        }
+        let router = Router::new()
+            .route("/.well-known/oauth-authorization-server", get(well_known))
+            .route("/register", post(register));
+        let (base_url, _server) = spawn_mock_as(router).await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let token_manager = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+
+        // Post-self-heal state on a mixed record: requesting pair cleared,
+        // MAS resource pair retained, provenance flag retained.
+        let post_heal = DcrCredentials {
+            client_id: String::new(),
+            client_secret: None,
+            client_secret_expires_at: 0,
+            registered_at: 0,
+            issuer: None,
+            resource_client_id: Some("mas-resource-client".to_string()),
+            resource_client_secret: Some("mas-resource-secret".to_string()),
+            registered_via_dcr: true,
+        };
+        token_manager.save_dcr("ep1", &post_heal).await.unwrap();
+
+        let (mut state, flow_mgr) = test_state_oauth_start("ep1", &base_url, None);
+        {
+            let mut cfg = state.config.write().await;
+            cfg.endpoints[0].client_id = Some("stale-dcr-client".to_string());
+            cfg.endpoints[0].client_secret = Some("stale-dcr-secret".to_string());
+        }
+        state.token_manager = Some(token_manager.clone());
+
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/ep1/oauth/start")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let authorize_url = body["authorize_url"].as_str().unwrap();
+        let state_param = extract_state_param(authorize_url);
+        let flow = flow_mgr
+            .consume_flow(&state_param)
+            .await
+            .expect("pending flow was registered");
+        assert_eq!(
+            flow.client_id, "fresh-dcr-client",
+            "post-self-heal mixed stub must still drive DCR re-registration \
+             (registered_via_dcr survives the clear); the stale config.toml \
+             client_id must NOT be used"
+        );
+
+        let persisted = token_manager.load_dcr("ep1").await.unwrap().unwrap();
+        assert_eq!(persisted.client_id, "fresh-dcr-client");
+        assert!(persisted.registered_via_dcr);
+        assert_eq!(
+            persisted.resource_client_id.as_deref(),
+            Some("mas-resource-client"),
+            "operator-set MAS resource pair must survive self-heal + re-registration"
+        );
+        assert_eq!(
+            persisted.resource_client_secret.as_deref(),
+            Some("mas-resource-secret")
+        );
+    }
+
+    /// Regression for PR #130 round-2 finding R4: a legacy `.dcr.json`
+    /// record (one with no `registered_via_dcr` field, which deserializes
+    /// as `false`) must survive an issuer change on the AS. Auto-discarding
+    /// it and silently re-registering would break the "manual/legacy
+    /// credentials survive" promise — the issuer-mismatch discard only
+    /// applies to DCR-provenanced records.
+    #[tokio::test]
+    async fn oauth_start_preserves_legacy_record_across_issuer_change() {
+        async fn well_known(headers: axum::http::HeaderMap) -> Json<Value> {
+            let issuer = mock_issuer(&headers);
+            Json(serde_json::json!({
+                "issuer": issuer,
+                "authorization_endpoint": format!("{issuer}/authorize"),
+                "token_endpoint": format!("{issuer}/token"),
+                "registration_endpoint": format!("{issuer}/register"),
+                "code_challenge_methods_supported": ["S256"],
+            }))
+        }
+        // If the code path ever falls through to /register the flow would
+        // end up with this id — the assertion below would fail.
+        async fn register() -> Json<Value> {
+            Json(serde_json::json!({ "client_id": "should-not-be-used" }))
+        }
+        let router = Router::new()
+            .route("/.well-known/oauth-authorization-server", get(well_known))
+            .route("/register", post(register));
+        let (base_url, _server) = spawn_mock_as(router).await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let token_manager = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+
+        // Legacy record: bound to a DIFFERENT issuer than the currently
+        // discovered one, `registered_via_dcr = false` (this is what
+        // pre-provenance-flag `.dcr.json` files deserialize as).
+        let stored = DcrCredentials {
+            client_id: "legacy-client".to_string(),
+            client_secret: Some("legacy-secret".to_string()),
+            client_secret_expires_at: 0,
+            registered_at: 42,
+            issuer: Some("https://old-as.example.com".to_string()),
+            resource_client_id: None,
+            resource_client_secret: None,
+            registered_via_dcr: false,
+        };
+        token_manager.save_dcr("ep1", &stored).await.unwrap();
+
+        let (mut state, flow_mgr) = test_state_oauth_start("ep1", &base_url, None);
+        {
+            let mut cfg = state.config.write().await;
+            cfg.endpoints[0].client_id = None;
+            cfg.endpoints[0].client_secret = None;
+        }
+        state.token_manager = Some(token_manager.clone());
+
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/ep1/oauth/start")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let authorize_url = body["authorize_url"].as_str().unwrap();
+        let state_param = extract_state_param(authorize_url);
+        let flow = flow_mgr
+            .consume_flow(&state_param)
+            .await
+            .expect("pending flow was registered");
+        assert_eq!(
+            flow.client_id, "legacy-client",
+            "legacy records (registered_via_dcr=false) must survive an issuer \
+             change; only DCR-provenanced records participate in the \
+             issuer-mismatch discard"
+        );
+        assert_eq!(flow.client_secret, Some("legacy-secret".to_string()));
+
+        let persisted = token_manager.load_dcr("ep1").await.unwrap().unwrap();
+        assert_eq!(persisted.client_id, "legacy-client");
+        assert_eq!(persisted.registered_at, 42);
+        assert!(!persisted.registered_via_dcr);
     }
 
     // -----------------------------------------------------------------------

--- a/src/management.rs
+++ b/src/management.rs
@@ -28,7 +28,9 @@ use crate::observability::payloads::StoredPayloads;
 use crate::observability::store::{AggregateBucket, CallRecord, QueryFilter};
 use crate::profile_registry::ProfileRegistry;
 use crate::registry::AdapterRegistry;
-use crate::token_manager::{dcr_issuer_allows_reuse, merge_scopes, DcrCredentials, TokenManager};
+use crate::token_manager::{
+    dcr_issuer_allows_reuse, merge_scopes, DcrCredentials, TokenError, TokenManager,
+};
 use crate::OAuthAdapterInners;
 
 // ---------------------------------------------------------------------------
@@ -1390,6 +1392,29 @@ async fn oauth_start(
                 (resp.client_id, resp.client_secret, true)
             }
             Err(e) => {
+                if creds.client_id.is_empty() {
+                    // Post-self-heal tombstone: the stored requesting
+                    // pair was cleared by a prior `invalid_client`
+                    // self-heal and there is nothing to fall back to.
+                    // Producing an authorize URL with `client_id=`
+                    // cannot succeed; surface a clear error so the
+                    // caller can retry once the registration endpoint
+                    // is reachable again.
+                    warn!(
+                        endpoint = %name,
+                        error = %e,
+                        "DCR re-registration failed and stored requesting client is a self-heal tombstone (no fallback)"
+                    );
+                    return error_response(
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        "dcr_registration_unavailable",
+                        Some(&format!(
+                            "DCR re-registration failed and no viable stored client_id remains. \
+                             Retry once the registration endpoint is reachable. Details: {e}"
+                        )),
+                    )
+                    .into_response();
+                }
                 warn!(
                     endpoint = %name,
                     error = %e,
@@ -1642,157 +1667,159 @@ async fn set_endpoint_credentials(
         .into_response();
     };
 
-    // Load the existing record so unspecified fields are preserved.
-    let existing = match tm.load_dcr(&name).await {
-        Ok(creds) => creds,
-        Err(e) => {
-            warn!(endpoint = %name, error = %e, "Failed to load endpoint DCR record during credential update");
-            None
+    // The requesting_touched flag depends only on the request body, so
+    // compute it once and reuse it inside the closure below.
+    let requesting_touched = body.client_id.is_some() || body.client_secret.is_some();
+
+    // Read-modify-write the DCR record under `dcr_write_lock` so that a
+    // concurrent `invalid_client` self-heal
+    // (`TokenManager::clear_dcr_requesting_client`) cannot land between
+    // our load and save and be silently clobbered by the merged record
+    // computed from the pre-heal snapshot.
+    let outcome = tm
+        .update_dcr(
+            &name,
+            |existing| -> Result<Option<DcrCredentials>, SetCredsError> {
+                // keep (absent) / clear (empty) / set (non-empty) per field.
+                let merge = |action: Option<&str>, current: Option<String>| match action {
+                    None => current,
+                    Some("") => None,
+                    Some(s) => Some(s.to_string()),
+                };
+
+                // client_id is a plain (non-optional) field on the record: absent
+                // keeps the stored id (empty for a resource-only EMA endpoint), a
+                // value replaces it.
+                let merged_client_id = match body.client_id.as_deref().map(str::trim) {
+                    None => existing
+                        .as_ref()
+                        .map(|c| c.client_id.clone())
+                        .unwrap_or_default(),
+                    Some(s) => s.to_string(),
+                };
+                let client_secret = merge(
+                    body.client_secret.as_deref().map(str::trim),
+                    existing.as_ref().and_then(|c| c.client_secret.clone()),
+                );
+                let resource_client_id = merge(
+                    body.resource_client_id.as_deref().map(str::trim),
+                    existing.as_ref().and_then(|c| c.resource_client_id.clone()),
+                );
+                let resource_client_secret = merge(
+                    body.resource_client_secret.as_deref().map(str::trim),
+                    existing
+                        .as_ref()
+                        .and_then(|c| c.resource_client_secret.clone()),
+                );
+
+                // A requesting secret has no meaning without a client_id to pair it with.
+                if client_secret.is_some() && merged_client_id.is_empty() {
+                    return Err(SetCredsError::Validation(
+                        "client_id must not be empty when setting client_secret",
+                    ));
+                }
+
+                // Symmetric guard: a resource secret must be paired with a resource client_id.
+                if resource_client_secret.is_some()
+                    && resource_client_id
+                        .as_deref()
+                        .map(str::trim)
+                        .unwrap_or("")
+                        .is_empty()
+                {
+                    return Err(SetCredsError::Validation(
+                        "resource_client_id must not be empty when setting resource_client_secret",
+                    ));
+                }
+
+                // Nothing left to persist → remove the DCR record entirely.
+                if merged_client_id.is_empty()
+                    && client_secret.is_none()
+                    && resource_client_id.is_none()
+                    && resource_client_secret.is_none()
+                {
+                    return Ok(None);
+                }
+
+                // If the caller touched the requesting client_id/secret at all
+                // (set OR clear), the requesting creds are now user-managed →
+                // force the DCR provenance flag off AND clear any previous
+                // `issuer` binding. The provenance flag alone is not enough:
+                // `oauth_start` rejects a credential whose stored `issuer`
+                // differs from the currently discovered one BEFORE it checks
+                // the provenance flag, so a manual replace that left the
+                // DCR-era `issuer` in place would be discarded on a later
+                // issuer change and silently overwritten by a fresh DCR
+                // registration — exactly the "manual credentials survive"
+                // promise this endpoint makes to callers. Updates that only
+                // touch the `resource_*` pair leave the requesting creds
+                // untouched, so preserve the existing provenance flag AND
+                // `issuer`.
+                let registered_via_dcr = if requesting_touched {
+                    false
+                } else {
+                    existing
+                        .as_ref()
+                        .map(|c| c.registered_via_dcr)
+                        .unwrap_or(false)
+                };
+                let issuer = if requesting_touched {
+                    None
+                } else {
+                    existing.as_ref().and_then(|c| c.issuer.clone())
+                };
+
+                Ok(Some(DcrCredentials {
+                    client_id: merged_client_id,
+                    client_secret,
+                    client_secret_expires_at: existing
+                        .as_ref()
+                        .map(|c| c.client_secret_expires_at)
+                        .unwrap_or(0),
+                    registered_at: existing.as_ref().map(|c| c.registered_at).unwrap_or_else(
+                        || {
+                            std::time::SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .unwrap_or_default()
+                                .as_secs()
+                        },
+                    ),
+                    // Manually-supplied credentials are user-managed and not
+                    // bound to a discovered issuer; preserve any existing
+                    // binding only when the requesting pair was not touched,
+                    // and never invent one.
+                    issuer,
+                    resource_client_id,
+                    resource_client_secret,
+                    registered_via_dcr,
+                }))
+            },
+        )
+        .await;
+
+    let saved = match outcome {
+        Ok(saved) => saved,
+        Err(SetCredsError::Validation(msg)) => {
+            return error_response(StatusCode::BAD_REQUEST, msg, None).into_response();
         }
-    };
-
-    // keep (absent) / clear (empty) / set (non-empty) per field.
-    let merge = |action: Option<&str>, current: Option<String>| match action {
-        None => current,
-        Some("") => None,
-        Some(s) => Some(s.to_string()),
-    };
-
-    // client_id is a plain (non-optional) field on the record: absent keeps the
-    // stored id (empty for a resource-only EMA endpoint), a value replaces it.
-    let merged_client_id = match body.client_id.as_deref().map(str::trim) {
-        None => existing
-            .as_ref()
-            .map(|c| c.client_id.clone())
-            .unwrap_or_default(),
-        Some(s) => s.to_string(),
-    };
-    let client_secret = merge(
-        body.client_secret.as_deref().map(str::trim),
-        existing.as_ref().and_then(|c| c.client_secret.clone()),
-    );
-    let resource_client_id = merge(
-        body.resource_client_id.as_deref().map(str::trim),
-        existing.as_ref().and_then(|c| c.resource_client_id.clone()),
-    );
-    let resource_client_secret = merge(
-        body.resource_client_secret.as_deref().map(str::trim),
-        existing
-            .as_ref()
-            .and_then(|c| c.resource_client_secret.clone()),
-    );
-
-    // A requesting secret has no meaning without a client_id to pair it with.
-    if client_secret.is_some() && merged_client_id.is_empty() {
-        return error_response(
-            StatusCode::BAD_REQUEST,
-            "client_id must not be empty when setting client_secret",
-            None,
-        )
-        .into_response();
-    }
-
-    // Symmetric guard: a resource secret must be paired with a resource client_id.
-    if resource_client_secret.is_some()
-        && resource_client_id
-            .as_deref()
-            .map(str::trim)
-            .unwrap_or("")
-            .is_empty()
-    {
-        return error_response(
-            StatusCode::BAD_REQUEST,
-            "resource_client_id must not be empty when setting resource_client_secret",
-            None,
-        )
-        .into_response();
-    }
-
-    let client_secret_set = client_secret.is_some();
-    let resource_client_secret_set = resource_client_secret.is_some();
-
-    // Nothing left to persist → remove the DCR record entirely.
-    if merged_client_id.is_empty()
-        && client_secret.is_none()
-        && resource_client_id.is_none()
-        && resource_client_secret.is_none()
-    {
-        if let Err(e) = tm.delete_dcr(&name).await {
+        Err(SetCredsError::Storage(e)) => {
             return error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                "Failed to clear credentials",
+                "Failed to persist credentials",
                 Some(&e.to_string()),
             )
             .into_response();
         }
-        return Json(serde_json::json!({
-            "ok": true,
-            "client_secret_set": false,
-            "resource_client_secret_set": false,
-        }))
-        .into_response();
-    }
-
-    // If the caller touched the requesting client_id/secret at all (set OR
-    // clear), the requesting creds are now user-managed → force the DCR
-    // provenance flag off AND clear any previous `issuer` binding. The
-    // provenance flag alone is not enough: `oauth_start` rejects a
-    // credential whose stored `issuer` differs from the currently
-    // discovered one BEFORE it checks the provenance flag, so a manual
-    // replace that left the DCR-era `issuer` in place would be discarded
-    // on a later issuer change and silently overwritten by a fresh DCR
-    // registration — exactly the "manual credentials survive" promise
-    // this endpoint makes to callers. Updates that only touch the
-    // `resource_*` pair leave the requesting creds untouched, so
-    // preserve the existing provenance flag AND `issuer`.
-    let requesting_touched = body.client_id.is_some() || body.client_secret.is_some();
-    let registered_via_dcr = if requesting_touched {
-        false
-    } else {
-        existing
-            .as_ref()
-            .map(|c| c.registered_via_dcr)
-            .unwrap_or(false)
-    };
-    let issuer = if requesting_touched {
-        None
-    } else {
-        existing.as_ref().and_then(|c| c.issuer.clone())
     };
 
-    let creds = DcrCredentials {
-        client_id: merged_client_id,
-        client_secret,
-        client_secret_expires_at: existing
-            .as_ref()
-            .map(|c| c.client_secret_expires_at)
-            .unwrap_or(0),
-        registered_at: existing
-            .as_ref()
-            .map(|c| c.registered_at)
-            .unwrap_or_else(|| {
-                std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs()
-            }),
-        // Manually-supplied credentials are user-managed and not bound to
-        // a discovered issuer; preserve any existing binding only when
-        // the requesting pair was not touched, and never invent one.
-        issuer,
-        resource_client_id,
-        resource_client_secret,
-        registered_via_dcr,
-    };
-
-    if let Err(e) = tm.save_dcr(&name, &creds).await {
-        return error_response(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "Failed to save credentials",
-            Some(&e.to_string()),
-        )
-        .into_response();
-    }
+    let client_secret_set = saved
+        .as_ref()
+        .and_then(|c| c.client_secret.as_ref())
+        .is_some();
+    let resource_client_secret_set = saved
+        .as_ref()
+        .and_then(|c| c.resource_client_secret.as_ref())
+        .is_some();
 
     Json(serde_json::json!({
         "ok": true,
@@ -1800,6 +1827,22 @@ async fn set_endpoint_credentials(
         "resource_client_secret_set": resource_client_secret_set,
     }))
     .into_response()
+}
+
+/// Error surface for the `set_endpoint_credentials` update closure. Split
+/// so the caller can render a `400 Bad Request` for validation failures
+/// (with the exact message) and a `500 Internal Server Error` for storage
+/// failures, while `From<TokenError>` lets `TokenManager::update_dcr`
+/// propagate IO/serde errors transparently.
+enum SetCredsError {
+    Validation(&'static str),
+    Storage(TokenError),
+}
+
+impl From<TokenError> for SetCredsError {
+    fn from(e: TokenError) -> Self {
+        SetCredsError::Storage(e)
+    }
 }
 
 /// GET /api/endpoints/:name/credentials
@@ -10524,6 +10567,83 @@ command = "echo"
         assert_eq!(persisted.client_id, "legacy-client");
         assert_eq!(persisted.registered_at, 42);
         assert!(!persisted.registered_via_dcr);
+    }
+
+    /// Regression for PR #130 round-3 finding R3-4: when a
+    /// post-self-heal DCR tombstone (`client_id=""`,
+    /// `registered_via_dcr=true`) triggers the re-registration heal path
+    /// and the registration endpoint is temporarily unreachable, the
+    /// auth-start handler must NOT fall back to the empty stored id
+    /// (which would yield an unusable `client_id=` authorize URL). It
+    /// must surface a clear `503 dcr_registration_unavailable` error
+    /// instead, leaving the tombstone in place for retry.
+    #[tokio::test]
+    async fn oauth_start_dcr_failure_on_tombstone_returns_error_not_empty_authorize_url() {
+        async fn well_known(headers: axum::http::HeaderMap) -> Json<Value> {
+            let issuer = mock_issuer(&headers);
+            Json(serde_json::json!({
+                "issuer": issuer,
+                "authorization_endpoint": format!("{issuer}/authorize"),
+                "token_endpoint": format!("{issuer}/token"),
+                "registration_endpoint": format!("{issuer}/register"),
+                "code_challenge_methods_supported": ["S256"],
+            }))
+        }
+        // Simulate the AS's registration endpoint being temporarily down.
+        async fn register() -> (StatusCode, Json<Value>) {
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({"error": "server_error"})),
+            )
+        }
+        let router = Router::new()
+            .route("/.well-known/oauth-authorization-server", get(well_known))
+            .route("/register", post(register));
+        let (base_url, _server) = spawn_mock_as(router).await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let token_manager = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let tombstone = DcrCredentials {
+            client_id: String::new(),
+            client_secret: None,
+            client_secret_expires_at: 0,
+            registered_at: 0,
+            issuer: None,
+            resource_client_id: None,
+            resource_client_secret: None,
+            registered_via_dcr: true,
+        };
+        token_manager.save_dcr("ep1", &tombstone).await.unwrap();
+
+        let (mut state, _flow_mgr) = test_state_oauth_start("ep1", &base_url, None);
+        {
+            let mut cfg = state.config.write().await;
+            cfg.endpoints[0].client_id = Some("stale-dcr-client".to_string());
+            cfg.endpoints[0].client_secret = Some("stale-dcr-secret".to_string());
+        }
+        state.token_manager = Some(token_manager.clone());
+
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/ep1/oauth/start")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "DCR failure on a tombstone must not fall back to the empty stored id"
+        );
+        let body = body_json(resp).await;
+        assert_eq!(body["error"], "dcr_registration_unavailable");
+
+        // Tombstone is preserved on disk so a retry can re-attempt registration.
+        let persisted = token_manager.load_dcr("ep1").await.unwrap().unwrap();
+        assert!(persisted.client_id.is_empty());
+        assert!(persisted.registered_via_dcr);
     }
 
     // -----------------------------------------------------------------------

--- a/src/management.rs
+++ b/src/management.rs
@@ -1332,7 +1332,58 @@ async fn oauth_start(
             None => (cid, config_client_secret, false),
         }
     } else if let Some(creds) = persisted_dcr {
-        (creds.client_id, creds.client_secret, true)
+        // Interactive auth-start heals a purged server-side registration by
+        // re-registering a FRESH client_id whenever the persisted record was
+        // itself minted via DCR AND a live `registration_endpoint` is
+        // available. Manual credentials (`registered_via_dcr == false`) and
+        // the no-registration-endpoint case reuse the stored record
+        // unchanged. See spec: Root cause analysis / Approach Part 2.
+        match (creds.registered_via_dcr, registration_endpoint.as_ref()) {
+            (true, Some(reg_endpoint)) => {
+                match dcr::register_client(reg_endpoint, &redirect_uri, &name, allow_insecure_oauth)
+                    .await
+                {
+                    Ok(resp) => {
+                        if let Some(ref tm) = state.token_manager {
+                            let new_creds = DcrCredentials {
+                                client_id: resp.client_id.clone(),
+                                client_secret: resp.client_secret.clone(),
+                                client_secret_expires_at: resp.client_secret_expires_at,
+                                registered_at: std::time::SystemTime::now()
+                                    .duration_since(std::time::UNIX_EPOCH)
+                                    .unwrap_or_default()
+                                    .as_secs(),
+                                issuer: issuer.clone(),
+                                // Preserve the per-endpoint MAS resource
+                                // credential pair (captured separately via
+                                // POST /credentials); it is a distinct
+                                // registration from the requesting client.
+                                resource_client_id: creds.resource_client_id.clone(),
+                                resource_client_secret: creds.resource_client_secret.clone(),
+                                registered_via_dcr: true,
+                            };
+                            if let Err(e) = tm.save_dcr(&name, &new_creds).await {
+                                warn!(
+                                    endpoint = %name,
+                                    error = %e,
+                                    "Failed to persist re-registered DCR credentials"
+                                );
+                            }
+                        }
+                        (resp.client_id, resp.client_secret, true)
+                    }
+                    Err(e) => {
+                        warn!(
+                            endpoint = %name,
+                            error = %e,
+                            "DCR re-registration failed; falling back to stored credentials"
+                        );
+                        (creds.client_id, creds.client_secret, true)
+                    }
+                }
+            }
+            _ => (creds.client_id, creds.client_secret, true),
+        }
     } else if let Some(ref reg_endpoint) = registration_endpoint {
         // Attempt dynamic client registration (URL guard + pinned client inside)
         match dcr::register_client(reg_endpoint, &redirect_uri, &name, allow_insecure_oauth).await {
@@ -9697,6 +9748,258 @@ command = "echo"
             .expect("pending flow was registered");
         assert_eq!(flow.client_id, "toml-id");
         assert_eq!(flow.client_secret, Some("toml-secret".to_string()));
+    }
+
+    // -----------------------------------------------------------------------
+    // Approach Part 2: interactive auth-start re-registers a fresh DCR client
+    // when the persisted record is DCR-provenanced and a live
+    // registration_endpoint is advertised. Manual credentials must never be
+    // re-registered, and a failed re-registration must fall back to the
+    // stored credentials so the flow still produces an authorize URL.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn oauth_start_reregisters_when_persisted_creds_are_dcr_and_registration_endpoint_available(
+    ) {
+        async fn well_known(headers: axum::http::HeaderMap) -> Json<Value> {
+            let issuer = mock_issuer(&headers);
+            Json(serde_json::json!({
+                "issuer": issuer,
+                "authorization_endpoint": format!("{issuer}/authorize"),
+                "token_endpoint": format!("{issuer}/token"),
+                "registration_endpoint": format!("{issuer}/register"),
+                "code_challenge_methods_supported": ["S256"],
+            }))
+        }
+        async fn register() -> Json<Value> {
+            Json(serde_json::json!({
+                "client_id": "fresh-dcr-client",
+                "client_secret": "fresh-dcr-secret",
+            }))
+        }
+        let router = Router::new()
+            .route("/.well-known/oauth-authorization-server", get(well_known))
+            .route("/register", post(register));
+        let (base_url, _server) = spawn_mock_as(router).await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let token_manager = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+
+        // Seed a per-endpoint MAS resource credential pair alongside the
+        // stale DCR client so we can assert re-registration preserves it
+        // (that pair is captured separately via POST /credentials and is a
+        // distinct registration from the requesting client).
+        let stored = DcrCredentials {
+            client_id: "stale-dcr-client".to_string(),
+            client_secret: Some("stale-dcr-secret".to_string()),
+            client_secret_expires_at: 0,
+            registered_at: 0,
+            issuer: Some(base_url.clone()),
+            resource_client_id: Some("mas-resource-client".to_string()),
+            resource_client_secret: Some("mas-resource-secret".to_string()),
+            registered_via_dcr: true,
+        };
+        token_manager.save_dcr("ep1", &stored).await.unwrap();
+
+        let (mut state, flow_mgr) = test_state_oauth_start("ep1", &base_url, None);
+        {
+            let mut cfg = state.config.write().await;
+            cfg.endpoints[0].client_id = None;
+            cfg.endpoints[0].client_secret = None;
+        }
+        state.token_manager = Some(token_manager.clone());
+
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/ep1/oauth/start")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let authorize_url = body["authorize_url"].as_str().unwrap();
+        let state_param = extract_state_param(authorize_url);
+        let flow = flow_mgr
+            .consume_flow(&state_param)
+            .await
+            .expect("pending flow was registered");
+        assert_eq!(
+            flow.client_id, "fresh-dcr-client",
+            "auth-start must use the freshly-registered client_id, not the stored one"
+        );
+        assert_eq!(flow.client_secret, Some("fresh-dcr-secret".to_string()));
+
+        let persisted = token_manager.load_dcr("ep1").await.unwrap().unwrap();
+        assert_eq!(persisted.client_id, "fresh-dcr-client");
+        assert_eq!(
+            persisted.client_secret,
+            Some("fresh-dcr-secret".to_string())
+        );
+        assert!(persisted.registered_via_dcr);
+        assert_eq!(persisted.issuer.as_deref(), Some(base_url.as_str()));
+        // The MAS resource credential pair is a distinct registration and
+        // must survive re-registration of the requesting client.
+        assert_eq!(
+            persisted.resource_client_id.as_deref(),
+            Some("mas-resource-client")
+        );
+        assert_eq!(
+            persisted.resource_client_secret.as_deref(),
+            Some("mas-resource-secret")
+        );
+    }
+
+    #[tokio::test]
+    async fn oauth_start_dcr_reregistration_falls_back_to_stored_creds_on_failure() {
+        async fn well_known(headers: axum::http::HeaderMap) -> Json<Value> {
+            let issuer = mock_issuer(&headers);
+            Json(serde_json::json!({
+                "issuer": issuer,
+                "authorization_endpoint": format!("{issuer}/authorize"),
+                "token_endpoint": format!("{issuer}/token"),
+                "registration_endpoint": format!("{issuer}/register"),
+                "code_challenge_methods_supported": ["S256"],
+            }))
+        }
+        async fn register() -> (StatusCode, Json<Value>) {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({})),
+            )
+        }
+        let router = Router::new()
+            .route("/.well-known/oauth-authorization-server", get(well_known))
+            .route("/register", post(register));
+        let (base_url, _server) = spawn_mock_as(router).await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let token_manager = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+
+        let stored = DcrCredentials {
+            client_id: "stored-dcr-client".to_string(),
+            client_secret: Some("stored-dcr-secret".to_string()),
+            client_secret_expires_at: 0,
+            registered_at: 42,
+            issuer: Some(base_url.clone()),
+            registered_via_dcr: true,
+            ..Default::default()
+        };
+        token_manager.save_dcr("ep1", &stored).await.unwrap();
+
+        let (mut state, flow_mgr) = test_state_oauth_start("ep1", &base_url, None);
+        {
+            let mut cfg = state.config.write().await;
+            cfg.endpoints[0].client_id = None;
+            cfg.endpoints[0].client_secret = None;
+        }
+        state.token_manager = Some(token_manager.clone());
+
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/ep1/oauth/start")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "DCR re-registration failure must fall back, not hard-fail the flow"
+        );
+        let body = body_json(resp).await;
+        let authorize_url = body["authorize_url"].as_str().unwrap();
+        let state_param = extract_state_param(authorize_url);
+        let flow = flow_mgr
+            .consume_flow(&state_param)
+            .await
+            .expect("pending flow was registered");
+        assert_eq!(flow.client_id, "stored-dcr-client");
+        assert_eq!(flow.client_secret, Some("stored-dcr-secret".to_string()));
+
+        let persisted = token_manager.load_dcr("ep1").await.unwrap().unwrap();
+        assert_eq!(persisted.client_id, "stored-dcr-client");
+        assert_eq!(
+            persisted.registered_at, 42,
+            "failed re-registration must not overwrite the persisted record"
+        );
+    }
+
+    #[tokio::test]
+    async fn oauth_start_does_not_reregister_manual_persisted_credentials() {
+        async fn well_known(headers: axum::http::HeaderMap) -> Json<Value> {
+            let issuer = mock_issuer(&headers);
+            Json(serde_json::json!({
+                "issuer": issuer,
+                "authorization_endpoint": format!("{issuer}/authorize"),
+                "token_endpoint": format!("{issuer}/token"),
+                "registration_endpoint": format!("{issuer}/register"),
+                "code_challenge_methods_supported": ["S256"],
+            }))
+        }
+        // If the code path ever hits /register, the persisted record and the
+        // flow would end up with this client_id — the asserts below would fail.
+        async fn register() -> Json<Value> {
+            Json(serde_json::json!({ "client_id": "should-not-be-used" }))
+        }
+        let router = Router::new()
+            .route("/.well-known/oauth-authorization-server", get(well_known))
+            .route("/register", post(register));
+        let (base_url, _server) = spawn_mock_as(router).await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let token_manager = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+
+        let stored = DcrCredentials {
+            client_id: "manual-client".to_string(),
+            client_secret: Some("manual-secret".to_string()),
+            client_secret_expires_at: 0,
+            registered_at: 7,
+            issuer: Some(base_url.clone()),
+            registered_via_dcr: false,
+            ..Default::default()
+        };
+        token_manager.save_dcr("ep1", &stored).await.unwrap();
+
+        let (mut state, flow_mgr) = test_state_oauth_start("ep1", &base_url, None);
+        {
+            let mut cfg = state.config.write().await;
+            cfg.endpoints[0].client_id = None;
+            cfg.endpoints[0].client_secret = None;
+        }
+        state.token_manager = Some(token_manager.clone());
+
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/ep1/oauth/start")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let authorize_url = body["authorize_url"].as_str().unwrap();
+        let state_param = extract_state_param(authorize_url);
+        let flow = flow_mgr
+            .consume_flow(&state_param)
+            .await
+            .expect("pending flow was registered");
+        assert_eq!(
+            flow.client_id, "manual-client",
+            "manual credentials must be reused as-is; never re-registered"
+        );
+        assert_eq!(flow.client_secret, Some("manual-secret".to_string()));
+
+        let persisted = token_manager.load_dcr("ep1").await.unwrap().unwrap();
+        assert_eq!(persisted.client_id, "manual-client");
+        assert_eq!(persisted.registered_at, 7);
+        assert!(!persisted.registered_via_dcr);
     }
 
     // -----------------------------------------------------------------------

--- a/src/management.rs
+++ b/src/management.rs
@@ -1393,10 +1393,18 @@ async fn oauth_start(
                     // operator-managed record on disk instead of clobbering
                     // it. Round-4 finding R4-4.
                     //
-                    // Note: the returned `(client_id, client_secret)` still
-                    // reflects the fresh DCR registration for the pending
-                    // authorize flow; only the persisted record follows the
-                    // operator's newer state.
+                    // On compare failure we ALSO refuse to continue the
+                    // auth-start with the unpersisted fresh DCR pair
+                    // (round-5 finding R5-2): otherwise a successful
+                    // callback would install `set_client_credentials`
+                    // on the running adapter and save a token set bound
+                    // to a `client_id` that never made it to disk,
+                    // bypassing the R5-3 callback guard when the
+                    // concurrent write was a manual rotation
+                    // (`registered_via_dcr = false`). `snapshot_matched`
+                    // uses `AtomicBool` (not `Cell`) so the future
+                    // produced by this async fn stays `Send` for axum's
+                    // `Handler` bound.
                     //
                     // `expected_client_id` is the ORIGINAL on-disk id
                     // captured at load time — not `creds.client_id`, which
@@ -1408,6 +1416,10 @@ async fn oauth_start(
                     let new_client_secret = resp.client_secret.clone();
                     let expires_at = resp.client_secret_expires_at;
                     let bind_issuer = issuer.clone();
+                    // `AtomicBool` (not `Cell`) so the future produced by
+                    // this async fn stays `Send` for axum's `Handler`
+                    // bound.
+                    let snapshot_matched = std::sync::atomic::AtomicBool::new(true);
                     let update_res: Result<Option<DcrCredentials>, TokenError> = tm
                         .update_dcr(&name, |current| {
                             let matches_snapshot = match (current.as_ref(), expected_client_id.as_deref()) {
@@ -1418,6 +1430,7 @@ async fn oauth_start(
                                 _ => false,
                             };
                             if !matches_snapshot {
+                                snapshot_matched.store(false, std::sync::atomic::Ordering::SeqCst);
                                 info!(
                                     endpoint = %name,
                                     expected_client_id = expected_client_id.as_deref().unwrap_or("<absent>"),
@@ -1457,6 +1470,21 @@ async fn oauth_start(
                             error = %e,
                             "Failed to persist re-registered DCR credentials"
                         );
+                    }
+                    if !snapshot_matched.load(std::sync::atomic::Ordering::SeqCst) {
+                        warn!(
+                            endpoint = %name,
+                            "Auth-start superseded by concurrent credential rotation; refusing to continue with unpersisted fresh DCR pair (R5-2)"
+                        );
+                        return error_response(
+                            StatusCode::CONFLICT,
+                            "auth_start_superseded",
+                            Some(
+                                "Endpoint credentials were rotated by a concurrent operation \
+                                 during this Authorize. Please click Authorize again.",
+                            ),
+                        )
+                        .into_response();
                     }
                 }
                 if config_client_id
@@ -10822,14 +10850,19 @@ command = "echo"
         );
     }
 
-    /// Round-4 finding R4-4: the persist of a freshly-registered DCR
-    /// requesting client uses `update_dcr` (compare-and-update) so a
-    /// concurrent operator write that lands between our snapshot and this
-    /// save — for example, a `POST /credentials` that rotated to manual
-    /// credentials — SURVIVES intact instead of being clobbered. This
-    /// test simulates the race by letting the mock `/register` handler
-    /// block until the test manually rotates the persisted record via
-    /// `save_dcr` to a manual-provenance record, then unblocks.
+    /// Round-4 finding R4-4 + round-5 finding R5-2: the persist of a
+    /// freshly-registered DCR requesting client uses `update_dcr`
+    /// (compare-and-update) so a concurrent operator write that lands
+    /// between our snapshot and this save — for example, a
+    /// `POST /credentials` that rotated to manual credentials — SURVIVES
+    /// intact instead of being clobbered (R4-4); AND the auth-start
+    /// handler refuses to continue with the unpersisted fresh DCR pair
+    /// on compare-failure, returning a `CONFLICT` superseded response
+    /// so no callback can install credentials into the running adapter
+    /// that never made it to disk (R5-2). This test simulates the race
+    /// by letting the mock `/register` handler block until the test
+    /// manually rotates the persisted record via `save_dcr` to a
+    /// manual-provenance record, then unblocks.
     #[tokio::test]
     async fn oauth_start_reregister_save_does_not_clobber_concurrent_manual_rotation() {
         use tokio::sync::oneshot;
@@ -10929,7 +10962,19 @@ command = "echo"
         proceed_tx.send(()).unwrap();
 
         let resp = start_fut.await.unwrap();
-        assert_eq!(resp.status(), StatusCode::OK);
+        // R5-2: the auth-start handler MUST refuse to continue with the
+        // unpersisted fresh DCR pair when the on-disk record was rotated
+        // out from under it. Otherwise a successful callback would install
+        // credentials on the running adapter that never made it to disk,
+        // bypassing the R5-3 callback guard (the manual write has
+        // `registered_via_dcr = false`, so the guard's provenance check
+        // never fires).
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let body_json: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body_json["error"], "auth_start_superseded");
 
         // The persisted record must be the operator's manual write, not
         // the concurrent DCR re-registration result.

--- a/src/management.rs
+++ b/src/management.rs
@@ -1297,14 +1297,38 @@ async fn oauth_start(
         None
     };
 
+    // Snapshot of the on-disk requesting `client_id` at load time.
+    // Used by R4-4's fresh-registration compare-and-update below so the
+    // save's expected value corresponds to what was actually on disk
+    // when we read it — the issuer-mismatch tombstone transformation
+    // below rewrites `persisted_dcr.client_id` to `""` in memory only
+    // and must NOT be treated as the on-disk snapshot for the compare.
+    let persisted_dcr_disk_client_id: Option<String> = persisted_dcr
+        .as_ref()
+        .filter(|c| c.registered_via_dcr)
+        .map(|c| c.client_id.clone());
+
     // Credential-to-issuer binding: if the stored DCR credentials were
     // registered against a DIFFERENT authorization server issuer than the one
-    // we just discovered, discard them so resolution falls through to dynamic
-    // re-registration (RFC 7591), exactly as if no creds existed. Legacy creds
-    // with no stored issuer are reused as-is (backward compatibility).
+    // we just discovered, invalidate them so resolution falls through to
+    // dynamic re-registration (RFC 7591). Legacy creds with no stored issuer
+    // are reused as-is (backward compatibility).
+    //
+    // Only the issuer-bound *requesting* pair
+    // (`client_id`/`client_secret`/`issuer`) is invalidated: the operator-set
+    // `resource_client_id`/`resource_client_secret` pair is a distinct
+    // registration at the MCP Authorization Server (Step 3, RFC 7523
+    // ID-JAG redemption) that has no dependency on the requesting client's
+    // IdP issuer, and must be carried forward. Converting to `None` here
+    // and letting the fresh-registration branch below build the record with
+    // `..Default::default()` would silently erase the operator's manual
+    // resource pair (round-4 finding R4-1). Instead we hand the resolver a
+    // tombstone whose `client_id` is empty (forcing the DCR re-register
+    // path, which already preserves `resource_*` via the record it carries
+    // forward) but whose resource pair is intact.
     //
     // Only DCR-provenanced records (`registered_via_dcr == true`) participate
-    // in the issuer-mismatch discard. Manually-supplied credentials and
+    // in the issuer-mismatch invalidation. Manually-supplied credentials and
     // legacy files (which deserialize with `registered_via_dcr = false`) are
     // preserved unconditionally — auto-discarding them and then silently
     // re-registering would break the "manual credentials survive" promise.
@@ -1317,9 +1341,18 @@ async fn oauth_start(
                 endpoint = %name,
                 stored_issuer = ?creds.issuer,
                 current_issuer = ?issuer,
-                "DCR credential issuer changed; discarding stored credentials and re-registering"
+                "DCR credential issuer changed; invalidating requesting pair (resource pair preserved) and re-registering"
             );
-            None
+            Some(DcrCredentials {
+                client_id: String::new(),
+                client_secret: None,
+                client_secret_expires_at: 0,
+                registered_at: creds.registered_at,
+                issuer: None,
+                resource_client_id: creds.resource_client_id,
+                resource_client_secret: creds.resource_client_secret,
+                registered_via_dcr: true,
+            })
         }
         other => other,
     };
@@ -1350,24 +1383,75 @@ async fn oauth_start(
         match dcr::register_client(reg_endpoint, &redirect_uri, &name, allow_insecure_oauth).await {
             Ok(resp) => {
                 if let Some(ref tm) = state.token_manager {
-                    let new_creds = DcrCredentials {
-                        client_id: resp.client_id.clone(),
-                        client_secret: resp.client_secret.clone(),
-                        client_secret_expires_at: resp.client_secret_expires_at,
-                        registered_at: std::time::SystemTime::now()
-                            .duration_since(std::time::UNIX_EPOCH)
-                            .unwrap_or_default()
-                            .as_secs(),
-                        issuer: issuer.clone(),
-                        // Preserve the per-endpoint MAS resource
-                        // credential pair (captured separately via
-                        // POST /credentials); it is a distinct
-                        // registration from the requesting client.
-                        resource_client_id: creds.resource_client_id.clone(),
-                        resource_client_secret: creds.resource_client_secret.clone(),
-                        registered_via_dcr: true,
-                    };
-                    if let Err(e) = tm.save_dcr(&name, &new_creds).await {
+                    // Compare-and-update via the atomic helper: only replace
+                    // the on-disk record when it still has the DCR provenance
+                    // AND its `client_id` matches the snapshot we resolved
+                    // before calling `register_client`. If a concurrent
+                    // `POST /credentials` landed between our snapshot and
+                    // this save (rotating to manual creds or replacing
+                    // resource_*), the compare fails and we leave the newer
+                    // operator-managed record on disk instead of clobbering
+                    // it. Round-4 finding R4-4.
+                    //
+                    // Note: the returned `(client_id, client_secret)` still
+                    // reflects the fresh DCR registration for the pending
+                    // authorize flow; only the persisted record follows the
+                    // operator's newer state.
+                    //
+                    // `expected_client_id` is the ORIGINAL on-disk id
+                    // captured at load time — not `creds.client_id`, which
+                    // the R4-1 issuer-mismatch branch may have rewritten
+                    // to `""` in memory (the file itself still holds the
+                    // pre-invalidation id until we save).
+                    let expected_client_id = persisted_dcr_disk_client_id.clone();
+                    let new_client_id = resp.client_id.clone();
+                    let new_client_secret = resp.client_secret.clone();
+                    let expires_at = resp.client_secret_expires_at;
+                    let bind_issuer = issuer.clone();
+                    let update_res: Result<Option<DcrCredentials>, TokenError> = tm
+                        .update_dcr(&name, |current| {
+                            let matches_snapshot = match (current.as_ref(), expected_client_id.as_deref()) {
+                                (Some(c), Some(expected)) => {
+                                    c.registered_via_dcr && c.client_id == expected
+                                }
+                                (None, None) => true,
+                                _ => false,
+                            };
+                            if !matches_snapshot {
+                                info!(
+                                    endpoint = %name,
+                                    expected_client_id = expected_client_id.as_deref().unwrap_or("<absent>"),
+                                    current_client_id = current
+                                        .as_ref()
+                                        .map(|c| c.client_id.as_str())
+                                        .unwrap_or("<absent>"),
+                                    current_registered_via_dcr = current
+                                        .as_ref()
+                                        .map(|c| c.registered_via_dcr)
+                                        .unwrap_or(false),
+                                    "Skipping fresh-DCR save: on-disk record diverged from snapshot (concurrent operator write)"
+                                );
+                                return Ok(current);
+                            }
+                            let (resource_client_id, resource_client_secret) = current
+                                .map(|c| (c.resource_client_id, c.resource_client_secret))
+                                .unwrap_or_default();
+                            Ok(Some(DcrCredentials {
+                                client_id: new_client_id.clone(),
+                                client_secret: new_client_secret.clone(),
+                                client_secret_expires_at: expires_at,
+                                registered_at: std::time::SystemTime::now()
+                                    .duration_since(std::time::UNIX_EPOCH)
+                                    .unwrap_or_default()
+                                    .as_secs(),
+                                issuer: bind_issuer.clone(),
+                                resource_client_id,
+                                resource_client_secret,
+                                registered_via_dcr: true,
+                            }))
+                        })
+                        .await;
+                    if let Err(e) = update_res {
                         warn!(
                             endpoint = %name,
                             error = %e,
@@ -10644,6 +10728,213 @@ command = "echo"
         let persisted = token_manager.load_dcr("ep1").await.unwrap().unwrap();
         assert!(persisted.client_id.is_empty());
         assert!(persisted.registered_via_dcr);
+    }
+
+    /// Round-4 finding R4-1: when the AS issuer changes, the DCR
+    /// requesting pair (`client_id`/`client_secret`/`issuer`) is
+    /// invalidated so `oauth_start` re-registers via RFC 7591, but the
+    /// operator-set `resource_client_id`/`resource_client_secret` pair is
+    /// a distinct MAS registration and MUST be carried through the
+    /// invalidation. Prior to the fix the mismatched record was collapsed
+    /// to `None`, and the fresh-registration branch built the new record
+    /// with `..Default::default()`, silently dropping the resource pair.
+    #[tokio::test]
+    async fn oauth_start_issuer_mismatch_preserves_resource_pair() {
+        async fn well_known(headers: axum::http::HeaderMap) -> Json<Value> {
+            let issuer = mock_issuer(&headers);
+            Json(serde_json::json!({
+                "issuer": issuer,
+                "authorization_endpoint": format!("{issuer}/authorize"),
+                "token_endpoint": format!("{issuer}/token"),
+                "registration_endpoint": format!("{issuer}/register"),
+                "code_challenge_methods_supported": ["S256"],
+            }))
+        }
+        async fn register() -> Json<Value> {
+            Json(serde_json::json!({
+                "client_id": "fresh-dcr-client",
+                "client_secret": "fresh-dcr-secret",
+            }))
+        }
+        let router = Router::new()
+            .route("/.well-known/oauth-authorization-server", get(well_known))
+            .route("/register", post(register));
+        let (base_url, _server) = spawn_mock_as(router).await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let token_manager = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        // Persisted DCR record bound to a DIFFERENT issuer than the AS
+        // will now advertise, alongside an operator-set MAS resource pair.
+        let stored = DcrCredentials {
+            client_id: "stale-dcr-client".to_string(),
+            client_secret: Some("stale-dcr-secret".to_string()),
+            client_secret_expires_at: 0,
+            registered_at: 0,
+            issuer: Some("https://old-idp.example.com".to_string()),
+            resource_client_id: Some("mas-resource-client".to_string()),
+            resource_client_secret: Some("mas-resource-secret".to_string()),
+            registered_via_dcr: true,
+        };
+        token_manager.save_dcr("ep1", &stored).await.unwrap();
+
+        let (mut state, flow_mgr) = test_state_oauth_start("ep1", &base_url, None);
+        {
+            let mut cfg = state.config.write().await;
+            cfg.endpoints[0].client_id = None;
+            cfg.endpoints[0].client_secret = None;
+        }
+        state.token_manager = Some(token_manager.clone());
+
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/ep1/oauth/start")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let authorize_url = body["authorize_url"].as_str().unwrap();
+        let state_param = extract_state_param(authorize_url);
+        let flow = flow_mgr
+            .consume_flow(&state_param)
+            .await
+            .expect("pending flow was registered");
+        assert_eq!(
+            flow.client_id, "fresh-dcr-client",
+            "issuer mismatch must invalidate the requesting pair and drive re-registration"
+        );
+
+        let persisted = token_manager.load_dcr("ep1").await.unwrap().unwrap();
+        assert_eq!(persisted.client_id, "fresh-dcr-client");
+        assert!(persisted.registered_via_dcr);
+        assert_eq!(persisted.issuer.as_deref(), Some(base_url.as_str()));
+        assert_eq!(
+            persisted.resource_client_id.as_deref(),
+            Some("mas-resource-client"),
+            "operator-set MAS resource pair must survive issuer-mismatch invalidation"
+        );
+        assert_eq!(
+            persisted.resource_client_secret.as_deref(),
+            Some("mas-resource-secret")
+        );
+    }
+
+    /// Round-4 finding R4-4: the persist of a freshly-registered DCR
+    /// requesting client uses `update_dcr` (compare-and-update) so a
+    /// concurrent operator write that lands between our snapshot and this
+    /// save — for example, a `POST /credentials` that rotated to manual
+    /// credentials — SURVIVES intact instead of being clobbered. This
+    /// test simulates the race by letting the mock `/register` handler
+    /// block until the test manually rotates the persisted record via
+    /// `save_dcr` to a manual-provenance record, then unblocks.
+    #[tokio::test]
+    async fn oauth_start_reregister_save_does_not_clobber_concurrent_manual_rotation() {
+        use tokio::sync::oneshot;
+
+        async fn well_known(headers: axum::http::HeaderMap) -> Json<Value> {
+            let issuer = mock_issuer(&headers);
+            Json(serde_json::json!({
+                "issuer": issuer,
+                "authorization_endpoint": format!("{issuer}/authorize"),
+                "token_endpoint": format!("{issuer}/token"),
+                "registration_endpoint": format!("{issuer}/register"),
+                "code_challenge_methods_supported": ["S256"],
+            }))
+        }
+        // `/register` waits for the test to signal (via `tx_ready`) that
+        // the operator's concurrent manual write has landed, then returns
+        // the fresh DCR response. This deterministically interleaves the
+        // manual write between the caller's snapshot and its save.
+        struct RegState {
+            ready_tx: tokio::sync::Mutex<Option<oneshot::Sender<()>>>,
+            proceed_rx: tokio::sync::Mutex<Option<oneshot::Receiver<()>>>,
+        }
+        async fn register(
+            axum::extract::State(s): axum::extract::State<Arc<RegState>>,
+        ) -> Json<Value> {
+            if let Some(tx) = s.ready_tx.lock().await.take() {
+                let _ = tx.send(());
+            }
+            if let Some(rx) = s.proceed_rx.lock().await.take() {
+                let _ = rx.await;
+            }
+            Json(serde_json::json!({
+                "client_id": "fresh-dcr-client",
+                "client_secret": "fresh-dcr-secret",
+            }))
+        }
+        let (ready_tx, ready_rx) = oneshot::channel::<()>();
+        let (proceed_tx, proceed_rx) = oneshot::channel::<()>();
+        let reg_state = Arc::new(RegState {
+            ready_tx: tokio::sync::Mutex::new(Some(ready_tx)),
+            proceed_rx: tokio::sync::Mutex::new(Some(proceed_rx)),
+        });
+        let router = Router::new()
+            .route("/.well-known/oauth-authorization-server", get(well_known))
+            .route("/register", post(register))
+            .with_state(reg_state);
+        let (base_url, _server) = spawn_mock_as(router).await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let token_manager = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let stored = DcrCredentials {
+            client_id: "stale-dcr-client".to_string(),
+            client_secret: Some("stale-dcr-secret".to_string()),
+            client_secret_expires_at: 0,
+            registered_at: 0,
+            issuer: Some(base_url.clone()),
+            resource_client_id: None,
+            resource_client_secret: None,
+            registered_via_dcr: true,
+        };
+        token_manager.save_dcr("ep1", &stored).await.unwrap();
+
+        let (mut state, _flow_mgr) = test_state_oauth_start("ep1", &base_url, None);
+        {
+            let mut cfg = state.config.write().await;
+            cfg.endpoints[0].client_id = None;
+            cfg.endpoints[0].client_secret = None;
+        }
+        state.token_manager = Some(token_manager.clone());
+
+        let app = management_routes(state);
+        let start_fut = tokio::spawn(async move {
+            app.oneshot(
+                Request::post("/api/endpoints/ep1/oauth/start")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+        });
+
+        // Wait until the register handler is entered (proves the caller
+        // already read its snapshot of the DCR file) before rotating.
+        ready_rx.await.expect("register endpoint reached");
+        let manual = DcrCredentials {
+            client_id: "operator-manual-client".to_string(),
+            client_secret: Some("operator-manual-secret".to_string()),
+            client_secret_expires_at: 0,
+            registered_at: 1_700_000_000,
+            issuer: None,
+            resource_client_id: None,
+            resource_client_secret: None,
+            registered_via_dcr: false,
+        };
+        token_manager.save_dcr("ep1", &manual).await.unwrap();
+        // Now let the mock AS finish returning the fresh DCR response.
+        proceed_tx.send(()).unwrap();
+
+        let resp = start_fut.await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // The persisted record must be the operator's manual write, not
+        // the concurrent DCR re-registration result.
+        let persisted = token_manager.load_dcr("ep1").await.unwrap().unwrap();
+        assert_eq!(persisted, manual, "concurrent manual rotation must survive");
     }
 
     // -----------------------------------------------------------------------

--- a/src/management.rs
+++ b/src/management.rs
@@ -1348,6 +1348,7 @@ async fn oauth_start(
                             .unwrap_or_default()
                             .as_secs(),
                         issuer: issuer.clone(),
+                        registered_via_dcr: true,
                         ..Default::default()
                     };
                     if let Err(e) = tm.save_dcr(&name, &creds).await {
@@ -1491,6 +1492,8 @@ async fn oauth_credentials(
         // Manually-supplied credentials are user-managed, not bound to a
         // discovered issuer; leave None so they are always reused as-is.
         issuer: None,
+        // User-supplied via /oauth/credentials → never auto-discard.
+        registered_via_dcr: false,
         ..Default::default()
     };
 
@@ -1638,6 +1641,20 @@ async fn set_endpoint_credentials(
         .into_response();
     }
 
+    // If the caller touched the requesting client_id/secret at all (set OR
+    // clear), the requesting creds are now user-managed → force the DCR
+    // provenance flag off. Updates that only touch the resource_* pair leave
+    // the requesting creds untouched, so preserve the existing flag.
+    let requesting_touched = body.client_id.is_some() || body.client_secret.is_some();
+    let registered_via_dcr = if requesting_touched {
+        false
+    } else {
+        existing
+            .as_ref()
+            .map(|c| c.registered_via_dcr)
+            .unwrap_or(false)
+    };
+
     let creds = DcrCredentials {
         client_id: merged_client_id,
         client_secret,
@@ -1659,6 +1676,7 @@ async fn set_endpoint_credentials(
         issuer: existing.as_ref().and_then(|c| c.issuer.clone()),
         resource_client_id,
         resource_client_secret,
+        registered_via_dcr,
     };
 
     if let Err(e) = tm.save_dcr(&name, &creds).await {
@@ -2656,6 +2674,9 @@ async fn oauth_setup(
                         ClientRegistration::Manual => None,
                         _ => Some(issuer.clone()),
                     },
+                    // Only true DCR (RFC 7591) counts as DCR provenance;
+                    // CIMD and manual paths are never auto-discarded.
+                    registered_via_dcr: used_dcr,
                     ..Default::default()
                 };
                 if let Err(e) = tm.save_dcr(&body.name, &creds).await {
@@ -2833,6 +2854,8 @@ async fn oauth_setup_credentials(
                 .as_secs(),
             // Manually-supplied credentials are user-managed; not issuer-bound.
             issuer: None,
+            // Manual credentials from the setup session → never auto-discard.
+            registered_via_dcr: false,
             ..Default::default()
         };
         if let Err(e) = tm.save_dcr(&name, &creds).await {
@@ -5424,6 +5447,8 @@ async fn create_organization(
                 client_secret_expires_at: 0,
                 registered_at: now,
                 issuer: Some(issuer.clone()),
+                // Org SSO secret is user-supplied via the create route.
+                registered_via_dcr: false,
                 ..Default::default()
             };
             if let Err(e) = tm.save_dcr(&name, &creds).await {
@@ -5721,6 +5746,8 @@ async fn update_organization(
                     client_secret_expires_at: 0,
                     registered_at: now,
                     issuer: Some(new_issuer.clone()),
+                    // Org SSO secret is user-supplied via the update route.
+                    registered_via_dcr: false,
                     ..Default::default()
                 };
                 if let Err(e) = tm.save_dcr(&new_name, &creds).await {

--- a/src/management.rs
+++ b/src/management.rs
@@ -1313,11 +1313,90 @@ async fn oauth_start(
         other => other,
     };
 
-    let (client_id, client_secret, dcr_used) = if let Some(cid) = config_client_id {
-        // TOML has a client_id. Prefer the DCR-persisted client_secret when
-        // the DCR record's client_id matches; otherwise fall back to whatever
-        // is in TOML (which may be None for endpoints added via the desktop
-        // UI — that is the bug this branch fixes).
+    // A DCR-provenanced record (`registered_via_dcr == true`) with a live
+    // `registration_endpoint` always takes the interactive re-registration
+    // heal path — including when `config.toml` still carries a stale DCR
+    // `client_id` from the initial setup commit (setup persists the DCR
+    // pair to TOML alongside the `.dcr.json` file, so `config_client_id`
+    // is `Some` for every setup-created endpoint and would otherwise skip
+    // this branch, breaking the RFC 7591 re-registration promise for the
+    // most common shape of DCR endpoint). The DCR file is the authoritative
+    // source for DCR-provenanced credentials — `watcher::resolve_oauth_client_creds`
+    // already prefers it at startup — so we do not need to rewrite `config.toml`
+    // here for the running adapter (Finding 2's `set_client_credentials`
+    // override propagates the newly minted pair after the callback succeeds,
+    // and the DCR file is what a restart consults). See spec: Root cause
+    // analysis / Approach Part 2.
+    let dcr_reregister = matches!(
+        (persisted_dcr.as_ref(), registration_endpoint.as_ref()),
+        (Some(creds), Some(_)) if creds.registered_via_dcr
+    );
+
+    let (client_id, client_secret, dcr_used) = if dcr_reregister {
+        // Safe: the `matches!` above proved both are `Some`.
+        let creds = persisted_dcr.as_ref().unwrap();
+        let reg_endpoint = registration_endpoint.as_ref().unwrap();
+        match dcr::register_client(reg_endpoint, &redirect_uri, &name, allow_insecure_oauth).await {
+            Ok(resp) => {
+                if let Some(ref tm) = state.token_manager {
+                    let new_creds = DcrCredentials {
+                        client_id: resp.client_id.clone(),
+                        client_secret: resp.client_secret.clone(),
+                        client_secret_expires_at: resp.client_secret_expires_at,
+                        registered_at: std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_secs(),
+                        issuer: issuer.clone(),
+                        // Preserve the per-endpoint MAS resource
+                        // credential pair (captured separately via
+                        // POST /credentials); it is a distinct
+                        // registration from the requesting client.
+                        resource_client_id: creds.resource_client_id.clone(),
+                        resource_client_secret: creds.resource_client_secret.clone(),
+                        registered_via_dcr: true,
+                    };
+                    if let Err(e) = tm.save_dcr(&name, &new_creds).await {
+                        warn!(
+                            endpoint = %name,
+                            error = %e,
+                            "Failed to persist re-registered DCR credentials"
+                        );
+                    }
+                }
+                if config_client_id
+                    .as_ref()
+                    .is_some_and(|cid| cid != &resp.client_id)
+                {
+                    info!(
+                        endpoint = %name,
+                        stale_config_client_id = ?config_client_id,
+                        fresh_dcr_client_id = %resp.client_id,
+                        "DCR re-registration minted a new client_id; config.toml still \
+                         carries the previous id — the running adapter's in-memory \
+                         override and the DCR file are the authoritative sources \
+                         (resolve_oauth_client_creds prefers the DCR file on restart)"
+                    );
+                }
+                (resp.client_id, resp.client_secret, true)
+            }
+            Err(e) => {
+                warn!(
+                    endpoint = %name,
+                    error = %e,
+                    "DCR re-registration failed; falling back to stored credentials"
+                );
+                (creds.client_id.clone(), creds.client_secret.clone(), true)
+            }
+        }
+    } else if let Some(cid) = config_client_id {
+        // TOML has a client_id and the DCR record (if any) is either
+        // manually supplied (`registered_via_dcr == false`) or the
+        // authorization server does not expose a registration endpoint —
+        // in both cases we reuse the record as-is. Prefer the
+        // DCR-persisted `client_secret` when the DCR `client_id` matches;
+        // otherwise fall back to whatever is in TOML (which may be `None`
+        // for endpoints added via the desktop UI).
         match persisted_dcr {
             Some(creds) if creds.client_id == cid => (cid, creds.client_secret, false),
             Some(creds) => {
@@ -1332,58 +1411,11 @@ async fn oauth_start(
             None => (cid, config_client_secret, false),
         }
     } else if let Some(creds) = persisted_dcr {
-        // Interactive auth-start heals a purged server-side registration by
-        // re-registering a FRESH client_id whenever the persisted record was
-        // itself minted via DCR AND a live `registration_endpoint` is
-        // available. Manual credentials (`registered_via_dcr == false`) and
-        // the no-registration-endpoint case reuse the stored record
-        // unchanged. See spec: Root cause analysis / Approach Part 2.
-        match (creds.registered_via_dcr, registration_endpoint.as_ref()) {
-            (true, Some(reg_endpoint)) => {
-                match dcr::register_client(reg_endpoint, &redirect_uri, &name, allow_insecure_oauth)
-                    .await
-                {
-                    Ok(resp) => {
-                        if let Some(ref tm) = state.token_manager {
-                            let new_creds = DcrCredentials {
-                                client_id: resp.client_id.clone(),
-                                client_secret: resp.client_secret.clone(),
-                                client_secret_expires_at: resp.client_secret_expires_at,
-                                registered_at: std::time::SystemTime::now()
-                                    .duration_since(std::time::UNIX_EPOCH)
-                                    .unwrap_or_default()
-                                    .as_secs(),
-                                issuer: issuer.clone(),
-                                // Preserve the per-endpoint MAS resource
-                                // credential pair (captured separately via
-                                // POST /credentials); it is a distinct
-                                // registration from the requesting client.
-                                resource_client_id: creds.resource_client_id.clone(),
-                                resource_client_secret: creds.resource_client_secret.clone(),
-                                registered_via_dcr: true,
-                            };
-                            if let Err(e) = tm.save_dcr(&name, &new_creds).await {
-                                warn!(
-                                    endpoint = %name,
-                                    error = %e,
-                                    "Failed to persist re-registered DCR credentials"
-                                );
-                            }
-                        }
-                        (resp.client_id, resp.client_secret, true)
-                    }
-                    Err(e) => {
-                        warn!(
-                            endpoint = %name,
-                            error = %e,
-                            "DCR re-registration failed; falling back to stored credentials"
-                        );
-                        (creds.client_id, creds.client_secret, true)
-                    }
-                }
-            }
-            _ => (creds.client_id, creds.client_secret, true),
-        }
+        // No config `client_id`, and either the record is
+        // manually-supplied (`registered_via_dcr == false`) or there is
+        // no live registration endpoint to re-register against. Reuse
+        // the stored record unchanged.
+        (creds.client_id, creds.client_secret, true)
     } else if let Some(ref reg_endpoint) = registration_endpoint {
         // Attempt dynamic client registration (URL guard + pinned client inside)
         match dcr::register_client(reg_endpoint, &redirect_uri, &name, allow_insecure_oauth).await {
@@ -1694,8 +1726,16 @@ async fn set_endpoint_credentials(
 
     // If the caller touched the requesting client_id/secret at all (set OR
     // clear), the requesting creds are now user-managed → force the DCR
-    // provenance flag off. Updates that only touch the resource_* pair leave
-    // the requesting creds untouched, so preserve the existing flag.
+    // provenance flag off AND clear any previous `issuer` binding. The
+    // provenance flag alone is not enough: `oauth_start` rejects a
+    // credential whose stored `issuer` differs from the currently
+    // discovered one BEFORE it checks the provenance flag, so a manual
+    // replace that left the DCR-era `issuer` in place would be discarded
+    // on a later issuer change and silently overwritten by a fresh DCR
+    // registration — exactly the "manual credentials survive" promise
+    // this endpoint makes to callers. Updates that only touch the
+    // `resource_*` pair leave the requesting creds untouched, so
+    // preserve the existing provenance flag AND `issuer`.
     let requesting_touched = body.client_id.is_some() || body.client_secret.is_some();
     let registered_via_dcr = if requesting_touched {
         false
@@ -1704,6 +1744,11 @@ async fn set_endpoint_credentials(
             .as_ref()
             .map(|c| c.registered_via_dcr)
             .unwrap_or(false)
+    };
+    let issuer = if requesting_touched {
+        None
+    } else {
+        existing.as_ref().and_then(|c| c.issuer.clone())
     };
 
     let creds = DcrCredentials {
@@ -1722,9 +1767,10 @@ async fn set_endpoint_credentials(
                     .unwrap_or_default()
                     .as_secs()
             }),
-        // Manually-supplied credentials are user-managed, not bound to a
-        // discovered issuer; preserve any existing binding but never invent one.
-        issuer: existing.as_ref().and_then(|c| c.issuer.clone()),
+        // Manually-supplied credentials are user-managed and not bound to
+        // a discovered issuer; preserve any existing binding only when
+        // the requesting pair was not touched, and never invent one.
+        issuer,
         resource_client_id,
         resource_client_secret,
         registered_via_dcr,
@@ -9221,6 +9267,119 @@ command = "echo"
         );
     }
 
+    /// Regression for PR #130 Finding 4: replacing a DCR-provenanced
+    /// requesting pair with a manual pair must clear the stored `issuer`
+    /// binding, not just flip `registered_via_dcr = false`. `oauth_start`
+    /// rejects a persisted DCR record whose `issuer` differs from the
+    /// currently discovered one BEFORE it checks the provenance flag, so
+    /// leaving the DCR-era issuer on the record would let a later issuer
+    /// change silently discard the manual credentials and overwrite them
+    /// with a fresh DCR registration — breaking the "manual credentials
+    /// survive" promise this endpoint makes.
+    #[tokio::test]
+    async fn endpoint_credentials_manual_replace_clears_issuer_binding() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (state, tm) = test_state_with_token_manager("ep1", tmp.path(), None, None).await;
+
+        // Seed a DCR-provenanced record with an `issuer` binding.
+        let stored = DcrCredentials {
+            client_id: "old-dcr-client".to_string(),
+            client_secret: Some("old-dcr-secret".to_string()),
+            client_secret_expires_at: 0,
+            registered_at: 42,
+            issuer: Some("https://as.example.com".to_string()),
+            resource_client_id: Some("res-client".to_string()),
+            resource_client_secret: Some("res-secret".to_string()),
+            registered_via_dcr: true,
+        };
+        tm.save_dcr("ep1", &stored).await.unwrap();
+
+        let app = management_routes(state);
+        // Manually replace the requesting pair only.
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/ep1/credentials")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "client_id": "manual-client",
+                            "client_secret": "manual-secret",
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let loaded = tm.load_dcr("ep1").await.unwrap().unwrap();
+        assert_eq!(loaded.client_id, "manual-client");
+        assert_eq!(loaded.client_secret.as_deref(), Some("manual-secret"));
+        assert!(
+            !loaded.registered_via_dcr,
+            "manual replace must flip the provenance flag off"
+        );
+        assert!(
+            loaded.issuer.is_none(),
+            "manual replace must clear the DCR-era issuer binding so a later \
+             issuer change does not silently discard the manual credentials"
+        );
+        // The MAS resource pair is untouched by a requesting-pair replace.
+        assert_eq!(loaded.resource_client_id.as_deref(), Some("res-client"));
+        assert_eq!(loaded.resource_client_secret.as_deref(), Some("res-secret"));
+    }
+
+    /// A resource-only update must NOT clear the stored `issuer` binding —
+    /// the DCR-provenanced requesting pair is untouched, so its issuer
+    /// binding stays valid.
+    #[tokio::test]
+    async fn endpoint_credentials_resource_only_update_preserves_issuer() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (state, tm) = test_state_with_token_manager("ep1", tmp.path(), None, None).await;
+
+        let stored = DcrCredentials {
+            client_id: "dcr-client".to_string(),
+            client_secret: Some("dcr-secret".to_string()),
+            client_secret_expires_at: 0,
+            registered_at: 42,
+            issuer: Some("https://as.example.com".to_string()),
+            resource_client_id: None,
+            resource_client_secret: None,
+            registered_via_dcr: true,
+        };
+        tm.save_dcr("ep1", &stored).await.unwrap();
+
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/ep1/credentials")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "resource_client_id": "res-client",
+                            "resource_client_secret": "res-secret",
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let loaded = tm.load_dcr("ep1").await.unwrap().unwrap();
+        assert!(
+            loaded.registered_via_dcr,
+            "resource-only update must preserve the DCR provenance flag"
+        );
+        assert_eq!(
+            loaded.issuer.as_deref(),
+            Some("https://as.example.com"),
+            "resource-only update must preserve the existing issuer binding"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // oauth_start: AS discovery when oauth_server_url is set
     // -----------------------------------------------------------------------
@@ -10000,6 +10159,93 @@ command = "echo"
         assert_eq!(persisted.client_id, "manual-client");
         assert_eq!(persisted.registered_at, 7);
         assert!(!persisted.registered_via_dcr);
+    }
+
+    /// Regression for PR #130 Finding 1: setup-created endpoints persist
+    /// the DCR `client_id`/`client_secret` into `config.toml` alongside
+    /// the `.dcr.json` file, so `config_client_id.is_some()` is true for
+    /// every setup-created endpoint. If the config-branch is checked
+    /// first, the DCR-provenanced re-registration heal path is
+    /// unreachable and stale server-side registrations loop forever. The
+    /// resolution must check DCR-provenanced re-registration BEFORE the
+    /// config branch and mint a fresh client_id.
+    #[tokio::test]
+    async fn oauth_start_reregisters_dcr_record_even_when_config_carries_stale_client_id() {
+        async fn well_known(headers: axum::http::HeaderMap) -> Json<Value> {
+            let issuer = mock_issuer(&headers);
+            Json(serde_json::json!({
+                "issuer": issuer,
+                "authorization_endpoint": format!("{issuer}/authorize"),
+                "token_endpoint": format!("{issuer}/token"),
+                "registration_endpoint": format!("{issuer}/register"),
+                "code_challenge_methods_supported": ["S256"],
+            }))
+        }
+        async fn register() -> Json<Value> {
+            Json(serde_json::json!({
+                "client_id": "fresh-dcr-client",
+                "client_secret": "fresh-dcr-secret",
+            }))
+        }
+        let router = Router::new()
+            .route("/.well-known/oauth-authorization-server", get(well_known))
+            .route("/register", post(register));
+        let (base_url, _server) = spawn_mock_as(router).await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let token_manager = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+
+        // The DCR record and `config.toml` BOTH carry the same stale
+        // `client_id` — this is exactly what setup writes on commit
+        // (see `oauth_setup_commit` in this module: DCR pair persisted
+        // to disk AND stamped into `config.toml`). The record is
+        // DCR-provenanced so the RFC 7591 heal path applies.
+        let stored = DcrCredentials {
+            client_id: "stale-dcr-client".to_string(),
+            client_secret: Some("stale-dcr-secret".to_string()),
+            client_secret_expires_at: 0,
+            registered_at: 0,
+            issuer: Some(base_url.clone()),
+            registered_via_dcr: true,
+            ..Default::default()
+        };
+        token_manager.save_dcr("ep1", &stored).await.unwrap();
+
+        let (mut state, flow_mgr) = test_state_oauth_start("ep1", &base_url, None);
+        {
+            let mut cfg = state.config.write().await;
+            cfg.endpoints[0].client_id = Some("stale-dcr-client".to_string());
+            cfg.endpoints[0].client_secret = Some("stale-dcr-secret".to_string());
+        }
+        state.token_manager = Some(token_manager.clone());
+
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/ep1/oauth/start")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let authorize_url = body["authorize_url"].as_str().unwrap();
+        let state_param = extract_state_param(authorize_url);
+        let flow = flow_mgr
+            .consume_flow(&state_param)
+            .await
+            .expect("pending flow was registered");
+        assert_eq!(
+            flow.client_id, "fresh-dcr-client",
+            "config.toml carrying the same stale DCR client_id must NOT block \
+             the DCR-provenanced re-registration heal path"
+        );
+        assert_eq!(flow.client_secret, Some("fresh-dcr-secret".to_string()));
+
+        let persisted = token_manager.load_dcr("ep1").await.unwrap().unwrap();
+        assert_eq!(persisted.client_id, "fresh-dcr-client");
+        assert!(persisted.registered_via_dcr);
     }
 
     // -----------------------------------------------------------------------

--- a/src/server.rs
+++ b/src/server.rs
@@ -2242,18 +2242,29 @@ async fn oauth_callback(
     // freshly discovered token endpoint used for this code exchange into the
     // adapter's in-memory override so the next proactive refresh POSTs to
     // the same URL we just succeeded against — without depending on whether
-    // startup-time discovery ran or returned the same result.
+    // startup-time discovery ran or returned the same result. Finally,
+    // propagate the requesting `client_id` / `client_secret` this exchange
+    // presented into the adapter's in-memory client-credentials override
+    // so the next proactive refresh POSTs the freshly re-registered
+    // credentials — otherwise a DCR re-registration during auth-start
+    // would leave the running adapter still posting the stale (now
+    // invalid) client_id, tripping the `invalid_client` self-heal on the
+    // very next refresh and looping.
     if let Some(ref inners) = state.oauth_adapter_inners {
         let inners = inners.read().await;
         if let Some(inner) = inners.get(&flow.endpoint_name) {
             inner
                 .set_token_endpoint_override(flow.token_endpoint.clone())
                 .await;
+            inner
+                .set_client_credentials(flow.client_id.clone(), flow.client_secret.clone())
+                .await;
             inner.apply_tokens(token_set.clone()).await;
             info!(
                 endpoint = %flow.endpoint_name,
                 token_endpoint = %flow.token_endpoint,
-                "Tokens applied to OAuth adapter; token endpoint override updated"
+                client_id = %flow.client_id,
+                "Tokens applied to OAuth adapter; token endpoint and client credentials overrides updated"
             );
         }
     }
@@ -5987,6 +5998,111 @@ mod tests {
         assert_eq!(
             loaded.resource_client_secret.as_deref(),
             Some("mas-resource-secret")
+        );
+    }
+
+    /// After a successful interactive re-authorization the callback must
+    /// propagate the requesting `client_id` / `client_secret` this exchange
+    /// presented into the running adapter's `client_credentials_override`,
+    /// so the next proactive refresh POSTs the freshly re-registered pair
+    /// (not the stale one from startup config) and does not immediately
+    /// loop through the `invalid_client` self-heal. Guards Finding 2 of
+    /// PR #130.
+    #[tokio::test]
+    async fn oauth_callback_success_propagates_client_credentials_to_running_adapter() {
+        use crate::adapter::oauth::{OAuthAdapter, OAuthAdapterConfig};
+        use axum::{routing::post, Router};
+
+        // Mock token endpoint that returns a valid access-token response.
+        let router = Router::new().route(
+            "/token",
+            post(|| async {
+                "{\"access_token\":\"fresh-access\",\"refresh_token\":\"fresh-refresh\",\"token_type\":\"Bearer\",\"expires_in\":3600}"
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _server = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let token_endpoint = format!("http://127.0.0.1:{}/token", addr.port());
+
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let endpoint_name = "propagate-ep";
+
+        // Build a real OAuthAdapter whose config carries the STALE
+        // client_id/client_secret baked in at startup, and register its
+        // inner in the shared `oauth_adapter_inners` map exactly like
+        // `main.rs` does.
+        let config = OAuthAdapterConfig {
+            endpoint_name: endpoint_name.to_string(),
+            url: "http://127.0.0.1:1/mcp".to_string(),
+            token_endpoint_url: token_endpoint.clone(),
+            client_id: "stale-client".to_string(),
+            client_secret: Some("stale-secret".to_string()),
+            heartbeat_interval_secs: 30,
+            probe_timeout_secs: 10,
+            probe_failure_threshold: 3,
+            server_type_override: None,
+            allow_insecure_oauth: true,
+            ema: None,
+        };
+        let adapter = OAuthAdapter::new(config, tm.clone());
+        let shared_inner = adapter.shared_inner();
+        let inners: OAuthAdapterInners = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+        inners
+            .write()
+            .await
+            .insert(endpoint_name.to_string(), shared_inner.clone());
+
+        // Pre-condition: the adapter's effective client credentials come
+        // from static config until the override is installed.
+        assert_eq!(shared_inner.effective_client_id().await, "stale-client");
+        assert_eq!(
+            shared_inner.effective_client_secret().await.as_deref(),
+            Some("stale-secret")
+        );
+
+        let flow_mgr = Arc::new(OAuthFlowManager::new());
+        let pkce = crate::oauth::PkceChallenge::generate();
+        // The pending flow carries the FRESH credentials minted by the
+        // DCR re-registration during auth-start.
+        let state_param = flow_mgr
+            .start_flow(
+                endpoint_name,
+                &token_endpoint,
+                "fresh-client",
+                Some("fresh-secret"),
+                pkce,
+                "http://127.0.0.1:9400/oauth/callback",
+                None,
+                false,
+            )
+            .await;
+
+        let mut app_state = test_app_state();
+        app_state.oauth_flow_manager = Some(flow_mgr);
+        app_state.token_manager = Some(tm.clone());
+        app_state.oauth_adapter_inners = Some(inners);
+
+        let params = OAuthCallbackParams {
+            code: Some("authcode".to_string()),
+            state: Some(state_param),
+            error: None,
+            iss: None,
+        };
+        let resp = oauth_callback(State(app_state), Query(params)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Post-condition: the callback propagated the fresh credentials
+        // into the adapter's in-memory override so the next refresh will
+        // POST them.
+        assert_eq!(shared_inner.effective_client_id().await, "fresh-client");
+        assert_eq!(
+            shared_inner.effective_client_secret().await.as_deref(),
+            Some("fresh-secret")
         );
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -2055,27 +2055,47 @@ async fn oauth_callback(
 
         // RFC 6749 §5.2: `invalid_client` means the AS no longer recognizes
         // the presented `client_id`. If this endpoint's credentials were
-        // minted via DCR (`registered_via_dcr == true`), discard the stale
-        // record so the next Authorize triggers a fresh RFC 7591
-        // registration. Manually-supplied credentials
-        // (`registered_via_dcr == false`) are never auto-deleted.
+        // minted via DCR (`registered_via_dcr == true`) AND the stored
+        // `client_id` still matches the one this exchange presented,
+        // atomically clear ONLY the requesting `client_id`/`client_secret`
+        // pair so the next Authorize triggers a fresh RFC 7591 registration.
+        // Manually-supplied credentials (`registered_via_dcr == false`) and
+        // a stored `client_id` that no longer matches (concurrent
+        // re-registration replaced the record) are never auto-discarded;
+        // operator-set `resource_client_id`/`resource_client_secret` are
+        // preserved.
         let mut discarded_dcr = false;
         if crate::adapter::oauth::is_invalid_client_error(&body) {
             if let Some(ref tm) = state.token_manager {
                 if let Ok(Some(creds)) = tm.load_dcr(&flow.endpoint_name).await {
                     if creds.registered_via_dcr {
-                        if let Err(e) = tm.delete_dcr(&flow.endpoint_name).await {
-                            error!(
-                                endpoint = %flow.endpoint_name,
-                                error = %e,
-                                "Failed to delete stale DCR credentials after invalid_client"
-                            );
-                        } else {
-                            discarded_dcr = true;
-                            info!(
-                                endpoint = %flow.endpoint_name,
-                                "Discarded stale DCR credentials after invalid_client during code exchange"
-                            );
+                        match tm
+                            .clear_dcr_requesting_client(&flow.endpoint_name, &flow.client_id)
+                            .await
+                        {
+                            Ok(true) => {
+                                discarded_dcr = true;
+                                info!(
+                                    endpoint = %flow.endpoint_name,
+                                    client_id = %flow.client_id,
+                                    "Cleared stale DCR requesting client after invalid_client during code exchange"
+                                );
+                            }
+                            Ok(false) => {
+                                info!(
+                                    endpoint = %flow.endpoint_name,
+                                    failing_client_id = %flow.client_id,
+                                    stored_client_id = %creds.client_id,
+                                    "invalid_client for stale client_id at code exchange; a newer registration is already persisted"
+                                );
+                            }
+                            Err(e) => {
+                                error!(
+                                    endpoint = %flow.endpoint_name,
+                                    error = %e,
+                                    "Failed to clear stale DCR requesting client after invalid_client"
+                                );
+                            }
                         }
                     }
                 }
@@ -5901,6 +5921,132 @@ mod tests {
             .unwrap()
             .expect("manual credential record must be preserved on invalid_client");
         assert_eq!(loaded, manual);
+    }
+
+    /// A mixed DCR record (requesting `client_id`/`client_secret` alongside
+    /// operator-set `resource_client_id`/`resource_client_secret`) must have
+    /// only the requesting pair cleared on `invalid_client` at code exchange;
+    /// the resource pair is a separate MAS registration and must survive.
+    #[tokio::test]
+    async fn oauth_callback_invalid_client_preserves_resource_pair() {
+        use crate::token_manager::DcrCredentials;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let endpoint_name = "mixed-ep";
+        let mixed = DcrCredentials {
+            client_id: "dcr-client-123".to_string(),
+            client_secret: Some("dcr-secret".to_string()),
+            client_secret_expires_at: 0,
+            registered_at: 1_700_000_000,
+            issuer: Some("https://as.example.com".to_string()),
+            resource_client_id: Some("mas-resource".to_string()),
+            resource_client_secret: Some("mas-resource-secret".to_string()),
+            registered_via_dcr: true,
+        };
+        tm.save_dcr(endpoint_name, &mixed).await.unwrap();
+
+        let (token_endpoint, _server) = spawn_invalid_client_token_endpoint().await;
+        let flow_mgr = Arc::new(OAuthFlowManager::new());
+        let pkce = crate::oauth::PkceChallenge::generate();
+        let state_param = flow_mgr
+            .start_flow(
+                endpoint_name,
+                &token_endpoint,
+                "dcr-client-123",
+                Some("dcr-secret"),
+                pkce,
+                "http://127.0.0.1:9400/oauth/callback",
+                None,
+                false,
+            )
+            .await;
+
+        let mut app_state = test_app_state();
+        app_state.oauth_flow_manager = Some(flow_mgr);
+        app_state.token_manager = Some(tm.clone());
+
+        let params = OAuthCallbackParams {
+            code: Some("authcode".to_string()),
+            state: Some(state_param),
+            error: None,
+            iss: None,
+        };
+        let resp = oauth_callback(State(app_state), Query(params)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let loaded = tm
+            .load_dcr(endpoint_name)
+            .await
+            .unwrap()
+            .expect("mixed record must persist so the resource pair is retained");
+        assert_eq!(loaded.client_id, "");
+        assert!(loaded.client_secret.is_none());
+        assert!(!loaded.registered_via_dcr);
+        assert_eq!(loaded.resource_client_id.as_deref(), Some("mas-resource"));
+        assert_eq!(
+            loaded.resource_client_secret.as_deref(),
+            Some("mas-resource-secret")
+        );
+    }
+
+    /// A concurrent re-registration replaced the DCR record with a NEWER
+    /// `client_id` while the in-flight code exchange is still using the
+    /// previous one. When that stale exchange returns `invalid_client`, the
+    /// self-heal must not touch the newer record.
+    #[tokio::test]
+    async fn oauth_callback_invalid_client_leaves_newer_registration_intact() {
+        use crate::token_manager::DcrCredentials;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let endpoint_name = "raced-ep";
+        // On-disk record is the newer registration; the flow below still
+        // presents the stale client_id it was started with.
+        let newer = DcrCredentials {
+            client_id: "fresh-client".to_string(),
+            client_secret: Some("fresh-secret".to_string()),
+            registered_via_dcr: true,
+            ..Default::default()
+        };
+        tm.save_dcr(endpoint_name, &newer).await.unwrap();
+
+        let (token_endpoint, _server) = spawn_invalid_client_token_endpoint().await;
+        let flow_mgr = Arc::new(OAuthFlowManager::new());
+        let pkce = crate::oauth::PkceChallenge::generate();
+        let state_param = flow_mgr
+            .start_flow(
+                endpoint_name,
+                &token_endpoint,
+                "stale-client",
+                None,
+                pkce,
+                "http://127.0.0.1:9400/oauth/callback",
+                None,
+                false,
+            )
+            .await;
+
+        let mut app_state = test_app_state();
+        app_state.oauth_flow_manager = Some(flow_mgr);
+        app_state.token_manager = Some(tm.clone());
+
+        let params = OAuthCallbackParams {
+            code: Some("authcode".to_string()),
+            state: Some(state_param),
+            error: None,
+            iss: None,
+        };
+        let _ = oauth_callback(State(app_state), Query(params)).await;
+
+        let loaded = tm
+            .load_dcr(endpoint_name)
+            .await
+            .unwrap()
+            .expect("newer registration must survive stale invalid_client");
+        assert_eq!(loaded.client_id, "fresh-client");
+        assert_eq!(loaded.client_secret.as_deref(), Some("fresh-secret"));
+        assert!(loaded.registered_via_dcr);
     }
 
     // --- /mcp/sse + initialize tools.listChanged capability ---

--- a/src/server.rs
+++ b/src/server.rs
@@ -5819,7 +5819,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn oauth_callback_invalid_client_deletes_dcr_registered_record() {
+    async fn oauth_callback_invalid_client_clears_dcr_registered_record() {
         use crate::token_manager::DcrCredentials;
         use axum::body::to_bytes;
 
@@ -5866,9 +5866,14 @@ mod tests {
         let resp = oauth_callback(State(app_state), Query(params)).await;
         assert_eq!(resp.status(), StatusCode::OK);
 
+        let loaded = tm.load_dcr(endpoint_name).await.unwrap().expect(
+            "pure-DCR self-heal must retain a stub record so the next authorize re-registers",
+        );
+        assert_eq!(loaded.client_id, "");
+        assert!(loaded.client_secret.is_none());
         assert!(
-            tm.load_dcr(endpoint_name).await.unwrap().is_none(),
-            "invalid_client at code exchange must delete the DCR-registered record"
+            loaded.registered_via_dcr,
+            "registered_via_dcr must survive so the next authorize prefers re-registration over the stale config.toml client_id"
         );
 
         let body = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
@@ -5993,7 +5998,10 @@ mod tests {
             .expect("mixed record must persist so the resource pair is retained");
         assert_eq!(loaded.client_id, "");
         assert!(loaded.client_secret.is_none());
-        assert!(!loaded.registered_via_dcr);
+        assert!(
+            loaded.registered_via_dcr,
+            "mixed-record self-heal must retain the DCR provenance flag so the next authorize prefers re-registration over the stale config.toml client_id"
+        );
         assert_eq!(loaded.resource_client_id.as_deref(), Some("mas-resource"));
         assert_eq!(
             loaded.resource_client_secret.as_deref(),

--- a/src/server.rs
+++ b/src/server.rs
@@ -2014,6 +2014,41 @@ async fn oauth_callback(
         }
     }
 
+    // Superseded-flow guard (round-4 finding R4-3): reject an
+    // endpoint-installing flow (`idp_issuer.is_none()`, i.e. a regular
+    // resource OAuth flow) whose `flow.client_id` no longer matches the
+    // currently persisted DCR requesting `client_id`. A DCR-provenanced
+    // record with a non-empty `client_id` that differs from `flow.client_id`
+    // means a concurrent re-registration replaced the requesting pair
+    // between authorize and callback; exchanging this code against the
+    // stale pair would either fail with `invalid_client` (racing the newer
+    // registration into the self-heal path) or succeed with a token bound
+    // to an already-superseded client. Neither is desirable — the user
+    // should just re-Authorize against the current pair. EMA IdP flows
+    // (`idp_issuer.is_some()`) install IdP credentials, not endpoint DCR
+    // credentials, and are exempt from this check.
+    if flow.idp_issuer.is_none() {
+        if let Some(ref tm) = state.token_manager {
+            if let Ok(Some(persisted)) = tm.load_dcr(&flow.endpoint_name).await {
+                if persisted.registered_via_dcr
+                    && !persisted.client_id.is_empty()
+                    && persisted.client_id != flow.client_id
+                {
+                    warn!(
+                        endpoint = %flow.endpoint_name,
+                        flow_client_id = %flow.client_id,
+                        current_client_id = %persisted.client_id,
+                        "Rejecting superseded OAuth callback: DCR client_id changed between authorize and callback"
+                    );
+                    return oauth_html_response(
+                        "<html><body><h1>OAuth Error</h1><p>This login session was superseded by a newer client registration. Please click Authorize again.</p><p>You can close this window.</p></body></html>"
+                            .to_string(),
+                    );
+                }
+            }
+        }
+    }
+
     // Exchange authorization code for tokens
     let client = reqwest::Client::new();
     let mut form_parts: Vec<(String, String)> = vec![
@@ -6007,6 +6042,106 @@ mod tests {
             loaded.resource_client_secret.as_deref(),
             Some("mas-resource-secret")
         );
+    }
+
+    /// Round-4 finding R4-3: if a fresh DCR re-registration lands
+    /// between authorize and callback, the persisted DCR `client_id`
+    /// will differ from the one baked into the pending flow. Exchanging
+    /// the auth code against the superseded `flow.client_id` would either
+    /// race the newer registration into the self-heal path or install a
+    /// token bound to an already-superseded client. The callback must
+    /// reject the flow with a clear "please Authorize again" error and
+    /// must NOT POST to the token endpoint.
+    #[tokio::test]
+    async fn oauth_callback_rejects_superseded_flow_when_dcr_client_id_changed() {
+        use crate::token_manager::DcrCredentials;
+        use axum::body::to_bytes;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        // Token endpoint counts POSTs so we can assert it was never hit.
+        let token_hits = Arc::new(AtomicUsize::new(0));
+        let hits = token_hits.clone();
+        let router = axum::Router::new().route(
+            "/token",
+            axum::routing::post(move || {
+                let hits = hits.clone();
+                async move {
+                    hits.fetch_add(1, Ordering::SeqCst);
+                    "{\"access_token\":\"unused\",\"token_type\":\"Bearer\",\"expires_in\":3600}"
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _server = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let token_endpoint = format!("http://127.0.0.1:{}/token", addr.port());
+
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let endpoint_name = "superseded-ep";
+        // The currently-persisted DCR record has the freshly re-registered
+        // client_id — a concurrent Authorize replaced the requesting pair
+        // while the older flow was still in flight.
+        tm.save_dcr(
+            endpoint_name,
+            &DcrCredentials {
+                client_id: "fresh-dcr-client".to_string(),
+                registered_via_dcr: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let flow_mgr = Arc::new(OAuthFlowManager::new());
+        let pkce = crate::oauth::PkceChallenge::generate();
+        // The pending flow was started against the SUPERSEDED client_id.
+        let state_param = flow_mgr
+            .start_flow(
+                endpoint_name,
+                &token_endpoint,
+                "stale-dcr-client",
+                None,
+                pkce,
+                "http://127.0.0.1:9400/oauth/callback",
+                None,
+                false,
+            )
+            .await;
+
+        let mut app_state = test_app_state();
+        app_state.oauth_flow_manager = Some(flow_mgr);
+        app_state.token_manager = Some(tm.clone());
+
+        let params = OAuthCallbackParams {
+            code: Some("authcode".to_string()),
+            state: Some(state_param),
+            error: None,
+            iss: None,
+        };
+        let resp = oauth_callback(State(app_state), Query(params)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        assert_eq!(
+            token_hits.load(Ordering::SeqCst),
+            0,
+            "superseded-flow guard must reject before POSTing to the token endpoint"
+        );
+
+        let body = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            body_str.contains("superseded"),
+            "error page must explain the flow was superseded: {body_str}"
+        );
+
+        // The persisted DCR record is untouched by the rejected callback.
+        let loaded = tm.load_dcr(endpoint_name).await.unwrap().unwrap();
+        assert_eq!(loaded.client_id, "fresh-dcr-client");
+        assert!(loaded.registered_via_dcr);
     }
 
     /// After a successful interactive re-authorization the callback must

--- a/src/server.rs
+++ b/src/server.rs
@@ -2052,11 +2052,49 @@ async fn oauth_callback(
         let status = token_response.status();
         let body = token_response.text().await.unwrap_or_default();
         error!(%status, body = %body, "Token endpoint returned error");
-        return oauth_html_response(format!(
-            "<html><body><h1>OAuth Error</h1><p>Token endpoint returned {}: {}</p><p>You can close this window.</p></body></html>",
-            html_escape(status.as_str()),
-            html_escape(&body)
-        ));
+
+        // RFC 6749 §5.2: `invalid_client` means the AS no longer recognizes
+        // the presented `client_id`. If this endpoint's credentials were
+        // minted via DCR (`registered_via_dcr == true`), discard the stale
+        // record so the next Authorize triggers a fresh RFC 7591
+        // registration. Manually-supplied credentials
+        // (`registered_via_dcr == false`) are never auto-deleted.
+        let mut discarded_dcr = false;
+        if crate::adapter::oauth::is_invalid_client_error(&body) {
+            if let Some(ref tm) = state.token_manager {
+                if let Ok(Some(creds)) = tm.load_dcr(&flow.endpoint_name).await {
+                    if creds.registered_via_dcr {
+                        if let Err(e) = tm.delete_dcr(&flow.endpoint_name).await {
+                            error!(
+                                endpoint = %flow.endpoint_name,
+                                error = %e,
+                                "Failed to delete stale DCR credentials after invalid_client"
+                            );
+                        } else {
+                            discarded_dcr = true;
+                            info!(
+                                endpoint = %flow.endpoint_name,
+                                "Discarded stale DCR credentials after invalid_client during code exchange"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        let error_html = if discarded_dcr {
+            format!(
+                "<html><body><h1>OAuth Error</h1><p>The authorization server no longer recognizes this client (<code>invalid_client</code>). The stale client registration for <strong>{}</strong> has been discarded — please click <em>Authorize</em> again to register a fresh client.</p><p>You can close this window.</p></body></html>",
+                html_escape(&flow.endpoint_name)
+            )
+        } else {
+            format!(
+                "<html><body><h1>OAuth Error</h1><p>Token endpoint returned {}: {}</p><p>You can close this window.</p></body></html>",
+                html_escape(status.as_str()),
+                html_escape(&body)
+            )
+        };
+        return oauth_html_response(error_html);
     }
 
     let token_json: serde_json::Value = match token_response.json().await {
@@ -5726,6 +5764,143 @@ mod tests {
             .is_none());
         // But the ordinary access token was still saved for the endpoint.
         assert!(tm.load("regular-ep").await.unwrap().is_some());
+    }
+
+    // --- invalid_client detection at the code-exchange step ---
+
+    /// Spawn a mock OAuth token endpoint that always returns HTTP 401 with
+    /// `{"error":"invalid_client"}`, mirroring an authorization server that
+    /// has purged the relay's dynamically-registered client.
+    async fn spawn_invalid_client_token_endpoint() -> (String, tokio::task::JoinHandle<()>) {
+        use axum::http::StatusCode;
+        use axum::{response::IntoResponse, routing::post, Router};
+        async fn handler() -> impl IntoResponse {
+            (StatusCode::UNAUTHORIZED, "{\"error\":\"invalid_client\"}")
+        }
+        let router = Router::new().route("/token", post(handler));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        (format!("http://127.0.0.1:{}/token", addr.port()), handle)
+    }
+
+    #[tokio::test]
+    async fn oauth_callback_invalid_client_deletes_dcr_registered_record() {
+        use crate::token_manager::DcrCredentials;
+        use axum::body::to_bytes;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let endpoint_name = "invalid-client-ep";
+        tm.save_dcr(
+            endpoint_name,
+            &DcrCredentials {
+                client_id: "dcr-client-123".to_string(),
+                registered_via_dcr: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let (token_endpoint, _server) = spawn_invalid_client_token_endpoint().await;
+        let flow_mgr = Arc::new(OAuthFlowManager::new());
+        let pkce = crate::oauth::PkceChallenge::generate();
+        let state_param = flow_mgr
+            .start_flow(
+                endpoint_name,
+                &token_endpoint,
+                "dcr-client-123",
+                None,
+                pkce,
+                "http://127.0.0.1:9400/oauth/callback",
+                None,
+                false,
+            )
+            .await;
+
+        let mut app_state = test_app_state();
+        app_state.oauth_flow_manager = Some(flow_mgr);
+        app_state.token_manager = Some(tm.clone());
+
+        let params = OAuthCallbackParams {
+            code: Some("authcode".to_string()),
+            state: Some(state_param),
+            error: None,
+            iss: None,
+        };
+        let resp = oauth_callback(State(app_state), Query(params)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        assert!(
+            tm.load_dcr(endpoint_name).await.unwrap().is_none(),
+            "invalid_client at code exchange must delete the DCR-registered record"
+        );
+
+        let body = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            body_str.contains("invalid_client"),
+            "error page should surface the invalid_client cause: {body_str}"
+        );
+        assert!(
+            body_str.contains("Authorize"),
+            "error page should invite the user to click Authorize again: {body_str}"
+        );
+    }
+
+    #[tokio::test]
+    async fn oauth_callback_invalid_client_preserves_manual_record() {
+        use crate::token_manager::DcrCredentials;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let endpoint_name = "manual-ep";
+        let manual = DcrCredentials {
+            client_id: "manual-client-abc".to_string(),
+            registered_via_dcr: false,
+            ..Default::default()
+        };
+        tm.save_dcr(endpoint_name, &manual).await.unwrap();
+
+        let (token_endpoint, _server) = spawn_invalid_client_token_endpoint().await;
+        let flow_mgr = Arc::new(OAuthFlowManager::new());
+        let pkce = crate::oauth::PkceChallenge::generate();
+        let state_param = flow_mgr
+            .start_flow(
+                endpoint_name,
+                &token_endpoint,
+                "manual-client-abc",
+                None,
+                pkce,
+                "http://127.0.0.1:9400/oauth/callback",
+                None,
+                false,
+            )
+            .await;
+
+        let mut app_state = test_app_state();
+        app_state.oauth_flow_manager = Some(flow_mgr);
+        app_state.token_manager = Some(tm.clone());
+
+        let params = OAuthCallbackParams {
+            code: Some("authcode".to_string()),
+            state: Some(state_param),
+            error: None,
+            iss: None,
+        };
+        let resp = oauth_callback(State(app_state), Query(params)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let loaded = tm
+            .load_dcr(endpoint_name)
+            .await
+            .unwrap()
+            .expect("manual credential record must be preserved on invalid_client");
+        assert_eq!(loaded, manual);
     }
 
     // --- /mcp/sse + initialize tools.listChanged capability ---

--- a/src/server.rs
+++ b/src/server.rs
@@ -2014,31 +2014,36 @@ async fn oauth_callback(
         }
     }
 
-    // Superseded-flow guard (round-4 finding R4-3): reject an
-    // endpoint-installing flow (`idp_issuer.is_none()`, i.e. a regular
-    // resource OAuth flow) whose `flow.client_id` no longer matches the
-    // currently persisted DCR requesting `client_id`. A DCR-provenanced
-    // record with a non-empty `client_id` that differs from `flow.client_id`
-    // means a concurrent re-registration replaced the requesting pair
-    // between authorize and callback; exchanging this code against the
-    // stale pair would either fail with `invalid_client` (racing the newer
-    // registration into the self-heal path) or succeed with a token bound
-    // to an already-superseded client. Neither is desirable — the user
-    // should just re-Authorize against the current pair. EMA IdP flows
+    // Superseded-flow guard (round-4 finding R4-3, tightened by round-5
+    // finding R5-3): reject an endpoint-installing flow
+    // (`idp_issuer.is_none()`, i.e. a regular resource OAuth flow) whose
+    // `flow.client_id` no longer matches the currently persisted requesting
+    // `client_id`. A persisted record with a non-empty `client_id` that
+    // differs from `flow.client_id` — regardless of provenance — means a
+    // concurrent re-registration OR a manual rotation replaced the
+    // requesting pair between authorize and callback; exchanging this code
+    // against the stale pair would either fail with `invalid_client`
+    // (racing the newer credentials into the self-heal path) or succeed
+    // with a token bound to an already-superseded client. Neither is
+    // desirable — the user should just re-Authorize against the current
+    // pair. The R5-3 tightening drops the earlier `registered_via_dcr`
+    // gate so a `POST /credentials` rotation to manual creds
+    // (`registered_via_dcr = false`) also supersedes any in-flight DCR
+    // callback. Empty `client_id` on disk means the record was cleared
+    // by the `invalid_client` self-heal (R4-1) and we let this exchange
+    // proceed so the callback can re-install a valid pair. EMA IdP flows
     // (`idp_issuer.is_some()`) install IdP credentials, not endpoint DCR
     // credentials, and are exempt from this check.
     if flow.idp_issuer.is_none() {
         if let Some(ref tm) = state.token_manager {
             if let Ok(Some(persisted)) = tm.load_dcr(&flow.endpoint_name).await {
-                if persisted.registered_via_dcr
-                    && !persisted.client_id.is_empty()
-                    && persisted.client_id != flow.client_id
-                {
+                if !persisted.client_id.is_empty() && persisted.client_id != flow.client_id {
                     warn!(
                         endpoint = %flow.endpoint_name,
                         flow_client_id = %flow.client_id,
                         current_client_id = %persisted.client_id,
-                        "Rejecting superseded OAuth callback: DCR client_id changed between authorize and callback"
+                        current_registered_via_dcr = persisted.registered_via_dcr,
+                        "Rejecting superseded OAuth callback: persisted client_id changed between authorize and callback"
                     );
                     return oauth_html_response(
                         "<html><body><h1>OAuth Error</h1><p>This login session was superseded by a newer client registration. Please click Authorize again.</p><p>You can close this window.</p></body></html>"
@@ -2266,8 +2271,56 @@ async fn oauth_callback(
         );
     }
 
-    // Existing endpoint re-auth flow: save tokens to disk
+    // Existing endpoint re-auth flow: save tokens to disk.
+    //
+    // Round-5 finding R5-3: before committing the token set or applying it
+    // to the running adapter, atomically revalidate `flow.client_id`
+    // against the on-disk DCR requesting `client_id` while holding
+    // `dcr_write_lock` (via `update_dcr`). The pre-exchange guard above
+    // sees a stale snapshot — a manual rotation OR a newer DCR
+    // registration could still land between that load and here. If the
+    // on-disk `client_id` diverged (non-empty and different from
+    // `flow.client_id`), skip the token save and adapter overrides so
+    // the newer/current credentials win. `update_dcr` returns the record
+    // unchanged either way — the write it performs is a no-op re-save,
+    // which is acceptable at the once-per-login cadence of a callback.
     if let Some(ref tm) = state.token_manager {
+        let mut superseded_at_commit = false;
+        if flow.idp_issuer.is_none() {
+            let flow_client_id = flow.client_id.clone();
+            // `AtomicBool` (not `Cell`) so the future produced by this
+            // async fn stays `Send` for axum's `Handler` bound.
+            let mismatch = std::sync::atomic::AtomicBool::new(false);
+            let _ = tm
+                .update_dcr(&flow.endpoint_name, |current| {
+                    if let Some(ref c) = current {
+                        if !c.client_id.is_empty() && c.client_id != flow_client_id {
+                            mismatch.store(true, std::sync::atomic::Ordering::SeqCst);
+                        }
+                    }
+                    Ok::<
+                        Option<crate::token_manager::DcrCredentials>,
+                        crate::token_manager::TokenError,
+                    >(current)
+                })
+                .await;
+            if mismatch.load(std::sync::atomic::Ordering::SeqCst) {
+                warn!(
+                    endpoint = %flow.endpoint_name,
+                    flow_client_id = %flow.client_id,
+                    "Refusing to commit superseded OAuth callback: persisted client_id changed between pre-exchange guard and commit (R5-3)"
+                );
+                superseded_at_commit = true;
+            }
+        }
+
+        if superseded_at_commit {
+            return oauth_html_response(
+                "<html><body><h1>OAuth Error</h1><p>This login session was superseded by a newer client registration. Please click Authorize again.</p><p>You can close this window.</p></body></html>"
+                    .to_string(),
+            );
+        }
+
         if let Err(e) = tm.save(&flow.endpoint_name, &token_set).await {
             error!(endpoint = %flow.endpoint_name, error = %e, "Failed to save tokens");
         }
@@ -6142,6 +6195,106 @@ mod tests {
         let loaded = tm.load_dcr(endpoint_name).await.unwrap().unwrap();
         assert_eq!(loaded.client_id, "fresh-dcr-client");
         assert!(loaded.registered_via_dcr);
+    }
+
+    /// Round-5 finding R5-3: the pre-exchange superseded-flow guard must
+    /// also reject when a concurrent manual rotation
+    /// (`registered_via_dcr = false`) replaced the requesting `client_id`
+    /// between authorize and callback. Before R5-3 the guard was gated on
+    /// `persisted.registered_via_dcr`, so an old DCR callback whose
+    /// `flow.client_id` no longer matched a manually-rotated record would
+    /// proceed to POST the token endpoint and install its stale pair into
+    /// the running adapter, silently overwriting the operator's manual
+    /// credentials in memory.
+    #[tokio::test]
+    async fn oauth_callback_rejects_superseded_flow_when_manual_rotation_changed_client_id() {
+        use crate::token_manager::DcrCredentials;
+        use axum::body::to_bytes;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        // Token endpoint counts POSTs so we can assert it was never hit.
+        let token_hits = Arc::new(AtomicUsize::new(0));
+        let hits = token_hits.clone();
+        let router = axum::Router::new().route(
+            "/token",
+            axum::routing::post(move || {
+                let hits = hits.clone();
+                async move {
+                    hits.fetch_add(1, Ordering::SeqCst);
+                    "{\"access_token\":\"unused\",\"token_type\":\"Bearer\",\"expires_in\":3600}"
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _server = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let token_endpoint = format!("http://127.0.0.1:{}/token", addr.port());
+
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let endpoint_name = "superseded-ep-manual";
+        // The currently-persisted record is an operator-supplied MANUAL
+        // rotation (`registered_via_dcr = false`) with a different
+        // `client_id` than the older DCR flow captured at authorize time.
+        tm.save_dcr(
+            endpoint_name,
+            &DcrCredentials {
+                client_id: "operator-manual-client".to_string(),
+                registered_via_dcr: false,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let flow_mgr = Arc::new(OAuthFlowManager::new());
+        let pkce = crate::oauth::PkceChallenge::generate();
+        let state_param = flow_mgr
+            .start_flow(
+                endpoint_name,
+                &token_endpoint,
+                "stale-dcr-client",
+                None,
+                pkce,
+                "http://127.0.0.1:9400/oauth/callback",
+                None,
+                false,
+            )
+            .await;
+
+        let mut app_state = test_app_state();
+        app_state.oauth_flow_manager = Some(flow_mgr);
+        app_state.token_manager = Some(tm.clone());
+
+        let params = OAuthCallbackParams {
+            code: Some("authcode".to_string()),
+            state: Some(state_param),
+            error: None,
+            iss: None,
+        };
+        let resp = oauth_callback(State(app_state), Query(params)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        assert_eq!(
+            token_hits.load(Ordering::SeqCst),
+            0,
+            "R5-3: guard must reject before POSTing to the token endpoint even when the current record is manual-provenance"
+        );
+
+        let body = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            body_str.contains("superseded"),
+            "error page must explain the flow was superseded: {body_str}"
+        );
+
+        // The operator's manual record survives untouched.
+        let loaded = tm.load_dcr(endpoint_name).await.unwrap().unwrap();
+        assert_eq!(loaded.client_id, "operator-manual-client");
+        assert!(!loaded.registered_via_dcr);
     }
 
     /// After a successful interactive re-authorization the callback must

--- a/src/token_manager.rs
+++ b/src/token_manager.rs
@@ -254,6 +254,55 @@ impl TokenManager {
         }
     }
 
+    /// Atomically invalidate the requesting `client_id`/`client_secret` pair
+    /// on a DCR record iff the stored `client_id` equals `expected_client_id`.
+    /// Used by the `invalid_client` self-heal paths (refresh grant + auth-code
+    /// exchange): the AS's `invalid_client` response only proves that the
+    /// requesting `client_id` we just presented is gone, so a concurrent
+    /// re-registration that replaced the file with a NEWER `client_id` must
+    /// survive this call. The optional `resource_client_id` /
+    /// `resource_client_secret` pair is a distinct registration and is always
+    /// preserved. When clearing empties the record entirely (no resource
+    /// pair, no requesting id), the underlying file is deleted so the next
+    /// authorize triggers a fresh RFC 7591 registration.
+    ///
+    /// Returns:
+    /// * `Ok(true)` when the requesting pair was cleared (or the file
+    ///   removed) because `expected_client_id` matched.
+    /// * `Ok(false)` when the record was absent OR the stored `client_id`
+    ///   did not match (nothing was mutated).
+    /// * `Err(_)` on IO / serialization failure.
+    pub async fn clear_dcr_requesting_client(
+        &self,
+        endpoint_name: &str,
+        expected_client_id: &str,
+    ) -> Result<bool, TokenError> {
+        let Some(existing) = self.load_dcr(endpoint_name).await? else {
+            return Ok(false);
+        };
+        if existing.client_id != expected_client_id {
+            return Ok(false);
+        }
+        // Nothing worth keeping → drop the file so the next authorize starts
+        // clean without a stub record on disk.
+        if existing.resource_client_id.is_none() && existing.resource_client_secret.is_none() {
+            self.delete_dcr(endpoint_name).await?;
+            return Ok(true);
+        }
+        let cleared = DcrCredentials {
+            client_id: String::new(),
+            client_secret: None,
+            client_secret_expires_at: 0,
+            registered_at: existing.registered_at,
+            issuer: None,
+            resource_client_id: existing.resource_client_id,
+            resource_client_secret: existing.resource_client_secret,
+            registered_via_dcr: false,
+        };
+        self.save_dcr(endpoint_name, &cleared).await?;
+        Ok(true)
+    }
+
     /// Save IdP credentials under `key` (a sanitized IdP issuer in v1; END-19
     /// re-keys to org). File written atomically (write to .tmp, rename).
     /// File permissions: 0600 on Unix.
@@ -498,6 +547,109 @@ mod tests {
         // Should not error on first or second call
         mgr.delete_dcr("nonexistent").await.unwrap();
         mgr.delete_dcr("nonexistent").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn clear_dcr_requesting_client_absent_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        let cleared = mgr
+            .clear_dcr_requesting_client("missing", "whatever")
+            .await
+            .unwrap();
+        assert!(!cleared);
+        assert!(mgr.load_dcr("missing").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn clear_dcr_requesting_client_deletes_pure_dcr_record() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        let creds = DcrCredentials {
+            client_id: "dead-client".to_string(),
+            client_secret: Some("dead-secret".to_string()),
+            registered_via_dcr: true,
+            ..make_dcr_creds()
+        };
+        mgr.save_dcr("ep", &creds).await.unwrap();
+
+        let cleared = mgr
+            .clear_dcr_requesting_client("ep", "dead-client")
+            .await
+            .unwrap();
+        assert!(cleared);
+        assert!(
+            mgr.load_dcr("ep").await.unwrap().is_none(),
+            "record with no resource_* pair must be removed entirely"
+        );
+    }
+
+    #[tokio::test]
+    async fn clear_dcr_requesting_client_preserves_resource_pair() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        let creds = DcrCredentials {
+            client_id: "dead-client".to_string(),
+            client_secret: Some("dead-secret".to_string()),
+            client_secret_expires_at: 0,
+            registered_at: 1_700_000_000,
+            issuer: Some("https://as.example.com".to_string()),
+            resource_client_id: Some("mas-resource".to_string()),
+            resource_client_secret: Some("mas-resource-secret".to_string()),
+            registered_via_dcr: true,
+        };
+        mgr.save_dcr("ep", &creds).await.unwrap();
+
+        let cleared = mgr
+            .clear_dcr_requesting_client("ep", "dead-client")
+            .await
+            .unwrap();
+        assert!(cleared);
+
+        let loaded = mgr.load_dcr("ep").await.unwrap().expect("record persists");
+        assert_eq!(loaded.client_id, "");
+        assert!(loaded.client_secret.is_none());
+        assert!(!loaded.registered_via_dcr);
+        assert!(loaded.issuer.is_none());
+        assert_eq!(
+            loaded.resource_client_id.as_deref(),
+            Some("mas-resource"),
+            "operator-set MAS resource client must survive requesting-pair clear"
+        );
+        assert_eq!(
+            loaded.resource_client_secret.as_deref(),
+            Some("mas-resource-secret")
+        );
+        assert_eq!(loaded.registered_at, 1_700_000_000);
+    }
+
+    #[tokio::test]
+    async fn clear_dcr_requesting_client_mismatched_id_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        // Simulate a concurrent re-registration: the on-disk record now
+        // holds a NEWER client_id than the caller's stale failing id.
+        let newer = DcrCredentials {
+            client_id: "fresh-client".to_string(),
+            client_secret: Some("fresh-secret".to_string()),
+            registered_via_dcr: true,
+            ..make_dcr_creds()
+        };
+        mgr.save_dcr("ep", &newer).await.unwrap();
+
+        let cleared = mgr
+            .clear_dcr_requesting_client("ep", "stale-client")
+            .await
+            .unwrap();
+        assert!(
+            !cleared,
+            "stale self-heal must not touch a concurrently re-registered record"
+        );
+
+        let loaded = mgr.load_dcr("ep").await.unwrap().unwrap();
+        assert_eq!(loaded.client_id, "fresh-client");
+        assert_eq!(loaded.client_secret.as_deref(), Some("fresh-secret"));
+        assert!(loaded.registered_via_dcr);
     }
 
     // --- Token construction tests (mirrors server.rs logic) ---

--- a/src/token_manager.rs
+++ b/src/token_manager.rs
@@ -165,11 +165,21 @@ pub fn merge_scopes(prior: Option<&str>, requested: &str) -> String {
 /// its current access token in an `RwLock`.
 pub struct TokenManager {
     token_dir: PathBuf,
+    /// Serializes DCR read-modify-write operations (`save_dcr`, `delete_dcr`,
+    /// `clear_dcr_requesting_client`) so a self-heal cannot interleave with a
+    /// concurrent re-registration or manual credential update and either
+    /// overwrite a newer record or be overwritten itself. Read-only paths
+    /// (`load_dcr`) do not take this lock; they observe whichever
+    /// atomically-renamed snapshot is on disk when they run.
+    dcr_write_lock: tokio::sync::Mutex<()>,
 }
 
 impl TokenManager {
     pub fn new(token_dir: PathBuf) -> Self {
-        Self { token_dir }
+        Self {
+            token_dir,
+            dcr_write_lock: tokio::sync::Mutex::new(()),
+        }
     }
 
     /// Save tokens for an endpoint. File written atomically (write to .tmp, rename).
@@ -210,8 +220,23 @@ impl TokenManager {
     }
 
     /// Save DCR credentials for an endpoint. File written atomically (write to .tmp, rename).
-    /// File permissions: 0600 on Unix.
+    /// File permissions: 0600 on Unix. Serialized against other DCR writers
+    /// (`delete_dcr`, `clear_dcr_requesting_client`) via `dcr_write_lock` so
+    /// a self-heal running concurrently cannot delete/overwrite a newer
+    /// record persisted here.
     pub async fn save_dcr(
+        &self,
+        endpoint_name: &str,
+        creds: &DcrCredentials,
+    ) -> Result<(), TokenError> {
+        let _guard = self.dcr_write_lock.lock().await;
+        self.save_dcr_locked(endpoint_name, creds).await
+    }
+
+    /// Inner `save_dcr` body executed while the DCR write lock is held. Split
+    /// out so `clear_dcr_requesting_client` can perform its read-modify-write
+    /// (load → compare → save/delete) under a single lock acquisition.
+    async fn save_dcr_locked(
         &self,
         endpoint_name: &str,
         creds: &DcrCredentials,
@@ -245,7 +270,15 @@ impl TokenManager {
     }
 
     /// Delete DCR credentials for an endpoint. No-op if file doesn't exist.
+    /// Serialized against other DCR writers (`save_dcr`,
+    /// `clear_dcr_requesting_client`) via `dcr_write_lock`.
     pub async fn delete_dcr(&self, endpoint_name: &str) -> Result<(), TokenError> {
+        let _guard = self.dcr_write_lock.lock().await;
+        self.delete_dcr_locked(endpoint_name).await
+    }
+
+    /// Inner `delete_dcr` body executed while the DCR write lock is held.
+    async fn delete_dcr_locked(&self, endpoint_name: &str) -> Result<(), TokenError> {
         let path = self.token_dir.join(format!("{}.dcr.json", endpoint_name));
         match tokio::fs::remove_file(&path).await {
             Ok(()) => Ok(()),
@@ -262,13 +295,25 @@ impl TokenManager {
     /// re-registration that replaced the file with a NEWER `client_id` must
     /// survive this call. The optional `resource_client_id` /
     /// `resource_client_secret` pair is a distinct registration and is always
-    /// preserved. When clearing empties the record entirely (no resource
-    /// pair, no requesting id), the underlying file is deleted so the next
-    /// authorize triggers a fresh RFC 7591 registration.
+    /// preserved.
+    ///
+    /// The cleared record intentionally KEEPS `registered_via_dcr = true`
+    /// even for pure-DCR (no resource pair) records: it is the auth-start
+    /// resolution signal that this endpoint must re-register via RFC 7591
+    /// rather than reuse the stale `client_id` still baked into
+    /// `config.toml` by the setup commit. If the file were deleted (or
+    /// `registered_via_dcr` cleared to `false`), the next interactive
+    /// Authorize would fall through to the config-branch, POST the dead
+    /// TOML `client_id`, and loop.
+    ///
+    /// Serialized against concurrent `save_dcr` / `delete_dcr` /
+    /// `clear_dcr_requesting_client` via `dcr_write_lock`, so the
+    /// load-then-write sequence is race-free with respect to a concurrent
+    /// re-registration that replaced the record with a newer `client_id`.
     ///
     /// Returns:
-    /// * `Ok(true)` when the requesting pair was cleared (or the file
-    ///   removed) because `expected_client_id` matched.
+    /// * `Ok(true)` when the requesting pair was cleared because
+    ///   `expected_client_id` matched.
     /// * `Ok(false)` when the record was absent OR the stored `client_id`
     ///   did not match (nothing was mutated).
     /// * `Err(_)` on IO / serialization failure.
@@ -277,17 +322,12 @@ impl TokenManager {
         endpoint_name: &str,
         expected_client_id: &str,
     ) -> Result<bool, TokenError> {
+        let _guard = self.dcr_write_lock.lock().await;
         let Some(existing) = self.load_dcr(endpoint_name).await? else {
             return Ok(false);
         };
         if existing.client_id != expected_client_id {
             return Ok(false);
-        }
-        // Nothing worth keeping → drop the file so the next authorize starts
-        // clean without a stub record on disk.
-        if existing.resource_client_id.is_none() && existing.resource_client_secret.is_none() {
-            self.delete_dcr(endpoint_name).await?;
-            return Ok(true);
         }
         let cleared = DcrCredentials {
             client_id: String::new(),
@@ -297,9 +337,11 @@ impl TokenManager {
             issuer: None,
             resource_client_id: existing.resource_client_id,
             resource_client_secret: existing.resource_client_secret,
-            registered_via_dcr: false,
+            // Preserve the DCR provenance signal so the next interactive
+            // Authorize takes the RFC 7591 re-registration heal path.
+            registered_via_dcr: existing.registered_via_dcr,
         };
-        self.save_dcr(endpoint_name, &cleared).await?;
+        self.save_dcr_locked(endpoint_name, &cleared).await?;
         Ok(true)
     }
 
@@ -562,7 +604,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn clear_dcr_requesting_client_deletes_pure_dcr_record() {
+    async fn clear_dcr_requesting_client_pure_dcr_retains_provenance_stub() {
         let tmp = tempfile::tempdir().unwrap();
         let mgr = TokenManager::new(tmp.path().to_path_buf());
         let creds = DcrCredentials {
@@ -578,9 +620,17 @@ mod tests {
             .await
             .unwrap();
         assert!(cleared);
+        let loaded = mgr
+            .load_dcr("ep")
+            .await
+            .unwrap()
+            .expect("pure-DCR self-heal must retain a stub record so auth-start re-registers");
+        assert_eq!(loaded.client_id, "");
+        assert!(loaded.client_secret.is_none());
+        assert!(loaded.issuer.is_none());
         assert!(
-            mgr.load_dcr("ep").await.unwrap().is_none(),
-            "record with no resource_* pair must be removed entirely"
+            loaded.registered_via_dcr,
+            "registered_via_dcr must survive so auth-start prefers re-registration over the stale config.toml client_id"
         );
     }
 
@@ -609,7 +659,10 @@ mod tests {
         let loaded = mgr.load_dcr("ep").await.unwrap().expect("record persists");
         assert_eq!(loaded.client_id, "");
         assert!(loaded.client_secret.is_none());
-        assert!(!loaded.registered_via_dcr);
+        assert!(
+            loaded.registered_via_dcr,
+            "mixed-record self-heal must retain the DCR provenance flag so auth-start prefers re-registration over the stale config.toml client_id"
+        );
         assert!(loaded.issuer.is_none());
         assert_eq!(
             loaded.resource_client_id.as_deref(),

--- a/src/token_manager.rs
+++ b/src/token_manager.rs
@@ -277,6 +277,43 @@ impl TokenManager {
         self.delete_dcr_locked(endpoint_name).await
     }
 
+    /// Atomically load-then-{save|delete} a DCR record for `endpoint_name`.
+    /// The `update` closure receives the freshly-loaded record (or `None`
+    /// when the file does not exist) and returns a decision:
+    /// * `Ok(Some(creds))` — persist `creds` via an atomic write.
+    /// * `Ok(None)` — remove the DCR file if it exists.
+    /// * `Err(e)` — propagate to the caller without touching disk.
+    ///
+    /// The load and the subsequent write both happen while
+    /// `dcr_write_lock` is held so no other writer (`save_dcr`,
+    /// `delete_dcr`, `clear_dcr_requesting_client`, another `update_dcr`)
+    /// can interleave a stale-write clobber between the read and the
+    /// write. This is the helper `set_endpoint_credentials` uses to fold
+    /// caller-supplied fields into the existing record without racing a
+    /// concurrent `invalid_client` self-heal.
+    pub async fn update_dcr<F, E>(
+        &self,
+        endpoint_name: &str,
+        update: F,
+    ) -> Result<Option<DcrCredentials>, E>
+    where
+        F: FnOnce(Option<DcrCredentials>) -> Result<Option<DcrCredentials>, E>,
+        E: From<TokenError>,
+    {
+        let _guard = self.dcr_write_lock.lock().await;
+        let existing = self.load_dcr(endpoint_name).await?;
+        match update(existing)? {
+            Some(creds) => {
+                self.save_dcr_locked(endpoint_name, &creds).await?;
+                Ok(Some(creds))
+            }
+            None => {
+                self.delete_dcr_locked(endpoint_name).await?;
+                Ok(None)
+            }
+        }
+    }
+
     /// Inner `delete_dcr` body executed while the DCR write lock is held.
     async fn delete_dcr_locked(&self, endpoint_name: &str) -> Result<(), TokenError> {
         let path = self.token_dir.join(format!("{}.dcr.json", endpoint_name));
@@ -311,11 +348,22 @@ impl TokenManager {
     /// load-then-write sequence is race-free with respect to a concurrent
     /// re-registration that replaced the record with a newer `client_id`.
     ///
+    /// The provenance check is re-evaluated on the freshly-loaded record
+    /// under the lock. Callers already gate on `registered_via_dcr`
+    /// before invoking this method, but that check reads a snapshot taken
+    /// outside the lock; between the caller's read and the lock
+    /// acquisition here, an operator can rotate to manual credentials
+    /// with the same `client_id` via `POST /api/endpoints/{name}/credentials`
+    /// (which sets `registered_via_dcr = false`). Re-checking under the
+    /// lock preserves the "manual credentials are never auto-discarded"
+    /// promise even for that same-id rotation race.
+    ///
     /// Returns:
     /// * `Ok(true)` when the requesting pair was cleared because
     ///   `expected_client_id` matched.
-    /// * `Ok(false)` when the record was absent OR the stored `client_id`
-    ///   did not match (nothing was mutated).
+    /// * `Ok(false)` when the record was absent, is no longer
+    ///   `registered_via_dcr`, OR the stored `client_id` did not match
+    ///   (nothing was mutated).
     /// * `Err(_)` on IO / serialization failure.
     pub async fn clear_dcr_requesting_client(
         &self,
@@ -326,6 +374,12 @@ impl TokenManager {
         let Some(existing) = self.load_dcr(endpoint_name).await? else {
             return Ok(false);
         };
+        if !existing.registered_via_dcr {
+            // Same-id rotation to manual creds landed between the caller's
+            // provenance check and this lock acquisition. Manually-supplied
+            // credentials are never auto-discarded.
+            return Ok(false);
+        }
         if existing.client_id != expected_client_id {
             return Ok(false);
         }
@@ -703,6 +757,172 @@ mod tests {
         assert_eq!(loaded.client_id, "fresh-client");
         assert_eq!(loaded.client_secret.as_deref(), Some("fresh-secret"));
         assert!(loaded.registered_via_dcr);
+    }
+
+    /// R3-1: an operator can rotate to manual credentials with the SAME
+    /// `client_id` between the self-heal caller's provenance snapshot and
+    /// `clear_dcr_requesting_client` acquiring `dcr_write_lock`. The
+    /// re-check under the lock must observe the flipped provenance flag
+    /// and leave the newly-manual credentials untouched.
+    #[tokio::test]
+    async fn clear_dcr_requesting_client_manual_same_id_rotation_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        // Same client_id as the caller's failing id, but the record has
+        // just been rotated to manual (registered_via_dcr = false) via
+        // POST /credentials.
+        let rotated_manual = DcrCredentials {
+            client_id: "shared-id".to_string(),
+            client_secret: Some("operator-secret".to_string()),
+            registered_via_dcr: false,
+            ..make_dcr_creds()
+        };
+        mgr.save_dcr("ep", &rotated_manual).await.unwrap();
+
+        let cleared = mgr
+            .clear_dcr_requesting_client("ep", "shared-id")
+            .await
+            .unwrap();
+        assert!(
+            !cleared,
+            "manual credentials with a matching client_id must survive the self-heal"
+        );
+
+        let loaded = mgr.load_dcr("ep").await.unwrap().unwrap();
+        assert_eq!(loaded.client_id, "shared-id");
+        assert_eq!(loaded.client_secret.as_deref(), Some("operator-secret"));
+        assert!(!loaded.registered_via_dcr);
+    }
+
+    /// R3-5: `update_dcr` must serialize its load-modify-save cycle
+    /// against a concurrent `clear_dcr_requesting_client`. Simulates the
+    /// race between a `POST /credentials` update that only touches the
+    /// resource pair and a token-endpoint `invalid_client` self-heal
+    /// firing on the same record: whichever writer runs second must
+    /// observe the other's committed state, never a pre-lock snapshot.
+    #[tokio::test]
+    async fn update_dcr_and_clear_dcr_requesting_client_serialize_via_write_lock() {
+        use std::sync::Arc;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        // Seed a mixed record: DCR-provenanced requesting pair alongside a
+        // separately-configured resource pair.
+        let seed = DcrCredentials {
+            client_id: "dcr-client".to_string(),
+            client_secret: Some("dcr-secret".to_string()),
+            client_secret_expires_at: 0,
+            registered_at: 100,
+            issuer: Some("https://as.example.com".to_string()),
+            resource_client_id: Some("res-client".to_string()),
+            resource_client_secret: Some("res-secret".to_string()),
+            registered_via_dcr: true,
+        };
+        mgr.save_dcr("ep", &seed).await.unwrap();
+
+        // Concurrent writers: (A) resource-only manual update that must
+        // preserve the requesting pair, (B) invalid_client self-heal that
+        // clears the requesting pair. Both fight over `dcr_write_lock`.
+        let a_mgr = mgr.clone();
+        let a = tokio::spawn(async move {
+            a_mgr
+                .update_dcr(
+                    "ep",
+                    |existing| -> Result<Option<DcrCredentials>, TokenError> {
+                        let base = existing.unwrap();
+                        Ok(Some(DcrCredentials {
+                            resource_client_secret: Some("res-secret-v2".to_string()),
+                            ..base
+                        }))
+                    },
+                )
+                .await
+        });
+        let b_mgr = mgr.clone();
+        let b = tokio::spawn(
+            async move { b_mgr.clear_dcr_requesting_client("ep", "dcr-client").await },
+        );
+        let (a_res, b_res) = tokio::join!(a, b);
+        a_res.unwrap().unwrap();
+        b_res.unwrap().unwrap();
+
+        // Regardless of interleaving, the on-disk record must be a
+        // consistent product of the two serialized writes:
+        //   * If A ran first: A wrote {dcr-client, dcr-secret,
+        //     res-secret-v2}; B then cleared the requesting pair,
+        //     leaving {"", None, res-secret-v2}.
+        //   * If B ran first: B cleared to {"", None, res-secret}; A then
+        //     merged onto the tombstone → {"", None, res-secret-v2}.
+        // Either way the resource_client_secret bump survives, and the
+        // requesting pair ends up cleared (B always runs at some point).
+        let final_state = mgr.load_dcr("ep").await.unwrap().unwrap();
+        assert!(
+            final_state.client_id.is_empty(),
+            "self-heal must have cleared the requesting client_id"
+        );
+        assert!(
+            final_state.client_secret.is_none(),
+            "self-heal must have cleared the requesting client_secret"
+        );
+        assert_eq!(
+            final_state.resource_client_secret.as_deref(),
+            Some("res-secret-v2"),
+            "the manual resource update must not be silently clobbered by the self-heal"
+        );
+        assert!(
+            final_state.registered_via_dcr,
+            "post-self-heal record retains DCR provenance"
+        );
+    }
+
+    /// `update_dcr` deletes the DCR file when the closure returns `Ok(None)`.
+    #[tokio::test]
+    async fn update_dcr_deletes_when_closure_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        mgr.save_dcr("ep", &make_dcr_creds()).await.unwrap();
+
+        let outcome = mgr
+            .update_dcr("ep", |existing| -> Result<_, TokenError> {
+                assert!(existing.is_some());
+                Ok(None)
+            })
+            .await
+            .unwrap();
+        assert!(outcome.is_none());
+        assert!(mgr.load_dcr("ep").await.unwrap().is_none());
+    }
+
+    /// `update_dcr` propagates closure errors without touching disk.
+    #[tokio::test]
+    async fn update_dcr_propagates_closure_errors_without_writing() {
+        #[derive(Debug)]
+        enum E {
+            Business,
+            #[allow(dead_code)]
+            Token(TokenError),
+        }
+        impl From<TokenError> for E {
+            fn from(e: TokenError) -> Self {
+                E::Token(e)
+            }
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        let seed = make_dcr_creds();
+        mgr.save_dcr("ep", &seed).await.unwrap();
+
+        let outcome = mgr
+            .update_dcr("ep", |_existing| -> Result<Option<DcrCredentials>, E> {
+                Err(E::Business)
+            })
+            .await;
+        assert!(matches!(outcome, Err(E::Business)));
+
+        // On-disk record is untouched.
+        let loaded = mgr.load_dcr("ep").await.unwrap().unwrap();
+        assert_eq!(loaded, seed);
     }
 
     // --- Token construction tests (mirrors server.rs logic) ---

--- a/src/token_manager.rs
+++ b/src/token_manager.rs
@@ -75,6 +75,16 @@ pub struct DcrCredentials {
     /// the IdP-facing legs and never substituted by the requesting secret.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resource_client_secret: Option<String>,
+    /// Provenance marker: `true` only when the requesting `client_id` came
+    /// from a dynamic client registration (RFC 7591) — i.e. the relay minted
+    /// it against a discovered `registration_endpoint`. `false` for
+    /// manually-supplied credentials (config.toml, `POST
+    /// /api/endpoints/{name}/credentials`, or `POST
+    /// /api/endpoints/{name}/oauth/credentials`) and for CIMD-resolved
+    /// clients. Legacy files predating this field deserialize as `false`
+    /// (conservative: never auto-discarded, same style as `issuer`).
+    #[serde(default)]
+    pub registered_via_dcr: bool,
 }
 
 /// Per-IdP credentials captured during EMA Step 1 (IdP SSO). Holds the ID Token
@@ -585,6 +595,36 @@ mod tests {
         let creds: DcrCredentials = serde_json::from_str(json).unwrap();
         assert_eq!(creds.client_id, "legacy-id");
         assert_eq!(creds.issuer, None);
+    }
+
+    #[test]
+    fn dcr_legacy_file_without_registered_via_dcr_loads_as_false() {
+        // Credential files written before the `registered_via_dcr` field
+        // existed must still deserialize, with the flag = false (treated as
+        // manual: never auto-discarded).
+        let json = r#"{"client_id":"legacy-id","client_secret":"legacy-secret","client_secret_expires_at":0,"registered_at":1700000000,"issuer":"https://auth.example.com"}"#;
+        let creds: DcrCredentials = serde_json::from_str(json).unwrap();
+        assert_eq!(creds.client_id, "legacy-id");
+        assert!(!creds.registered_via_dcr);
+    }
+
+    #[tokio::test]
+    async fn dcr_round_trip_preserves_registered_via_dcr() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        let creds = DcrCredentials {
+            client_id: "dcr-minted".to_string(),
+            client_secret: Some("dcr-secret".to_string()),
+            client_secret_expires_at: 0,
+            registered_at: 1_700_000_000,
+            issuer: Some("https://auth.example.com".to_string()),
+            registered_via_dcr: true,
+            ..Default::default()
+        };
+        mgr.save_dcr("dcr-ep", &creds).await.unwrap();
+        let loaded = mgr.load_dcr("dcr-ep").await.unwrap().unwrap();
+        assert!(loaded.registered_via_dcr);
+        assert_eq!(loaded, creds);
     }
 
     // --- dcr_issuer_allows_reuse() decision tests ---


### PR DESCRIPTION
## Problem

When an authorization server purges a relay's dynamically-registered OAuth client (e.g. after a broken connection or server-side cleanup), the relay kept reusing the dead `client_id` from `{name}.dcr.json`. The AS rejected the request with `invalid_client` — at the authorize endpoint the failure is browser-visible only, so no callback ever reached the relay, and at the token endpoint the error body was not inspected. The stale record persisted forever with no recovery path other than the user manually disconnecting or deleting the file.

`{name}.dcr.json` also stores manually-supplied credentials (`POST /api/endpoints/{name}/credentials`), which must never be auto-discarded. The record needed a provenance marker before any self-heal logic could be added safely.

## Changes

Three commits, all on `panghy/dcr-provenance-flag`:

1. **`feat(dcr): add registered_via_dcr provenance flag to DcrCredentials`** — adds `#[serde(default)] pub registered_via_dcr: bool` to `DcrCredentials`. Set to `true` only where credentials originate from `dcr::register_client`; manual-credential paths persist it as `false`. Legacy `{name}.dcr.json` files (missing the field) deserialize as `false` and are treated as manual — conservative default, so they are never auto-discarded.

2. **`feat(oauth): re-register fresh DCR client on interactive auth-start`** — in `management.rs` auth-start Step 2, when the persisted record has `registered_via_dcr == true` and discovery returned a `registration_endpoint`, register a fresh client instead of reusing the stored one. Interactive authorize already goes through the consent screen, so a new `client_id` adds no user friction and eliminates the browser-only stale-client failure mode. On registration failure, falls back to the stored credentials (server may have temporarily lost DCR support). `resource_client_id` / `resource_client_secret` fields are preserved across re-registration. TOML and manually-supplied credentials keep today's behavior exactly.

3. **`feat(oauth): discard stale DCR credentials on invalid_client at token endpoints`** — parses the OAuth error body on token-endpoint failures in both (a) the refresh grant (`adapter/oauth/mod.rs`) and (b) the authorization-code exchange (`server.rs` callback). If `error == "invalid_client"` (RFC 6749 §5.2) and the endpoint's DCR record has `registered_via_dcr == true`, deletes `{name}.dcr.json` so the next auth-start re-registers a fresh client. Self-heals non-interactive paths (watcher, JIT, EMA refresh). Manually-supplied credentials (`registered_via_dcr == false`) are never touched.

## Guarantees

- **Manually-supplied credentials are never auto-deleted or re-registered** under any error condition — the provenance flag gates every self-heal path.
- **Legacy `{name}.dcr.json` files** (written before this change, missing the new field) load fine via `#[serde(default)]` and are treated as manual — same backward-compat pattern as the existing `issuer` field.
- A DCR endpoint whose registration was purged server-side now recovers by clicking authorize once, with no manual disconnect or file deletion needed.

## Verification

`cd packages/relay && cargo fmt --check && cargo clippy -- -D warnings && cargo test` — all green.
