### PR TITLE
chore: bump version to 0.1.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "endara-relay"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endara-relay"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 description = "Local MCP tool aggregator — aggregate multiple MCP servers behind a single endpoint"
 license = "Apache-2.0"


### PR DESCRIPTION
Scenario 3 base-version bump after the v0.1.12 stable release. Updates the Cargo.toml version field to 0.1.13 and the matching one-line Cargo.lock entry via cargo update --workspace. cargo fmt --check is clean.