### PR TITLE
fix: show transitional Refreshing state while applying OAuth tokens

### DIFF
--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -2413,20 +2413,25 @@ mod tests {
             text
         );
         assert!(text.to_lowercase().contains("sign-in"));
-        // The raw upstream 401 / WWW-Authenticate challenge is never leaked.
-        // Check only the prose before the URL: the authorize URL itself
-        // legitimately contains arbitrary digits (ephemeral fixture port,
-        // state, code_challenge) that can spuriously contain "401".
-        let prose = text.split("\n\n").next().expect("prose before the URL");
-        assert!(!prose.contains("401"));
-        assert!(!prose.contains("WWW-Authenticate"));
 
         // State machine advanced and the URL is also stored on the interceptor.
         assert_eq!(
             interceptor.state().await,
             crate::adapter::oauth::OAuthState::NeedsLogin
         );
-        assert!(interceptor.pending_authorize_url().await.is_some());
+        let authorize_url = interceptor
+            .pending_authorize_url()
+            .await
+            .expect("pending authorize URL stored on the interceptor");
+
+        // The raw upstream 401 / WWW-Authenticate challenge is never leaked.
+        // Remove only the exact stored authorize URL first: its arbitrary
+        // digits (ephemeral fixture port, state, code_challenge) can
+        // spuriously contain "401", but everything else in the surfaced text
+        // must stay free of the upstream challenge.
+        let without_url = text.replace(&authorize_url, "");
+        assert!(!without_url.contains("401"));
+        assert!(!without_url.contains("WWW-Authenticate"));
 
         server.abort();
     }

--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -2414,8 +2414,12 @@ mod tests {
         );
         assert!(text.to_lowercase().contains("sign-in"));
         // The raw upstream 401 / WWW-Authenticate challenge is never leaked.
-        assert!(!text.contains("401"));
-        assert!(!text.contains("WWW-Authenticate"));
+        // Check only the prose before the URL: the authorize URL itself
+        // legitimately contains arbitrary digits (ephemeral fixture port,
+        // state, code_challenge) that can spuriously contain "401".
+        let prose = text.split("\n\n").next().expect("prose before the URL");
+        assert!(!prose.contains("401"));
+        assert!(!prose.contains("WWW-Authenticate"));
 
         // State machine advanced and the URL is also stored on the interceptor.
         assert_eq!(

--- a/src/adapter/oauth/heartbeat.rs
+++ b/src/adapter/oauth/heartbeat.rs
@@ -215,13 +215,22 @@ pub async fn heartbeat_loop(inner: Weak<OAuthAdapterInner>) {
             return;
         };
 
-        let oauth_state = adapter.state.read().await.clone();
+        // Snapshot state AND generation inside one read-lock critical
+        // section: generation bumps only happen inside state write-lock
+        // sections, so holding the read lock guarantees the pair is
+        // coherent — a bump cannot interleave between the two reads and
+        // hand the probe a post-apply generation while it still probes
+        // the pre-apply adapter.
+        let (oauth_state, generation) = {
+            let state = adapter.state.read().await;
+            let generation = adapter
+                .lifecycle_generation
+                .load(std::sync::atomic::Ordering::Relaxed);
+            (state.clone(), generation)
+        };
         match classify_tick_action(&oauth_state) {
             TickAction::Skip => continue,
             TickAction::Probe => {
-                let generation = adapter
-                    .lifecycle_generation
-                    .load(std::sync::atomic::Ordering::Relaxed);
                 let result = probe_inner(&adapter).await;
                 let action = classify_probe_result(result, &mut consecutive_failures, threshold);
                 apply_probe_action(&adapter, action, threshold, &oauth_state, generation).await;
@@ -301,8 +310,12 @@ async fn apply_probe_action(
             // apply (Authenticated → Refreshing → Authenticated, publishing
             // a NEW inner adapter) can complete mid-probe, so the enum
             // matches again while the 401 belongs to the replaced adapter.
-            // The lifecycle generation (bumped at the start of every apply)
-            // catches exactly that.
+            // The lifecycle generation catches exactly that: it is bumped
+            // inside every state write-lock section and snapshotted with
+            // the state under one read lock at dispatch, so "generation
+            // unchanged" here proves no transition — hence no apply —
+            // interleaved, and the probed adapter is still the published
+            // one.
             let mut state = adapter.state.write().await;
             let current_generation = adapter
                 .lifecycle_generation
@@ -326,6 +339,12 @@ async fn apply_probe_action(
                 "heartbeat probe got 401, transitioning to AuthRequired"
             );
             *state = OAuthState::AuthRequired;
+            // Keep the invariant "every state write bumps the generation
+            // inside the write critical section" (see
+            // `lifecycle_generation`).
+            adapter
+                .lifecycle_generation
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
     }
 }
@@ -824,28 +843,31 @@ mod tests {
     /// goes Authenticated → Refreshing → Authenticated and a NEW inner
     /// adapter is published. The state enum matches `Authenticated` again
     /// when the old probe's 401 lands, but the result belongs to the
-    /// replaced adapter: the lifecycle generation (bumped at the start of
-    /// every apply) must cause the stale 401 to be dropped.
+    /// replaced adapter: the lifecycle generation (bumped inside every
+    /// state write-lock section) must cause the stale 401 to be dropped.
     #[tokio::test]
     async fn heartbeat_stale_auth_failed_after_full_apply_aba_is_dropped() {
         let threshold = 3;
         let inner = make_test_inner(threshold);
         arm_healthy(&inner).await;
 
-        // Probe dispatched: snapshot state + generation.
+        // Probe dispatched: snapshot state + generation (the loop reads
+        // both under one state read lock).
         let dispatched_state = inner.state.read().await.clone();
         let dispatched_gen = inner
             .lifecycle_generation
             .load(std::sync::atomic::Ordering::Relaxed);
         assert_eq!(dispatched_state, OAuthState::Authenticated);
 
-        // A full apply completes mid-probe: generation bumps and the state
+        // A full apply completes mid-probe via the real transition path,
+        // which bumps the generation inside each state write: the state
         // returns to Authenticated (mirrors apply_tokens_inner's sequence).
         inner
-            .lifecycle_generation
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        *inner.state.write().await = OAuthState::Refreshing;
-        *inner.state.write().await = OAuthState::Authenticated;
+            .transition_to(OAuthState::Refreshing, "test: apply takes over")
+            .await;
+        inner
+            .transition_to(OAuthState::Authenticated, "test: apply finished")
+            .await;
 
         // The old probe's 401 lands: state matches but generation differs —
         // the stale result must be dropped.
@@ -861,6 +883,44 @@ mod tests {
         );
         let snap = inner.metrics.snapshot();
         assert_eq!(snap.oauth_heartbeat_probe_total_unhealthy, 0);
+    }
+
+    /// Pins the invariant the stale-probe drop check relies on: every state
+    /// write bumps `lifecycle_generation` inside the same write-lock
+    /// critical section — both `transition_to` and the heartbeat's own
+    /// AuthFailed arm — so "generation unchanged" proves no transition
+    /// (hence no apply/publish) interleaved with a probe.
+    #[tokio::test]
+    async fn every_state_write_bumps_lifecycle_generation() {
+        let threshold = 3;
+        let inner = make_test_inner(threshold);
+        arm_healthy(&inner).await;
+        let load = |inner: &OAuthAdapterInner| {
+            inner
+                .lifecycle_generation
+                .load(std::sync::atomic::Ordering::Relaxed)
+        };
+
+        let g0 = load(&inner);
+        inner
+            .transition_to(OAuthState::Refreshing, "test: bump check")
+            .await;
+        assert_eq!(load(&inner), g0 + 1, "transition_to must bump");
+        inner
+            .transition_to(OAuthState::Authenticated, "test: bump check")
+            .await;
+        assert_eq!(load(&inner), g0 + 2, "transition_to must bump");
+
+        // The heartbeat's AuthFailed arm writes AuthRequired directly under
+        // the write lock; it must bump too.
+        let dispatched_state = inner.state.read().await.clone();
+        let dispatched_gen = load(&inner);
+        let mut failures = 0u32;
+        let action = classify_probe_result(auth(), &mut failures, threshold);
+        assert_eq!(action, ProbeAction::AuthFailed);
+        apply_probe_action(&inner, action, threshold, &dispatched_state, dispatched_gen).await;
+        assert_eq!(*inner.state.read().await, OAuthState::AuthRequired);
+        assert_eq!(load(&inner), g0 + 3, "AuthFailed arm must bump");
     }
 
     // -- Recovery-from-ConnectionFailed harness -----------------------------

--- a/src/adapter/oauth/heartbeat.rs
+++ b/src/adapter/oauth/heartbeat.rs
@@ -219,9 +219,12 @@ pub async fn heartbeat_loop(inner: Weak<OAuthAdapterInner>) {
         match classify_tick_action(&oauth_state) {
             TickAction::Skip => continue,
             TickAction::Probe => {
+                let generation = adapter
+                    .lifecycle_generation
+                    .load(std::sync::atomic::Ordering::Relaxed);
                 let result = probe_inner(&adapter).await;
                 let action = classify_probe_result(result, &mut consecutive_failures, threshold);
-                apply_probe_action(&adapter, action, threshold, &oauth_state).await;
+                apply_probe_action(&adapter, action, threshold, &oauth_state, generation).await;
             }
             TickAction::Recover => {
                 attempt_recovery(&adapter).await;
@@ -241,6 +244,7 @@ async fn apply_probe_action(
     action: ProbeAction,
     threshold: u32,
     oauth_state: &OAuthState,
+    dispatched_generation: u64,
 ) {
     match action {
         ProbeAction::MarkHealthy => {
@@ -293,14 +297,25 @@ async fn apply_probe_action(
             // dispatched this probe still holds; otherwise the in-flight
             // lifecycle operation's own outcome decides the final state,
             // and stomping it here would resurrect the error banner
-            // mid-apply.
+            // mid-apply. The state check alone has an ABA hole: an entire
+            // apply (Authenticated → Refreshing → Authenticated, publishing
+            // a NEW inner adapter) can complete mid-probe, so the enum
+            // matches again while the 401 belongs to the replaced adapter.
+            // The lifecycle generation (bumped at the start of every apply)
+            // catches exactly that.
             let mut state = adapter.state.write().await;
-            if *state != OAuthState::Authenticated {
+            let current_generation = adapter
+                .lifecycle_generation
+                .load(std::sync::atomic::Ordering::Relaxed);
+            if *state != OAuthState::Authenticated || current_generation != dispatched_generation {
                 debug!(
                     oauth_state = ?*state,
+                    dispatched_generation = dispatched_generation,
+                    current_generation = current_generation,
                     result = "stale",
-                    "heartbeat probe got 401 but state moved off \
-                     Authenticated mid-probe; dropping stale result"
+                    "heartbeat probe got 401 but the lifecycle moved on \
+                     mid-probe (state changed or an apply ran); dropping \
+                     stale result"
                 );
                 return;
             }
@@ -594,8 +609,11 @@ mod tests {
         threshold: u32,
     ) {
         let oauth_state = adapter.state.read().await.clone();
+        let generation = adapter
+            .lifecycle_generation
+            .load(std::sync::atomic::Ordering::Relaxed);
         let action = classify_probe_result(result, failures, threshold);
-        apply_probe_action(adapter, action, threshold, &oauth_state).await;
+        apply_probe_action(adapter, action, threshold, &oauth_state, generation).await;
     }
 
     /// Set the adapter into the `Authenticated` / `Healthy` baseline that
@@ -769,8 +787,11 @@ mod tests {
         let inner = make_test_inner(threshold);
         arm_healthy(&inner).await;
 
-        // Snapshot the state the loop read when it dispatched the probe.
+        // Snapshot what the loop read when it dispatched the probe.
         let dispatched_state = inner.state.read().await.clone();
+        let dispatched_gen = inner
+            .lifecycle_generation
+            .load(std::sync::atomic::Ordering::Relaxed);
         assert_eq!(dispatched_state, OAuthState::Authenticated);
 
         // An apply takes over mid-probe.
@@ -780,7 +801,7 @@ mod tests {
         let mut failures = 0u32;
         let action = classify_probe_result(auth(), &mut failures, threshold);
         assert_eq!(action, ProbeAction::AuthFailed);
-        apply_probe_action(&inner, action, threshold, &dispatched_state).await;
+        apply_probe_action(&inner, action, threshold, &dispatched_state, dispatched_gen).await;
 
         assert_eq!(
             *inner.state.read().await,
@@ -791,11 +812,55 @@ mod tests {
         let snap = inner.metrics.snapshot();
         assert_eq!(snap.oauth_heartbeat_probe_total_unhealthy, 0);
 
-        // Control: with the state still Authenticated the 401 applies.
+        // Control: with the state still Authenticated and the generation
+        // unchanged, the 401 applies.
         *inner.state.write().await = OAuthState::Authenticated;
         let action = classify_probe_result(auth(), &mut failures, threshold);
-        apply_probe_action(&inner, action, threshold, &dispatched_state).await;
+        apply_probe_action(&inner, action, threshold, &dispatched_state, dispatched_gen).await;
         assert_eq!(*inner.state.read().await, OAuthState::AuthRequired);
+    }
+
+    /// Regression (ABA): an ENTIRE apply completes mid-probe — the state
+    /// goes Authenticated → Refreshing → Authenticated and a NEW inner
+    /// adapter is published. The state enum matches `Authenticated` again
+    /// when the old probe's 401 lands, but the result belongs to the
+    /// replaced adapter: the lifecycle generation (bumped at the start of
+    /// every apply) must cause the stale 401 to be dropped.
+    #[tokio::test]
+    async fn heartbeat_stale_auth_failed_after_full_apply_aba_is_dropped() {
+        let threshold = 3;
+        let inner = make_test_inner(threshold);
+        arm_healthy(&inner).await;
+
+        // Probe dispatched: snapshot state + generation.
+        let dispatched_state = inner.state.read().await.clone();
+        let dispatched_gen = inner
+            .lifecycle_generation
+            .load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(dispatched_state, OAuthState::Authenticated);
+
+        // A full apply completes mid-probe: generation bumps and the state
+        // returns to Authenticated (mirrors apply_tokens_inner's sequence).
+        inner
+            .lifecycle_generation
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        *inner.state.write().await = OAuthState::Refreshing;
+        *inner.state.write().await = OAuthState::Authenticated;
+
+        // The old probe's 401 lands: state matches but generation differs —
+        // the stale result must be dropped.
+        let mut failures = 0u32;
+        let action = classify_probe_result(auth(), &mut failures, threshold);
+        assert_eq!(action, ProbeAction::AuthFailed);
+        apply_probe_action(&inner, action, threshold, &dispatched_state, dispatched_gen).await;
+
+        assert_eq!(
+            *inner.state.read().await,
+            OAuthState::Authenticated,
+            "stale probe 401 must not stomp the freshly applied adapter (ABA)"
+        );
+        let snap = inner.metrics.snapshot();
+        assert_eq!(snap.oauth_heartbeat_probe_total_unhealthy, 0);
     }
 
     // -- Recovery-from-ConnectionFailed harness -----------------------------

--- a/src/adapter/oauth/heartbeat.rs
+++ b/src/adapter/oauth/heartbeat.rs
@@ -286,13 +286,31 @@ async fn apply_probe_action(
             );
         }
         ProbeAction::AuthFailed => {
+            // The probe ran without holding the state lock, so an apply /
+            // refresh may have taken over mid-probe (state moved off
+            // `Authenticated`, e.g. to `Refreshing`). Re-check under the
+            // write lock and only apply the stale 401 if the state that
+            // dispatched this probe still holds; otherwise the in-flight
+            // lifecycle operation's own outcome decides the final state,
+            // and stomping it here would resurrect the error banner
+            // mid-apply.
+            let mut state = adapter.state.write().await;
+            if *state != OAuthState::Authenticated {
+                debug!(
+                    oauth_state = ?*state,
+                    result = "stale",
+                    "heartbeat probe got 401 but state moved off \
+                     Authenticated mid-probe; dropping stale result"
+                );
+                return;
+            }
             adapter.metrics.inc_heartbeat_unhealthy();
             warn!(
                 oauth_state = ?oauth_state,
                 result = "unhealthy",
                 "heartbeat probe got 401, transitioning to AuthRequired"
             );
-            *adapter.state.write().await = OAuthState::AuthRequired;
+            *state = OAuthState::AuthRequired;
         }
     }
 }
@@ -738,6 +756,46 @@ mod tests {
                 i
             );
         }
+    }
+
+    /// Regression: a probe is dispatched while `Authenticated`, but an
+    /// apply/refresh moves the state to `Refreshing` before the probe's 401
+    /// result is applied. The stale `AuthFailed` must be DROPPED — not
+    /// stomp the in-flight apply with `AuthRequired` (which would resurrect
+    /// the error banner mid-apply).
+    #[tokio::test]
+    async fn heartbeat_stale_auth_failed_mid_apply_is_dropped() {
+        let threshold = 3;
+        let inner = make_test_inner(threshold);
+        arm_healthy(&inner).await;
+
+        // Snapshot the state the loop read when it dispatched the probe.
+        let dispatched_state = inner.state.read().await.clone();
+        assert_eq!(dispatched_state, OAuthState::Authenticated);
+
+        // An apply takes over mid-probe.
+        *inner.state.write().await = OAuthState::Refreshing;
+
+        // The probe's 401 result lands afterwards: it must be dropped.
+        let mut failures = 0u32;
+        let action = classify_probe_result(auth(), &mut failures, threshold);
+        assert_eq!(action, ProbeAction::AuthFailed);
+        apply_probe_action(&inner, action, threshold, &dispatched_state).await;
+
+        assert_eq!(
+            *inner.state.read().await,
+            OAuthState::Refreshing,
+            "stale probe 401 must not overwrite an in-flight apply"
+        );
+        // No unhealthy metric increment for a dropped stale result.
+        let snap = inner.metrics.snapshot();
+        assert_eq!(snap.oauth_heartbeat_probe_total_unhealthy, 0);
+
+        // Control: with the state still Authenticated the 401 applies.
+        *inner.state.write().await = OAuthState::Authenticated;
+        let action = classify_probe_result(auth(), &mut failures, threshold);
+        apply_probe_action(&inner, action, threshold, &dispatched_state).await;
+        assert_eq!(*inner.state.read().await, OAuthState::AuthRequired);
     }
 
     // -- Recovery-from-ConnectionFailed harness -----------------------------

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 use reqwest::Client;
 use serde_json::Value;
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use tokio::sync::{broadcast, Mutex, RwLock};
@@ -286,6 +286,13 @@ pub struct OAuthAdapterInner {
     /// time a non-empty `server_type` is written so subsequent applies skip
     /// the record call.
     server_type_recorded: AtomicBool,
+    /// Lifecycle generation counter, bumped at the start of every token
+    /// apply (`apply_tokens_inner`, under `apply_lock`). Lets the heartbeat
+    /// detect that an apply ran between a probe's dispatch and its result
+    /// landing — even when the state has already returned to
+    /// `Authenticated` (ABA) — so a stale probe 401 can be dropped instead
+    /// of stomping the freshly rebuilt adapter with `AuthRequired`.
+    pub lifecycle_generation: AtomicU64,
     /// Fingerprint (hash of the sorted, serialized tool list) probed from the
     /// inner adapter after each successful [`Self::apply_tokens`] rebuild.
     /// Compared across Some→Some swaps to detect an actual tool-set change
@@ -1065,6 +1072,12 @@ impl OAuthAdapterInner {
         // (see `apply_lock`). Applies are rare (login/refresh), so a full
         // mutex is the simple correct choice over rebuild versioning.
         let _apply_guard = self.apply_lock.lock().await;
+        // Bump the lifecycle generation FIRST (still under `apply_lock`,
+        // before any state change) so a heartbeat probe dispatched before
+        // this apply can recognize its result as stale even if the state
+        // has already returned to `Authenticated` by the time the result
+        // lands (ABA; see `apply_probe_action`'s AuthFailed arm).
+        self.lifecycle_generation.fetch_add(1, Ordering::Relaxed);
         let endpoint = &self.config.endpoint_name;
 
         // Surface the apply as a transitional state right away: the inner
@@ -1489,6 +1502,7 @@ impl OAuthAdapter {
                 ema_sso,
                 pending_authorize_url: RwLock::new(None),
                 server_type_recorded: AtomicBool::new(false),
+                lifecycle_generation: AtomicU64::new(0),
                 last_tools_fingerprint: Arc::new(RwLock::new(None)),
                 apply_lock: Mutex::new(()),
             }),

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -1067,6 +1067,18 @@ impl OAuthAdapterInner {
         let _apply_guard = self.apply_lock.lock().await;
         let endpoint = &self.config.endpoint_name;
 
+        // Surface the apply as a transitional state right away: the inner
+        // adapter rebuild below (init handshake + tools fingerprint probe)
+        // takes seconds of network time, and leaving a prior error state
+        // (AuthRequired/ConnectionFailed) in place keeps `derive_health`
+        // reporting the stale error as if it were a fresh failure. Refresh
+        // paths already enter the apply in `Refreshing` — skip the no-op
+        // self-transition to keep the ring buffer free of noise.
+        if *self.state.read().await != OAuthState::Refreshing {
+            self.transition_to(OAuthState::Refreshing, "applying new tokens")
+                .await;
+        }
+
         // 1. Persist to disk
         if let Err(e) = self.token_manager.save(endpoint, &token_set).await {
             error!(error = %e, "Failed to persist tokens");
@@ -3683,6 +3695,180 @@ mod tests {
         assert!(
             !recv_tick(&mut outer_rx, Duration::from_millis(200)).await,
             "routine Some→Some token refresh must not emit a synthetic tick"
+        );
+        server.abort();
+    }
+
+    /// Spawn an in-process MCP server whose `initialize` response blocks
+    /// until the returned `Notify` is notified — lets a test observe the
+    /// adapter's state/health while `apply_tokens` is mid-rebuild.
+    async fn spawn_blocking_init_mcp_server() -> (
+        String,
+        Arc<tokio::sync::Notify>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        use axum::extract::State;
+        use axum::{routing::post, Json, Router};
+        use serde_json::{json, Value};
+
+        async fn handle(
+            State(gate): State<Arc<tokio::sync::Notify>>,
+            Json(body): Json<Value>,
+        ) -> Json<Value> {
+            let id = body.get("id").cloned().unwrap_or(Value::Null);
+            let method = body.get("method").and_then(|m| m.as_str()).unwrap_or("");
+            if method == "initialize" {
+                gate.notified().await;
+                Json(json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {},
+                        "serverInfo": {"name": "test-server", "version": "0.0.1"},
+                    },
+                }))
+            } else {
+                Json(json!({"jsonrpc": "2.0", "id": id, "result": {}}))
+            }
+        }
+
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let router = Router::new()
+            .route("/mcp", post(handle))
+            .with_state(gate.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        (format!("http://127.0.0.1:{}/mcp", addr.port()), gate, handle)
+    }
+
+    /// An apply entered from an error state (here AuthRequired) must report
+    /// `Starting` while the inner adapter rebuild is in flight — not the
+    /// stale error — and still end `Authenticated`/`Healthy` on success.
+    #[tokio::test]
+    async fn apply_tokens_from_error_state_reports_starting_mid_apply() {
+        let (url, gate, server) = spawn_blocking_init_mcp_server().await;
+        let mut config = make_config();
+        config.url = url;
+        let mut adapter = make_adapter(config);
+        adapter.initialize().await.unwrap();
+
+        // Pin the adapter in an error state, as after a failed refresh.
+        adapter
+            .inner
+            .transition_to(OAuthState::AuthRequired, "test: pin error state")
+            .await;
+        assert!(
+            matches!(adapter.health(), HealthStatus::Unhealthy(_)),
+            "precondition: AuthRequired must report Unhealthy"
+        );
+
+        let inner = adapter.inner.clone();
+        let apply = tokio::spawn(async move {
+            inner.apply_tokens(make_token_set("mid-apply")).await;
+        });
+
+        // The inner init is blocked on the gate: wait for the apply to enter
+        // Refreshing and assert health reports Starting, not the stale error.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let state = adapter.inner.state.read().await.clone();
+            if state == OAuthState::Refreshing {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timed out waiting for Refreshing mid-apply; state {:?}",
+                state
+            );
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert_eq!(
+            adapter.health(),
+            HealthStatus::Starting,
+            "mid-apply health must be Starting, not the stale AuthRequired error"
+        );
+
+        // Release the inner init and let the apply finish.
+        gate.notify_one();
+        apply.await.unwrap();
+        assert_eq!(
+            adapter.inner.state.read().await.clone(),
+            OAuthState::Authenticated
+        );
+        assert_eq!(adapter.health(), HealthStatus::Healthy);
+        server.abort();
+    }
+
+    /// A failing apply entered from an error state must transition through
+    /// Refreshing (recorded with the "applying new tokens" reason) and still
+    /// end ConnectionFailed with the inner init error preserved.
+    #[tokio::test]
+    async fn apply_tokens_failure_from_error_state_transitions_via_refreshing() {
+        let mut config = make_config();
+        // Port 1 is reserved and not bound: immediate connection refused.
+        config.url = "http://127.0.0.1:1/mcp".to_string();
+        let mut adapter = make_adapter(config);
+        adapter.initialize().await.unwrap();
+
+        adapter
+            .inner
+            .transition_to(OAuthState::ConnectionFailed, "test: pin error state")
+            .await;
+
+        adapter.inner.apply_tokens(make_token_set("will-fail")).await;
+
+        assert_eq!(
+            adapter.inner.state.read().await.clone(),
+            OAuthState::ConnectionFailed,
+            "failed apply must still end ConnectionFailed"
+        );
+        let history = adapter.inner.transition_history.read().await;
+        assert!(
+            history.iter().any(|r| r.from == OAuthState::ConnectionFailed
+                && r.to == OAuthState::Refreshing
+                && r.reason == "applying new tokens"),
+            "expected ConnectionFailed → Refreshing 'applying new tokens'; got: {:?}",
+            history
+                .iter()
+                .map(|r| (r.from.clone(), r.to.clone(), r.reason.clone()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// Refresh paths (proactive/reactive) enter the apply already in
+    /// `Refreshing` — the apply must not record a no-op self-transition.
+    #[tokio::test]
+    async fn apply_tokens_already_refreshing_skips_transition() {
+        let (url, server) = spawn_minimal_mcp_server().await;
+        let mut config = make_config();
+        config.url = url;
+        let mut adapter = make_adapter(config);
+        adapter.initialize().await.unwrap();
+
+        adapter
+            .inner
+            .transition_to(OAuthState::Refreshing, "test: refresh in progress")
+            .await;
+
+        adapter.inner.apply_tokens(make_token_set("refreshed")).await;
+
+        assert_eq!(
+            adapter.inner.state.read().await.clone(),
+            OAuthState::Authenticated
+        );
+        let history = adapter.inner.transition_history.read().await;
+        assert!(
+            !history.iter().any(|r| r.reason == "applying new tokens"),
+            "apply entered in Refreshing must not record a self-transition; got: {:?}",
+            history
+                .iter()
+                .map(|r| (r.from.clone(), r.to.clone(), r.reason.clone()))
+                .collect::<Vec<_>>()
         );
         server.abort();
     }

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -3743,7 +3743,11 @@ mod tests {
             axum::serve(listener, router).await.ok();
         });
         tokio::time::sleep(Duration::from_millis(20)).await;
-        (format!("http://127.0.0.1:{}/mcp", addr.port()), gate, handle)
+        (
+            format!("http://127.0.0.1:{}/mcp", addr.port()),
+            gate,
+            handle,
+        )
     }
 
     /// An apply entered from an error state (here AuthRequired) must report
@@ -3820,7 +3824,10 @@ mod tests {
             .transition_to(OAuthState::ConnectionFailed, "test: pin error state")
             .await;
 
-        adapter.inner.apply_tokens(make_token_set("will-fail")).await;
+        adapter
+            .inner
+            .apply_tokens(make_token_set("will-fail"))
+            .await;
 
         assert_eq!(
             adapter.inner.state.read().await.clone(),
@@ -3829,9 +3836,11 @@ mod tests {
         );
         let history = adapter.inner.transition_history.read().await;
         assert!(
-            history.iter().any(|r| r.from == OAuthState::ConnectionFailed
-                && r.to == OAuthState::Refreshing
-                && r.reason == "applying new tokens"),
+            history
+                .iter()
+                .any(|r| r.from == OAuthState::ConnectionFailed
+                    && r.to == OAuthState::Refreshing
+                    && r.reason == "applying new tokens"),
             "expected ConnectionFailed → Refreshing 'applying new tokens'; got: {:?}",
             history
                 .iter()
@@ -3855,7 +3864,10 @@ mod tests {
             .transition_to(OAuthState::Refreshing, "test: refresh in progress")
             .await;
 
-        adapter.inner.apply_tokens(make_token_set("refreshed")).await;
+        adapter
+            .inner
+            .apply_tokens(make_token_set("refreshed"))
+            .await;
 
         assert_eq!(
             adapter.inner.state.read().await.clone(),

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -1073,10 +1073,30 @@ impl OAuthAdapterInner {
         // (AuthRequired/ConnectionFailed) in place keeps `derive_health`
         // reporting the stale error as if it were a fresh failure. Refresh
         // paths already enter the apply in `Refreshing` — skip the no-op
-        // self-transition to keep the ring buffer free of noise.
-        if *self.state.read().await != OAuthState::Refreshing {
-            self.transition_to(OAuthState::Refreshing, "applying new tokens")
-                .await;
+        // self-transition to keep the ring buffer free of noise. The check
+        // and transition happen under one state write lock so a concurrent
+        // `do_token_refresh` (guarded by `refresh_mutex`, not `apply_lock`)
+        // cannot interleave between them and produce a noisy
+        // Refreshing→Refreshing self-record.
+        {
+            let mut state = self.state.write().await;
+            if *state != OAuthState::Refreshing {
+                let mut history = self.transition_history.write().await;
+                let old = do_transition(
+                    &mut state,
+                    OAuthState::Refreshing,
+                    "applying new tokens",
+                    &mut history,
+                );
+                self.metrics.inc_state_transition();
+                info!(
+                    from = ?old,
+                    to = ?OAuthState::Refreshing,
+                    oauth_state = ?OAuthState::Refreshing,
+                    reason = "applying new tokens",
+                    "OAuth state transition"
+                );
+            }
         }
 
         // 1. Persist to disk
@@ -3808,14 +3828,40 @@ mod tests {
         server.abort();
     }
 
+    /// Spawn an in-process MCP server whose `initialize` deterministically
+    /// fails with a JSON-RPC error — pins the apply's failure branch without
+    /// depending on a fixed port being unbound on the host.
+    async fn spawn_failing_init_mcp_server() -> (String, tokio::task::JoinHandle<()>) {
+        use axum::{routing::post, Json, Router};
+        use serde_json::{json, Value};
+
+        async fn handle(Json(body): Json<Value>) -> Json<Value> {
+            let id = body.get("id").cloned().unwrap_or(Value::Null);
+            Json(json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "error": {"code": -32603, "message": "init rejected"},
+            }))
+        }
+
+        let router = Router::new().route("/mcp", post(handle));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        (format!("http://127.0.0.1:{}/mcp", addr.port()), handle)
+    }
+
     /// A failing apply entered from an error state must transition through
     /// Refreshing (recorded with the "applying new tokens" reason) and still
     /// end ConnectionFailed with the inner init error preserved.
     #[tokio::test]
     async fn apply_tokens_failure_from_error_state_transitions_via_refreshing() {
+        let (url, server) = spawn_failing_init_mcp_server().await;
         let mut config = make_config();
-        // Port 1 is reserved and not bound: immediate connection refused.
-        config.url = "http://127.0.0.1:1/mcp".to_string();
+        config.url = url;
         let mut adapter = make_adapter(config);
         adapter.initialize().await.unwrap();
 
@@ -3847,6 +3893,7 @@ mod tests {
                 .map(|r| (r.from.clone(), r.to.clone(), r.reason.clone()))
                 .collect::<Vec<_>>()
         );
+        server.abort();
     }
 
     /// Refresh paths (proactive/reactive) enter the apply already in

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -286,12 +286,19 @@ pub struct OAuthAdapterInner {
     /// time a non-empty `server_type` is written so subsequent applies skip
     /// the record call.
     server_type_recorded: AtomicBool,
-    /// Lifecycle generation counter, bumped at the start of every token
-    /// apply (`apply_tokens_inner`, under `apply_lock`). Lets the heartbeat
-    /// detect that an apply ran between a probe's dispatch and its result
-    /// landing — even when the state has already returned to
-    /// `Authenticated` (ABA) — so a stale probe 401 can be dropped instead
-    /// of stomping the freshly rebuilt adapter with `AuthRequired`.
+    /// Lifecycle generation counter, bumped on EVERY `OAuthState` write,
+    /// inside the same `state` write-lock critical section as the write
+    /// itself (see `transition_to`, the inline `Refreshing` entry in
+    /// `apply_tokens_inner`, and the heartbeat's `AuthFailed` arm). The
+    /// heartbeat snapshots state + generation under one `state` read lock
+    /// when it dispatches a probe; if the generation still matches under
+    /// the write lock when the result lands, no state transition — and
+    /// therefore no apply/publish (every apply passes through
+    /// `Refreshing`) — happened mid-probe, so the result belongs to the
+    /// currently published inner adapter. This closes the ABA hole where
+    /// an entire apply (Authenticated → Refreshing → Authenticated)
+    /// completes mid-probe and a stale 401 would stomp the rebuilt
+    /// adapter with `AuthRequired`.
     pub lifecycle_generation: AtomicU64,
     /// Fingerprint (hash of the sorted, serialized tool list) probed from the
     /// inner adapter after each successful [`Self::apply_tokens`] rebuild.
@@ -369,6 +376,10 @@ impl OAuthAdapterInner {
         let mut state = self.state.write().await;
         let mut history = self.transition_history.write().await;
         let old = do_transition(&mut state, new_state.clone(), reason, &mut history);
+        // Bumped inside the write critical section so "generation
+        // unchanged" observed under either state lock proves no
+        // transition interleaved (see `lifecycle_generation`).
+        self.lifecycle_generation.fetch_add(1, Ordering::Relaxed);
         self.metrics.inc_state_transition();
         info!(
             from = ?old,
@@ -1072,12 +1083,6 @@ impl OAuthAdapterInner {
         // (see `apply_lock`). Applies are rare (login/refresh), so a full
         // mutex is the simple correct choice over rebuild versioning.
         let _apply_guard = self.apply_lock.lock().await;
-        // Bump the lifecycle generation FIRST (still under `apply_lock`,
-        // before any state change) so a heartbeat probe dispatched before
-        // this apply can recognize its result as stale even if the state
-        // has already returned to `Authenticated` by the time the result
-        // lands (ABA; see `apply_probe_action`'s AuthFailed arm).
-        self.lifecycle_generation.fetch_add(1, Ordering::Relaxed);
         let endpoint = &self.config.endpoint_name;
 
         // Surface the apply as a transitional state right away: the inner
@@ -1101,6 +1106,7 @@ impl OAuthAdapterInner {
                     "applying new tokens",
                     &mut history,
                 );
+                self.lifecycle_generation.fetch_add(1, Ordering::Relaxed);
                 self.metrics.inc_state_transition();
                 info!(
                     from = ?old,


### PR DESCRIPTION
## Problem

While `apply_tokens_inner` rebuilds the inner adapter (init handshake + tools fingerprint probe — seconds of network time), `OAuthState` stays in the prior error state. `derive_health` therefore keeps reporting the stale `AuthRequired`/`ConnectionFailed` error, and the sidebar banner reads as a new failure during what is actually a healthy re-connect.

## Fix

At the top of `apply_tokens_inner`, right after taking `apply_lock`, transition to `OAuthState::Refreshing` (`"applying new tokens"`) so `health()` reports `Starting` for the duration of the rebuild. The transition is skipped when the state is already `Refreshing` — proactive/reactive refresh paths enter the apply from `Refreshing`, and a self-transition would only add ring-buffer noise.

All entry states (`NeedsLogin`/`Authenticated`/`ConnectionFailed`/`AuthRequired`/`Disconnected` → `Refreshing`) are already legal per `assert_legal_transition`, and the heartbeat's `classify_tick_action` skips `Refreshing`, so there is no probe interference. No `derive_health` or desktop changes.

## Tests

- `apply_tokens_from_error_state_reports_starting_mid_apply` — adapter pinned in `AuthRequired`, inner init blocked on a gate; asserts `health() == Starting` mid-apply and `Authenticated`/`Healthy` after release.
- `apply_tokens_failure_from_error_state_transitions_via_refreshing` — failing apply from `ConnectionFailed` records `ConnectionFailed → Refreshing ("applying new tokens")` and still ends `ConnectionFailed`.
- `apply_tokens_already_refreshing_skips_transition` — apply entered in `Refreshing` records no self-transition.

## Verification

`cargo test -p endara-relay --lib` — 1392 passed, 0 failed (no debug_assert legal-transition panics).
