### PR TITLE
feat: add writeFile sandbox global with write_dirs allowlist

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -608,12 +608,17 @@ impl From<toml::de::Error> for ConfigError {
     }
 }
 
-/// Expand `~` prefix to the user's home directory.
+/// Expand `~` prefix to the user's home directory. `HOME` takes precedence
+/// (tests override it); `dirs::home_dir()` covers platforms where `HOME`
+/// is unset, e.g. Windows.
 pub fn expand_tilde(path: &Path) -> PathBuf {
     let s = path.to_string_lossy();
     if s.starts_with("~/") || s == "~" {
-        if let Some(home) = std::env::var_os("HOME") {
-            return PathBuf::from(home).join(s.strip_prefix("~/").unwrap_or(""));
+        let home = std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .or_else(dirs::home_dir);
+        if let Some(home) = home {
+            return home.join(s.strip_prefix("~/").unwrap_or(""));
         }
     }
     path.to_path_buf()

--- a/src/config.rs
+++ b/src/config.rs
@@ -81,6 +81,15 @@ pub struct RelayConfig {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub log_retention_days: Option<u32>,
+    /// Allowlist of directories the JS sandbox's `writeFile` may write into.
+    /// Each entry must be an absolute path (a leading `~/` is expanded to the
+    /// user's home directory). Relative entries are a hard validation error.
+    /// Entries that do not exist or are not directories are warned about and
+    /// skipped at resolution time (see [`resolve_write_roots`]) — the relay
+    /// never creates them. `None`/empty means writing is disabled entirely.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub write_dirs: Option<Vec<PathBuf>>,
 }
 
 impl Default for RelayConfig {
@@ -105,6 +114,7 @@ impl Default for RelayConfig {
             validate_inputs: None,
             observability: ObservabilityConfig::default(),
             log_retention_days: None,
+            write_dirs: None,
         }
     }
 }
@@ -320,6 +330,35 @@ pub fn validate_profiles(config: &Config) -> Result<(), Vec<String>> {
             }
         }
     }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
+}
+
+/// Validate `relay.write_dirs`: every entry must be an absolute path after
+/// tilde expansion. Fail-fast like [`validate_profiles`] — a relative entry
+/// is a configuration error, never a warning. Existence is deliberately NOT
+/// checked here; missing/non-directory entries are warned about and skipped
+/// at resolution time by [`resolve_write_roots`].
+pub fn validate_write_dirs(config: &Config) -> Result<(), Vec<String>> {
+    let dirs = match &config.relay.write_dirs {
+        Some(d) if !d.is_empty() => d,
+        _ => return Ok(()),
+    };
+
+    let errors: Vec<String> = dirs
+        .iter()
+        .filter(|d| !expand_tilde(d).is_absolute())
+        .map(|d| {
+            format!(
+                "relay.write_dirs entry '{}' must be an absolute path",
+                d.display()
+            )
+        })
+        .collect();
 
     if errors.is_empty() {
         Ok(())
@@ -580,6 +619,44 @@ pub fn expand_tilde(path: &Path) -> PathBuf {
     path.to_path_buf()
 }
 
+/// Resolve `relay.write_dirs` into the effective allowlist of write roots.
+///
+/// Each configured entry is tilde-expanded and canonicalized. Entries that do
+/// not exist or are not directories are **warned about and skipped** — the
+/// relay never creates them (locked design decision: warn-and-skip, no
+/// auto-creation). Canonicalization resolves symlinks so later path-containment
+/// checks against these roots cannot be escaped via a symlinked root.
+///
+/// Returns the (possibly empty) list of canonical, existing directory roots.
+pub fn resolve_write_roots(config: &Config) -> Vec<PathBuf> {
+    let dirs = match &config.relay.write_dirs {
+        Some(d) if !d.is_empty() => d,
+        _ => return Vec::new(),
+    };
+
+    let mut roots = Vec::new();
+    for dir in dirs {
+        let expanded = expand_tilde(dir);
+        match std::fs::canonicalize(&expanded) {
+            Ok(canonical) if canonical.is_dir() => roots.push(canonical),
+            Ok(_) => {
+                tracing::warn!(
+                    path = %expanded.display(),
+                    "relay.write_dirs entry is not a directory; skipping"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    path = %expanded.display(),
+                    error = %e,
+                    "relay.write_dirs entry does not exist or is inaccessible; skipping (directories are never auto-created)"
+                );
+            }
+        }
+    }
+    roots
+}
+
 /// Create a default configuration with the system hostname and no endpoints.
 pub fn default_config() -> Config {
     Config {
@@ -635,6 +712,8 @@ pub fn parse_and_validate(contents: &str) -> Result<Config, ConfigError> {
     resolve_env_vars(&mut config)?;
     validate(&config)?;
     validate_profiles(&config).map_err(|errors| ConfigError::ValidationError(errors.join("; ")))?;
+    validate_write_dirs(&config)
+        .map_err(|errors| ConfigError::ValidationError(errors.join("; ")))?;
     Ok(config)
 }
 
@@ -664,6 +743,11 @@ pub fn parse_and_validate_graceful(
     // duplicate paths, and missing endpoint refs are hard startup errors,
     // never per-endpoint warnings.
     validate_profiles(&config).map_err(|errors| ConfigError::ValidationError(errors.join("; ")))?;
+
+    // write_dirs validation is also fail-fast: a relative entry is a
+    // configuration error, mirroring profile validation above.
+    validate_write_dirs(&config)
+        .map_err(|errors| ConfigError::ValidationError(errors.join("; ")))?;
 
     Ok((config, warnings))
 }
@@ -1917,6 +2001,7 @@ js_execution = false
                 validate_inputs: None,
                 observability: ObservabilityConfig::default(),
                 log_retention_days: None,
+                write_dirs: None,
             },
             endpoints,
             profiles: None,
@@ -3172,5 +3257,170 @@ log_retention_days = 0
         let toml_str = toml::to_string_pretty(&config).unwrap();
         let parsed: Config = toml::from_str(&toml_str).unwrap();
         assert_eq!(parsed.relay.log_retention_days, Some(14));
+    }
+
+    // --- write_dirs tests ---
+
+    #[test]
+    fn write_dirs_defaults_to_none() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+"#;
+        let config = parse_and_validate(toml_str).unwrap();
+        assert_eq!(config.relay.write_dirs, None);
+    }
+
+    #[test]
+    fn write_dirs_parses_absolute_entries() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+write_dirs = ["/tmp/media", "/var/data/out"]
+"#;
+        let config = parse_and_validate(toml_str).unwrap();
+        assert_eq!(
+            config.relay.write_dirs,
+            Some(vec![
+                PathBuf::from("/tmp/media"),
+                PathBuf::from("/var/data/out")
+            ])
+        );
+    }
+
+    #[test]
+    fn write_dirs_relative_entry_is_hard_error() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+write_dirs = ["relative/path"]
+"#;
+        let err = parse_and_validate(toml_str).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::ValidationError(ref msg) if msg.contains("relative/path")
+                && msg.contains("absolute")),
+            "expected write_dirs validation error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn write_dirs_relative_entry_is_hard_error_in_graceful_path() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+write_dirs = ["relative/path"]
+"#;
+        let err = parse_and_validate_graceful(toml_str).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::ValidationError(_)),
+            "graceful path must also fail-fast on relative write_dirs, got {err:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_dirs_tilde_entry_passes_validation() {
+        // `~/…` expands to an absolute path under $HOME, so validation
+        // accepts it even though the literal entry is not absolute.
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+write_dirs = ["~/endara-media"]
+"#;
+        let config = parse_and_validate(toml_str).unwrap();
+        assert_eq!(
+            config.relay.write_dirs,
+            Some(vec![PathBuf::from("~/endara-media")])
+        );
+    }
+
+    #[test]
+    fn write_dirs_empty_list_is_valid() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+write_dirs = []
+"#;
+        let config = parse_and_validate(toml_str).unwrap();
+        assert_eq!(config.relay.write_dirs, Some(vec![]));
+        assert!(resolve_write_roots(&config).is_empty());
+    }
+
+    #[test]
+    fn write_dirs_round_trips() {
+        let config = Config {
+            relay: RelayConfig {
+                machine_name: "test".to_string(),
+                write_dirs: Some(vec![PathBuf::from("/tmp/media")]),
+                ..RelayConfig::default()
+            },
+            endpoints: vec![],
+            profiles: None,
+            organizations: Vec::new(),
+        };
+        let toml_str = toml::to_string_pretty(&config).unwrap();
+        let parsed: Config = toml::from_str(&toml_str).unwrap();
+        assert_eq!(
+            parsed.relay.write_dirs,
+            Some(vec![PathBuf::from("/tmp/media")])
+        );
+    }
+
+    // --- resolve_write_roots tests ---
+
+    fn config_with_write_dirs(dirs: Vec<PathBuf>) -> Config {
+        Config {
+            relay: RelayConfig {
+                machine_name: "test".to_string(),
+                write_dirs: Some(dirs),
+                ..RelayConfig::default()
+            },
+            endpoints: vec![],
+            profiles: None,
+            organizations: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn resolve_write_roots_none_yields_empty() {
+        let config = default_config();
+        assert!(resolve_write_roots(&config).is_empty());
+    }
+
+    #[test]
+    fn resolve_write_roots_keeps_existing_directories_canonicalized() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = config_with_write_dirs(vec![tmp.path().to_path_buf()]);
+        let roots = resolve_write_roots(&config);
+        assert_eq!(roots, vec![tmp.path().canonicalize().unwrap()]);
+    }
+
+    #[test]
+    fn resolve_write_roots_skips_missing_directories_without_creating() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("does-not-exist");
+        let config = config_with_write_dirs(vec![missing.clone(), tmp.path().to_path_buf()]);
+        let roots = resolve_write_roots(&config);
+        assert_eq!(
+            roots,
+            vec![tmp.path().canonicalize().unwrap()],
+            "missing entry must be skipped, existing one kept"
+        );
+        assert!(
+            !missing.exists(),
+            "resolve must never create the missing directory"
+        );
+    }
+
+    #[test]
+    fn resolve_write_roots_skips_plain_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("not-a-dir.txt");
+        std::fs::write(&file, "x").unwrap();
+        let config = config_with_write_dirs(vec![file]);
+        assert!(
+            resolve_write_roots(&config).is_empty(),
+            "a plain file must not become a write root"
+        );
     }
 }

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -973,11 +973,17 @@ fn write_file_native(
         .to_string(context)?
         .to_std_string_escaped();
 
-    let data = args
+    let data_val = args
         .get(1)
-        .ok_or_else(|| JsNativeError::typ().with_message("writeFile: missing data"))?
-        .to_string(context)?
-        .to_std_string_escaped();
+        .ok_or_else(|| JsNativeError::typ().with_message("writeFile: missing data"))?;
+    if !data_val.is_string() {
+        // Reject rather than coerce: ToString would silently write
+        // "[object Object]" for objects or "1,2,3" for arrays.
+        return Err(JsNativeError::typ()
+            .with_message("writeFile: data must be a string")
+            .into());
+    }
+    let data = data_val.to_string(context)?.to_std_string_escaped();
 
     let encoding = match args.get(2) {
         Some(v) if !v.is_undefined() && !v.is_null() => {
@@ -1002,20 +1008,30 @@ fn write_file_native(
     if files_written >= limits.max_files_per_run {
         return Err(JsNativeError::error()
             .with_message(format!(
-                "writeFile: per-run limit of {} files reached — no further files can \
-                 be written by this script run",
+                "writeFile: per-run limit of {} file writes reached — no further files \
+                 can be written by this script run",
                 limits.max_files_per_run
             ))
             .into());
     }
 
     // Per-file size cap, checked before base64 decoding so an oversized
-    // payload is rejected without allocating the decoded bytes. Base64
-    // padding means the ≈3n/4 estimate is an upper bound on the decoded
-    // size, so a payload that passes here cannot exceed the cap once decoded.
+    // payload is rejected without allocating the decoded bytes. The ≈3n/4
+    // estimate subtracts trailing '=' padding so it is an exact upper bound
+    // on the decoded size — a payload whose decoded length is exactly the
+    // cap is accepted, and one that passes here cannot exceed the cap.
     let estimated_len = match encoding.as_str() {
         "utf8" => Some(data.len()),
-        "base64" => Some(data.len().saturating_mul(3) / 4),
+        "base64" => {
+            let padding = data
+                .as_bytes()
+                .iter()
+                .rev()
+                .take(2)
+                .filter(|&&b| b == b'=')
+                .count();
+            Some((data.len().saturating_mul(3) / 4).saturating_sub(padding))
+        }
         _ => None,
     };
     if let Some(estimated_len) = estimated_len {
@@ -1035,6 +1051,12 @@ fn write_file_native(
                 .into());
         }
     }
+
+    // Validate the destination before decoding: a disallowed path fails
+    // with the actionable path error (instead of a decode error) and never
+    // pays the decode allocation.
+    let (dest, matched_root) = resolve_write_path(&path_str, &write_roots)
+        .map_err(|msg| JsNativeError::error().with_message(msg))?;
 
     let bytes: Vec<u8> = match encoding.as_str() {
         "utf8" => data.into_bytes(),
@@ -1069,10 +1091,8 @@ fn write_file_native(
             .into());
     }
 
-    let dest = resolve_write_path(&path_str, &write_roots)
+    write_atomic(&dest, &bytes, &matched_root)
         .map_err(|msg| JsNativeError::error().with_message(msg))?;
-
-    write_atomic(&dest, &bytes).map_err(|msg| JsNativeError::error().with_message(msg))?;
 
     SANDBOX_STATE.with(|cell| {
         if let Some(state) = cell.borrow_mut().as_mut() {
@@ -1086,10 +1106,14 @@ fn write_file_native(
 }
 
 /// Validate `path_str` against the allowlist and return the canonical
-/// destination path. Rejections (empty/NUL path, relative path, `..`
-/// components, destinations outside every root — including via symlinks)
-/// come back as `Err(message)` before anything touches the filesystem.
-fn resolve_write_path(path_str: &str, write_roots: &[PathBuf]) -> Result<PathBuf, String> {
+/// destination path together with the allowlisted root it matched.
+/// Rejections (empty/NUL path, relative path, `..` components, destinations
+/// outside every root — including via symlinks) come back as `Err(message)`
+/// before anything touches the filesystem.
+fn resolve_write_path(
+    path_str: &str,
+    write_roots: &[PathBuf],
+) -> Result<(PathBuf, PathBuf), String> {
     if path_str.is_empty() {
         return Err(
             "writeFile: path must not be empty — writeFile requires an absolute \
@@ -1140,17 +1164,17 @@ fn resolve_write_path(path_str: &str, write_roots: &[PathBuf]) -> Result<PathBuf
         resolved.push(name);
     }
 
-    if !write_roots.iter().any(|root| resolved.starts_with(root)) {
-        return Err(write_dirs_rejection_message(path_str, write_roots));
+    match write_roots.iter().find(|root| resolved.starts_with(root)) {
+        Some(root) => Ok((resolved, root.clone())),
+        None => Err(write_dirs_rejection_message(path_str, write_roots)),
     }
-    Ok(resolved)
 }
 
 /// The actionable "not inside a configured write directory" message. When
 /// roots are configured, the currently-allowed directories are listed.
 fn write_dirs_rejection_message(path_str: &str, write_roots: &[PathBuf]) -> String {
     let mut msg = format!(
-        "writeFile: {} is not inside a configured write directory. Add one under \
+        "writeFile: '{}' is not inside a configured write directory. Add one under \
          [relay] write_dirs in ~/.endara/config.toml, or in the Endara desktop app \
          under Settings → Write directories.",
         path_str
@@ -1168,10 +1192,18 @@ fn write_dirs_rejection_message(path_str: &str, write_roots: &[PathBuf]) -> Stri
 
 /// Write `bytes` to `dest` via a temp file in the destination directory plus
 /// an atomic rename, creating missing parent directories first. `dest` must
-/// already be validated by [`resolve_write_path`], so any directories created
-/// here sit inside the matched root. On failure the temp file is removed —
-/// no partial destination file is ever observable.
-fn write_atomic(dest: &Path, bytes: &[u8]) -> Result<(), String> {
+/// already be validated by [`resolve_write_path`] against `root` (the
+/// allowlisted root it matched), so any directories created here sit inside
+/// that root. After `create_dir_all` the destination directory is
+/// re-canonicalized and containment is re-asserted, closing the
+/// validate→write window in which a checked directory could be swapped for
+/// a symlink pointing outside the root. If the root itself was deleted
+/// after config resolution, `create_dir_all` recreates it — still inside
+/// the allowed prefix; the "directories are never auto-created" stance in
+/// [`crate::config::resolve_write_roots`] only covers resolution time. On
+/// failure the temp file is removed — no partial destination file is ever
+/// observable.
+fn write_atomic(dest: &Path, bytes: &[u8], root: &Path) -> Result<(), String> {
     let dir = dest
         .parent()
         .ok_or_else(|| format!("writeFile: '{}' has no parent directory", dest.display()))?;
@@ -1185,11 +1217,20 @@ fn write_atomic(dest: &Path, bytes: &[u8]) -> Result<(), String> {
             e
         )
     })?;
+    let canonical_dir = std::fs::canonicalize(dir)
+        .map_err(|e| format!("writeFile: failed to resolve '{}': {}", dest.display(), e))?;
+    if !canonical_dir.starts_with(root) {
+        return Err(format!(
+            "writeFile: '{}' escaped the configured write directory during the write",
+            dest.display()
+        ));
+    }
+    let final_dest = canonical_dir.join(file_name);
     let unique = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let tmp = dir.join(format!(
+    let tmp = canonical_dir.join(format!(
         ".{}.{}.{}.tmp",
         file_name.to_string_lossy(),
         std::process::id(),
@@ -1203,7 +1244,7 @@ fn write_atomic(dest: &Path, bytes: &[u8]) -> Result<(), String> {
             e
         ));
     }
-    if let Err(e) = std::fs::rename(&tmp, dest) {
+    if let Err(e) = std::fs::rename(&tmp, &final_dest) {
         let _ = std::fs::remove_file(&tmp);
         return Err(format!(
             "writeFile: failed to finalise '{}': {}",
@@ -3156,6 +3197,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_write_file_base64_exactly_at_cap_with_padding_accepted() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = canonical_root(&dir);
+        let sandbox = write_sandbox(vec![root.clone()])
+            .await
+            .with_write_limits(WriteLimits {
+                max_file_bytes: 4,
+                max_files_per_run: 64,
+                max_total_bytes_per_run: 1024,
+            });
+        let dest = root.join("exact.bin");
+        // "YWJjZA==" decodes to exactly 4 bytes ("abcd"). The naive 3n/4
+        // estimate (6) would over-count the two padding bytes and reject a
+        // payload that is exactly at the cap.
+        let script = format!(
+            "return writeFile({}, \"YWJjZA==\", {{ encoding: \"base64\" }});",
+            js_quote(dest.to_str().unwrap())
+        );
+        let result = sandbox.execute(&script).await.unwrap();
+        assert_eq!(result, json!(dest.to_str().unwrap()));
+        assert_eq!(std::fs::read(&dest).unwrap(), b"abcd");
+    }
+
+    #[tokio::test]
+    async fn test_write_file_rejects_non_string_data() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = canonical_root(&dir);
+        let sandbox = write_sandbox(vec![root.clone()]).await;
+        let dest = root.join("obj.txt");
+        let script = format!(
+            "return writeFile({}, {{ a: 1 }});",
+            js_quote(dest.to_str().unwrap())
+        );
+        let err = sandbox.execute(&script).await.unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("data must be a string"),
+            "unexpected error: {}",
+            msg
+        );
+        assert!(dir_entries(&root).is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_write_file_path_error_precedes_decode_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = canonical_root(&dir);
+        let sandbox = write_sandbox(vec![root.clone()]).await;
+        // Disallowed path AND invalid base64: the actionable path error
+        // must win, and the payload must never be decoded.
+        let script =
+            "return writeFile(\"/definitely/not/allowed/x.bin\", \"!!!!\", { encoding: \"base64\" });";
+        let err = sandbox.execute(script).await.unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("not inside a configured write directory"),
+            "unexpected error: {}",
+            msg
+        );
+        assert!(
+            !msg.contains("invalid base64"),
+            "path validation must precede base64 decoding: {}",
+            msg
+        );
+    }
+
+    #[tokio::test]
     async fn test_write_file_per_run_file_count_limit() {
         let dir = tempfile::tempdir().unwrap();
         let root = canonical_root(&dir);
@@ -3167,7 +3275,7 @@ mod tests {
         let err = sandbox.execute(&script).await.unwrap_err();
         let msg = format!("{}", err);
         assert!(
-            msg.contains("per-run limit of 64 files"),
+            msg.contains("per-run limit of 64 file writes"),
             "unexpected error: {}",
             msg
         );

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -1226,17 +1226,30 @@ fn write_atomic(dest: &Path, bytes: &[u8], root: &Path) -> Result<(), String> {
         ));
     }
     let final_dest = canonical_dir.join(file_name);
+    // Process-wide monotonic counter: concurrent writes to the same
+    // destination can observe the same SystemTime, so the timestamp alone
+    // does not make the temp name unique within this process.
+    static TMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let unique = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
     let tmp = canonical_dir.join(format!(
-        ".{}.{}.{}.tmp",
+        ".{}.{}.{}.{}.tmp",
         file_name.to_string_lossy(),
         std::process::id(),
-        unique
+        unique,
+        seq
     ));
-    if let Err(e) = std::fs::write(&tmp, bytes) {
+    // create_new(true) guarantees this call exclusively owns the temp file
+    // even if the name somehow collides (e.g. across processes).
+    let write_result = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&tmp)
+        .and_then(|mut f| std::io::Write::write_all(&mut f, bytes));
+    if let Err(e) = write_result {
         let _ = std::fs::remove_file(&tmp);
         return Err(format!(
             "writeFile: failed to write '{}': {}",

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -1,10 +1,14 @@
 //! JavaScript execution sandbox using boa_engine.
 //!
 //! Provides a sandboxed JS runtime with access to MCP tools via a `tools` global object.
-//! No filesystem or network access is available from within the sandbox.
+//! No network access is available from within the sandbox. Filesystem access is
+//! limited to a single allowlisted write primitive: `writeFile(absPath, data, opts?)`
+//! accepts absolute paths only and validates the fully-resolved destination against
+//! the user-configured `relay.write_dirs` allowlist (empty allowlist = writing
+//! disabled). There is no read primitive.
 
 use std::cell::RefCell;
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -364,6 +368,7 @@ fn run_js(script: &str, catalog: &[ToolInfo]) -> Result<Value, JsSandboxError> {
 
     register_call_tool(&mut context)?;
     register_call_tool_with_retry(&mut context)?;
+    register_write_file(&mut context)?;
     register_tools_object(&mut context, catalog)?;
     register_json_parse_wrapper(&mut context)?;
 
@@ -864,6 +869,230 @@ fn register_json_parse_wrapper(context: &mut Context) -> Result<(), JsSandboxErr
         .map_err(|e| {
             JsSandboxError::Internal(format!("failed to install JSON.parse wrapper: {}", e))
         })?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Native function: __write_file(path, data, encoding) -> canonical_path_string
+//
+// Backs the JS-facing `writeFile(absPath, data, opts?)` global. Absolute
+// paths only; the fully-resolved destination must sit inside one of the
+// canonical `relay.write_dirs` roots carried in [`SandboxState`]. Every
+// rejection is a thrown JS Error and never leaves a partial file behind.
+// ---------------------------------------------------------------------------
+
+fn register_write_file(context: &mut Context) -> Result<(), JsSandboxError> {
+    let f = NativeFunction::from_fn_ptr(write_file_native);
+    let js_func = f.to_js_function(context.realm());
+    context
+        .register_global_property(
+            boa_engine::js_string!("__write_file"),
+            js_func,
+            Attribute::READONLY | Attribute::NON_ENUMERABLE,
+        )
+        .map_err(|e| JsSandboxError::Internal(format!("failed to register __write_file: {}", e)))?;
+    const SRC: &str = r#"
+function writeFile(path, data, opts) {
+  var encoding = (opts && opts.encoding !== undefined) ? opts.encoding : "utf8";
+  return __write_file(path, data, encoding);
+}
+"#;
+    context
+        .eval(Source::from_bytes(SRC.as_bytes()))
+        .map_err(|e| {
+            JsSandboxError::Internal(format!("failed to create writeFile helper: {}", e))
+        })?;
+    Ok(())
+}
+
+fn write_file_native(
+    _this: &JsValue,
+    args: &[JsValue],
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    let path_str = args
+        .first()
+        .ok_or_else(|| JsNativeError::typ().with_message("writeFile: missing path"))?
+        .to_string(context)?
+        .to_std_string_escaped();
+
+    let data = args
+        .get(1)
+        .ok_or_else(|| JsNativeError::typ().with_message("writeFile: missing data"))?
+        .to_string(context)?
+        .to_std_string_escaped();
+
+    let encoding = match args.get(2) {
+        Some(v) if !v.is_undefined() && !v.is_null() => {
+            v.to_string(context)?.to_std_string_escaped()
+        }
+        _ => "utf8".to_string(),
+    };
+
+    let bytes: Vec<u8> = match encoding.as_str() {
+        "utf8" => data.into_bytes(),
+        "base64" => {
+            use base64::Engine as _;
+            base64::engine::general_purpose::STANDARD
+                .decode(data.as_bytes())
+                .map_err(|e| {
+                    JsNativeError::error()
+                        .with_message(format!("writeFile: invalid base64 data: {}", e))
+                })?
+        }
+        other => {
+            return Err(JsNativeError::typ()
+                .with_message(format!(
+                    "writeFile: unsupported encoding '{}' (expected \"utf8\" or \"base64\")",
+                    other
+                ))
+                .into())
+        }
+    };
+
+    let write_roots = SANDBOX_STATE.with(|cell| {
+        let borrow = cell.borrow();
+        let state = borrow
+            .as_ref()
+            .ok_or_else(|| JsNativeError::error().with_message("sandbox state not initialised"))?;
+        Ok::<Vec<PathBuf>, JsError>(state.write_roots.clone())
+    })?;
+
+    let dest = resolve_write_path(&path_str, &write_roots)
+        .map_err(|msg| JsNativeError::error().with_message(msg))?;
+
+    write_atomic(&dest, &bytes).map_err(|msg| JsNativeError::error().with_message(msg))?;
+
+    let dest_str = dest.to_string_lossy();
+    Ok(JsValue::from(boa_engine::js_string!(dest_str.as_ref())))
+}
+
+/// Validate `path_str` against the allowlist and return the canonical
+/// destination path. Rejections (empty/NUL path, relative path, `..`
+/// components, destinations outside every root — including via symlinks)
+/// come back as `Err(message)` before anything touches the filesystem.
+fn resolve_write_path(path_str: &str, write_roots: &[PathBuf]) -> Result<PathBuf, String> {
+    if path_str.is_empty() {
+        return Err(
+            "writeFile: path must not be empty — writeFile requires an absolute \
+             path inside a configured write directory"
+                .to_string(),
+        );
+    }
+    if path_str.contains('\0') {
+        return Err("writeFile: path must not contain a NUL byte".to_string());
+    }
+    let path = Path::new(path_str);
+    if !path.is_absolute() {
+        return Err(format!(
+            "writeFile: '{}' is a relative path — writeFile requires an absolute path \
+             inside a configured write directory",
+            path_str
+        ));
+    }
+    if path.components().any(|c| matches!(c, Component::ParentDir)) {
+        return Err(format!(
+            "writeFile: '{}' contains a '..' path component, which is not allowed",
+            path_str
+        ));
+    }
+    if write_roots.is_empty() {
+        return Err(write_dirs_rejection_message(path_str, write_roots));
+    }
+
+    // Canonicalize the deepest existing ancestor, then re-append the
+    // not-yet-existing components. This resolves symlinks in every existing
+    // part of the path — so a symlink inside a root pointing outside is
+    // caught by the prefix check below — without requiring the destination
+    // itself to exist yet.
+    let mut existing: &Path = path;
+    let mut missing: Vec<std::ffi::OsString> = Vec::new();
+    while !existing.exists() {
+        match (existing.parent(), existing.file_name()) {
+            (Some(parent), Some(name)) => {
+                missing.push(name.to_os_string());
+                existing = parent;
+            }
+            _ => return Err(write_dirs_rejection_message(path_str, write_roots)),
+        }
+    }
+    let mut resolved = std::fs::canonicalize(existing)
+        .map_err(|e| format!("writeFile: failed to resolve '{}': {}", path_str, e))?;
+    for name in missing.iter().rev() {
+        resolved.push(name);
+    }
+
+    if !write_roots.iter().any(|root| resolved.starts_with(root)) {
+        return Err(write_dirs_rejection_message(path_str, write_roots));
+    }
+    Ok(resolved)
+}
+
+/// The actionable "not inside a configured write directory" message. When
+/// roots are configured, the currently-allowed directories are listed.
+fn write_dirs_rejection_message(path_str: &str, write_roots: &[PathBuf]) -> String {
+    let mut msg = format!(
+        "writeFile: {} is not inside a configured write directory. Add one under \
+         [relay] write_dirs in ~/.endara/config.toml, or in the Endara desktop app \
+         under Settings → Write directories.",
+        path_str
+    );
+    if !write_roots.is_empty() {
+        let list = write_roots
+            .iter()
+            .map(|r| r.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        msg.push_str(&format!(" Currently allowed: {}.", list));
+    }
+    msg
+}
+
+/// Write `bytes` to `dest` via a temp file in the destination directory plus
+/// an atomic rename, creating missing parent directories first. `dest` must
+/// already be validated by [`resolve_write_path`], so any directories created
+/// here sit inside the matched root. On failure the temp file is removed —
+/// no partial destination file is ever observable.
+fn write_atomic(dest: &Path, bytes: &[u8]) -> Result<(), String> {
+    let dir = dest
+        .parent()
+        .ok_or_else(|| format!("writeFile: '{}' has no parent directory", dest.display()))?;
+    let file_name = dest
+        .file_name()
+        .ok_or_else(|| format!("writeFile: '{}' does not name a file", dest.display()))?;
+    std::fs::create_dir_all(dir).map_err(|e| {
+        format!(
+            "writeFile: failed to create parent directories for '{}': {}",
+            dest.display(),
+            e
+        )
+    })?;
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tmp = dir.join(format!(
+        ".{}.{}.{}.tmp",
+        file_name.to_string_lossy(),
+        std::process::id(),
+        unique
+    ));
+    if let Err(e) = std::fs::write(&tmp, bytes) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(format!(
+            "writeFile: failed to write '{}': {}",
+            dest.display(),
+            e
+        ));
+    }
+    if let Err(e) = std::fs::rename(&tmp, dest) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(format!(
+            "writeFile: failed to finalise '{}': {}",
+            dest.display(),
+            e
+        ));
+    }
     Ok(())
 }
 
@@ -2434,6 +2663,326 @@ mod tests {
         let sandbox = JsSandbox::new(reg, Duration::from_secs(5));
         let result = sandbox.execute(r#"return typeof fetch;"#).await.unwrap();
         assert_eq!(result, json!("undefined"));
+    }
+
+    // --- writeFile tests ---
+
+    /// Build a sandbox whose `writeFile` allowlist is `roots`.
+    async fn write_sandbox(roots: Vec<PathBuf>) -> JsSandbox {
+        let reg = make_registry().await;
+        JsSandbox::new(reg, Duration::from_secs(10)).with_write_roots(roots)
+    }
+
+    /// Canonicalized tempdir path, matching what `resolve_write_roots`
+    /// produces for configured roots (on macOS `/var/...` → `/private/var/...`).
+    fn canonical_root(dir: &tempfile::TempDir) -> PathBuf {
+        dir.path().canonicalize().unwrap()
+    }
+
+    /// Quote a Rust string as a JS string literal (handles NUL, quotes, …).
+    fn js_quote(s: &str) -> String {
+        serde_json::to_string(s).unwrap()
+    }
+
+    /// Sorted file names directly inside `dir`.
+    fn dir_entries(dir: &std::path::Path) -> Vec<String> {
+        let mut v: Vec<String> = std::fs::read_dir(dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        v.sort();
+        v
+    }
+
+    #[tokio::test]
+    async fn test_write_file_utf8_returns_canonical_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = canonical_root(&dir);
+        let sandbox = write_sandbox(vec![root.clone()]).await;
+        // Pass the possibly non-canonical tempdir path; the returned path
+        // must be the canonical one and sit under the canonical root.
+        let raw = dir.path().join("out.txt");
+        let script = format!(
+            "return writeFile({}, \"hello ✓ writeFile\");",
+            js_quote(raw.to_str().unwrap())
+        );
+        let result = sandbox.execute(&script).await.unwrap();
+        let expected = root.join("out.txt");
+        assert_eq!(result, json!(expected.to_string_lossy()));
+        assert!(PathBuf::from(result.as_str().unwrap()).starts_with(&root));
+        assert_eq!(
+            std::fs::read(&expected).unwrap(),
+            "hello ✓ writeFile".as_bytes()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_write_file_base64_decodes_bytes() {
+        use base64::Engine as _;
+        let dir = tempfile::tempdir().unwrap();
+        let root = canonical_root(&dir);
+        let sandbox = write_sandbox(vec![root.clone()]).await;
+        let bytes: Vec<u8> = (0u8..=255).collect();
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+        let dest = root.join("blob.bin");
+        let script = format!(
+            "return writeFile({}, {}, {{ encoding: \"base64\" }});",
+            js_quote(dest.to_str().unwrap()),
+            js_quote(&b64)
+        );
+        let result = sandbox.execute(&script).await.unwrap();
+        assert_eq!(result, json!(dest.to_string_lossy()));
+        assert_eq!(std::fs::read(&dest).unwrap(), bytes);
+    }
+
+    #[tokio::test]
+    async fn test_write_file_creates_nested_parents_inside_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = canonical_root(&dir);
+        let sandbox = write_sandbox(vec![root.clone()]).await;
+        let dest = root.join("a/b/c/file.txt");
+        let script = format!(
+            "return writeFile({}, \"nested\");",
+            js_quote(dest.to_str().unwrap())
+        );
+        sandbox.execute(&script).await.unwrap();
+        assert_eq!(std::fs::read(&dest).unwrap(), b"nested");
+        assert!(root.join("a/b/c").is_dir());
+    }
+
+    #[tokio::test]
+    async fn test_write_file_overwrite_leaves_no_temp_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = canonical_root(&dir);
+        let sandbox = write_sandbox(vec![root.clone()]).await;
+        let dest = root.join("out.txt");
+        for content in ["first", "second"] {
+            let script = format!(
+                "return writeFile({}, {});",
+                js_quote(dest.to_str().unwrap()),
+                js_quote(content)
+            );
+            sandbox.execute(&script).await.unwrap();
+        }
+        assert_eq!(std::fs::read(&dest).unwrap(), b"second");
+        assert_eq!(dir_entries(&root), vec!["out.txt".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_write_file_second_allowlisted_root_writable() {
+        let dir_a = tempfile::tempdir().unwrap();
+        let dir_b = tempfile::tempdir().unwrap();
+        let root_a = canonical_root(&dir_a);
+        let root_b = canonical_root(&dir_b);
+        let sandbox = write_sandbox(vec![root_a.clone(), root_b.clone()]).await;
+        let dest = root_b.join("b.txt");
+        let script = format!(
+            "return writeFile({}, \"in b\");",
+            js_quote(dest.to_str().unwrap())
+        );
+        let result = sandbox.execute(&script).await.unwrap();
+        assert_eq!(result, json!(dest.to_string_lossy()));
+        assert_eq!(std::fs::read(&dest).unwrap(), b"in b");
+        assert!(dir_entries(&root_a).is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_write_file_rejects_relative_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = canonical_root(&dir);
+        let sandbox = write_sandbox(vec![root.clone()]).await;
+        let err = sandbox
+            .execute(r#"return writeFile("relative/x.txt", "d");"#)
+            .await
+            .unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("requires an absolute path"),
+            "unexpected error: {}",
+            msg
+        );
+        assert!(dir_entries(&root).is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_write_file_rejects_dotdot_component() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = canonical_root(&dir);
+        let sandbox = write_sandbox(vec![root.clone()]).await;
+        let path = format!("{}/sub/../x.txt", root.display());
+        let script = format!("return writeFile({}, \"d\");", js_quote(&path));
+        let err = sandbox.execute(&script).await.unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("'..'"), "unexpected error: {}", msg);
+        assert!(dir_entries(&root).is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_write_file_rejects_root_prefix_string_trick() {
+        // "/tmp/rootXsibling/…" must not match root "/tmp/rootX" — the
+        // prefix check is component-wise, not a string prefix.
+        let dir = tempfile::tempdir().unwrap();
+        let root = canonical_root(&dir);
+        let sandbox = write_sandbox(vec![root.clone()]).await;
+        let sibling = format!("{}sibling", root.display());
+        let path = format!("{}/x.txt", sibling);
+        let script = format!("return writeFile({}, \"d\");", js_quote(&path));
+        let err = sandbox.execute(&script).await.unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("not inside a configured write directory"),
+            "unexpected error: {}",
+            msg
+        );
+        assert!(!PathBuf::from(&sibling).exists());
+        assert!(dir_entries(&root).is_empty());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_write_file_rejects_symlink_escape() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let root = canonical_root(&dir);
+        let sandbox = write_sandbox(vec![root.clone()]).await;
+        std::os::unix::fs::symlink(outside.path(), root.join("link")).unwrap();
+        let path = root.join("link/x.txt");
+        let script = format!(
+            "return writeFile({}, \"d\");",
+            js_quote(path.to_str().unwrap())
+        );
+        let err = sandbox.execute(&script).await.unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("not inside a configured write directory"),
+            "unexpected error: {}",
+            msg
+        );
+        assert!(dir_entries(outside.path()).is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_write_file_rejects_empty_and_nul_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = canonical_root(&dir);
+        let sandbox = write_sandbox(vec![root.clone()]).await;
+
+        let err = sandbox
+            .execute(r#"return writeFile("", "d");"#)
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{}", err).contains("must not be empty"),
+            "unexpected error: {}",
+            err
+        );
+
+        let path = format!("{}/x\u{0}.txt", root.display());
+        let script = format!("return writeFile({}, \"d\");", js_quote(&path));
+        let err = sandbox.execute(&script).await.unwrap_err();
+        assert!(
+            format!("{}", err).contains("NUL"),
+            "unexpected error: {}",
+            err
+        );
+        assert!(dir_entries(&root).is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_write_file_rejects_path_under_no_root_lists_allowed() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let root = canonical_root(&dir);
+        let sandbox = write_sandbox(vec![root.clone()]).await;
+        let path = outside.path().join("x.txt");
+        let script = format!(
+            "return writeFile({}, \"d\");",
+            js_quote(path.to_str().unwrap())
+        );
+        let err = sandbox.execute(&script).await.unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("not inside a configured write directory"),
+            "unexpected error: {}",
+            msg
+        );
+        assert!(
+            msg.contains("[relay] write_dirs in ~/.endara/config.toml"),
+            "unexpected error: {}",
+            msg
+        );
+        assert!(
+            msg.contains("Settings → Write directories"),
+            "unexpected error: {}",
+            msg
+        );
+        assert!(
+            msg.contains(&format!("Currently allowed: {}", root.display())),
+            "unexpected error: {}",
+            msg
+        );
+        assert!(dir_entries(outside.path()).is_empty());
+        assert!(dir_entries(&root).is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_write_file_rejects_when_no_roots_configured() {
+        let dir = tempfile::tempdir().unwrap();
+        let sandbox = write_sandbox(Vec::new()).await;
+        let path = dir.path().join("x.txt");
+        let script = format!(
+            "return writeFile({}, \"d\");",
+            js_quote(path.to_str().unwrap())
+        );
+        let err = sandbox.execute(&script).await.unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("not inside a configured write directory"),
+            "unexpected error: {}",
+            msg
+        );
+        assert!(
+            msg.contains("[relay] write_dirs in ~/.endara/config.toml"),
+            "unexpected error: {}",
+            msg
+        );
+        assert!(
+            !msg.contains("Currently allowed"),
+            "empty allowlist must not list directories: {}",
+            msg
+        );
+        assert!(dir_entries(dir.path()).is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_write_file_rejects_bad_encoding_and_bad_base64() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = canonical_root(&dir);
+        let sandbox = write_sandbox(vec![root.clone()]).await;
+        let dest = root.join("x.txt");
+
+        let script = format!(
+            "return writeFile({}, \"d\", {{ encoding: \"hex\" }});",
+            js_quote(dest.to_str().unwrap())
+        );
+        let err = sandbox.execute(&script).await.unwrap_err();
+        assert!(
+            format!("{}", err).contains("unsupported encoding"),
+            "unexpected error: {}",
+            err
+        );
+
+        let script = format!(
+            "return writeFile({}, \"not base64!!\", {{ encoding: \"base64\" }});",
+            js_quote(dest.to_str().unwrap())
+        );
+        let err = sandbox.execute(&script).await.unwrap_err();
+        assert!(
+            format!("{}", err).contains("invalid base64"),
+            "unexpected error: {}",
+            err
+        );
+        assert!(dir_entries(&root).is_empty());
     }
 
     #[tokio::test]

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -131,10 +131,44 @@ struct SandboxState {
     /// Snapshot of the `relay.write_dirs` allowlist (canonical directory
     /// roots, resolved by [`crate::config::resolve_write_roots`]) taken when
     /// the script entered the sandbox. Empty means writing is disabled.
-    /// Read by the `writeFile` native function (Task 2) to validate absolute
-    /// destination paths; until that lands the field is populated but unread.
-    #[allow(dead_code)]
+    /// Read by the `writeFile` native function to validate absolute
+    /// destination paths.
     write_roots: Vec<PathBuf>,
+    /// Per-run `writeFile` resource limits. Production runs always use
+    /// [`WriteLimits::default`]; tests may shrink them via
+    /// [`JsSandbox::with_write_limits`].
+    write_limits: WriteLimits,
+    /// Number of files successfully written by `writeFile` during this run.
+    /// A fresh [`SandboxState`] is installed per run, so this resets per run.
+    files_written: usize,
+    /// Total bytes successfully written by `writeFile` during this run.
+    /// A fresh [`SandboxState`] is installed per run, so this resets per run.
+    bytes_written: usize,
+}
+
+/// Per-run `writeFile` resource limits. These are per-script-run only —
+/// there is no cross-run quota, no TTL sweep, and the relay never deletes
+/// files: a breach throws before the offending file is written and leaves
+/// every existing file untouched.
+#[derive(Clone, Copy)]
+struct WriteLimits {
+    /// Maximum size of a single written file, checked before base64 decoding
+    /// (payload size estimated as ≈3n/4 from the base64 string length).
+    max_file_bytes: usize,
+    /// Maximum number of files a single script run may write.
+    max_files_per_run: usize,
+    /// Maximum total bytes a single script run may write across all files.
+    max_total_bytes_per_run: usize,
+}
+
+impl Default for WriteLimits {
+    fn default() -> Self {
+        Self {
+            max_file_bytes: 32 * 1024 * 1024,
+            max_files_per_run: 64,
+            max_total_bytes_per_run: 256 * 1024 * 1024,
+        }
+    }
 }
 
 thread_local! {
@@ -172,6 +206,10 @@ pub struct JsSandbox {
     /// empty (writing disabled); set via [`Self::with_write_roots`] by
     /// [`MetaToolHandler::execute_tools`].
     write_roots: Vec<PathBuf>,
+    /// Per-run `writeFile` resource limits carried into [`SandboxState`].
+    /// Defaults to [`WriteLimits::default`]; tests may shrink them via
+    /// [`Self::with_write_limits`].
+    write_limits: WriteLimits,
 }
 
 impl JsSandbox {
@@ -206,6 +244,7 @@ impl JsSandbox {
             client_json: String::new(),
             request_uid: String::new(),
             write_roots: Vec::new(),
+            write_limits: WriteLimits::default(),
         }
     }
 
@@ -247,6 +286,15 @@ impl JsSandbox {
         self
     }
 
+    /// Test-only: shrink the per-run `writeFile` limits so limit-boundary
+    /// behaviour can be exercised without multi-hundred-megabyte writes.
+    /// Production runs always use [`WriteLimits::default`].
+    #[cfg(test)]
+    fn with_write_limits(mut self, write_limits: WriteLimits) -> Self {
+        self.write_limits = write_limits;
+        self
+    }
+
     /// Execute a JavaScript script in the sandbox.
     pub async fn execute(&self, script: &str) -> Result<Value, JsSandboxError> {
         let registry = self.registry.clone();
@@ -255,6 +303,7 @@ impl JsSandbox {
         let client_json = self.client_json.clone();
         let request_uid = self.request_uid.clone();
         let write_roots = self.write_roots.clone();
+        let write_limits = self.write_limits;
         let script = script.to_string();
         let handle = tokio::runtime::Handle::current();
         let catalog = self.registry.merged_catalog().await;
@@ -272,6 +321,7 @@ impl JsSandbox {
                     client_json,
                     request_uid,
                     write_roots,
+                    write_limits,
                 )
             }),
         )
@@ -300,6 +350,7 @@ fn execute_in_sandbox(
     client_json: String,
     request_uid: String,
     write_roots: Vec<PathBuf>,
+    write_limits: WriteLimits,
 ) -> Result<Value, JsSandboxError> {
     let deadline = std::time::Instant::now() + sandbox_timeout;
     SANDBOX_STATE.with(|cell| {
@@ -311,6 +362,9 @@ fn execute_in_sandbox(
             client_json,
             request_uid,
             write_roots,
+            write_limits,
+            files_written: 0,
+            bytes_written: 0,
         });
     });
     let result = run_js(script, catalog);
@@ -877,8 +931,11 @@ fn register_json_parse_wrapper(context: &mut Context) -> Result<(), JsSandboxErr
 //
 // Backs the JS-facing `writeFile(absPath, data, opts?)` global. Absolute
 // paths only; the fully-resolved destination must sit inside one of the
-// canonical `relay.write_dirs` roots carried in [`SandboxState`]. Every
-// rejection is a thrown JS Error and never leaves a partial file behind.
+// canonical `relay.write_dirs` roots carried in [`SandboxState`]. Per-run
+// resource limits ([`WriteLimits`]) cap the size of each file, the number
+// of files, and the total bytes written by a single script run. Every
+// rejection is a thrown JS Error and never leaves a partial file behind;
+// the relay never deletes existing files.
 // ---------------------------------------------------------------------------
 
 fn register_write_file(context: &mut Context) -> Result<(), JsSandboxError> {
@@ -929,6 +986,56 @@ fn write_file_native(
         _ => "utf8".to_string(),
     };
 
+    let (write_roots, limits, files_written, bytes_written) = SANDBOX_STATE.with(|cell| {
+        let borrow = cell.borrow();
+        let state = borrow
+            .as_ref()
+            .ok_or_else(|| JsNativeError::error().with_message("sandbox state not initialised"))?;
+        Ok::<(Vec<PathBuf>, WriteLimits, usize, usize), JsError>((
+            state.write_roots.clone(),
+            state.write_limits,
+            state.files_written,
+            state.bytes_written,
+        ))
+    })?;
+
+    if files_written >= limits.max_files_per_run {
+        return Err(JsNativeError::error()
+            .with_message(format!(
+                "writeFile: per-run limit of {} files reached — no further files can \
+                 be written by this script run",
+                limits.max_files_per_run
+            ))
+            .into());
+    }
+
+    // Per-file size cap, checked before base64 decoding so an oversized
+    // payload is rejected without allocating the decoded bytes. Base64
+    // padding means the ≈3n/4 estimate is an upper bound on the decoded
+    // size, so a payload that passes here cannot exceed the cap once decoded.
+    let estimated_len = match encoding.as_str() {
+        "utf8" => Some(data.len()),
+        "base64" => Some(data.len().saturating_mul(3) / 4),
+        _ => None,
+    };
+    if let Some(estimated_len) = estimated_len {
+        if estimated_len > limits.max_file_bytes {
+            return Err(JsNativeError::error()
+                .with_message(format!(
+                    "writeFile: data is {}{} bytes, which exceeds the per-file limit \
+                     of {} bytes",
+                    if encoding == "base64" {
+                        "approximately "
+                    } else {
+                        ""
+                    },
+                    estimated_len,
+                    limits.max_file_bytes
+                ))
+                .into());
+        }
+    }
+
     let bytes: Vec<u8> = match encoding.as_str() {
         "utf8" => data.into_bytes(),
         "base64" => {
@@ -950,18 +1057,29 @@ fn write_file_native(
         }
     };
 
-    let write_roots = SANDBOX_STATE.with(|cell| {
-        let borrow = cell.borrow();
-        let state = borrow
-            .as_ref()
-            .ok_or_else(|| JsNativeError::error().with_message("sandbox state not initialised"))?;
-        Ok::<Vec<PathBuf>, JsError>(state.write_roots.clone())
-    })?;
+    if bytes_written.saturating_add(bytes.len()) > limits.max_total_bytes_per_run {
+        return Err(JsNativeError::error()
+            .with_message(format!(
+                "writeFile: writing {} more bytes would exceed the per-run total \
+                 write limit of {} bytes ({} bytes already written)",
+                bytes.len(),
+                limits.max_total_bytes_per_run,
+                bytes_written
+            ))
+            .into());
+    }
 
     let dest = resolve_write_path(&path_str, &write_roots)
         .map_err(|msg| JsNativeError::error().with_message(msg))?;
 
     write_atomic(&dest, &bytes).map_err(|msg| JsNativeError::error().with_message(msg))?;
+
+    SANDBOX_STATE.with(|cell| {
+        if let Some(state) = cell.borrow_mut().as_mut() {
+            state.files_written += 1;
+            state.bytes_written = state.bytes_written.saturating_add(bytes.len());
+        }
+    });
 
     let dest_str = dest.to_string_lossy();
     Ok(JsValue::from(boa_engine::js_string!(dest_str.as_ref())))
@@ -2983,6 +3101,151 @@ mod tests {
             err
         );
         assert!(dir_entries(&root).is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_write_file_per_file_cap_one_byte_over_throws() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = canonical_root(&dir);
+        let sandbox = write_sandbox(vec![root.clone()]).await;
+        let dest = root.join("big.txt");
+        // One byte over the 32 MB per-file cap.
+        let script = format!(
+            "return writeFile({}, \"a\".repeat({}));",
+            js_quote(dest.to_str().unwrap()),
+            32 * 1024 * 1024 + 1
+        );
+        let err = sandbox.execute(&script).await.unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("exceeds the per-file limit"),
+            "unexpected error: {}",
+            msg
+        );
+        assert!(dir_entries(&root).is_empty(), "no partial file may remain");
+    }
+
+    #[tokio::test]
+    async fn test_write_file_per_file_cap_base64_checked_before_decode() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = canonical_root(&dir);
+        let sandbox = write_sandbox(vec![root.clone()]).await;
+        let dest = root.join("big.bin");
+        // '!' is not valid base64: if the payload were decoded first this
+        // would fail with "invalid base64". The ≈3n/4 pre-decode estimate
+        // must reject it as oversized instead.
+        let repeat = (32usize * 1024 * 1024 / 3) * 4 + 8;
+        let script = format!(
+            "return writeFile({}, \"!\".repeat({}), {{ encoding: \"base64\" }});",
+            js_quote(dest.to_str().unwrap()),
+            repeat
+        );
+        let err = sandbox.execute(&script).await.unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("exceeds the per-file limit"),
+            "unexpected error: {}",
+            msg
+        );
+        assert!(
+            !msg.contains("invalid base64"),
+            "size cap must fire before base64 decoding: {}",
+            msg
+        );
+        assert!(dir_entries(&root).is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_write_file_per_run_file_count_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = canonical_root(&dir);
+        let sandbox = write_sandbox(vec![root.clone()]).await;
+        let script = format!(
+            "for (var i = 0; i < 65; i++) {{ writeFile({} + \"/f\" + i + \".txt\", \"x\"); }}",
+            js_quote(root.to_str().unwrap())
+        );
+        let err = sandbox.execute(&script).await.unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("per-run limit of 64 files"),
+            "unexpected error: {}",
+            msg
+        );
+        // The first 64 files remain intact; the 65th was never written.
+        let entries = dir_entries(&root);
+        assert_eq!(entries.len(), 64);
+        for i in 0..64 {
+            let f = root.join(format!("f{}.txt", i));
+            assert_eq!(std::fs::read(&f).unwrap(), b"x", "missing {}", f.display());
+        }
+        assert!(!root.join("f64.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn test_write_file_per_run_total_bytes_limit_preexisting_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = canonical_root(&dir);
+        let sandbox = write_sandbox(vec![root.clone()])
+            .await
+            .with_write_limits(WriteLimits {
+                max_file_bytes: 64,
+                max_files_per_run: 64,
+                max_total_bytes_per_run: 100,
+            });
+        // A pre-existing file the relay must never touch.
+        let existing = root.join("existing.txt");
+        std::fs::write(&existing, b"pre-existing").unwrap();
+        // 40 + 40 = 80 bytes fit; the third 40-byte write would reach 120.
+        let script = format!(
+            r#"
+var root = {};
+writeFile(root + "/a.txt", "a".repeat(40));
+writeFile(root + "/b.txt", "b".repeat(40));
+writeFile(root + "/c.txt", "c".repeat(40));
+"#,
+            js_quote(root.to_str().unwrap())
+        );
+        let err = sandbox.execute(&script).await.unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("per-run total write limit"),
+            "unexpected error: {}",
+            msg
+        );
+        assert_eq!(std::fs::read(&existing).unwrap(), b"pre-existing");
+        assert_eq!(std::fs::read(root.join("a.txt")).unwrap(), vec![b'a'; 40]);
+        assert_eq!(std::fs::read(root.join("b.txt")).unwrap(), vec![b'b'; 40]);
+        assert!(!root.join("c.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn test_write_file_limits_reset_between_runs() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = canonical_root(&dir);
+        let sandbox = write_sandbox(vec![root.clone()])
+            .await
+            .with_write_limits(WriteLimits {
+                max_file_bytes: 1024,
+                max_files_per_run: 2,
+                max_total_bytes_per_run: 100,
+            });
+        // Each run writes 2 files totalling 80 bytes — exactly at the
+        // per-run file limit and near the byte limit. If the counters did
+        // not reset between runs the second run would throw.
+        for run in ["first", "second"] {
+            let script = format!(
+                r#"
+var root = {};
+writeFile(root + "/{run}-1.txt", "x".repeat(40));
+writeFile(root + "/{run}-2.txt", "y".repeat(40));
+return "ok";
+"#,
+                js_quote(root.to_str().unwrap())
+            );
+            let result = sandbox.execute(&script).await.unwrap();
+            assert_eq!(result, json!("ok"), "run '{}' should succeed", run);
+        }
+        assert_eq!(dir_entries(&root).len(), 4);
     }
 
     #[tokio::test]

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -4,6 +4,7 @@
 //! No filesystem or network access is available from within the sandbox.
 
 use std::cell::RefCell;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -53,6 +54,21 @@ fn jittered_backoff_ms(base: u64, rng: &mut impl rand::Rng) -> u64 {
     let factor: f64 = rng.random_range(0.75..=1.25);
     (base as f64 * factor) as u64
 }
+
+// ---------------------------------------------------------------------------
+// Shared write-roots handle
+// ---------------------------------------------------------------------------
+
+/// Shared, hot-reloadable allowlist of canonical directory roots the sandbox
+/// may write into (resolved from `relay.write_dirs` by
+/// [`crate::config::resolve_write_roots`]). A single handle is created in
+/// `main.rs` and shared by the global [`MetaToolHandler`], every per-profile
+/// handler (via [`crate::profile_registry::ProfileRegistry`]), and the config
+/// watcher — which swaps the contents on hot reload so all handlers observe
+/// the new allowlist without being rebuilt. Uses `std::sync::RwLock` (not
+/// tokio's): reads are brief snapshots taken without holding the guard across
+/// an `.await`.
+pub type SharedWriteRoots = Arc<std::sync::RwLock<Vec<PathBuf>>>;
 
 // ---------------------------------------------------------------------------
 // Error types
@@ -108,6 +124,13 @@ struct SandboxState {
     /// event emitters (`ToolCallEvent::Started.request_uid`) — the
     /// blocking-thread hop otherwise drops the outer request span.
     request_uid: String,
+    /// Snapshot of the `relay.write_dirs` allowlist (canonical directory
+    /// roots, resolved by [`crate::config::resolve_write_roots`]) taken when
+    /// the script entered the sandbox. Empty means writing is disabled.
+    /// Read by the `writeFile` native function (Task 2) to validate absolute
+    /// destination paths; until that lands the field is populated but unread.
+    #[allow(dead_code)]
+    write_roots: Vec<PathBuf>,
 }
 
 thread_local! {
@@ -140,6 +163,11 @@ pub struct JsSandbox {
     /// [`MetaToolHandler::execute_tools`] so inner upstream tool calls
     /// re-establish the outer request's `request{request_uid=...}` span.
     request_uid: String,
+    /// `relay.write_dirs` allowlist snapshot (canonical directory roots)
+    /// carried into [`SandboxState`] for the running script. Defaults to
+    /// empty (writing disabled); set via [`Self::with_write_roots`] by
+    /// [`MetaToolHandler::execute_tools`].
+    write_roots: Vec<PathBuf>,
 }
 
 impl JsSandbox {
@@ -173,6 +201,7 @@ impl JsSandbox {
             use_real_backoff: false,
             client_json: String::new(),
             request_uid: String::new(),
+            write_roots: Vec::new(),
         }
     }
 
@@ -195,6 +224,16 @@ impl JsSandbox {
         self
     }
 
+    /// Attach the `relay.write_dirs` allowlist snapshot (canonical directory
+    /// roots resolved by [`crate::config::resolve_write_roots`]) so the
+    /// running script's `writeFile` can validate destination paths. An empty
+    /// list means writing is disabled. Used by
+    /// [`MetaToolHandler::execute_tools`].
+    pub fn with_write_roots(mut self, write_roots: Vec<PathBuf>) -> Self {
+        self.write_roots = write_roots;
+        self
+    }
+
     /// Test-only: opt this sandbox into the real backoff schedule. Without
     /// this, `cfg(test)` builds short-circuit retry sleeps to zero so the
     /// suite stays fast. Used by the deadline-budget test.
@@ -211,6 +250,7 @@ impl JsSandbox {
         let use_real_backoff = self.use_real_backoff;
         let client_json = self.client_json.clone();
         let request_uid = self.request_uid.clone();
+        let write_roots = self.write_roots.clone();
         let script = script.to_string();
         let handle = tokio::runtime::Handle::current();
         let catalog = self.registry.merged_catalog().await;
@@ -227,6 +267,7 @@ impl JsSandbox {
                     use_real_backoff,
                     client_json,
                     request_uid,
+                    write_roots,
                 )
             }),
         )
@@ -254,6 +295,7 @@ fn execute_in_sandbox(
     use_real_backoff: bool,
     client_json: String,
     request_uid: String,
+    write_roots: Vec<PathBuf>,
 ) -> Result<Value, JsSandboxError> {
     let deadline = std::time::Instant::now() + sandbox_timeout;
     SANDBOX_STATE.with(|cell| {
@@ -264,6 +306,7 @@ fn execute_in_sandbox(
             use_real_backoff,
             client_json,
             request_uid,
+            write_roots,
         });
     });
     let result = run_js(script, catalog);
@@ -1110,6 +1153,13 @@ pub struct MetaToolHandler {
     /// tools `execute_tools` can reach via the JS sandbox.
     registry: Arc<dyn MetaToolRegistry>,
     sandbox_timeout: Duration,
+    /// Shared, hot-reloadable `relay.write_dirs` allowlist handle. The
+    /// handler snapshots it per `execute_tools` call (see
+    /// [`Self::execute_tools`]) so a running script keeps the allowlist it
+    /// started with while later scripts observe a hot-reloaded value.
+    /// Defaults to an empty (writing-disabled) handle; production wiring
+    /// passes the process-wide handle via [`Self::with_write_roots`].
+    write_roots: SharedWriteRoots,
     /// Memoized per-tool search index reused across `search_tools` calls.
     /// Holds `(generation, docs)` where `generation` is the registry's
     /// `catalog_generation` at the time the docs were built. The `Arc` lets
@@ -1152,10 +1202,21 @@ impl MetaToolHandler {
         Self {
             registry,
             sandbox_timeout,
+            write_roots: Arc::new(std::sync::RwLock::new(Vec::new())),
             search_index_cache: Arc::new(RwLock::new(None)),
             #[cfg(test)]
             search_index_rebuild_count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         }
+    }
+
+    /// Attach the shared `relay.write_dirs` allowlist handle. The handle is
+    /// shared with the config watcher, which swaps its contents on hot
+    /// reload; the handler reads a snapshot per `execute_tools` call. Called
+    /// by `main.rs` (global handler) and `ProfileRegistry::rebuild`
+    /// (per-profile handlers).
+    pub fn with_write_roots(mut self, write_roots: SharedWriteRoots) -> Self {
+        self.write_roots = write_roots;
+        self
     }
 
     /// Test-only accessor returning the number of times the search index has
@@ -1305,9 +1366,19 @@ impl MetaToolHandler {
         client_json: &str,
         request_uid: &str,
     ) -> Result<Value, JsSandboxError> {
+        // Snapshot the shared allowlist for this script run. The brief
+        // std-RwLock read never crosses an `.await`; a poisoned lock (a
+        // writer panicked mid-swap) degrades to writing-disabled rather
+        // than propagating the panic into the request path.
+        let write_roots = self
+            .write_roots
+            .read()
+            .map(|guard| guard.clone())
+            .unwrap_or_default();
         let sandbox = JsSandbox::from_dyn(self.registry.clone(), self.sandbox_timeout)
             .with_client(client_json.to_string())
-            .with_request_uid(request_uid.to_string());
+            .with_request_uid(request_uid.to_string())
+            .with_write_roots(write_roots);
         sandbox.execute(script).await
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -842,14 +842,22 @@ async fn main() {
             let js_execution_mode = Arc::new(AtomicBool::new(
                 cfg.relay.local_js_execution.unwrap_or(false),
             ));
-            let meta_tool_handler = Arc::new(MetaToolHandler::new(
-                registry.clone(),
-                Duration::from_secs(30),
-            ));
+            // Shared `relay.write_dirs` allowlist handle: one handle backs
+            // the global MetaToolHandler, every per-profile handler (via
+            // ProfileRegistry), and the config watcher — which swaps the
+            // contents on hot reload (mirroring `js_execution_mode`).
+            let write_roots: js_sandbox::SharedWriteRoots =
+                Arc::new(std::sync::RwLock::new(config::resolve_write_roots(&cfg)));
+            let meta_tool_handler = Arc::new(
+                MetaToolHandler::new(registry.clone(), Duration::from_secs(30))
+                    .with_write_roots(write_roots.clone()),
+            );
             // Build the relay-wide profile registry. R3.A will populate
             // `ProfileContext::meta_tool_handler` per profile; for now the
             // registry just exposes filtered views of `AdapterRegistry`.
-            let profile_registry = Arc::new(ProfileRegistry::new((*registry).clone()));
+            let profile_registry = Arc::new(
+                ProfileRegistry::new((*registry).clone()).with_write_roots(write_roots.clone()),
+            );
             profile_registry
                 .rebuild(cfg.profiles.as_deref().unwrap_or(&[]))
                 .await;
@@ -1031,6 +1039,7 @@ async fn main() {
                         registry.clone(),
                         cfg.relay.machine_name.clone(),
                         js_execution_mode.clone(),
+                        write_roots.clone(),
                         profile_registry.clone(),
                         token_manager.clone(),
                         oauth_flow_manager.clone(),

--- a/src/management.rs
+++ b/src/management.rs
@@ -6700,6 +6700,7 @@ mod tests {
                 validate_inputs: None,
                 observability: crate::config::ObservabilityConfig::default(),
                 log_retention_days: None,
+                write_dirs: None,
             },
             endpoints: vec![EndpointConfig {
                 name: "echo".to_string(),
@@ -9328,6 +9329,7 @@ command = "echo"
                 validate_inputs: None,
                 observability: crate::config::ObservabilityConfig::default(),
                 log_retention_days: None,
+                write_dirs: None,
             },
             endpoints: vec![EndpointConfig {
                 name: name.to_string(),
@@ -9873,6 +9875,7 @@ command = "echo"
                 validate_inputs: None,
                 observability: crate::config::ObservabilityConfig::default(),
                 log_retention_days: None,
+                write_dirs: None,
             },
             endpoints: vec![EndpointConfig {
                 name: name.to_string(),
@@ -11440,6 +11443,7 @@ command = "echo"
                 validate_inputs: None,
                 observability: crate::config::ObservabilityConfig::default(),
                 log_retention_days: None,
+                write_dirs: None,
             },
             endpoints: vec![EndpointConfig {
                 name: name.to_string(),
@@ -11566,6 +11570,7 @@ client_id = "client123"
                 validate_inputs: None,
                 observability: crate::config::ObservabilityConfig::default(),
                 log_retention_days: None,
+                write_dirs: None,
             },
             endpoints: vec![],
             profiles: None,
@@ -11632,6 +11637,7 @@ client_id = "client123"
                 validate_inputs: None,
                 observability: crate::config::ObservabilityConfig::default(),
                 log_retention_days: None,
+                write_dirs: None,
             },
             endpoints: endpoint_names
                 .iter()
@@ -12196,6 +12202,7 @@ client_id = "client123"
                 validate_inputs: None,
                 observability: crate::config::ObservabilityConfig::default(),
                 log_retention_days: None,
+                write_dirs: None,
             },
             endpoints: vec![EndpointConfig {
                 name: "existing".to_string(),

--- a/src/profile_registry.rs
+++ b/src/profile_registry.rs
@@ -29,7 +29,7 @@ use tokio::sync::{broadcast, RwLock};
 
 use crate::adapter::{AdapterError, ToolInfo};
 use crate::config::ProfileConfig;
-use crate::js_sandbox::MetaToolHandler;
+use crate::js_sandbox::{MetaToolHandler, SharedWriteRoots};
 use crate::registry::{AdapterRegistry, MetaToolRegistry};
 
 /// Runtime state for a single resolved profile.
@@ -347,6 +347,13 @@ pub struct ProfileRegistry {
     /// each [`ProfileContext`]) so it stays in lockstep with the global
     /// handler's value and is reapplied on every hot reload.
     sandbox_timeout: Duration,
+    /// Shared `relay.write_dirs` allowlist handle passed through to each
+    /// profile's [`MetaToolHandler`] at rebuild time. The same handle backs
+    /// the global handler and is swapped in place by the config watcher on
+    /// hot reload, so per-profile sandboxes always observe the current
+    /// allowlist. Defaults to an empty (writing-disabled) handle; production
+    /// wiring installs the process-wide handle via [`Self::with_write_roots`].
+    write_roots: SharedWriteRoots,
     /// Profile-membership broadcast — fan-out for
     /// `notifications/tools/list_changed` on `/mcp/{profile}/sse` streams
     /// when the *profile itself* changes (endpoint added/removed from the
@@ -387,8 +394,19 @@ impl ProfileRegistry {
             profiles: Arc::new(RwLock::new(HashMap::new())),
             adapter_registry,
             sandbox_timeout,
+            write_roots: Arc::new(std::sync::RwLock::new(Vec::new())),
             profiles_changed_tx,
         }
+    }
+
+    /// Install the shared `relay.write_dirs` allowlist handle used for every
+    /// per-profile [`MetaToolHandler`] built by [`Self::rebuild`]. Production
+    /// wiring in `main.rs` passes the same handle given to the global handler
+    /// and the config watcher, so hot reloads propagate to profile sandboxes
+    /// without a rebuild.
+    pub fn with_write_roots(mut self, write_roots: SharedWriteRoots) -> Self {
+        self.write_roots = write_roots;
+        self
     }
 
     /// Subscribe to the profile-membership broadcast. Each `recv()` yields
@@ -438,7 +456,8 @@ impl ProfileRegistry {
             // view (locked decision Relay #2). The handler's search-index
             // cache is private to this context, so per-profile catalogs
             // never bleed into a different profile's search results.
-            let handler = MetaToolHandler::new(Arc::new(view.clone()), self.sandbox_timeout);
+            let handler = MetaToolHandler::new(Arc::new(view.clone()), self.sandbox_timeout)
+                .with_write_roots(self.write_roots.clone());
             let ctx = ProfileContext {
                 config: profile.clone(),
                 registry_view: view,

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -6,6 +6,7 @@ use crate::adapter::stdio::{IsolationMode, StdioAdapter, StdioConfig};
 use crate::adapter::{FailedAdapter, McpAdapter, StartingAdapter};
 use crate::config::{self, Config, ConfigDiff, ConfigOrganization, EndpointConfig, Transport};
 use crate::events::ToolCallEventBus;
+use crate::js_sandbox::SharedWriteRoots;
 use crate::oauth::OAuthFlowManager;
 use crate::profile_registry::ProfileRegistry;
 use crate::registry::AdapterRegistry;
@@ -38,6 +39,7 @@ impl ConfigWatcher {
         registry: Arc<AdapterRegistry>,
         machine_name: String,
         js_execution_mode: Arc<AtomicBool>,
+        write_roots: SharedWriteRoots,
         profile_registry: Arc<ProfileRegistry>,
         token_manager: Arc<TokenManager>,
         oauth_flow_manager: Arc<OAuthFlowManager>,
@@ -60,6 +62,7 @@ impl ConfigWatcher {
                 registry,
                 machine_name,
                 js_execution_mode,
+                write_roots,
                 profile_registry,
                 token_manager,
                 oauth_adapter_inners,
@@ -81,6 +84,7 @@ async fn watch_loop(
     registry: Arc<AdapterRegistry>,
     _machine_name: String,
     js_execution_mode: Arc<AtomicBool>,
+    write_roots: SharedWriteRoots,
     profile_registry: Arc<ProfileRegistry>,
     token_manager: Arc<TokenManager>,
     oauth_adapter_inners: OAuthAdapterInners,
@@ -138,6 +142,7 @@ async fn watch_loop(
             &shared_config,
             &registry,
             &js_execution_mode,
+            &write_roots,
             &profile_registry,
             &token_manager,
             &oauth_adapter_inners,
@@ -169,6 +174,7 @@ async fn reload_and_apply(
     shared_config: &Arc<RwLock<Config>>,
     registry: &Arc<AdapterRegistry>,
     js_execution_mode: &Arc<AtomicBool>,
+    write_roots: &SharedWriteRoots,
     profile_registry: &Arc<ProfileRegistry>,
     token_manager: &Arc<TokenManager>,
     oauth_adapter_inners: &OAuthAdapterInners,
@@ -220,6 +226,26 @@ async fn reload_and_apply(
     if new_js_mode != old_js_mode {
         js_execution_mode.store(new_js_mode, Ordering::Relaxed);
         info!(js_execution_mode = new_js_mode, "JS execution mode updated");
+    }
+
+    // Re-resolve the write_dirs allowlist and swap the shared handle if it
+    // changed. Every MetaToolHandler (global and per-profile) holds this
+    // same handle, so the next execute_tools snapshot sees the new roots.
+    let new_write_roots = config::resolve_write_roots(&new_config);
+    {
+        let changed = write_roots
+            .read()
+            .map(|current| *current != new_write_roots)
+            .unwrap_or(true);
+        if changed {
+            if let Ok(mut guard) = write_roots.write() {
+                *guard = new_write_roots;
+                info!(
+                    write_roots = guard.len(),
+                    "Sandbox write_dirs allowlist updated"
+                );
+            }
+        }
     }
 
     // Update the input-validation toggle if it changed. The flag lives on the
@@ -1396,6 +1422,10 @@ mod tests {
         // Leak the tempdir so it lives for the duration of the test
         std::mem::forget(tmp);
         (token_manager, inners)
+    }
+
+    fn empty_write_roots() -> SharedWriteRoots {
+        Arc::new(std::sync::RwLock::new(Vec::new()))
     }
 
     fn http_endpoint(name: &str, url: &str) -> EndpointConfig {
@@ -2774,6 +2804,7 @@ toon_output = true
                     &current_config,
                     &registry,
                     &js_mode,
+                    &empty_write_roots(),
                     &profile_registry,
                     &tm,
                     &inners,
@@ -2818,6 +2849,7 @@ toon_output = true
                     &current_config,
                     &registry,
                     &js_mode,
+                    &empty_write_roots(),
                     &profile_registry,
                     &tm,
                     &inners,
@@ -2878,6 +2910,7 @@ toon_output = true
                     &current_config,
                     &registry,
                     &js_mode,
+                    &empty_write_roots(),
                     &profile_registry,
                     &tm,
                     &inners,
@@ -2912,6 +2945,140 @@ toon_output = true
                     .map(|p| p.name.clone())
                     .collect();
                 assert_eq!(baseline_names, vec!["Work".to_string()]);
+            }
+        }
+
+        // ---- write_dirs hot reload -------------------------------------
+        //
+        // `relay.write_dirs` mirrors the `js_execution_mode` hot-reload
+        // wiring: `reload_and_apply` re-resolves the allowlist from the new
+        // config and swaps the shared handle in place, so every
+        // MetaToolHandler (global and per-profile) observes the update
+        // without being rebuilt.
+        mod write_dirs {
+            use super::super::*;
+            use crate::profile_registry::ProfileRegistry;
+            use std::sync::atomic::AtomicBool;
+            use std::sync::Arc;
+            use tokio::sync::RwLock;
+
+            const CONFIG_NO_WRITE_DIRS: &str = r#"
+[relay]
+machine_name = "test"
+"#;
+
+            /// Editing `relay.write_dirs` in `config.toml` and driving a
+            /// watcher reload swaps the shared handle: adding a dir
+            /// populates it (canonicalized), removing the key empties it.
+            #[tokio::test]
+            async fn write_dirs_hot_reload_updates_shared_handle() {
+                let tmp = tempfile::tempdir().unwrap();
+                let allowed_dir = tmp.path().join("media");
+                std::fs::create_dir(&allowed_dir).unwrap();
+                let path = tmp.path().join("config.toml");
+                std::fs::write(&path, CONFIG_NO_WRITE_DIRS).unwrap();
+                let (initial, _warnings) = config::load_config_graceful(&path).unwrap();
+
+                let registry = Arc::new(AdapterRegistry::new());
+                let profile_registry = Arc::new(ProfileRegistry::new((*registry).clone()));
+                let current_config = Arc::new(RwLock::new(initial));
+                let js_mode = Arc::new(AtomicBool::new(false));
+                let (tm, inners) = test_oauth_infra();
+                let write_roots = empty_write_roots();
+
+                // No write_dirs → allowlist stays empty.
+                assert!(write_roots.read().unwrap().is_empty());
+
+                // Add a write_dirs entry pointing at an existing dir.
+                let config_with_dir = format!(
+                    "[relay]\nmachine_name = \"test\"\nwrite_dirs = [\"{}\"]\n",
+                    allowed_dir.display()
+                );
+                std::fs::write(&path, config_with_dir).unwrap();
+                reload_and_apply(
+                    &path,
+                    &current_config,
+                    &registry,
+                    &js_mode,
+                    &write_roots,
+                    &profile_registry,
+                    &tm,
+                    &inners,
+                    None,
+                    None,
+                )
+                .await
+                .expect("reload adding write_dirs should succeed");
+                assert_eq!(
+                    *write_roots.read().unwrap(),
+                    vec![allowed_dir.canonicalize().unwrap()],
+                    "shared handle must carry the canonicalized new root"
+                );
+
+                // Remove the key again → allowlist empties.
+                std::fs::write(&path, CONFIG_NO_WRITE_DIRS).unwrap();
+                reload_and_apply(
+                    &path,
+                    &current_config,
+                    &registry,
+                    &js_mode,
+                    &write_roots,
+                    &profile_registry,
+                    &tm,
+                    &inners,
+                    None,
+                    None,
+                )
+                .await
+                .expect("reload removing write_dirs should succeed");
+                assert!(
+                    write_roots.read().unwrap().is_empty(),
+                    "removing write_dirs must empty the shared handle"
+                );
+            }
+
+            /// A reload whose write_dirs entry does not exist on disk
+            /// resolves to an empty allowlist (warn-and-skip) and never
+            /// creates the directory.
+            #[tokio::test]
+            async fn write_dirs_hot_reload_skips_missing_dir_without_creating() {
+                let tmp = tempfile::tempdir().unwrap();
+                let missing = tmp.path().join("never-created");
+                let path = tmp.path().join("config.toml");
+                let config_with_missing = format!(
+                    "[relay]\nmachine_name = \"test\"\nwrite_dirs = [\"{}\"]\n",
+                    missing.display()
+                );
+                std::fs::write(&path, CONFIG_NO_WRITE_DIRS).unwrap();
+                let (initial, _warnings) = config::load_config_graceful(&path).unwrap();
+
+                let registry = Arc::new(AdapterRegistry::new());
+                let profile_registry = Arc::new(ProfileRegistry::new((*registry).clone()));
+                let current_config = Arc::new(RwLock::new(initial));
+                let js_mode = Arc::new(AtomicBool::new(false));
+                let (tm, inners) = test_oauth_infra();
+                let write_roots = empty_write_roots();
+
+                std::fs::write(&path, config_with_missing).unwrap();
+                reload_and_apply(
+                    &path,
+                    &current_config,
+                    &registry,
+                    &js_mode,
+                    &write_roots,
+                    &profile_registry,
+                    &tm,
+                    &inners,
+                    None,
+                    None,
+                )
+                .await
+                .expect("reload with missing write_dirs entry still applies");
+                assert!(
+                    write_roots.read().unwrap().is_empty(),
+                    "missing dir must be skipped"
+                );
+                assert!(!missing.exists(), "reload must never create the directory");
             }
         }
 
@@ -3077,6 +3244,7 @@ command = "/bin/true"
                     &current_config,
                     &registry,
                     &js_mode,
+                    &empty_write_roots(),
                     &profile_registry,
                     &tm,
                     &inners,
@@ -3254,6 +3422,7 @@ validate_inputs = false
                     &current_config,
                     &registry,
                     &js_mode,
+                    &empty_write_roots(),
                     &profile_registry,
                     &tm,
                     &inners,
@@ -3278,6 +3447,7 @@ validate_inputs = false
                     &current_config,
                     &registry,
                     &js_mode,
+                    &empty_write_roots(),
                     &profile_registry,
                     &tm,
                     &inners,
@@ -3401,6 +3571,7 @@ command = "/bin/true"
                     &shared_config,
                     &registry,
                     &js_mode,
+                    &empty_write_roots(),
                     &profile_registry,
                     &token_manager,
                     &inners,

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -238,13 +238,17 @@ async fn reload_and_apply(
             .map(|current| *current != new_write_roots)
             .unwrap_or(true);
         if changed {
-            if let Ok(mut guard) = write_roots.write() {
-                *guard = new_write_roots;
-                info!(
-                    write_roots = guard.len(),
-                    "Sandbox write_dirs allowlist updated"
-                );
-            }
+            // Recover from a poisoned lock instead of skipping the swap —
+            // otherwise the allowlist would be frozen on every subsequent
+            // reload. The guarded data is a plain Vec<PathBuf>, safe to
+            // overwrite. Mirrors the read-side poison-degrade choice in
+            // `MetaToolHandler::execute_tools`.
+            let mut guard = write_roots.write().unwrap_or_else(|p| p.into_inner());
+            *guard = new_write_roots;
+            info!(
+                write_roots = guard.len(),
+                "Sandbox write_dirs allowlist updated"
+            );
         }
     }
 

--- a/tests/fixtures/image_mcp_server.sh
+++ b/tests/fixtures/image_mcp_server.sh
@@ -25,7 +25,10 @@ while IFS= read -r line; do
             echo "{\"jsonrpc\":\"2.0\",\"result\":{\"content\":[{\"type\":\"image\",\"mimeType\":\"image/jpeg\",\"data\":\"$IMG_B64\"}]},\"id\":$id}"
             ;;
         *)
-            echo "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32601,\"message\":\"Method not found\"},\"id\":$id}"
+            # Notifications (no id) must not produce a response.
+            if [ -n "$id" ]; then
+                echo "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32601,\"message\":\"Method not found\"},\"id\":$id}"
+            fi
             ;;
     esac
 done

--- a/tests/fixtures/image_mcp_server.sh
+++ b/tests/fixtures/image_mcp_server.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# A minimal MCP server that responds to JSON-RPC requests over stdin/stdout.
+# Supports: initialize, tools/list, tools/call (get_image tool).
+#
+# The get_image tool returns a content array with a single image block:
+# { type: "image", mimeType: "image/jpeg", data: <base64> } carrying a
+# synthetic 322-byte JPEG (SOI FF D8 FF ... EOI FF D9). The same base64
+# payload is hardcoded as JPEG_BASE64 in tests/write_file_integration.rs.
+
+IMG_B64="/9j/4AAQSkZJRgABAQAAAQABAAADChEYHyYtNDtCSVBXXmVsc3qBiI+WnaSrsrnAx87V3OPq8fj/Bg0UGyIpMDc+RUxTWmFob3Z9hIuSmaCnrrW8w8rR2N/m7fT7AgkQFx4lLDM6QUhPVl1ka3J5gIeOlZyjqrG4v8bN1Nvi6fD3/gUMExohKC82PURLUllgZ251fIOKkZifpq20u8LJ0Nfe5ezz+gEIDxYdJCsyOUBHTlVcY2pxeH+GjZSboqmwt77FzNPa4ejv9v0ECxIZICcuNTxDSlFYX2ZtdHuCiZCXnqWss7rByM/W3eTr8vkABw4VHCMqMTg/Rk1UW2JpcHd+hYyTmqGor7a9xMvS2eDn7vX8AwoRGB8mLTQ7QklQV15lbHN6gYiPlp2kq7K5wMfO1dzj6vH4/wYNFBsiKTD/2Q=="
+
+while IFS= read -r line; do
+    # Parse the method from JSON (simple grep-based extraction)
+    method=$(echo "$line" | sed -n 's/.*"method"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    id=$(echo "$line" | sed -n 's/.*"id"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p')
+
+    case "$method" in
+        "initialize")
+            echo "{\"jsonrpc\":\"2.0\",\"result\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{\"tools\":{}},\"serverInfo\":{\"name\":\"image-mcp\",\"version\":\"0.1.0\"}},\"id\":$id}"
+            ;;
+        "tools/list")
+            echo "{\"jsonrpc\":\"2.0\",\"result\":{\"tools\":[{\"name\":\"get_image\",\"description\":\"Returns a synthetic JPEG as an image content block\",\"inputSchema\":{\"type\":\"object\",\"properties\":{}}}]},\"id\":$id}"
+            ;;
+        "tools/call")
+            echo "{\"jsonrpc\":\"2.0\",\"result\":{\"content\":[{\"type\":\"image\",\"mimeType\":\"image/jpeg\",\"data\":\"$IMG_B64\"}]},\"id\":$id}"
+            ;;
+        *)
+            echo "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32601,\"message\":\"Method not found\"},\"id\":$id}"
+            ;;
+    esac
+done

--- a/tests/hot_reload_integration.rs
+++ b/tests/hot_reload_integration.rs
@@ -70,6 +70,7 @@ async fn test_config_diff_add_endpoint() {
             validate_inputs: None,
             observability: config::ObservabilityConfig::default(),
             log_retention_days: None,
+            write_dirs: None,
         },
         endpoints: vec![config::EndpointConfig {
             name: "echo-ep".to_string(),
@@ -110,6 +111,7 @@ async fn test_config_diff_add_endpoint() {
             validate_inputs: None,
             observability: config::ObservabilityConfig::default(),
             log_retention_days: None,
+            write_dirs: None,
         },
         endpoints: vec![
             config::EndpointConfig {
@@ -264,6 +266,7 @@ async fn test_config_diff_remove_endpoint() {
             validate_inputs: None,
             observability: config::ObservabilityConfig::default(),
             log_retention_days: None,
+            write_dirs: None,
         },
         endpoints: vec![
             config::EndpointConfig {
@@ -329,6 +332,7 @@ async fn test_config_diff_remove_endpoint() {
             validate_inputs: None,
             observability: config::ObservabilityConfig::default(),
             log_retention_days: None,
+            write_dirs: None,
         },
         endpoints: vec![config::EndpointConfig {
             name: "echo-ep".to_string(),

--- a/tests/management_api_integration.rs
+++ b/tests/management_api_integration.rs
@@ -96,6 +96,7 @@ fn test_config() -> Config {
             validate_inputs: None,
             observability: ObservabilityConfig::default(),
             log_retention_days: None,
+            write_dirs: None,
         },
         endpoints: vec![EndpointConfig {
             name: "echo".to_string(),

--- a/tests/oauth_setup_integration.rs
+++ b/tests/oauth_setup_integration.rs
@@ -31,6 +31,7 @@ fn empty_config() -> Config {
             validate_inputs: None,
             observability: ObservabilityConfig::default(),
             log_retention_days: None,
+            write_dirs: None,
         },
         endpoints: vec![EndpointConfig {
             name: "echo".to_string(),

--- a/tests/write_file_integration.rs
+++ b/tests/write_file_integration.rs
@@ -1,0 +1,219 @@
+//! Integration test: tool → writeFile → disk round-trip for binary payloads.
+//!
+//! Starts relay with an image fixture MCP server whose `get_image` tool
+//! returns a `{ type: "image", mimeType: "image/jpeg", data: <base64> }`
+//! content block carrying a synthetic JPEG. A sandbox script finds the
+//! image block and writes it via `writeFile(path, img.data, { encoding:
+//! "base64" })` into a tempdir configured as the write root, proving the
+//! payload reaches disk byte-for-byte without the base64 ever appearing
+//! in the script's returned JSON. A companion negative case runs the same
+//! script against a relay with no `relay.write_dirs` configured and
+//! asserts the `__sandbox_error`-surfaced message names the config key
+//! and the desktop setting.
+
+use endara_relay::adapter::stdio::{StdioAdapter, StdioConfig};
+use endara_relay::adapter::McpAdapter;
+use endara_relay::js_sandbox::{MetaToolHandler, SharedWriteRoots};
+use endara_relay::profile_registry::ProfileRegistry;
+use endara_relay::registry::AdapterRegistry;
+use endara_relay::server::{
+    build_router, start_server, AppState, MetaToolSchemas, SessionIdentityStore,
+};
+use serde_json::json;
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Base64 of the synthetic 322-byte JPEG served by the fixture — the same
+/// string hardcoded as `IMG_B64` in `tests/fixtures/image_mcp_server.sh`.
+/// Starts with SOI `FF D8 FF` and ends with EOI `FF D9`.
+const JPEG_BASE64: &str = "/9j/4AAQSkZJRgABAQAAAQABAAADChEYHyYtNDtCSVBXXmVsc3qBiI+WnaSrsrnAx87V3OPq8fj/Bg0UGyIpMDc+RUxTWmFob3Z9hIuSmaCnrrW8w8rR2N/m7fT7AgkQFx4lLDM6QUhPVl1ka3J5gIeOlZyjqrG4v8bN1Nvi6fD3/gUMExohKC82PURLUllgZ251fIOKkZifpq20u8LJ0Nfe5ezz+gEIDxYdJCsyOUBHTlVcY2pxeH+GjZSboqmwt77FzNPa4ejv9v0ECxIZICcuNTxDSlFYX2ZtdHuCiZCXnqWss7rByM/W3eTr8vkABw4VHCMqMTg/Rk1UW2JpcHd+hYyTmqGor7a9xMvS2eDn7vX8AwoRGB8mLTQ7QklQV15lbHN6gYiPlp2kq7K5wMfO1dzj6vH4/wYNFBsiKTD/2Q==";
+
+fn image_script_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("image_mcp_server.sh")
+}
+
+/// Start a relay in JS execution mode backed by the image fixture, with
+/// the given `relay.write_dirs` allowlist (canonical roots). An empty
+/// vec models a relay with no write directories configured.
+async fn setup_server(write_roots: Vec<PathBuf>) -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let registry = AdapterRegistry::new();
+    let config = StdioConfig {
+        command: "bash".to_string(),
+        args: vec![image_script_path().to_string_lossy().to_string()],
+        env: HashMap::new(),
+        server_type_override: None,
+        endpoint_name: "img-test".into(),
+        ..Default::default()
+    };
+    let mut adapter = StdioAdapter::new(config);
+    adapter.initialize().await.expect("adapter init failed");
+    registry
+        .register(
+            "img-ep".into(),
+            Box::new(adapter),
+            "stdio".into(),
+            None,
+            Some("img_ep".into()),
+        )
+        .await;
+
+    let registry_arc = Arc::new(registry.clone());
+    let shared_roots: SharedWriteRoots = Arc::new(std::sync::RwLock::new(write_roots));
+    let state = AppState {
+        registry: registry.clone(),
+        js_execution_mode: Arc::new(AtomicBool::new(true)),
+        meta_tool_handler: Arc::new(
+            MetaToolHandler::new(registry_arc, Duration::from_secs(30))
+                .with_write_roots(shared_roots),
+        ),
+        profile_registry: Arc::new(ProfileRegistry::new(registry.clone())),
+        oauth_flow_manager: None,
+        token_manager: None,
+        oauth_adapter_inners: None,
+        setup_manager: None,
+        started_at: std::time::Instant::now(),
+        toon_enabled: false,
+        session_identities: Arc::new(std::sync::Mutex::new(SessionIdentityStore::default())),
+        meta_tool_schemas: MetaToolSchemas::new(),
+    };
+    let router = build_router(state);
+    let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
+    let (bound_addr, handle) = start_server(router, addr)
+        .await
+        .expect("server start failed");
+    (bound_addr, handle)
+}
+
+/// The sandbox script: call the fixture tool, find the image content
+/// block, and write its base64 payload to `dest` — returning only the
+/// written path and mimeType (never the payload).
+fn round_trip_script(dest: &Path) -> String {
+    let dest_js = serde_json::to_string(dest.to_str().unwrap()).unwrap();
+    format!(
+        r#"
+        var r = tools["get_image"]({{}});
+        var img = null;
+        for (var i = 0; i < r.content.length; i++) {{
+            if (r.content[i].type === "image") {{ img = r.content[i]; break; }}
+        }}
+        if (!img) throw new Error("no image content block in tool result");
+        var p = writeFile({dest_js}, img.data, {{ encoding: "base64" }});
+        return {{ path: p, mimeType: img.mimeType }};
+    "#
+    )
+}
+
+async fn call_execute_tools(addr: SocketAddr, script: &str) -> serde_json::Value {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{}/mcp/tools/call", addr))
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {
+                "name": "execute_tools",
+                "arguments": { "script": script }
+            },
+            "id": 1
+        }))
+        .send()
+        .await
+        .expect("request failed");
+    resp.json().await.expect("invalid JSON response")
+}
+
+#[tokio::test]
+async fn test_image_tool_write_file_round_trip() {
+    let dir = tempfile::tempdir().unwrap();
+    // Canonicalize so the configured root and the expected returned path
+    // survive platform symlinks (macOS /var → /private/var).
+    let root = std::fs::canonicalize(dir.path()).unwrap();
+    let (addr, _handle) = setup_server(vec![root.clone()]).await;
+
+    let dest = root.join("whatsapp").join("msg-123.jpg");
+    let body = call_execute_tools(addr, &round_trip_script(&dest)).await;
+
+    // The base64 payload must never appear anywhere in the response.
+    let body_str = serde_json::to_string(&body).unwrap();
+    assert!(
+        !body_str.contains(JPEG_BASE64),
+        "base64 payload leaked into the script's returned JSON: {}",
+        body_str
+    );
+
+    let text = body["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_else(|| panic!("expected text content, got: {}", body));
+    let inner: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(inner["mimeType"], "image/jpeg", "got: {}", inner);
+
+    // writeFile returns the canonical absolute destination under the root.
+    let returned = PathBuf::from(inner["path"].as_str().expect("path string"));
+    assert!(
+        returned.is_absolute(),
+        "returned path not absolute: {inner}"
+    );
+    assert!(
+        returned.starts_with(&root),
+        "returned path {} not under root {}",
+        returned.display(),
+        root.display()
+    );
+    assert_eq!(returned, dest);
+
+    // On-disk bytes match the source payload exactly.
+    use base64::Engine as _;
+    let expected = base64::engine::general_purpose::STANDARD
+        .decode(JPEG_BASE64)
+        .unwrap();
+    let written = std::fs::read(&dest).expect("written file missing");
+    assert_eq!(
+        written.len(),
+        expected.len(),
+        "on-disk size differs from source payload"
+    );
+    assert_eq!(&written[..3], &[0xFF, 0xD8, 0xFF], "missing JPEG SOI bytes");
+    assert_eq!(
+        written, expected,
+        "on-disk bytes differ from source payload"
+    );
+}
+
+#[tokio::test]
+async fn test_write_file_errors_when_no_write_dirs_configured() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = std::fs::canonicalize(dir.path()).unwrap();
+    // No write_dirs configured — writing is disabled.
+    let (addr, _handle) = setup_server(Vec::new()).await;
+
+    let dest = root.join("whatsapp").join("msg-123.jpg");
+    let body = call_execute_tools(addr, &round_trip_script(&dest)).await;
+
+    let error = body
+        .get("error")
+        .unwrap_or_else(|| panic!("expected JSON-RPC error, got: {}", body));
+    assert_eq!(error["code"].as_i64().unwrap(), -32603, "got: {error}");
+    let msg = error["message"].as_str().unwrap_or("");
+    // The uncaught writeFile throw is captured by the sandbox's
+    // `__sandbox_error` catch handler and surfaces as a JsError.
+    assert!(
+        msg.contains("JavaScript error") && msg.contains("Error: writeFile"),
+        "expected __sandbox_error-surfaced writeFile error, got: {msg}"
+    );
+    assert!(
+        msg.contains("[relay] write_dirs in ~/.endara/config.toml"),
+        "error should name the config key, got: {msg}"
+    );
+    assert!(
+        msg.contains("Settings → Write directories"),
+        "error should name the desktop setting, got: {msg}"
+    );
+    assert!(!dest.exists(), "no file must be written when disabled");
+}


### PR DESCRIPTION
## Summary

Adds a `writeFile(path, data, options?)` global to the relay's JS sandbox (`execute_tools`), so tool scripts can persist generated media/artifacts (images, audio, downloads) to disk — gated by an explicit `write_dirs` allowlist.

User-visible behavior:

- New optional `write_dirs` array under `[relay]` config: a list of absolute directory paths that sandbox scripts are allowed to write into. When empty or absent, every write is denied — writes are strictly opt-in.
- Inside `execute_tools` scripts, `writeFile(absPath, data, opts?)` supports `utf8` (default) and `base64` encodings, so binary tool output (images, audio) can reach disk.
- Writes are atomic (temp file + rename) and parent directories are auto-created, but only inside the matched allowlisted root.
- Out-of-allowlist writes fail with an actionable error naming `[relay] write_dirs` and the desktop Settings page.
- End-to-end coverage includes an image round-trip integration test (MCP server → writeFile → read back byte-identical) plus hot-reload coverage of the new config key.

## Safety properties

- **Absolute-path allowlist**: only absolute destinations inside directories explicitly listed in `write_dirs` are writable; relative/empty/NUL paths and `..` components are rejected outright.
- **Canonical-prefix enforcement**: the fully-resolved destination (canonicalized deepest existing ancestor + remaining components) must sit inside one of the canonical `write_dirs` roots, so symlink and normalization escapes cannot break out of an allowed root.
- **Per-run resource limits**: 32 MB per file, 64 files per run, 256 MB total per run — a runaway script cannot exhaust disk.

## Linear

END-21 — add writeFile so tool media can reach the filesystem.

## Commits

- feat: add write_dirs allowlist config and plumb write roots to SandboxState
- feat: add writeFile sandbox global with write_dirs allowlist enforcement
- feat: enforce per-run writeFile resource limits (32 MB/file, 64 files, 256 MB total)
- test: end-to-end image round-trip integration test for writeFile
