### PR TITLE
docs: document writeFile sandbox global and write_dirs allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ startup_init_timeout_secs = 60    # Optional — cap on how long the MCP listene
 log_retention_days = 7            # Optional — days of daily-rotated relay.log.YYYY-MM-DD
                                   # files to keep; older files are pruned at startup.
                                   # 0 disables pruning (default: 7). CLI: --log-retention-days
+write_dirs = ["/Users/me/exports"] # Optional — allowlist of absolute directories that
+                                  # sandbox scripts may write into via writeFile()
+                                  # (default: none — writing disabled). Hot-reloadable.
 
 # STDIO endpoint — spawns a child process
 [[endpoints]]
@@ -311,6 +314,21 @@ return { repos: repos.length, firstRepoIssues: issues };
 ```
 
 The JS sandbox is powered by [boa_engine](https://crates.io/crates/boa_engine) and runs entirely in-process — no external runtime needed.
+
+#### Writing files from the sandbox
+
+Scripts can save results to disk with the `writeFile(absPath, data, opts?)` global — but only into directories you explicitly allowlist under `[relay] write_dirs` (absolute paths; also manageable from Endara Desktop's Settings). With no `write_dirs` configured, writing is disabled entirely.
+
+```javascript
+const report = await call("github__list_issues", { repo: "endara-relay" });
+writeFile("/Users/me/exports/issues.json", JSON.stringify(report));
+writeFile("/Users/me/exports/logo.png", pngBase64, { encoding: "base64" });
+```
+
+- **Allowlist enforcement** — the fully-resolved destination (symlinks and `..` included) must land inside one of the canonical `write_dirs` roots; escapes are rejected with a distinct error. Allowlisted directories are never auto-created, but missing parent directories *inside* a root are.
+- **Atomic writes** — data is written to a temp file in the destination directory and renamed into place, so readers never observe partial files.
+- **Encodings** — `utf8` (default) writes the string as-is; `base64` decodes the payload first.
+- **Per-run limits** — a single script run may write at most 64 files, 32 MB per file, and 256 MB in total; a breach throws before the offending file is written. The relay never deletes files it wrote.
 
 ### TOON tool output
 

--- a/README.md
+++ b/README.md
@@ -127,8 +127,10 @@ startup_init_timeout_secs = 60    # Optional — cap on how long the MCP listene
 log_retention_days = 7            # Optional — days of daily-rotated relay.log.YYYY-MM-DD
                                   # files to keep; older files are pruned at startup.
                                   # 0 disables pruning (default: 7). CLI: --log-retention-days
-write_dirs = ["/Users/me/exports"] # Optional — allowlist of absolute directories that
-                                  # sandbox scripts may write into via writeFile()
+write_dirs = ["/absolute/path/to/exports"]
+                                  # Optional — allowlist of absolute directories that
+                                  # sandbox scripts may write into via writeFile();
+                                  # a leading ~/ is expanded to your home directory
                                   # (default: none — writing disabled). Hot-reloadable.
 
 # STDIO endpoint — spawns a child process
@@ -317,15 +319,17 @@ The JS sandbox is powered by [boa_engine](https://crates.io/crates/boa_engine) a
 
 #### Writing files from the sandbox
 
-Scripts can save results to disk with the `writeFile(absPath, data, opts?)` global — but only into directories you explicitly allowlist under `[relay] write_dirs` (absolute paths; also manageable from Endara Desktop's Settings). With no `write_dirs` configured, writing is disabled entirely.
+Scripts can save results to disk with the `writeFile(absPath, data, opts?)` global — but only into directories you explicitly allowlist under `[relay] write_dirs` (absolute paths, `~/` shorthand accepted; also manageable from Endara Desktop's Settings). With no `write_dirs` configured, writing is disabled entirely.
+
+`writeFile` is synchronous: it returns the canonical path of the written file, and throws a JS `Error` on any rejection or failure — never leaving a partial file behind. `data` must be a string (objects are rejected, not coerced — `JSON.stringify` first).
 
 ```javascript
 const report = await call("github__list_issues", { repo: "endara-relay" });
-writeFile("/Users/me/exports/issues.json", JSON.stringify(report));
-writeFile("/Users/me/exports/logo.png", pngBase64, { encoding: "base64" });
+writeFile("/absolute/path/to/exports/issues.json", JSON.stringify(report));
+writeFile("/absolute/path/to/exports/logo.png", pngBase64, { encoding: "base64" });
 ```
 
-- **Allowlist enforcement** — the fully-resolved destination (symlinks and `..` included) must land inside one of the canonical `write_dirs` roots; escapes are rejected with a distinct error. Allowlisted directories are never auto-created, but missing parent directories *inside* a root are.
+- **Allowlist enforcement** — the fully-resolved destination must land inside one of the canonical `write_dirs` roots: symlinks are resolved, and `..` path components are rejected outright; escapes are rejected with a distinct error. Allowlisted directories are never auto-created, but missing parent directories *inside* a root are.
 - **Atomic writes** — data is written to a temp file in the destination directory and renamed into place, so readers never observe partial files.
 - **Encodings** — `utf8` (default) writes the string as-is; `base64` decodes the payload first.
 - **Per-run limits** — a single script run may write at most 64 files, 32 MB per file, and 256 MB in total; a breach throws before the offending file is written. The relay never deletes files it wrote.


### PR DESCRIPTION
README staleness sweep after v0.1.12: the last README refresh (#129) covered v0.1.10/v0.1.11, so the `writeFile` sandbox feature shipped in #136 was undocumented.

## Changes

- **Config reference** — add `write_dirs` to the `[relay]` table example (allowlist of absolute directories, default none / writing disabled, hot-reloadable).
- **JS execution mode** — new "Writing files from the sandbox" subsection documenting the `writeFile(absPath, data, opts?)` global:
  - allowlist enforcement against canonical `write_dirs` roots (symlink/`..` escapes rejected; roots never auto-created, parents inside a root are)
  - atomic temp-file + rename writes
  - `utf8` (default) and `base64` encodings
  - per-run limits: 64 files, 32 MB/file, 256 MB total

No version fields touched. Docs only.
