### PR TITLE
feat: surface error cause chain and macOS Local Network hint in adapter connection errors

### DIFF
--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -9,6 +9,7 @@ use crate::events::{
     annotations_from_value, current_request_context, ToolCallEvent, ToolCallEventBus,
 };
 use crate::jsonrpc::{self, JsonRpcResponse};
+use crate::local_network::with_local_network_hint;
 use crate::protocol::{self, detect_upstream_dialect, ProtocolVersion};
 use async_trait::async_trait;
 use reqwest::Client;
@@ -584,10 +585,9 @@ impl HttpAdapter {
             if e.is_timeout() {
                 AdapterError::Timeout(self.config.timeout_secs)
             } else if e.is_connect() {
-                AdapterError::ConnectionFailed(format!(
-                    "{}: {}",
-                    self.config.url,
-                    format_error_chain(&e)
+                AdapterError::ConnectionFailed(with_local_network_hint(
+                    &self.config.url,
+                    format!("{}: {}", self.config.url, format_error_chain(&e)),
                 ))
             } else {
                 AdapterError::HttpError {
@@ -737,10 +737,9 @@ impl HttpAdapter {
             if e.is_timeout() {
                 AdapterError::Timeout(self.config.timeout_secs)
             } else if e.is_connect() {
-                AdapterError::ConnectionFailed(format!(
-                    "{}: {}",
-                    self.config.url,
-                    format_error_chain(&e)
+                AdapterError::ConnectionFailed(with_local_network_hint(
+                    &self.config.url,
+                    format!("{}: {}", self.config.url, format_error_chain(&e)),
                 ))
             } else {
                 AdapterError::HttpError {
@@ -1145,10 +1144,9 @@ impl McpAdapter for HttpAdapter {
                         if e.is_timeout() {
                             AdapterError::Timeout(self.config.timeout_secs)
                         } else if e.is_connect() {
-                            AdapterError::ConnectionFailed(format!(
-                                "{}: {}",
-                                self.config.url,
-                                format_error_chain(&e)
+                            AdapterError::ConnectionFailed(with_local_network_hint(
+                                &self.config.url,
+                                format!("{}: {}", self.config.url, format_error_chain(&e)),
                             ))
                         } else {
                             AdapterError::HttpError {

--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -2,7 +2,9 @@ use super::oauth::jit::{self, JitInterceptor};
 use super::server_name::{sanitize_server_name, ServerNameError};
 use super::server_type_resolution::{effective_server_type, strip_mcp_server_suffix};
 use super::stdio::{iso8601_now, RingBuffer};
-use super::{AdapterError, HealthStatus, McpAdapter, ToolInfo, DISCOVER_PROBE_TIMEOUT};
+use super::{
+    format_error_chain, AdapterError, HealthStatus, McpAdapter, ToolInfo, DISCOVER_PROBE_TIMEOUT,
+};
 use crate::events::{
     annotations_from_value, current_request_context, ToolCallEvent, ToolCallEventBus,
 };
@@ -582,11 +584,15 @@ impl HttpAdapter {
             if e.is_timeout() {
                 AdapterError::Timeout(self.config.timeout_secs)
             } else if e.is_connect() {
-                AdapterError::ConnectionFailed(format!("{}: {}", self.config.url, e))
+                AdapterError::ConnectionFailed(format!(
+                    "{}: {}",
+                    self.config.url,
+                    format_error_chain(&e)
+                ))
             } else {
                 AdapterError::HttpError {
                     status: 0,
-                    body: e.to_string(),
+                    body: format_error_chain(&e),
                 }
             }
         })?;
@@ -731,11 +737,15 @@ impl HttpAdapter {
             if e.is_timeout() {
                 AdapterError::Timeout(self.config.timeout_secs)
             } else if e.is_connect() {
-                AdapterError::ConnectionFailed(format!("{}: {}", self.config.url, e))
+                AdapterError::ConnectionFailed(format!(
+                    "{}: {}",
+                    self.config.url,
+                    format_error_chain(&e)
+                ))
             } else {
                 AdapterError::HttpError {
                     status: 0,
-                    body: e.to_string(),
+                    body: format_error_chain(&e),
                 }
             }
         })?;
@@ -1135,11 +1145,15 @@ impl McpAdapter for HttpAdapter {
                         if e.is_timeout() {
                             AdapterError::Timeout(self.config.timeout_secs)
                         } else if e.is_connect() {
-                            AdapterError::ConnectionFailed(format!("{}: {}", self.config.url, e))
+                            AdapterError::ConnectionFailed(format!(
+                                "{}: {}",
+                                self.config.url,
+                                format_error_chain(&e)
+                            ))
                         } else {
                             AdapterError::HttpError {
                                 status: 0,
-                                body: e.to_string(),
+                                body: format_error_chain(&e),
                             }
                         }
                     });

--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -3,7 +3,8 @@ use super::server_name::{sanitize_server_name, ServerNameError};
 use super::server_type_resolution::{effective_server_type, strip_mcp_server_suffix};
 use super::stdio::{iso8601_now, RingBuffer};
 use super::{
-    format_error_chain, AdapterError, HealthStatus, McpAdapter, ToolInfo, DISCOVER_PROBE_TIMEOUT,
+    connect_error_message, format_error_chain, AdapterError, HealthStatus, McpAdapter, ToolInfo,
+    DISCOVER_PROBE_TIMEOUT,
 };
 use crate::events::{
     annotations_from_value, current_request_context, ToolCallEvent, ToolCallEventBus,
@@ -587,7 +588,7 @@ impl HttpAdapter {
             } else if e.is_connect() {
                 AdapterError::ConnectionFailed(with_local_network_hint(
                     &self.config.url,
-                    format!("{}: {}", self.config.url, format_error_chain(&e)),
+                    connect_error_message(&self.config.url, &e),
                 ))
             } else {
                 AdapterError::HttpError {
@@ -739,7 +740,7 @@ impl HttpAdapter {
             } else if e.is_connect() {
                 AdapterError::ConnectionFailed(with_local_network_hint(
                     &self.config.url,
-                    format!("{}: {}", self.config.url, format_error_chain(&e)),
+                    connect_error_message(&self.config.url, &e),
                 ))
             } else {
                 AdapterError::HttpError {
@@ -1146,7 +1147,7 @@ impl McpAdapter for HttpAdapter {
                         } else if e.is_connect() {
                             AdapterError::ConnectionFailed(with_local_network_hint(
                                 &self.config.url,
-                                format!("{}: {}", self.config.url, format_error_chain(&e)),
+                                connect_error_message(&self.config.url, &e),
                             ))
                         } else {
                             AdapterError::HttpError {

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -129,6 +129,27 @@ pub fn truncate_for_display(s: &str, max_chars: usize) -> String {
     }
 }
 
+/// Format an error together with its full `source()` chain, joined with ": ".
+///
+/// reqwest's top-level `Display` for transport failures is just "error sending
+/// request for url (…)" — the actionable detail (e.g. "tcp connect error:
+/// No route to host (os error 65)") lives in the source chain, so walk it and
+/// append every layer. Layers whose text is already embedded in the message
+/// are skipped to avoid duplication.
+pub fn format_error_chain(err: &dyn std::error::Error) -> String {
+    let mut msg = err.to_string();
+    let mut source = err.source();
+    while let Some(s) = source {
+        let layer = s.to_string();
+        if !msg.contains(&layer) {
+            msg.push_str(": ");
+            msg.push_str(&layer);
+        }
+        source = s.source();
+    }
+    msg
+}
+
 /// Errors that can occur in adapter operations.
 #[derive(Debug, thiserror::Error)]
 pub enum AdapterError {
@@ -546,6 +567,84 @@ mod tests {
     fn failed_adapter_without_override_returns_none() {
         let adapter = FailedAdapter::new("validation failed".to_string());
         assert_eq!(adapter.configured_server_type(), None);
+    }
+
+    /// `format_error_chain` walks the full `source()` chain, joining each
+    /// layer with ": " and skipping layers already embedded in the message.
+    #[test]
+    fn format_error_chain_joins_all_source_layers() {
+        #[derive(Debug)]
+        struct Layer {
+            msg: &'static str,
+            source: Option<Box<dyn std::error::Error>>,
+        }
+        impl std::fmt::Display for Layer {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(self.msg)
+            }
+        }
+        impl std::error::Error for Layer {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                self.source.as_deref()
+            }
+        }
+
+        let root = Layer {
+            msg: "No route to host (os error 65)",
+            source: None,
+        };
+        let mid = Layer {
+            msg: "tcp connect error",
+            source: Some(Box::new(root)),
+        };
+        let top = Layer {
+            msg: "error sending request",
+            source: Some(Box::new(mid)),
+        };
+        assert_eq!(
+            format_error_chain(&top),
+            "error sending request: tcp connect error: No route to host (os error 65)"
+        );
+    }
+
+    /// A layer whose text is already embedded in the accumulated message is
+    /// not appended again (some errors include their source in `Display`).
+    #[test]
+    fn format_error_chain_skips_duplicated_layers() {
+        let io = std::io::Error::other("disk full");
+        let wrapped = std::io::Error::other(io);
+        assert_eq!(format_error_chain(&wrapped), "disk full");
+    }
+
+    /// End-to-end against a real reqwest transport failure: a request to a
+    /// closed local port must surface the OS-level cause (e.g. "Connection
+    /// refused"), not just reqwest's top-level "error sending request" text.
+    #[tokio::test]
+    async fn format_error_chain_surfaces_os_cause_for_connect_refused() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let err = reqwest::Client::new()
+            .get(format!("http://{addr}/"))
+            .send()
+            .await
+            .expect_err("request to a closed port must fail");
+        assert!(err.is_connect());
+
+        let chain = format_error_chain(&err);
+        assert!(
+            chain.starts_with(&err.to_string()),
+            "chain must begin with the top-level message, got {chain:?}"
+        );
+        assert!(
+            chain.len() > err.to_string().len(),
+            "chain must include more than the top-level message, got {chain:?}"
+        );
+        assert!(
+            chain.to_lowercase().contains("refused"),
+            "chain must name the OS-level cause, got {chain:?}"
+        );
     }
 
     #[test]

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -135,7 +135,10 @@ pub fn truncate_for_display(s: &str, max_chars: usize) -> String {
 /// request for url (…)" — the actionable detail (e.g. "tcp connect error:
 /// No route to host (os error 65)") lives in the source chain, so walk it and
 /// append every layer. Layers whose text is already embedded in the message
-/// are skipped to avoid duplication.
+/// are skipped to avoid duplication. The dedup is substring containment, so a
+/// layer with very generic text (e.g. just "error") that happens to appear in
+/// the accumulated message is silently dropped — an accepted tradeoff to keep
+/// the common reqwest/hyper chains clean.
 pub(crate) fn format_error_chain(err: &dyn std::error::Error) -> String {
     let mut msg = err.to_string();
     let mut source = err.source();

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -136,7 +136,7 @@ pub fn truncate_for_display(s: &str, max_chars: usize) -> String {
 /// No route to host (os error 65)") lives in the source chain, so walk it and
 /// append every layer. Layers whose text is already embedded in the message
 /// are skipped to avoid duplication.
-pub fn format_error_chain(err: &dyn std::error::Error) -> String {
+pub(crate) fn format_error_chain(err: &dyn std::error::Error) -> String {
     let mut msg = err.to_string();
     let mut source = err.source();
     while let Some(s) = source {
@@ -148,6 +148,29 @@ pub fn format_error_chain(err: &dyn std::error::Error) -> String {
         source = s.source();
     }
     msg
+}
+
+/// Chain-format a connect error, prefixing `url` only when the chain does not
+/// already name it: reqwest's top-level `Display` usually embeds
+/// "for url (…)", so an unconditional prefix would duplicate the URL. The
+/// containment check also tries the parsed/normalized form of `url` (e.g.
+/// reqwest renders "http://host:1" as "http://host:1/").
+pub(crate) fn connect_error_message(url: &str, err: &dyn std::error::Error) -> String {
+    let chain = format_error_chain(err);
+    if message_names_url(url, &chain) {
+        chain
+    } else {
+        format!("{url}: {chain}")
+    }
+}
+
+/// True when `message` already contains `url`, either verbatim or in its
+/// parsed/normalized form.
+fn message_names_url(url: &str, message: &str) -> bool {
+    if message.contains(url) {
+        return true;
+    }
+    url::Url::parse(url).is_ok_and(|u| message.contains(u.as_str()))
 }
 
 /// Errors that can occur in adapter operations.
@@ -604,6 +627,42 @@ mod tests {
         assert_eq!(
             format_error_chain(&top),
             "error sending request: tcp connect error: No route to host (os error 65)"
+        );
+    }
+
+    /// When the chain already names the URL (reqwest's "for url (…)"), no
+    /// prefix is added — the URL must appear exactly once.
+    #[test]
+    fn connect_error_message_skips_prefix_when_chain_names_url() {
+        let url = "http://192.168.1.10:8123/mcp";
+        let err = std::io::Error::other(format!(
+            "error sending request for url ({url}): tcp connect error"
+        ));
+        let msg = connect_error_message(url, &err);
+        assert_eq!(msg, err.to_string());
+        assert_eq!(msg.matches(url).count(), 1);
+    }
+
+    /// reqwest renders the parsed URL, which may differ from the configured
+    /// string (e.g. a trailing slash added to an empty path) — the normalized
+    /// form also counts as "already named".
+    #[test]
+    fn connect_error_message_recognizes_normalized_url() {
+        let err = std::io::Error::other(
+            "error sending request for url (http://127.0.0.1:1/): tcp connect error",
+        );
+        let msg = connect_error_message("http://127.0.0.1:1", &err);
+        assert_eq!(msg, err.to_string());
+    }
+
+    /// When the chain does not mention the URL, it is prefixed so the message
+    /// still identifies the endpoint.
+    #[test]
+    fn connect_error_message_prefixes_url_when_absent_from_chain() {
+        let err = std::io::Error::other("tcp connect error: Connection refused (os error 111)");
+        assert_eq!(
+            connect_error_message("http://192.168.1.10:8123/mcp", &err),
+            "http://192.168.1.10:8123/mcp: tcp connect error: Connection refused (os error 111)"
         );
     }
 

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -8,6 +8,7 @@ use crate::events::{
     annotations_from_value, current_request_context, ToolCallEvent, ToolCallEventBus,
 };
 use crate::jsonrpc::{self, JsonRpcResponse};
+use crate::local_network::with_local_network_hint;
 use crate::protocol::{self, detect_upstream_dialect, ProtocolVersion};
 use async_trait::async_trait;
 use reqwest::Client;
@@ -364,10 +365,9 @@ impl SseAdapter {
             .await
             .map_err(|e| {
                 if e.is_connect() {
-                    AdapterError::ConnectionFailed(format!(
-                        "{}: {}",
-                        self.config.url,
-                        format_error_chain(&e)
+                    AdapterError::ConnectionFailed(with_local_network_hint(
+                        &self.config.url,
+                        format!("{}: {}", self.config.url, format_error_chain(&e)),
                     ))
                 } else {
                     AdapterError::HttpError {
@@ -587,10 +587,9 @@ impl SseAdapter {
                 if e.is_timeout() {
                     AdapterError::Timeout(self.config.timeout_secs)
                 } else if e.is_connect() {
-                    AdapterError::ConnectionFailed(format!(
-                        "{}: {}",
-                        endpoint,
-                        format_error_chain(&e)
+                    AdapterError::ConnectionFailed(with_local_network_hint(
+                        &endpoint,
+                        format!("{}: {}", endpoint, format_error_chain(&e)),
                     ))
                 } else {
                     AdapterError::HttpError {
@@ -653,10 +652,9 @@ impl SseAdapter {
                 if e.is_timeout() {
                     AdapterError::Timeout(self.config.timeout_secs)
                 } else if e.is_connect() {
-                    AdapterError::ConnectionFailed(format!(
-                        "{}: {}",
-                        endpoint,
-                        format_error_chain(&e)
+                    AdapterError::ConnectionFailed(with_local_network_hint(
+                        &endpoint,
+                        format!("{}: {}", endpoint, format_error_chain(&e)),
                     ))
                 } else {
                     AdapterError::HttpError {

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -2,7 +2,8 @@ use super::server_name::{sanitize_server_name, ServerNameError};
 use super::server_type_resolution::{effective_server_type, strip_mcp_server_suffix};
 use super::stdio::{iso8601_now, RingBuffer};
 use super::{
-    format_error_chain, AdapterError, HealthStatus, McpAdapter, ToolInfo, DISCOVER_PROBE_TIMEOUT,
+    connect_error_message, format_error_chain, AdapterError, HealthStatus, McpAdapter, ToolInfo,
+    DISCOVER_PROBE_TIMEOUT,
 };
 use crate::events::{
     annotations_from_value, current_request_context, ToolCallEvent, ToolCallEventBus,
@@ -367,7 +368,7 @@ impl SseAdapter {
                 if e.is_connect() {
                     AdapterError::ConnectionFailed(with_local_network_hint(
                         &self.config.url,
-                        format!("{}: {}", self.config.url, format_error_chain(&e)),
+                        connect_error_message(&self.config.url, &e),
                     ))
                 } else {
                     AdapterError::HttpError {
@@ -589,7 +590,7 @@ impl SseAdapter {
                 } else if e.is_connect() {
                     AdapterError::ConnectionFailed(with_local_network_hint(
                         &endpoint,
-                        format!("{}: {}", endpoint, format_error_chain(&e)),
+                        connect_error_message(&endpoint, &e),
                     ))
                 } else {
                     AdapterError::HttpError {
@@ -654,7 +655,7 @@ impl SseAdapter {
                 } else if e.is_connect() {
                     AdapterError::ConnectionFailed(with_local_network_hint(
                         &endpoint,
-                        format!("{}: {}", endpoint, format_error_chain(&e)),
+                        connect_error_message(&endpoint, &e),
                     ))
                 } else {
                     AdapterError::HttpError {

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -1,7 +1,9 @@
 use super::server_name::{sanitize_server_name, ServerNameError};
 use super::server_type_resolution::{effective_server_type, strip_mcp_server_suffix};
 use super::stdio::{iso8601_now, RingBuffer};
-use super::{AdapterError, HealthStatus, McpAdapter, ToolInfo, DISCOVER_PROBE_TIMEOUT};
+use super::{
+    format_error_chain, AdapterError, HealthStatus, McpAdapter, ToolInfo, DISCOVER_PROBE_TIMEOUT,
+};
 use crate::events::{
     annotations_from_value, current_request_context, ToolCallEvent, ToolCallEventBus,
 };
@@ -353,7 +355,7 @@ impl SseAdapter {
         let sse_client = Client::builder()
             .default_headers(sse_headers)
             .build()
-            .map_err(|e| AdapterError::ConnectionFailed(e.to_string()))?;
+            .map_err(|e| AdapterError::ConnectionFailed(format_error_chain(&e)))?;
 
         let resp = sse_client
             .get(&self.config.url)
@@ -362,11 +364,15 @@ impl SseAdapter {
             .await
             .map_err(|e| {
                 if e.is_connect() {
-                    AdapterError::ConnectionFailed(format!("{}: {}", self.config.url, e))
+                    AdapterError::ConnectionFailed(format!(
+                        "{}: {}",
+                        self.config.url,
+                        format_error_chain(&e)
+                    ))
                 } else {
                     AdapterError::HttpError {
                         status: 0,
-                        body: e.to_string(),
+                        body: format_error_chain(&e),
                     }
                 }
             })?;
@@ -581,11 +587,15 @@ impl SseAdapter {
                 if e.is_timeout() {
                     AdapterError::Timeout(self.config.timeout_secs)
                 } else if e.is_connect() {
-                    AdapterError::ConnectionFailed(format!("{}: {}", endpoint, e))
+                    AdapterError::ConnectionFailed(format!(
+                        "{}: {}",
+                        endpoint,
+                        format_error_chain(&e)
+                    ))
                 } else {
                     AdapterError::HttpError {
                         status: 0,
-                        body: e.to_string(),
+                        body: format_error_chain(&e),
                     }
                 }
             })?;
@@ -643,11 +653,15 @@ impl SseAdapter {
                 if e.is_timeout() {
                     AdapterError::Timeout(self.config.timeout_secs)
                 } else if e.is_connect() {
-                    AdapterError::ConnectionFailed(format!("{}: {}", endpoint, e))
+                    AdapterError::ConnectionFailed(format!(
+                        "{}: {}",
+                        endpoint,
+                        format_error_chain(&e)
+                    ))
                 } else {
                     AdapterError::HttpError {
                         status: 0,
-                        body: e.to_string(),
+                        body: format_error_chain(&e),
                     }
                 }
             })?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod container_stats;
 pub mod events;
 pub mod js_sandbox;
 pub mod jsonrpc;
+pub mod local_network;
 pub mod management;
 pub mod management_listener;
 pub mod oauth;

--- a/src/local_network.rs
+++ b/src/local_network.rs
@@ -57,6 +57,10 @@ fn is_mdns_local_domain(domain: &str) -> bool {
 
 /// Appends [`LOCAL_NETWORK_HINT`] to `message` when running on macOS and
 /// `url` targets a private/LAN host; otherwise returns `message` unchanged.
+///
+/// Messages that clearly indicate ECONNREFUSED are excluded: a refused
+/// connection means the host was reachable, so the Local Network permission
+/// is not the cause (TCC denial surfaces as "No route to host" / os error 65).
 pub fn with_local_network_hint(url: &str, message: String) -> String {
     with_local_network_hint_inner(url, message, cfg!(target_os = "macos"))
 }
@@ -64,11 +68,16 @@ pub fn with_local_network_hint(url: &str, message: String) -> String {
 /// Testable core of [`with_local_network_hint`] with the platform gate as a
 /// parameter.
 fn with_local_network_hint_inner(url: &str, message: String, is_macos: bool) -> String {
-    if is_macos && url_targets_private_host(url) {
+    if is_macos && url_targets_private_host(url) && !is_connection_refused(&message) {
         format!("{message} ({LOCAL_NETWORK_HINT})")
     } else {
         message
     }
+}
+
+/// True when the error text clearly names ECONNREFUSED.
+fn is_connection_refused(message: &str) -> bool {
+    message.to_ascii_lowercase().contains("connection refused")
 }
 
 /// True when `url` parses and its host classifies as private/LAN.
@@ -145,6 +154,23 @@ mod tests {
         assert!(!host("https://example.com/mcp"));
         assert!(!host("https://api.example.local.com/"));
         assert!(!host("http://local/"));
+    }
+
+    #[test]
+    fn hint_suppressed_for_connection_refused() {
+        let refused =
+            "http://192.168.1.10:8123/: tcp connect error: Connection refused (os error 61)"
+                .to_string();
+        assert_eq!(
+            with_local_network_hint_inner("http://192.168.1.10:8123/", refused.clone(), true),
+            refused
+        );
+
+        let unreachable =
+            "http://192.168.1.10:8123/: tcp connect error: No route to host (os error 65)"
+                .to_string();
+        let hinted = with_local_network_hint_inner("http://192.168.1.10:8123/", unreachable, true);
+        assert!(hinted.contains("Privacy & Security → Local Network"));
     }
 
     #[test]

--- a/src/local_network.rs
+++ b/src/local_network.rs
@@ -1,0 +1,156 @@
+//! macOS Local Network permission hint for LAN connect failures.
+//!
+//! On macOS, outbound connections to devices on the local network are gated
+//! by the per-app Local Network privacy permission (TCC). When the user has
+//! not granted it, connect attempts to private/LAN addresses fail with
+//! opaque OS errors (typically "No route to host"). This module classifies
+//! whether a connect target is a private/LAN host and, on macOS, appends an
+//! actionable hint to transport-level connect error messages.
+
+use std::net::{Ipv4Addr, Ipv6Addr};
+use url::{Host, Url};
+
+/// Hint appended to connect-failure messages for private/LAN targets on macOS.
+pub const LOCAL_NETWORK_HINT: &str = "this server is on your local network, so macOS may be \
+    blocking the connection — check System Settings → Privacy & Security → Local Network and \
+    allow Endara Desktop, then restart the app after granting";
+
+/// Returns true when `host` is a private/LAN target: an RFC 1918 or
+/// link-local IPv4 address, a unique-local or link-local IPv6 address, or an
+/// mDNS `.local` hostname.
+///
+/// Loopback targets (`localhost`, `127.0.0.0/8`, `::1`) return false: the
+/// macOS Local Network permission does not gate loopback traffic, so the
+/// hint would be misleading.
+pub fn is_private_or_local_host(host: &Host<&str>) -> bool {
+    match host {
+        Host::Domain(domain) => is_mdns_local_domain(domain),
+        Host::Ipv4(ip) => is_private_ipv4(*ip),
+        Host::Ipv6(ip) => is_private_ipv6(*ip),
+    }
+}
+
+/// RFC 1918 private ranges plus IPv4 link-local (`169.254.0.0/16`).
+fn is_private_ipv4(ip: Ipv4Addr) -> bool {
+    ip.is_private() || ip.is_link_local()
+}
+
+/// IPv6 unique-local (`fc00::/7`) plus link-local (`fe80::/10`).
+fn is_private_ipv6(ip: Ipv6Addr) -> bool {
+    let first = ip.segments()[0];
+    (first & 0xfe00) == 0xfc00 || (first & 0xffc0) == 0xfe80
+}
+
+/// mDNS `.local` hostname (case-insensitive, tolerating a trailing dot).
+fn is_mdns_local_domain(domain: &str) -> bool {
+    let trimmed = domain.strip_suffix('.').unwrap_or(domain);
+    trimmed
+        .rsplit_once('.')
+        .is_some_and(|(_, tld)| tld.eq_ignore_ascii_case("local"))
+}
+
+/// Appends [`LOCAL_NETWORK_HINT`] to `message` when running on macOS and
+/// `url` targets a private/LAN host; otherwise returns `message` unchanged.
+pub fn with_local_network_hint(url: &str, message: String) -> String {
+    with_local_network_hint_inner(url, message, cfg!(target_os = "macos"))
+}
+
+/// Testable core of [`with_local_network_hint`] with the platform gate as a
+/// parameter.
+fn with_local_network_hint_inner(url: &str, message: String, is_macos: bool) -> String {
+    if is_macos && url_targets_private_host(url) {
+        format!("{message} ({LOCAL_NETWORK_HINT})")
+    } else {
+        message
+    }
+}
+
+/// True when `url` parses and its host classifies as private/LAN.
+fn url_targets_private_host(url: &str) -> bool {
+    Url::parse(url)
+        .ok()
+        .as_ref()
+        .and_then(Url::host)
+        .is_some_and(|host| is_private_or_local_host(&host))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn host(url: &str) -> bool {
+        url_targets_private_host(url)
+    }
+
+    #[test]
+    fn rfc1918_and_link_local_ipv4_are_private() {
+        assert!(host("http://10.0.0.5:8080/mcp"));
+        assert!(host("http://172.16.0.1/sse"));
+        assert!(host("http://172.31.255.254/"));
+        assert!(host("http://192.168.1.10:8123/mcp_server/sse"));
+        assert!(host("http://169.254.10.20/"));
+    }
+
+    #[test]
+    fn public_and_non_private_ipv4_are_not_private() {
+        assert!(!host("http://8.8.8.8/"));
+        assert!(!host("http://172.15.0.1/"));
+        assert!(!host("http://172.32.0.1/"));
+        assert!(!host("http://1.2.3.4:9000/mcp"));
+    }
+
+    #[test]
+    fn loopback_is_not_private() {
+        assert!(!host("http://127.0.0.1:8000/mcp"));
+        assert!(!host("http://localhost:8000/mcp"));
+        assert!(!host("http://[::1]:8000/mcp"));
+    }
+
+    #[test]
+    fn private_ipv6_ranges_are_private() {
+        assert!(host("http://[fc00::1]/"));
+        assert!(host("http://[fd12:3456:789a::1]:8080/mcp"));
+        assert!(host("http://[fe80::1]/"));
+    }
+
+    #[test]
+    fn public_ipv6_is_not_private() {
+        assert!(!host("http://[2001:db8::1]/"));
+        assert!(!host("http://[2606:4700::1111]/"));
+    }
+
+    #[test]
+    fn dot_local_hostnames_are_private() {
+        assert!(host("http://homeassistant.local:8123/mcp_server/sse"));
+        assert!(host("http://Printer.LOCAL/"));
+        assert!(host("http://hub.local./"));
+    }
+
+    #[test]
+    fn other_domains_are_not_private() {
+        assert!(!host("https://example.com/mcp"));
+        assert!(!host("https://api.example.local.com/"));
+        assert!(!host("http://local/"));
+    }
+
+    #[test]
+    fn hint_appended_only_on_macos_and_private_target() {
+        let msg = || "connection failed".to_string();
+        let hinted = with_local_network_hint_inner("http://192.168.1.10:8123/", msg(), true);
+        assert!(hinted.starts_with("connection failed ("));
+        assert!(hinted.contains("Privacy & Security → Local Network"));
+
+        assert_eq!(
+            with_local_network_hint_inner("https://example.com/", msg(), true),
+            "connection failed"
+        );
+        assert_eq!(
+            with_local_network_hint_inner("http://192.168.1.10:8123/", msg(), false),
+            "connection failed"
+        );
+        assert_eq!(
+            with_local_network_hint_inner("not a url", msg(), true),
+            "connection failed"
+        );
+    }
+}

--- a/src/local_network.rs
+++ b/src/local_network.rs
@@ -13,7 +13,8 @@ use url::{Host, Url};
 /// Hint appended to connect-failure messages for private/LAN targets on macOS.
 pub const LOCAL_NETWORK_HINT: &str = "this server is on your local network, so macOS may be \
     blocking the connection — check System Settings → Privacy & Security → Local Network and \
-    allow Endara Desktop, then restart the app after granting";
+    allow the Endara app (or the terminal that launched the relay), then restart it after \
+    granting";
 
 /// Returns true when `host` is a private/LAN target: an RFC 1918 or
 /// link-local IPv4 address, a unique-local or link-local IPv6 address, or an
@@ -35,8 +36,13 @@ fn is_private_ipv4(ip: Ipv4Addr) -> bool {
     ip.is_private() || ip.is_link_local()
 }
 
-/// IPv6 unique-local (`fc00::/7`) plus link-local (`fe80::/10`).
+/// IPv6 unique-local (`fc00::/7`) plus link-local (`fe80::/10`). An
+/// IPv4-mapped address (`::ffff:a.b.c.d`) classifies as its embedded IPv4
+/// address.
 fn is_private_ipv6(ip: Ipv6Addr) -> bool {
+    if let Some(v4) = ip.to_ipv4_mapped() {
+        return is_private_ipv4(v4);
+    }
     let first = ip.segments()[0];
     (first & 0xfe00) == 0xfc00 || (first & 0xffc0) == 0xfe80
 }
@@ -117,6 +123,14 @@ mod tests {
     fn public_ipv6_is_not_private() {
         assert!(!host("http://[2001:db8::1]/"));
         assert!(!host("http://[2606:4700::1111]/"));
+    }
+
+    #[test]
+    fn ipv4_mapped_ipv6_classifies_as_embedded_ipv4() {
+        assert!(host("http://[::ffff:192.168.1.10]:8123/"));
+        assert!(host("http://[::ffff:10.0.0.5]/"));
+        assert!(!host("http://[::ffff:8.8.8.8]/"));
+        assert!(!host("http://[::ffff:127.0.0.1]/"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod advertise;
 mod container_runtime;
 mod container_stats;
 mod jsonrpc;
+mod local_network;
 mod prefix;
 mod profile_registry;
 mod protocol;


### PR DESCRIPTION
## Summary

Transport-level connection errors from the HTTP/SSE MCP adapters previously showed only reqwest's top-level message ('error sending request for url (...)'), hiding the OS-level cause. Diagnosed from a real support case: connecting to a Home Assistant server on the LAN failed silently because macOS's Local Network permission was granted while the relay was already running.

## Changes

- format_error_chain helper (src/adapter/mod.rs): walks std::error::Error::source() with dedup and joins the chain, so errors now read e.g. 'error sending request ...: error trying to connect: tcp connect error: No route to host (os error 65)'. Applied at all 7 reqwest error-mapping sites in http.rs (3) and sse.rs (4) for ConnectionFailed / HttpError status 0.
- New src/local_network.rs: classifies private/LAN targets (RFC 1918, IPv4/IPv6 link-local, IPv6 ULA, .local mDNS names; loopback and public hosts excluded). On macOS, connect failures to such targets append a hint to check System Settings -> Privacy & Security -> Local Network and restart the app. Wired at all 6 is_connect() ConnectionFailed sites, composing around the chain-formatted message.

## Testing

- 11 new unit tests (chain formatting: synthetic chain, dedup, real connect-refused; LAN classification + hint gating incl. public-host and non-macOS negatives).
- cargo test -p endara-relay --lib: 1351 passed. cargo clippy --lib: clean.
- Known pre-existing failures in multi_server_integration/tool_listing (sandbox cannot spawn npx servers) are unrelated.

Companion PR: endara-ai/endara-desktop declares NSLocalNetworkUsageDescription.