### PR TITLE
chore: bump version to 0.1.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "endara-relay"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endara-relay"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 description = "Local MCP tool aggregator — aggregate multiple MCP servers behind a single endpoint"
 license = "Apache-2.0"


### PR DESCRIPTION
Scenario 3 base-version bump after the stable v0.1.11 release.

- `Cargo.toml` version → `0.1.12`
- `Cargo.lock` refreshed via `cargo update --workspace` (one-line change)

Verified with `cargo fmt --check` and `cargo check`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author