### PR TITLE
feat(logging): prune daily-rotated relay logs after configurable retention window

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ async-trait = "0.1"
 axum = { version = "0.8", features = ["form", "json"] }
 base64 = "0.22"
 boa_engine = "0.20"
-chrono = { version = "0.4.44", default-features = false, features = ["clock"] }
+chrono = { version = "0.4.44", default-features = false, features = ["clock", "std"] }
 clap = { version = "4", features = ["derive"] }
 dirs = "6.0.0"
 futures-util = "0.3.32"

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,6 +74,12 @@ pub struct RelayConfig {
     /// falls back to [`ObservabilityConfig::default`].
     #[serde(default)]
     pub observability: ObservabilityConfig,
+    /// Number of days to retain daily-rotated relay log files. When `None`,
+    /// defaults to 7 days at runtime. When `Some(0)`, log pruning is disabled
+    /// entirely.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub log_retention_days: Option<u32>,
 }
 
 impl Default for RelayConfig {
@@ -97,6 +103,7 @@ impl Default for RelayConfig {
             session_identity_max_sessions: None,
             validate_inputs: None,
             observability: ObservabilityConfig::default(),
+            log_retention_days: None,
         }
     }
 }
@@ -1908,6 +1915,7 @@ js_execution = false
                 session_identity_max_sessions: None,
                 validate_inputs: None,
                 observability: ObservabilityConfig::default(),
+                log_retention_days: None,
             },
             endpoints,
             profiles: None,
@@ -3114,5 +3122,54 @@ resource = "https://api.githubcopilot.com/mcp/"
             !diff_configs(&with_org, &with_org).organizations_changed,
             "identical orgs should not be flagged as changed"
         );
+    }
+
+    #[test]
+    fn log_retention_days_defaults_to_none() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+"#;
+        let config = parse_and_validate(toml_str).unwrap();
+        assert_eq!(config.relay.log_retention_days, None);
+    }
+
+    #[test]
+    fn log_retention_days_parses_nonzero() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+log_retention_days = 14
+"#;
+        let config = parse_and_validate(toml_str).unwrap();
+        assert_eq!(config.relay.log_retention_days, Some(14));
+    }
+
+    #[test]
+    fn log_retention_days_parses_zero() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+log_retention_days = 0
+"#;
+        let config = parse_and_validate(toml_str).unwrap();
+        assert_eq!(config.relay.log_retention_days, Some(0));
+    }
+
+    #[test]
+    fn log_retention_days_round_trips() {
+        let config = Config {
+            relay: RelayConfig {
+                machine_name: "test".to_string(),
+                log_retention_days: Some(14),
+                ..RelayConfig::default()
+            },
+            endpoints: vec![],
+            profiles: None,
+            organizations: Vec::new(),
+        };
+        let toml_str = toml::to_string_pretty(&config).unwrap();
+        let parsed: Config = toml::from_str(&toml_str).unwrap();
+        assert_eq!(parsed.relay.log_retention_days, Some(14));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -76,7 +76,8 @@ pub struct RelayConfig {
     pub observability: ObservabilityConfig,
     /// Number of days to retain daily-rotated relay log files. When `None`,
     /// defaults to 7 days at runtime. When `Some(0)`, log pruning is disabled
-    /// entirely.
+    /// entirely. Cleanup runs at startup; long-running relays accumulate logs
+    /// until restarted.
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub log_retention_days: Option<u32>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,9 @@ use tracing::{error, info, warn};
 pub type OAuthAdapterInners = Arc<RwLock<HashMap<String, Arc<OAuthAdapterInner>>>>;
 use watcher::ConfigWatcher;
 
+/// Default number of days to retain daily-rotated relay log files.
+const DEFAULT_LOG_RETENTION_DAYS: u32 = 7;
+
 #[derive(Parser)]
 #[command(name = "endara-relay", version, about = "Endara Relay agent")]
 struct Cli {
@@ -92,6 +95,10 @@ enum Commands {
         #[arg(long)]
         file_log_level: Option<String>,
 
+        /// Number of days to retain daily-rotated relay log files (overrides config.toml)
+        #[arg(long)]
+        log_retention_days: Option<u32>,
+
         /// Disable TOON (Token-Oriented Object Notation) conversion of JSON
         /// tool responses. Overrides `relay.toon_output` from config.toml.
         /// When unset, TOON conversion defaults to on.
@@ -120,11 +127,82 @@ fn expand_tilde(path: &str) -> PathBuf {
     }
 }
 
+/// Sweep old daily-rotated relay log files from the log directory.
+/// Enumerates `relay.log.YYYY-MM-DD` files, parses the trailing date, and
+/// deletes those older than `today - retention_days`. Never deletes the live
+/// `relay.log`. Best-effort: logs warnings on errors but never fails startup.
+fn sweep_old_logs(log_dir: &std::path::Path, retention_days: u32) {
+    if retention_days == 0 {
+        return;
+    }
+
+    let today = chrono::Local::now().date_naive();
+    let cutoff = today - chrono::Days::new(retention_days as u64);
+
+    let entries = match std::fs::read_dir(log_dir) {
+        Ok(e) => e,
+        Err(err) => {
+            warn!(error = %err, path = %log_dir.display(), "Failed to read log directory for cleanup");
+            return;
+        }
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(err) => {
+                warn!(error = %err, "Failed to read directory entry during log cleanup");
+                continue;
+            }
+        };
+
+        let path = entry.path();
+        let file_name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+
+        // Only process files matching "relay.log.YYYY-MM-DD"
+        if !file_name.starts_with("relay.log.") {
+            continue;
+        }
+
+        // Never delete the live "relay.log" file
+        if file_name == "relay.log" {
+            continue;
+        }
+
+        // Extract the date suffix (everything after "relay.log.")
+        let date_str = &file_name["relay.log.".len()..];
+
+        // Parse as YYYY-MM-DD
+        let file_date = match chrono::NaiveDate::parse_from_str(date_str, "%Y-%m-%d") {
+            Ok(d) => d,
+            Err(_) => {
+                // Skip files that don't match the expected date format
+                continue;
+            }
+        };
+
+        if file_date < cutoff {
+            match std::fs::remove_file(&path) {
+                Ok(()) => {
+                    info!(path = %path.display(), "Deleted old log file");
+                }
+                Err(err) => {
+                    warn!(error = %err, path = %path.display(), "Failed to delete old log file");
+                }
+            }
+        }
+    }
+}
+
 fn init_tracing(
     color_mode: ColorMode,
     log_format: &str,
     file_log_level: Option<String>,
     log_dir: &std::path::Path,
+    retention_days: u32,
 ) {
     use std::io::IsTerminal;
     use tracing_subscriber::fmt;
@@ -147,7 +225,16 @@ fn init_tracing(
             .unwrap_or("debug,endara_relay=trace"),
     );
 
-    let file_appender = tracing_appender::rolling::daily(log_dir, "relay.log");
+    let file_appender = if retention_days > 0 {
+        tracing_appender::rolling::Builder::new()
+            .rotation(tracing_appender::rolling::Rotation::DAILY)
+            .filename_prefix("relay.log")
+            .max_log_files(retention_days as usize)
+            .build(log_dir)
+            .expect("Failed to create rolling file appender")
+    } else {
+        tracing_appender::rolling::daily(log_dir, "relay.log")
+    };
     let file_layer = fmt::layer()
         .with_writer(file_appender)
         .with_ansi(false)
@@ -197,6 +284,7 @@ async fn main() {
             log_format,
             color,
             file_log_level,
+            log_retention_days,
             no_toon,
         } => {
             let data_dir_path = expand_tilde(&data_dir);
@@ -204,8 +292,44 @@ async fn main() {
             let config_explicit = config.is_some();
             let config_path = config.unwrap_or_else(|| data_dir_path.join("config.toml"));
 
-            init_tracing(color, &log_format, file_log_level, &log_dir);
+            // Load config early to determine the effective log retention value
+            // before initializing tracing. On error, use eprintln since tracing
+            // isn't up yet, then exit.
+            let (cfg, validation_warnings) = match config::load_config_graceful(&config_path) {
+                Ok((cfg, warnings)) => (cfg, warnings),
+                Err(config::ConfigError::IoError(ref io_err))
+                    if io_err.kind() == std::io::ErrorKind::NotFound =>
+                {
+                    match config::create_default_config_file(&config_path) {
+                        Ok(cfg) => (cfg, Vec::new()),
+                        Err(e) => {
+                            eprintln!("Failed to create default configuration: {}", e);
+                            std::process::exit(1);
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!("Failed to load configuration: {}", e);
+                    std::process::exit(1);
+                }
+            };
+
+            // Resolve effective retention: CLI → config → default
+            let effective_retention = log_retention_days
+                .or(cfg.relay.log_retention_days)
+                .unwrap_or(DEFAULT_LOG_RETENTION_DAYS);
+
+            init_tracing(
+                color,
+                &log_format,
+                file_log_level.clone(),
+                &log_dir,
+                effective_retention,
+            );
             info!(config = %config_path.display(), data_dir = %data_dir_path.display(), "Starting endara-relay");
+
+            // Sweep old logs after tracing is initialized so warnings go through the tracing layer
+            sweep_old_logs(&log_dir, effective_retention);
 
             // First-run config copy: when using a non-default data dir without an
             // explicit --config, copy the production config so dev instances inherit
@@ -249,46 +373,16 @@ async fn main() {
                 }
             }
 
-            let (cfg, validation_warnings) = match config::load_config_graceful(&config_path) {
-                Ok((cfg, warnings)) => {
-                    info!(
-                        machine_name = %cfg.relay.machine_name,
-                        endpoints = cfg.endpoints.len(),
-                        warnings = warnings.len(),
-                        "Configuration loaded successfully"
-                    );
-                    for w in &warnings {
-                        warn!("{}", w);
-                    }
-                    (cfg, warnings)
-                }
-                Err(config::ConfigError::IoError(ref io_err))
-                    if io_err.kind() == std::io::ErrorKind::NotFound =>
-                {
-                    info!(
-                        path = %config_path.display(),
-                        "Config file not found, creating default configuration"
-                    );
-                    match config::create_default_config_file(&config_path) {
-                        Ok(cfg) => {
-                            info!(
-                                machine_name = %cfg.relay.machine_name,
-                                path = %config_path.display(),
-                                "Created default configuration"
-                            );
-                            (cfg, Vec::new())
-                        }
-                        Err(e) => {
-                            error!(error = %e, "Failed to create default configuration");
-                            std::process::exit(1);
-                        }
-                    }
-                }
-                Err(e) => {
-                    error!(error = %e, "Failed to load configuration");
-                    std::process::exit(1);
-                }
-            };
+            // Log config load success now that tracing is initialized
+            info!(
+                machine_name = %cfg.relay.machine_name,
+                endpoints = cfg.endpoints.len(),
+                warnings = validation_warnings.len(),
+                "Configuration loaded successfully"
+            );
+            for w in &validation_warnings {
+                warn!("{}", w);
+            }
 
             // Collect endpoint names that have validation warnings
             let warned_names = config::warned_endpoint_names(&validation_warnings);
@@ -961,5 +1055,106 @@ async fn main() {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn sweep_old_logs_removes_old_files() {
+        let temp_dir = TempDir::new().unwrap();
+        let log_dir = temp_dir.path();
+
+        // Create a live relay.log file
+        fs::write(log_dir.join("relay.log"), "current log").unwrap();
+
+        // Create dated log files spanning 20 days (NOT including today)
+        let today = chrono::Local::now().date_naive();
+        for i in 1..=20 {
+            let date = today - chrono::Days::new(i);
+            let file_name = format!("relay.log.{}", date.format("%Y-%m-%d"));
+            fs::write(log_dir.join(&file_name), format!("log from day {}", i)).unwrap();
+        }
+
+        // Sweep with retention of 7 days (keeps files from the last 7 days, not counting today)
+        sweep_old_logs(log_dir, 7);
+
+        // Check that the live log is still there
+        assert!(log_dir.join("relay.log").exists());
+
+        // Check that only the 7 most recent dated files remain
+        let mut remaining = Vec::new();
+        for entry in fs::read_dir(log_dir).unwrap() {
+            let entry = entry.unwrap();
+            let name = entry.file_name().into_string().unwrap();
+            if name.starts_with("relay.log.") {
+                remaining.push(name);
+            }
+        }
+        assert_eq!(
+            remaining.len(),
+            7,
+            "Expected 7 dated files, got: {:?}",
+            remaining
+        );
+
+        // Verify the newest 7 dated files are kept (days 1-7 ago)
+        for i in 1..=7 {
+            let date = today - chrono::Days::new(i);
+            let file_name = format!("relay.log.{}", date.format("%Y-%m-%d"));
+            assert!(
+                log_dir.join(&file_name).exists(),
+                "Expected {} to exist",
+                file_name
+            );
+        }
+
+        // Verify files older than 7 days are deleted (days 8-20 ago)
+        for i in 8..=20 {
+            let date = today - chrono::Days::new(i);
+            let file_name = format!("relay.log.{}", date.format("%Y-%m-%d"));
+            assert!(
+                !log_dir.join(&file_name).exists(),
+                "Expected {} to be deleted",
+                file_name
+            );
+        }
+    }
+
+    #[test]
+    fn sweep_old_logs_retention_zero_is_noop() {
+        let temp_dir = TempDir::new().unwrap();
+        let log_dir = temp_dir.path();
+
+        // Create some old log files
+        let today = chrono::Local::now().date_naive();
+        let old_date = today - chrono::Days::new(30);
+        let file_name = format!("relay.log.{}", old_date.format("%Y-%m-%d"));
+        fs::write(log_dir.join(&file_name), "old log").unwrap();
+
+        // Sweep with retention of 0 (disabled)
+        sweep_old_logs(log_dir, 0);
+
+        // File should still exist
+        assert!(log_dir.join(&file_name).exists());
+    }
+
+    #[test]
+    fn sweep_old_logs_never_deletes_live_log() {
+        let temp_dir = TempDir::new().unwrap();
+        let log_dir = temp_dir.path();
+
+        // Create the live relay.log file
+        fs::write(log_dir.join("relay.log"), "current log").unwrap();
+
+        // Sweep with retention of 1 day
+        sweep_old_logs(log_dir, 1);
+
+        // Live log should still exist
+        assert!(log_dir.join("relay.log").exists());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,8 +136,14 @@ fn sweep_old_logs(log_dir: &std::path::Path, retention_days: u32) {
         return;
     }
 
-    let today = chrono::Local::now().date_naive();
-    let cutoff = today - chrono::Days::new(retention_days as u64);
+    let today = chrono::Utc::now().date_naive();
+    let cutoff = match today.checked_sub_days(chrono::Days::new(retention_days as u64)) {
+        Some(date) => date,
+        None => {
+            info!("Log retention window exceeds representable range; skipping sweep");
+            return;
+        }
+    };
 
     let entries = match std::fs::read_dir(log_dir) {
         Ok(e) => e,
@@ -226,10 +232,14 @@ fn init_tracing(
     );
 
     let file_appender = if retention_days > 0 {
+        // `max_log_files(N)` counts the currently-open dated file too, so
+        // `.max_log_files(7)` retains only 6 prior days plus today. Add 1 to
+        // `retention_days` so the appender reserves one slot for the live file,
+        // matching the sweep's semantics: "keep N days of prior history".
         tracing_appender::rolling::Builder::new()
             .rotation(tracing_appender::rolling::Rotation::DAILY)
             .filename_prefix("relay.log")
-            .max_log_files(retention_days as usize)
+            .max_log_files((retention_days as usize).saturating_add(1))
             .build(log_dir)
             .expect("Failed to create rolling file appender")
     } else {
@@ -292,6 +302,57 @@ async fn main() {
             let config_explicit = config.is_some();
             let config_path = config.unwrap_or_else(|| data_dir_path.join("config.toml"));
 
+            // First-run config copy: when using a non-default data dir without an
+            // explicit --config, copy the production config so dev instances inherit
+            // the same endpoint setup. This runs BEFORE config load so the copied
+            // file is picked up during load.
+            let default_data_dir = dirs::home_dir()
+                .map(|h| h.join(".endara"))
+                .unwrap_or_default();
+            if !config_explicit && data_dir_path != default_data_dir {
+                let resolved_config = config::expand_tilde(&config_path);
+                if !resolved_config.exists() {
+                    let production_config = default_data_dir.join("config.toml");
+                    if production_config.exists() {
+                        // Ensure the data dir and standard subdirs exist
+                        if let Err(e) = std::fs::create_dir_all(&data_dir_path) {
+                            eprintln!(
+                                "Warning: Failed to create data directory {}: {}",
+                                data_dir_path.display(),
+                                e
+                            );
+                        }
+                        for sub in &["logs", "tokens"] {
+                            let sub_path = data_dir_path.join(sub);
+                            if let Err(e) = std::fs::create_dir_all(&sub_path) {
+                                eprintln!(
+                                    "Warning: Failed to create subdirectory {}: {}",
+                                    sub_path.display(),
+                                    e
+                                );
+                            }
+                        }
+                        match std::fs::copy(&production_config, &resolved_config) {
+                            Ok(_) => {
+                                eprintln!(
+                                    "Copied production config from {} to {}",
+                                    production_config.display(),
+                                    resolved_config.display()
+                                );
+                            }
+                            Err(e) => {
+                                eprintln!(
+                                    "Warning: Failed to copy production config from {} to {}: {}",
+                                    production_config.display(),
+                                    resolved_config.display(),
+                                    e
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+
             // Load config early to determine the effective log retention value
             // before initializing tracing. On error, use eprintln since tracing
             // isn't up yet, then exit.
@@ -330,48 +391,6 @@ async fn main() {
 
             // Sweep old logs after tracing is initialized so warnings go through the tracing layer
             sweep_old_logs(&log_dir, effective_retention);
-
-            // First-run config copy: when using a non-default data dir without an
-            // explicit --config, copy the production config so dev instances inherit
-            // the same endpoint setup.
-            let default_data_dir = dirs::home_dir()
-                .map(|h| h.join(".endara"))
-                .unwrap_or_default();
-            if !config_explicit && data_dir_path != default_data_dir {
-                let resolved_config = config::expand_tilde(&config_path);
-                if !resolved_config.exists() {
-                    let production_config = default_data_dir.join("config.toml");
-                    if production_config.exists() {
-                        // Ensure the data dir and standard subdirs exist
-                        if let Err(e) = std::fs::create_dir_all(&data_dir_path) {
-                            warn!(error = %e, path = %data_dir_path.display(), "Failed to create data directory");
-                        }
-                        for sub in &["logs", "tokens"] {
-                            let sub_path = data_dir_path.join(sub);
-                            if let Err(e) = std::fs::create_dir_all(&sub_path) {
-                                warn!(error = %e, path = %sub_path.display(), "Failed to create subdirectory");
-                            }
-                        }
-                        match std::fs::copy(&production_config, &resolved_config) {
-                            Ok(_) => {
-                                info!(
-                                    src = %production_config.display(),
-                                    dst = %resolved_config.display(),
-                                    "Copied production config to dev data directory"
-                                );
-                            }
-                            Err(e) => {
-                                warn!(
-                                    error = %e,
-                                    src = %production_config.display(),
-                                    dst = %resolved_config.display(),
-                                    "Failed to copy production config"
-                                );
-                            }
-                        }
-                    }
-                }
-            }
 
             // Log config load success now that tracing is initialized
             info!(
@@ -1073,7 +1092,8 @@ mod tests {
         fs::write(log_dir.join("relay.log"), "current log").unwrap();
 
         // Create dated log files spanning 20 days (NOT including today)
-        let today = chrono::Local::now().date_naive();
+        // Use UTC dates to match sweep_old_logs timezone
+        let today = chrono::Utc::now().date_naive();
         for i in 1..=20 {
             let date = today - chrono::Days::new(i);
             let file_name = format!("relay.log.{}", date.format("%Y-%m-%d"));
@@ -1131,7 +1151,7 @@ mod tests {
         let log_dir = temp_dir.path();
 
         // Create some old log files
-        let today = chrono::Local::now().date_naive();
+        let today = chrono::Utc::now().date_naive();
         let old_date = today - chrono::Days::new(30);
         let file_name = format!("relay.log.{}", old_date.format("%Y-%m-%d"));
         fs::write(log_dir.join(&file_name), "old log").unwrap();
@@ -1156,5 +1176,33 @@ mod tests {
 
         // Live log should still exist
         assert!(log_dir.join("relay.log").exists());
+    }
+
+    #[test]
+    fn sweep_old_logs_handles_max_retention_without_panic() {
+        let temp_dir = TempDir::new().unwrap();
+        let log_dir = temp_dir.path();
+
+        // Create a few old log files
+        let today = chrono::Utc::now().date_naive();
+        for i in 1..=5 {
+            let date = today - chrono::Days::new(i);
+            let file_name = format!("relay.log.{}", date.format("%Y-%m-%d"));
+            fs::write(log_dir.join(&file_name), format!("log from day {}", i)).unwrap();
+        }
+
+        // Call sweep with u32::MAX - should not panic, should retain everything
+        sweep_old_logs(log_dir, u32::MAX);
+
+        // All files should still exist (treated as "retain everything")
+        for i in 1..=5 {
+            let date = today - chrono::Days::new(i);
+            let file_name = format!("relay.log.{}", date.format("%Y-%m-%d"));
+            assert!(
+                log_dir.join(&file_name).exists(),
+                "Expected {} to exist after max retention sweep",
+                file_name
+            );
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,8 @@ enum Commands {
         #[arg(long)]
         file_log_level: Option<String>,
 
-        /// Number of days to retain daily-rotated relay log files (overrides config.toml)
+        /// Number of days to retain daily-rotated relay log files (overrides config.toml).
+        /// Cleanup runs at startup; long-running relays accumulate logs until restarted.
         #[arg(long)]
         log_retention_days: Option<u32>,
 
@@ -208,7 +209,6 @@ fn init_tracing(
     log_format: &str,
     file_log_level: Option<String>,
     log_dir: &std::path::Path,
-    retention_days: u32,
 ) {
     use std::io::IsTerminal;
     use tracing_subscriber::fmt;
@@ -231,20 +231,7 @@ fn init_tracing(
             .unwrap_or("debug,endara_relay=trace"),
     );
 
-    let file_appender = if retention_days > 0 {
-        // `max_log_files(N)` counts the currently-open dated file too, so
-        // `.max_log_files(7)` retains only 6 prior days plus today. Add 1 to
-        // `retention_days` so the appender reserves one slot for the live file,
-        // matching the sweep's semantics: "keep N days of prior history".
-        tracing_appender::rolling::Builder::new()
-            .rotation(tracing_appender::rolling::Rotation::DAILY)
-            .filename_prefix("relay.log")
-            .max_log_files((retention_days as usize).saturating_add(1))
-            .build(log_dir)
-            .expect("Failed to create rolling file appender")
-    } else {
-        tracing_appender::rolling::daily(log_dir, "relay.log")
-    };
+    let file_appender = tracing_appender::rolling::daily(log_dir, "relay.log");
     let file_layer = fmt::layer()
         .with_writer(file_appender)
         .with_ansi(false)
@@ -380,16 +367,14 @@ async fn main() {
                 .or(cfg.relay.log_retention_days)
                 .unwrap_or(DEFAULT_LOG_RETENTION_DAYS);
 
-            init_tracing(
-                color,
-                &log_format,
-                file_log_level.clone(),
-                &log_dir,
-                effective_retention,
-            );
+            init_tracing(color, &log_format, file_log_level.clone(), &log_dir);
             info!(config = %config_path.display(), data_dir = %data_dir_path.display(), "Starting endara-relay");
 
-            // Sweep old logs after tracing is initialized so warnings go through the tracing layer
+            // Sweep old logs after tracing is initialized so warnings go through the tracing layer.
+            // Retention is enforced by this startup sweep only — long-running relays that never
+            // restart will accumulate log files until the next restart. This is an accepted
+            // tradeoff to avoid tracing-appender 0.2.4's max_log_files prefix-based cleanup
+            // pitfalls (which can delete the live relay.log or unrelated files).
             sweep_old_logs(&log_dir, effective_retention);
 
             // Log config load success now that tracing is initialized

--- a/src/management.rs
+++ b/src/management.rs
@@ -6589,6 +6589,7 @@ mod tests {
                 session_identity_max_sessions: None,
                 validate_inputs: None,
                 observability: crate::config::ObservabilityConfig::default(),
+                log_retention_days: None,
             },
             endpoints: vec![EndpointConfig {
                 name: "echo".to_string(),
@@ -9046,6 +9047,7 @@ command = "echo"
                 session_identity_max_sessions: None,
                 validate_inputs: None,
                 observability: crate::config::ObservabilityConfig::default(),
+                log_retention_days: None,
             },
             endpoints: vec![EndpointConfig {
                 name: name.to_string(),
@@ -9590,6 +9592,7 @@ command = "echo"
                 session_identity_max_sessions: None,
                 validate_inputs: None,
                 observability: crate::config::ObservabilityConfig::default(),
+                log_retention_days: None,
             },
             endpoints: vec![EndpointConfig {
                 name: name.to_string(),
@@ -11020,6 +11023,7 @@ command = "echo"
                 session_identity_max_sessions: None,
                 validate_inputs: None,
                 observability: crate::config::ObservabilityConfig::default(),
+                log_retention_days: None,
             },
             endpoints: vec![EndpointConfig {
                 name: name.to_string(),
@@ -11145,6 +11149,7 @@ client_id = "client123"
                 session_identity_max_sessions: None,
                 validate_inputs: None,
                 observability: crate::config::ObservabilityConfig::default(),
+                log_retention_days: None,
             },
             endpoints: vec![],
             profiles: None,
@@ -11210,6 +11215,7 @@ client_id = "client123"
                 session_identity_max_sessions: None,
                 validate_inputs: None,
                 observability: crate::config::ObservabilityConfig::default(),
+                log_retention_days: None,
             },
             endpoints: endpoint_names
                 .iter()
@@ -11773,6 +11779,7 @@ client_id = "client123"
                 session_identity_max_sessions: None,
                 validate_inputs: None,
                 observability: crate::config::ObservabilityConfig::default(),
+                log_retention_days: None,
             },
             endpoints: vec![EndpointConfig {
                 name: "existing".to_string(),

--- a/tests/hot_reload_integration.rs
+++ b/tests/hot_reload_integration.rs
@@ -69,6 +69,7 @@ async fn test_config_diff_add_endpoint() {
             session_identity_max_sessions: None,
             validate_inputs: None,
             observability: config::ObservabilityConfig::default(),
+            log_retention_days: None,
         },
         endpoints: vec![config::EndpointConfig {
             name: "echo-ep".to_string(),
@@ -108,6 +109,7 @@ async fn test_config_diff_add_endpoint() {
             session_identity_max_sessions: None,
             validate_inputs: None,
             observability: config::ObservabilityConfig::default(),
+            log_retention_days: None,
         },
         endpoints: vec![
             config::EndpointConfig {
@@ -261,6 +263,7 @@ async fn test_config_diff_remove_endpoint() {
             session_identity_max_sessions: None,
             validate_inputs: None,
             observability: config::ObservabilityConfig::default(),
+            log_retention_days: None,
         },
         endpoints: vec![
             config::EndpointConfig {
@@ -325,6 +328,7 @@ async fn test_config_diff_remove_endpoint() {
             session_identity_max_sessions: None,
             validate_inputs: None,
             observability: config::ObservabilityConfig::default(),
+            log_retention_days: None,
         },
         endpoints: vec![config::EndpointConfig {
             name: "echo-ep".to_string(),

--- a/tests/management_api_integration.rs
+++ b/tests/management_api_integration.rs
@@ -95,6 +95,7 @@ fn test_config() -> Config {
             session_identity_max_sessions: None,
             validate_inputs: None,
             observability: ObservabilityConfig::default(),
+            log_retention_days: None,
         },
         endpoints: vec![EndpointConfig {
             name: "echo".to_string(),

--- a/tests/oauth_setup_integration.rs
+++ b/tests/oauth_setup_integration.rs
@@ -30,6 +30,7 @@ fn empty_config() -> Config {
             session_identity_max_sessions: None,
             validate_inputs: None,
             observability: ObservabilityConfig::default(),
+            log_retention_days: None,
         },
         endpoints: vec![EndpointConfig {
             name: "echo".to_string(),


### PR DESCRIPTION
Adds automatic pruning of rotated daily relay log files so they no longer accumulate forever in the data-dir logs directory.

## What changes for users

- By default, Endara Relay now keeps only the **last 7 days** of rotated relay.log.YYYY-MM-DD files. Older files are deleted automatically.
- Retention is fully configurable:
  - Config: add **log_retention_days = N** under the **[relay]** table in config.toml.
  - CLI: pass **--log-retention-days N** to the start subcommand (overrides config).
  - Set to **0** to disable pruning entirely and keep the pre-change behaviour.
- Cleanup runs **once at startup**. Long-running relays that never restart will accumulate files until the next restart — the on-disk footprint is reclaimed on the next boot.
- The live relay.log is never touched and the on-disk file naming (relay.log.YYYY-MM-DD) is unchanged.

## Implementation notes

- New optional field **log_retention_days: Option<u32>** on **RelayConfig** with **#[serde(default)]** and **#[serde(skip_serializing_if = ...)]** so existing configs round-trip unchanged.
- File appender remains the plain **tracing_appender::rolling::daily(...)** helper — no reliance on **Builder::max_log_files**. That builder option treats every file whose name starts with the prefix as a deletion candidate (including the live relay.log and unrelated files like relay.log.backup) and its retained count is soft, so we drive retention entirely from our own date-aware sweep instead.
- New **sweep_old_logs(log_dir, retention_days)** helper enumerates **relay.log.YYYY-MM-DD** files, parses the trailing date in UTC (matching tracing-appender's rotation timezone), and deletes files older than **today - retention_days**. Uses **checked_sub_days** so out-of-range values (e.g. **u32::MAX**) skip the sweep instead of panicking. Best-effort: individual file errors log a warning but never fail startup.
- **main()** loads config and runs the first-run production-config copy **before** init_tracing so the effective retention value (CLI flag → config → default 7) can flow through, and dev data-dirs still inherit the production config. Pre-tracing config-load errors keep their existing eprintln/exit paths.

## Tests

- 4 config parse tests: omitted key, = 14, = 0, round-trip.
- Sweep tests: 15 files across 20 days with retention=7 (UTC-seeded), retention=0 no-op, live relay.log untouched, and **u32::MAX** retention returns without panic.
- All existing tests still pass; **RelayConfig { ... }** literals in tests and integration fixtures updated to include the new field.

Verification: **cargo fmt --check**, **cargo clippy --all-targets -- -D warnings**, and **cargo test** all clean.
