### PR TITLE
fix: emit tools-changed tick when OAuth inner adapter readiness changes

### DIFF
--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -1068,12 +1068,25 @@ impl OAuthAdapterInner {
                 // `health() == Healthy` is guaranteed to also see
                 // `inner_adapter == Some(_)`.
                 // Bind a forwarder against the new inner's tools-changed
-                // receiver (if any) before publishing it. No synthetic tick
-                // is emitted on swap — real ticks come from inner reconnects.
+                // receiver (if any) before publishing it. A synthetic tick is
+                // emitted on the outer broadcast only when the inner's
+                // readiness changed (None→Some here; Some→None on the failure
+                // branch below) so the registry invalidates its stale merged
+                // catalog the moment the endpoint becomes listable — routine
+                // Some→Some token refreshes stay silent to avoid spamming
+                // clients with `list_changed` on every refresh.
                 let rx = adapter.subscribe_tools_changed();
-                *self.inner_adapter.write().await = Some(adapter);
+                let was_listable = {
+                    let mut guard = self.inner_adapter.write().await;
+                    let was = guard.is_some();
+                    *guard = Some(adapter);
+                    was
+                };
                 *self.inner_health.write().await = HealthStatus::Healthy;
                 self.swap_tools_forwarder(rx).await;
+                if !was_listable {
+                    let _ = self.outer_tools_changed_tx.send(());
+                }
                 self.transition_to(
                     OAuthState::Authenticated,
                     "tokens applied, inner adapter ready",
@@ -1083,8 +1096,13 @@ impl OAuthAdapterInner {
             Err(e) => {
                 // Capture inner adapter's health before clearing it
                 *self.inner_health.write().await = adapter.health();
-                *self.inner_adapter.write().await = None;
+                let was_listable = self.inner_adapter.write().await.take().is_some();
                 self.swap_tools_forwarder(None).await;
+                // Some→None: the endpoint just lost its tools — tick so the
+                // registry drops them from the merged catalog.
+                if was_listable {
+                    let _ = self.outer_tools_changed_tx.send(());
+                }
                 self.transition_to(
                     OAuthState::ConnectionFailed,
                     &format!("inner adapter init failed: {}", e),
@@ -3513,6 +3531,204 @@ mod tests {
             !recv_tick(&mut outer_rx, Duration::from_millis(150)).await,
             "no tick should reach outer subscriber after forwarder disabled"
         );
+    }
+
+    // --- apply_tokens readiness-change synthetic tick ---
+
+    fn make_token_set(access: &str) -> TokenSet {
+        TokenSet {
+            access_token: access.to_string(),
+            refresh_token: None,
+            expires_at: None,
+            token_type: "Bearer".to_string(),
+            scope: None,
+            issued_at: None,
+        }
+    }
+
+    /// Regression: when `apply_tokens` transitions the inner adapter from
+    /// `None` to `Some` (endpoint just became listable, e.g. after the OAuth
+    /// callback), a synthetic tick must reach the outer tools-changed
+    /// broadcast so the registry invalidates its stale merged catalog.
+    #[tokio::test]
+    async fn apply_tokens_none_to_some_emits_outer_tick() {
+        let (url, server) = spawn_minimal_mcp_server().await;
+        let mut config = make_config();
+        config.url = url;
+        let mut adapter = make_adapter(config);
+        adapter.initialize().await.unwrap();
+        let mut outer_rx = adapter.subscribe_tools_changed().expect("outer rx");
+
+        adapter.inner.apply_tokens(make_token_set("test-access")).await;
+
+        assert!(
+            recv_tick(&mut outer_rx, Duration::from_millis(500)).await,
+            "None→Some inner readiness transition must emit a synthetic outer tick"
+        );
+        server.abort();
+    }
+
+    /// A routine Some→Some token refresh (inner adapter rebuilt, endpoint
+    /// stays listable) must NOT emit a synthetic tick — that would spam
+    /// clients with `notifications/tools/list_changed` on every refresh.
+    #[tokio::test]
+    async fn apply_tokens_some_to_some_refresh_emits_no_tick() {
+        let (url, server) = spawn_minimal_mcp_server().await;
+        let mut config = make_config();
+        config.url = url;
+        let mut adapter = make_adapter(config);
+        adapter.initialize().await.unwrap();
+
+        // First apply: None→Some (tick expected, not asserted here).
+        adapter.inner.apply_tokens(make_token_set("first")).await;
+
+        let mut outer_rx = adapter.subscribe_tools_changed().expect("outer rx");
+        drain(&mut outer_rx).await;
+
+        // Second apply: Some→Some routine refresh.
+        adapter.inner.apply_tokens(make_token_set("second")).await;
+
+        assert!(
+            !recv_tick(&mut outer_rx, Duration::from_millis(200)).await,
+            "routine Some→Some token refresh must not emit a synthetic tick"
+        );
+        server.abort();
+    }
+
+    /// When `apply_tokens` fails inner init while a previous inner adapter
+    /// existed (Some→None: endpoint just lost its tools), a synthetic tick
+    /// must fire so the registry drops the stale tools from the catalog.
+    #[tokio::test]
+    async fn apply_tokens_some_to_none_failure_emits_outer_tick() {
+        let (url, server) = spawn_minimal_mcp_server().await;
+        let mut config = make_config();
+        config.url = url;
+        let mut adapter = make_adapter(config);
+        adapter.initialize().await.unwrap();
+
+        // First apply succeeds: inner becomes Some.
+        adapter.inner.apply_tokens(make_token_set("first")).await;
+        assert!(adapter.inner.inner_adapter.read().await.is_some());
+
+        let mut outer_rx = adapter.subscribe_tools_changed().expect("outer rx");
+        drain(&mut outer_rx).await;
+
+        // Kill the upstream so the next inner init fails: Some→None.
+        server.abort();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        adapter.inner.apply_tokens(make_token_set("second")).await;
+        assert!(adapter.inner.inner_adapter.read().await.is_none());
+
+        assert!(
+            recv_tick(&mut outer_rx, Duration::from_millis(500)).await,
+            "Some→None inner readiness transition must emit a synthetic outer tick"
+        );
+    }
+
+    /// Spawn an in-process MCP server that also answers `tools/list` with a
+    /// single tool, so a registry-level test can observe the merged catalog
+    /// rebuild after `apply_tokens`.
+    async fn spawn_mcp_server_with_tools() -> (String, tokio::task::JoinHandle<()>) {
+        use axum::{routing::post, Json, Router};
+        use serde_json::{json, Value};
+
+        async fn handle(Json(body): Json<Value>) -> Json<Value> {
+            let id = body.get("id").cloned().unwrap_or(Value::Null);
+            let method = body.get("method").and_then(|m| m.as_str()).unwrap_or("");
+            match method {
+                "initialize" => Json(json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {},
+                        "serverInfo": {"name": "test-server", "version": "0.0.1"},
+                    },
+                })),
+                "tools/list" => Json(json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {
+                        "tools": [{
+                            "name": "oauth_tool",
+                            "description": "a tool",
+                            "inputSchema": {"type": "object"},
+                        }],
+                    },
+                })),
+                _ => Json(json!({"jsonrpc": "2.0", "id": id, "result": {}})),
+            }
+        }
+
+        let router = Router::new().route("/mcp", post(handle));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        (format!("http://127.0.0.1:{}/mcp", addr.port()), handle)
+    }
+
+    /// Registry-level regression: after `apply_tokens` makes an OAuth
+    /// endpoint listable (None→Some), the registry's tools-changed listener
+    /// must bump `catalog_generation` and the merged catalog must rebuild
+    /// with the endpoint's tools — no restart required.
+    #[tokio::test]
+    async fn registry_rebuilds_merged_catalog_after_apply_tokens() {
+        use crate::registry::AdapterRegistry;
+
+        let (url, server) = spawn_mcp_server_with_tools().await;
+        let mut config = make_config();
+        config.url = url;
+        let mut adapter = make_adapter(config);
+        adapter.initialize().await.unwrap();
+        let inner = adapter.shared_inner();
+
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "test".into(),
+                Box::new(adapter),
+                "oauth".into(),
+                None,
+                Some("test".into()),
+            )
+            .await;
+
+        // Before tokens the inner adapter is None → empty merged catalog.
+        let catalog = registry.merged_catalog().await;
+        assert!(
+            catalog.is_empty(),
+            "expected empty catalog before apply_tokens, got {:?}",
+            catalog.iter().map(|t| &t.name).collect::<Vec<_>>()
+        );
+
+        let gen_before = registry.catalog_generation();
+        inner.apply_tokens(make_token_set("test-access")).await;
+
+        // The synthetic tick reaches the registry listener asynchronously.
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while registry.catalog_generation() <= gen_before
+            && std::time::Instant::now() < deadline
+        {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            registry.catalog_generation() > gen_before,
+            "catalog generation must bump after apply_tokens readiness change"
+        );
+
+        // Merged catalog rebuild now sees the endpoint's tools (single
+        // active adapter → no prefix).
+        let catalog = registry.merged_catalog().await;
+        assert_eq!(
+            catalog.iter().map(|t| t.name.as_str()).collect::<Vec<_>>(),
+            vec!["oauth_tool"],
+            "merged catalog must contain the endpoint's tools after apply_tokens"
+        );
+
+        server.abort();
     }
 
     // --- Refresh-time token endpoint discovery fallback tests ---

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -292,6 +292,13 @@ pub struct OAuthAdapterInner {
     /// baseline, so the next Some→Some swap must tick to be safe — see
     /// `swap_tools_forwarder`). `Arc` so the forwarder task can share it.
     last_tools_fingerprint: Arc<RwLock<Option<u64>>>,
+    /// Serializes [`Self::apply_tokens`] end-to-end. The OAuth callback,
+    /// proactive refresh, and reactive (401) refresh can all apply tokens
+    /// concurrently; without serialization, interleaved applies could
+    /// publish adapter B while a resumed apply A overwrites the fingerprint
+    /// baseline with A's — a later catalog equal to A would then be treated
+    /// as unchanged and the invalidation tick suppressed (PR #140 review).
+    apply_lock: Mutex<()>,
 }
 
 impl OAuthAdapterInner {
@@ -1047,6 +1054,12 @@ impl OAuthAdapterInner {
     }
 
     async fn apply_tokens_inner(self: &Arc<Self>, token_set: TokenSet) {
+        // Serialize the whole apply: callback, proactive refresh, and
+        // reactive refresh may overlap, and interleaved applies could pair
+        // the published adapter with another apply's fingerprint baseline
+        // (see `apply_lock`). Applies are rare (login/refresh), so a full
+        // mutex is the simple correct choice over rebuild versioning.
+        let _apply_guard = self.apply_lock.lock().await;
         let endpoint = &self.config.endpoint_name;
 
         // 1. Persist to disk
@@ -1440,6 +1453,7 @@ impl OAuthAdapter {
                 pending_authorize_url: RwLock::new(None),
                 server_type_recorded: AtomicBool::new(false),
                 last_tools_fingerprint: Arc::new(RwLock::new(None)),
+                apply_lock: Mutex::new(()),
             }),
         }
     }

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -281,6 +281,14 @@ pub struct OAuthAdapterInner {
     /// time a non-empty `server_type` is written so subsequent applies skip
     /// the record call.
     server_type_recorded: AtomicBool,
+    /// Fingerprint (hash of the sorted, serialized tool list) probed from the
+    /// inner adapter after each successful [`Self::apply_tokens`] rebuild.
+    /// Compared across Some→Some swaps to detect an actual tool-set change
+    /// (e.g. an OAuth callback re-login under a different account/scope, see
+    /// PR #140 review) without spamming clients with `list_changed` on
+    /// routine token refreshes. `None` until a probe succeeds; cleared when
+    /// the inner adapter is torn down.
+    last_tools_fingerprint: RwLock<Option<u64>>,
 }
 
 impl OAuthAdapterInner {
@@ -314,6 +322,19 @@ impl OAuthAdapterInner {
         http_config.server_type_override = server_type_override;
         http_config.endpoint_name = endpoint_name;
         HttpAdapter::new_with_client_inner(http_config, client)
+    }
+
+    /// Hash the adapter's tool list into an order-insensitive fingerprint.
+    /// Returns `None` when `tools/list` fails — callers treat an unknown
+    /// probe conservatively (see `apply_tokens_inner`).
+    async fn probe_tools_fingerprint(adapter: &HttpAdapter) -> Option<u64> {
+        use std::hash::{Hash, Hasher};
+        let mut tools = adapter.list_tools().await.ok()?;
+        tools.sort_by(|a, b| a.name.cmp(&b.name));
+        let serialized = serde_json::to_string(&tools).ok()?;
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        serialized.hash(&mut hasher);
+        Some(hasher.finish())
     }
 
     /// Transition to a new `OAuthState`.
@@ -1069,13 +1090,19 @@ impl OAuthAdapterInner {
                 // `inner_adapter == Some(_)`.
                 // Bind a forwarder against the new inner's tools-changed
                 // receiver (if any) before publishing it. A synthetic tick is
-                // emitted on the outer broadcast only when the inner's
-                // readiness changed (None→Some here; Some→None on the failure
-                // branch below) so the registry invalidates its stale merged
-                // catalog the moment the endpoint becomes listable — routine
-                // Some→Some token refreshes stay silent to avoid spamming
-                // clients with `list_changed` on every refresh.
+                // emitted on the outer broadcast when the inner's readiness
+                // changed (None→Some here; Some→None on the failure branch
+                // below) and when a Some→Some swap actually changed the tool
+                // set — an OAuth callback re-login under a different
+                // account/scope rebuilds the inner adapter too, and its
+                // different catalog must reach the registry's caches.
+                // Change detection probes the new inner's tool list once and
+                // compares its fingerprint against the previous successful
+                // probe, so routine Some→Some token refreshes with an
+                // unchanged tool set stay silent and clients aren't spammed
+                // with `list_changed` on every refresh.
                 let rx = adapter.subscribe_tools_changed();
+                let new_fingerprint = Self::probe_tools_fingerprint(&adapter).await;
                 let was_listable = {
                     let mut guard = self.inner_adapter.write().await;
                     let was = guard.is_some();
@@ -1084,7 +1111,26 @@ impl OAuthAdapterInner {
                 };
                 *self.inner_health.write().await = HealthStatus::Healthy;
                 self.swap_tools_forwarder(rx).await;
-                if !was_listable {
+                let should_tick = if !was_listable {
+                    true
+                } else {
+                    let old_fingerprint = *self.last_tools_fingerprint.read().await;
+                    match (old_fingerprint, new_fingerprint) {
+                        // Both probes succeeded: tick only on an actual change.
+                        (Some(old), Some(new)) => old != new,
+                        // Baseline unknown (previous probe failed): cached
+                        // tools may be stale — tick to be safe.
+                        (None, Some(_)) => true,
+                        // New probe failed: a change is undetectable, and the
+                        // registry's own refetch would fail too — stay silent
+                        // and keep the previous baseline.
+                        (_, None) => false,
+                    }
+                };
+                if new_fingerprint.is_some() {
+                    *self.last_tools_fingerprint.write().await = new_fingerprint;
+                }
+                if should_tick {
                     let _ = self.outer_tools_changed_tx.send(());
                 }
                 self.transition_to(
@@ -1097,6 +1143,7 @@ impl OAuthAdapterInner {
                 // Capture inner adapter's health before clearing it
                 *self.inner_health.write().await = adapter.health();
                 let was_listable = self.inner_adapter.write().await.take().is_some();
+                *self.last_tools_fingerprint.write().await = None;
                 self.swap_tools_forwarder(None).await;
                 // Some→None: the endpoint just lost its tools — tick so the
                 // registry drops them from the merged catalog.
@@ -1375,6 +1422,7 @@ impl OAuthAdapter {
                 ema_sso,
                 pending_authorize_url: RwLock::new(None),
                 server_type_recorded: AtomicBool::new(false),
+                last_tools_fingerprint: RwLock::new(None),
             }),
         }
     }
@@ -3559,7 +3607,10 @@ mod tests {
         adapter.initialize().await.unwrap();
         let mut outer_rx = adapter.subscribe_tools_changed().expect("outer rx");
 
-        adapter.inner.apply_tokens(make_token_set("test-access")).await;
+        adapter
+            .inner
+            .apply_tokens(make_token_set("test-access"))
+            .await;
 
         assert!(
             recv_tick(&mut outer_rx, Duration::from_millis(500)).await,
@@ -3571,6 +3622,11 @@ mod tests {
     /// A routine Some→Some token refresh (inner adapter rebuilt, endpoint
     /// stays listable) must NOT emit a synthetic tick — that would spam
     /// clients with `notifications/tools/list_changed` on every refresh.
+    /// This variant pins the probe-failure path: the minimal server answers
+    /// `tools/list` without a `tools` field, so both fingerprint probes fail
+    /// and the swap must stay silent (a change is undetectable and the
+    /// registry's own refetch would fail too). The unchanged-tools no-tick
+    /// path is pinned by `apply_tokens_some_to_some_tool_change_emits_tick`.
     #[tokio::test]
     async fn apply_tokens_some_to_some_refresh_emits_no_tick() {
         let (url, server) = spawn_minimal_mcp_server().await;
@@ -3591,6 +3647,101 @@ mod tests {
         assert!(
             !recv_tick(&mut outer_rx, Duration::from_millis(200)).await,
             "routine Some→Some token refresh must not emit a synthetic tick"
+        );
+        server.abort();
+    }
+
+    /// Spawn an in-process MCP server whose `tools/list` response reflects
+    /// the current value of the shared `tool_name` — lets a test change the
+    /// upstream tool set between `apply_tokens` calls.
+    async fn spawn_mcp_server_with_mutable_tools(
+        tool_name: Arc<std::sync::RwLock<String>>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        use axum::extract::State;
+        use axum::{routing::post, Json, Router};
+        use serde_json::{json, Value};
+
+        async fn handle(
+            State(tool_name): State<Arc<std::sync::RwLock<String>>>,
+            Json(body): Json<Value>,
+        ) -> Json<Value> {
+            let id = body.get("id").cloned().unwrap_or(Value::Null);
+            let method = body.get("method").and_then(|m| m.as_str()).unwrap_or("");
+            match method {
+                "initialize" => Json(json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {},
+                        "serverInfo": {"name": "test-server", "version": "0.0.1"},
+                    },
+                })),
+                "tools/list" => {
+                    let name = tool_name.read().unwrap().clone();
+                    Json(json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": {
+                            "tools": [{
+                                "name": name,
+                                "description": "a tool",
+                                "inputSchema": {"type": "object"},
+                            }],
+                        },
+                    }))
+                }
+                _ => Json(json!({"jsonrpc": "2.0", "id": id, "result": {}})),
+            }
+        }
+
+        let router = Router::new()
+            .route("/mcp", post(handle))
+            .with_state(tool_name);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        (format!("http://127.0.0.1:{}/mcp", addr.port()), handle)
+    }
+
+    /// PR #140 review follow-up: a Some→Some swap that actually changes the
+    /// tool set (e.g. an OAuth callback re-login under a different
+    /// account/scope) must emit a tick so the registry's caches don't go
+    /// stale, while an unchanged Some→Some swap stays silent.
+    #[tokio::test]
+    async fn apply_tokens_some_to_some_tool_change_emits_tick() {
+        let tool_name = Arc::new(std::sync::RwLock::new("alpha".to_string()));
+        let (url, server) = spawn_mcp_server_with_mutable_tools(tool_name.clone()).await;
+        let mut config = make_config();
+        config.url = url;
+        let mut adapter = make_adapter(config);
+        adapter.initialize().await.unwrap();
+        let mut outer_rx = adapter.subscribe_tools_changed().expect("outer rx");
+
+        // None→Some: tick, and the fingerprint baseline is stored.
+        adapter.inner.apply_tokens(make_token_set("first")).await;
+        assert!(
+            recv_tick(&mut outer_rx, Duration::from_millis(500)).await,
+            "None→Some must tick"
+        );
+        drain(&mut outer_rx).await;
+
+        // Some→Some with an unchanged tool set: silent.
+        adapter.inner.apply_tokens(make_token_set("second")).await;
+        assert!(
+            !recv_tick(&mut outer_rx, Duration::from_millis(200)).await,
+            "unchanged Some→Some swap must not emit a tick"
+        );
+
+        // Some→Some with a changed tool set: tick.
+        *tool_name.write().unwrap() = "beta".to_string();
+        adapter.inner.apply_tokens(make_token_set("third")).await;
+        assert!(
+            recv_tick(&mut outer_rx, Duration::from_millis(500)).await,
+            "Some→Some swap with a changed tool set must emit a tick"
         );
         server.abort();
     }
@@ -3709,9 +3860,7 @@ mod tests {
 
         // The synthetic tick reaches the registry listener asynchronously.
         let deadline = std::time::Instant::now() + Duration::from_secs(2);
-        while registry.catalog_generation() <= gen_before
-            && std::time::Instant::now() < deadline
-        {
+        while registry.catalog_generation() <= gen_before && std::time::Instant::now() < deadline {
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
         assert!(
@@ -3729,6 +3878,80 @@ mod tests {
         );
 
         server.abort();
+    }
+
+    /// Registry-level regression for the PR #140 review: a Some→Some
+    /// `apply_tokens` swap that changes the tool set (OAuth callback
+    /// re-login under a different account/scope) must reach the registry —
+    /// generation bump + merged catalog rebuilt with the new tools.
+    #[tokio::test]
+    async fn registry_rebuilds_merged_catalog_after_some_to_some_tool_change() {
+        use crate::registry::AdapterRegistry;
+
+        let tool_name = Arc::new(std::sync::RwLock::new("alpha".to_string()));
+        let (url, server) = spawn_mcp_server_with_mutable_tools(tool_name.clone()).await;
+        let mut config = make_config();
+        config.url = url;
+        let mut adapter = make_adapter(config);
+        adapter.initialize().await.unwrap();
+        let inner = adapter.shared_inner();
+
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "test".into(),
+                Box::new(adapter),
+                "oauth".into(),
+                None,
+                Some("test".into()),
+            )
+            .await;
+
+        // First apply: None→Some, catalog picks up "alpha".
+        let gen_before = inner_apply_and_wait(&registry, &inner, "first").await;
+        let catalog = registry.merged_catalog().await;
+        assert_eq!(
+            catalog.iter().map(|t| t.name.as_str()).collect::<Vec<_>>(),
+            vec!["alpha"],
+            "merged catalog must contain the initial tool set"
+        );
+
+        // Re-login changes the upstream tool set; the Some→Some swap must
+        // tick so the registry rebuilds with "beta".
+        *tool_name.write().unwrap() = "beta".to_string();
+        inner.apply_tokens(make_token_set("second")).await;
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while registry.catalog_generation() <= gen_before && std::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            registry.catalog_generation() > gen_before,
+            "catalog generation must bump after a Some→Some tool change"
+        );
+        let catalog = registry.merged_catalog().await;
+        assert_eq!(
+            catalog.iter().map(|t| t.name.as_str()).collect::<Vec<_>>(),
+            vec!["beta"],
+            "merged catalog must reflect the changed tool set"
+        );
+
+        server.abort();
+    }
+
+    /// Apply tokens and wait for the registry's generation to settle past
+    /// the tick triggered by the apply; returns the settled generation.
+    async fn inner_apply_and_wait(
+        registry: &crate::registry::AdapterRegistry,
+        inner: &Arc<OAuthAdapterInner>,
+        token: &str,
+    ) -> u64 {
+        let gen_before = registry.catalog_generation();
+        inner.apply_tokens(make_token_set(token)).await;
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while registry.catalog_generation() <= gen_before && std::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        registry.catalog_generation()
     }
 
     // --- Refresh-time token endpoint discovery fallback tests ---

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -287,8 +287,11 @@ pub struct OAuthAdapterInner {
     /// (e.g. an OAuth callback re-login under a different account/scope, see
     /// PR #140 review) without spamming clients with `list_changed` on
     /// routine token refreshes. `None` until a probe succeeds; cleared when
-    /// the inner adapter is torn down.
-    last_tools_fingerprint: RwLock<Option<u64>>,
+    /// the inner adapter is torn down AND whenever the forwarder relays an
+    /// inner `tools_changed` tick (the upstream drifted from the probed
+    /// baseline, so the next Some→Some swap must tick to be safe — see
+    /// `swap_tools_forwarder`). `Arc` so the forwarder task can share it.
+    last_tools_fingerprint: Arc<RwLock<Option<u64>>>,
 }
 
 impl OAuthAdapterInner {
@@ -1297,6 +1300,13 @@ impl OAuthAdapterInner {
     /// `Some`, spawn a fresh forwarder that pumps each inner tick into
     /// `outer_tools_changed_tx`. `Lagged` is forwarded as a tick (matching the
     /// registry listener); `Closed` ends the task.
+    ///
+    /// Each relayed tick also clears `last_tools_fingerprint`: an inner
+    /// `tools_changed` notification means the upstream tool set drifted from
+    /// the baseline probed at `apply_tokens` time, so a later Some→Some swap
+    /// that happens to reproduce the original set must still tick (the
+    /// registry's caches followed the drift). An unknown baseline makes the
+    /// next swap tick unconditionally — safe, at worst one extra tick.
     async fn swap_tools_forwarder(&self, rx: Option<broadcast::Receiver<()>>) {
         let mut handle_guard = self.inner_forwarder_handle.lock().await;
         if let Some(h) = handle_guard.take() {
@@ -1304,13 +1314,16 @@ impl OAuthAdapterInner {
         }
         let Some(mut rx) = rx else { return };
         let outer_tx = self.outer_tools_changed_tx.clone();
+        let fingerprint = self.last_tools_fingerprint.clone();
         let join = tokio::spawn(async move {
             loop {
                 match rx.recv().await {
                     Ok(()) => {
+                        *fingerprint.write().await = None;
                         let _ = outer_tx.send(());
                     }
                     Err(broadcast::error::RecvError::Lagged(_)) => {
+                        *fingerprint.write().await = None;
                         let _ = outer_tx.send(());
                     }
                     Err(broadcast::error::RecvError::Closed) => break,
@@ -1426,7 +1439,7 @@ impl OAuthAdapter {
                 ema_sso,
                 pending_authorize_url: RwLock::new(None),
                 server_type_recorded: AtomicBool::new(false),
-                last_tools_fingerprint: RwLock::new(None),
+                last_tools_fingerprint: Arc::new(RwLock::new(None)),
             }),
         }
     }
@@ -3746,6 +3759,60 @@ mod tests {
         assert!(
             recv_tick(&mut outer_rx, Duration::from_millis(500)).await,
             "Some→Some swap with a changed tool set must emit a tick"
+        );
+        server.abort();
+    }
+
+    /// PR #140 review follow-up (round 2): a forwarded inner `tools_changed`
+    /// tick must invalidate the stored fingerprint. Sequence pinned here:
+    /// tool set A is probed (baseline = A), the inner notifies a change (the
+    /// registry's caches follow the drift, baseline must be cleared), then a
+    /// re-login reproduces A — without invalidation the A==A comparison
+    /// would suppress the tick and leave the registry's caches stale.
+    #[tokio::test]
+    async fn inner_tick_invalidates_fingerprint_so_relogin_to_same_tools_ticks() {
+        let tool_name = Arc::new(std::sync::RwLock::new("alpha".to_string()));
+        let (url, server) = spawn_mcp_server_with_mutable_tools(tool_name.clone()).await;
+        let mut config = make_config();
+        config.url = url;
+        let mut adapter = make_adapter(config);
+        adapter.initialize().await.unwrap();
+        let mut outer_rx = adapter.subscribe_tools_changed().expect("outer rx");
+
+        // Baseline: apply with tool set A → fingerprint stored.
+        adapter.inner.apply_tokens(make_token_set("first")).await;
+        assert!(
+            recv_tick(&mut outer_rx, Duration::from_millis(500)).await,
+            "None→Some must tick"
+        );
+        assert!(
+            adapter.inner.last_tools_fingerprint.read().await.is_some(),
+            "baseline fingerprint must be stored after a successful probe"
+        );
+
+        // Simulate the inner adapter notifying a tool change (upstream
+        // drifted to B): bind the forwarder to a manual channel and tick it.
+        let (inner_tx, inner_rx) = broadcast::channel::<()>(16);
+        adapter.inner.swap_tools_forwarder(Some(inner_rx)).await;
+        inner_tx.send(()).expect("inner send");
+        assert!(
+            recv_tick(&mut outer_rx, Duration::from_millis(500)).await,
+            "forwarded inner tick must reach the outer broadcast"
+        );
+        assert!(
+            adapter.inner.last_tools_fingerprint.read().await.is_none(),
+            "forwarded inner tick must clear the fingerprint baseline"
+        );
+        drain(&mut outer_rx).await;
+
+        // Re-login reproducing the ORIGINAL tool set A: the baseline is
+        // unknown, so the Some→Some swap must tick even though the probed
+        // set equals the pre-drift baseline.
+        adapter.inner.apply_tokens(make_token_set("second")).await;
+        assert!(
+            recv_tick(&mut outer_rx, Duration::from_millis(500)).await,
+            "re-login after an inner tool change must tick even if the \
+             probed set matches the stale baseline"
         );
         server.abort();
     }

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -1130,14 +1130,18 @@ impl OAuthAdapterInner {
                 if new_fingerprint.is_some() {
                     *self.last_tools_fingerprint.write().await = new_fingerprint;
                 }
-                if should_tick {
-                    let _ = self.outer_tools_changed_tx.send(());
-                }
                 self.transition_to(
                     OAuthState::Authenticated,
                     "tokens applied, inner adapter ready",
                 )
                 .await;
+                // Tick only after the Authenticated transition so a racing
+                // registry rebuild can't read pre-transition health (e.g.
+                // Refreshing→Starting) and cache the new tools with a stale
+                // UNAVAILABLE label; inner+health are already published.
+                if should_tick {
+                    let _ = self.outer_tools_changed_tx.send(());
+                }
             }
             Err(e) => {
                 // Capture inner adapter's health before clearing it

--- a/src/management.rs
+++ b/src/management.rs
@@ -5469,6 +5469,7 @@ async fn list_idp_providers() -> impl IntoResponse {
 /// organization. Returns the discovered metadata (used to compose the SSO URL)
 /// or a ready-to-return `400` response. The SSRF guard inside discovery rejects
 /// internal/loopback hosts unless `allow_insecure` is set.
+#[allow(clippy::result_large_err)] // Err is a ready-to-return axum Response
 async fn validate_org_issuer(
     issuer: &str,
     allow_insecure: bool,
@@ -5490,6 +5491,7 @@ async fn validate_org_issuer(
 /// DCR when a registration endpoint exists), returning the resolved id and which
 /// path produced it. A `422 client_id_required` response is returned when the
 /// IdP supports neither CIMD nor DCR and no explicit `client_id` was supplied.
+#[allow(clippy::result_large_err)] // Err is a ready-to-return axum Response
 async fn resolve_org_client(
     org_client_id: Option<&str>,
     disc: &crate::oauth::discovery::DiscoveryResult,

--- a/tests/mcp_server_integration.rs
+++ b/tests/mcp_server_integration.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use endara_relay::adapter::oauth::{OAuthAdapter, OAuthAdapterConfig};
 use endara_relay::adapter::stdio::{StdioAdapter, StdioConfig};
 use endara_relay::adapter::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
 use endara_relay::config::ProfileConfig;
@@ -8,6 +9,7 @@ use endara_relay::registry::AdapterRegistry;
 use endara_relay::server::{
     build_router, start_server, AppState, MetaToolSchemas, SessionIdentityStore,
 };
+use endara_relay::token_manager::{TokenManager, TokenSet};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -471,5 +473,213 @@ async fn profile_tools_list_excludes_out_of_profile_tools() {
         names.len(),
         3,
         "expected exactly gmail__send_email + 2 meta-tools, got: {names:?}"
+    );
+}
+
+/// Spawn an in-process HTTP MCP upstream that answers `initialize` and serves
+/// one tool (`craft_tool`) on `tools/list`. Stands in for the OAuth-protected
+/// server that only becomes reachable once tokens are applied.
+async fn spawn_oauth_upstream() -> (String, tokio::task::JoinHandle<()>) {
+    use axum::{routing::post, Json, Router};
+
+    async fn handle(Json(body): Json<Value>) -> Json<Value> {
+        let id = body.get("id").cloned().unwrap_or(Value::Null);
+        let method = body.get("method").and_then(|m| m.as_str()).unwrap_or("");
+        match method {
+            "initialize" => Json(json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "serverInfo": {"name": "oauth-upstream", "version": "0.0.1"},
+                },
+            })),
+            "tools/list" => Json(json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": {
+                    "tools": [{
+                        "name": "craft_tool",
+                        "description": "a tool behind OAuth",
+                        "inputSchema": {"type": "object"},
+                    }],
+                },
+            })),
+            _ => Json(json!({"jsonrpc": "2.0", "id": id, "result": {}})),
+        }
+    }
+
+    let router = Router::new().route("/mcp", post(handle));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, router).await.ok();
+    });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    (format!("http://127.0.0.1:{}/mcp", addr.port()), handle)
+}
+
+/// POST `tools/list` to the relay's native MCP route and return the tool names.
+async fn fetch_tool_names(client: &reqwest::Client, addr: SocketAddr) -> Vec<String> {
+    let resp = client
+        .post(format!("http://{}/mcp/tools/list", addr))
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "method": "tools/list",
+            "id": 1
+        }))
+        .send()
+        .await
+        .expect("tools/list request failed");
+    assert!(resp.status().is_success());
+    let body: Value = resp.json().await.unwrap();
+    body["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .map(|t| t["name"].as_str().unwrap().to_string())
+        .collect()
+}
+
+/// End-to-end regression for the reported symptom: an OAuth endpoint whose
+/// inner adapter is not ready (`list_tools` → `Ok(vec![])`) leaves its tools
+/// out of the merged catalog, and the catalog is then cached by the first
+/// `tools/list`. Completing the login (`apply_tokens`) must emit a
+/// tools-changed tick so the registry invalidates the stale cache and fans a
+/// relay-wide `tools_changed` tick out for the endpoint (the client
+/// `list_changed` path) — the next `tools/list` must include the endpoint's
+/// tools without a relay restart.
+///
+/// Fails when the readiness-change tick in `apply_tokens_inner` is reverted:
+/// the relay-wide broadcast never fires and the cached catalog stays empty
+/// for the endpoint.
+#[tokio::test]
+async fn oauth_login_heals_stale_empty_tools_list() {
+    let (upstream_url, _upstream) = spawn_oauth_upstream().await;
+
+    // OAuth adapter with no persisted tokens: initialize() leaves it in
+    // NeedsLogin with no inner transport, so list_tools returns Ok(vec![]).
+    let token_dir = tempfile::tempdir().expect("tempdir");
+    let token_manager = Arc::new(TokenManager::new(token_dir.path().to_path_buf()));
+    let mut oauth = OAuthAdapter::new(
+        OAuthAdapterConfig {
+            endpoint_name: "craft".to_string(),
+            url: upstream_url,
+            token_endpoint_url: "http://127.0.0.1:1/token".to_string(),
+            client_id: "test-client".to_string(),
+            client_secret: None,
+            heartbeat_interval_secs: 30,
+            probe_timeout_secs: 10,
+            probe_failure_threshold: 3,
+            server_type_override: None,
+            allow_insecure_oauth: false,
+            ema: None,
+        },
+        token_manager,
+    );
+    oauth.initialize().await.expect("oauth initialize failed");
+    let oauth_inner = oauth.shared_inner();
+
+    let registry = AdapterRegistry::new();
+    registry
+        .register(
+            "craft".into(),
+            Box::new(oauth),
+            "oauth".into(),
+            None,
+            Some("craft".into()),
+        )
+        .await;
+    registry
+        .register(
+            "other".into(),
+            Box::new(NamedToolAdapter { tool: "probe" }),
+            "stdio".into(),
+            None,
+            Some("other".into()),
+        )
+        .await;
+
+    let registry_arc = Arc::new(registry.clone());
+    let state = AppState {
+        registry: registry.clone(),
+        js_execution_mode: Arc::new(AtomicBool::new(false)),
+        meta_tool_handler: Arc::new(MetaToolHandler::new(registry_arc, Duration::from_secs(30))),
+        profile_registry: Arc::new(ProfileRegistry::new(registry.clone())),
+        oauth_flow_manager: None,
+        token_manager: None,
+        oauth_adapter_inners: None,
+        setup_manager: None,
+        started_at: std::time::Instant::now(),
+        toon_enabled: false,
+        session_identities: Arc::new(std::sync::Mutex::new(SessionIdentityStore::default())),
+        meta_tool_schemas: MetaToolSchemas::new(),
+    };
+    let router = build_router(state);
+    let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
+    let (addr, _handle) = start_server(router, addr)
+        .await
+        .expect("server start failed");
+    let client = reqwest::Client::new();
+
+    // Step 1: tools/list before login — the other endpoint's tool is served,
+    // the OAuth endpoint contributes nothing, and the merged catalog is now
+    // cached in this stale-empty state.
+    let names = fetch_tool_names(&client, addr).await;
+    assert!(
+        names.iter().any(|n| n == "other__probe"),
+        "other endpoint's tool missing before login: {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| n.starts_with("craft__")),
+        "OAuth endpoint must contribute no tools before login: {names:?}"
+    );
+
+    // Step 2: subscribe to the relay-wide tools-changed broadcast BEFORE the
+    // login completes so the tick cannot be missed.
+    let mut tools_changed_rx = registry.subscribe_tools_changed();
+
+    // Step 3: OAuth login completes — tokens applied, inner adapter built
+    // against the upstream (None→Some readiness transition).
+    oauth_inner
+        .apply_tokens(TokenSet {
+            access_token: "test-access".to_string(),
+            refresh_token: None,
+            expires_at: None,
+            token_type: "Bearer".to_string(),
+            scope: None,
+            issued_at: None,
+        })
+        .await;
+
+    // Step 4: the relay-wide broadcast must fire for the endpoint — this is
+    // what drives `notifications/tools/list_changed` to connected clients.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        match tokio::time::timeout(remaining, tools_changed_rx.recv()).await {
+            Ok(Ok(endpoint)) if endpoint == "craft" => break,
+            Ok(Ok(_)) => continue,
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => continue,
+            Ok(Err(e)) => panic!("tools_changed broadcast closed unexpectedly: {e}"),
+            Err(_) => panic!(
+                "relay-wide tools_changed broadcast never fired for the OAuth \
+                 endpoint after apply_tokens (stale-empty catalog would never heal)"
+            ),
+        }
+    }
+
+    // Step 5: the registry invalidates its caches before fanning the tick
+    // out, so the next tools/list must rebuild the catalog and include the
+    // OAuth endpoint's tools.
+    let names = fetch_tool_names(&client, addr).await;
+    assert!(
+        names.iter().any(|n| n == "craft__craft_tool"),
+        "OAuth endpoint's tool missing after login healed the catalog: {names:?}"
+    );
+    assert!(
+        names.iter().any(|n| n == "other__probe"),
+        "other endpoint's tool disappeared after login: {names:?}"
     );
 }


### PR DESCRIPTION
## Problem

MCP clients connected to the relay saw a permanently stale-empty tool catalog for an OAuth endpoint (e.g. Craft) that authenticated *after* the merged catalog was first cached:

1. OAuth adapter's inner connection not ready yet → its tool listing succeeds with zero tools.
2. The registry caches the merged catalog with zero tools for that endpoint.
3. Tokens are later applied and the inner adapter becomes ready, but no tools-changed tick is emitted and no apply-tokens call site invalidates the catalog cache.
4. Clients keep getting zero tools from the merged catalog until a manual Refresh, while the desktop UI (which queries the adapter directly) shows the endpoint Healthy with tools — exactly the reported symptom on v0.1.13-rc.1.

## Fix

`apply_tokens_inner` now emits a synthetic tick on the outer tools-changed channel when inner-adapter **readiness** changes:

- None → Some (login / recovery): tick → registry invalidates caches and pushes `notifications/tools/list_changed` to clients.
- Some → None (token application failure): tick, so the catalog reflects the endpoint going away.
- Some → Some (routine token refresh): **no tick** — avoids notification spam.

## Tests

- 4 regression tests (written first, confirmed failing pre-fix): None→Some tick, Some→None tick, Some→Some silence, registry merged-catalog rebuild on tick.
- End-to-end integration test `oauth_login_heals_stale_empty_tools_list`: real `OAuthAdapter` over the real `/mcp` route; proves the stale-empty catalog heals after `apply_tokens` and the relay-wide tools_changed broadcast fires. Independently verified to fail with the fix reverted.
- Full suite green; the only failures are pre-existing environment-dependent `multi_server_integration` / `tool_listing_integration` cases that fail identically on pristine `main`.
