### PR TITLE
feat: force-consent re-authorization (oauth/reset) + Google access_type=offline

### DIFF
--- a/src/adapter/oauth/heartbeat.rs
+++ b/src/adapter/oauth/heartbeat.rs
@@ -161,7 +161,7 @@ fn classify_tick_action(state: &OAuthState) -> TickAction {
 async fn attempt_recovery(adapter: &Arc<OAuthAdapterInner>) {
     match adapter.do_token_refresh().await {
         Ok(tokens) => {
-            adapter.apply_tokens(tokens).await;
+            adapter.apply_refreshed_tokens(tokens).await;
         }
         Err(e) => {
             debug!(

--- a/src/adapter/oauth/jit.rs
+++ b/src/adapter/oauth/jit.rs
@@ -291,6 +291,13 @@ impl JitInterceptor {
             urlencoding(&state_param),
             urlencoding(&code_challenge),
         );
+        // Google needs `access_type=offline` for a refresh token (shared
+        // helper); a JIT-initiated Google grant is access-token-only
+        // without it.
+        crate::oauth::append_google_authorize_params(
+            &mut authorize_url,
+            &disc.authorization_endpoint,
+        );
         // Scope accumulation for step-up authorization: when this endpoint
         // already has a persisted token with a granted scope, request the
         // UNION of previously-granted scopes and the scopes we'd request today

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -14,7 +14,7 @@ use crate::oauth::client::ENDARA_CLIENT_METADATA_URL;
 use crate::oauth::discovery::{discover_oauth_server, DiscoveryResult};
 use crate::oauth::ema::{self, EmaError};
 use crate::oauth::{OAuthError, OAuthFlowManager, PkceChallenge};
-use crate::token_manager::{TokenManager, TokenSet};
+use crate::token_manager::{TokenError, TokenManager, TokenSet};
 use async_trait::async_trait;
 use reqwest::Client;
 use serde_json::Value;
@@ -823,7 +823,7 @@ impl OAuthAdapterInner {
             '?'
         };
         let scope = ema::compose_idp_scope(ema.resource_scope.as_deref(), true);
-        let authorize_url = format!(
+        let mut authorize_url = format!(
             "{}{}response_type=code&client_id={}&redirect_uri={}&state={}&code_challenge={}&code_challenge_method=S256&scope={}",
             ema.idp_authorization_endpoint,
             sep,
@@ -832,6 +832,12 @@ impl OAuthAdapterInner {
             form_urlencode(&state_param),
             form_urlencode(&code_challenge),
             form_urlencode(&scope),
+        );
+        // Google needs `access_type=offline` for a refresh token (shared
+        // helper); a Google-fronted IdP grant is access-token-only without it.
+        crate::oauth::append_google_authorize_params(
+            &mut authorize_url,
+            &ema.idp_authorization_endpoint,
         );
         info!(
             endpoint = %self.config.endpoint_name,
@@ -1055,16 +1061,39 @@ impl OAuthAdapterInner {
         self: &Arc<Self>,
         token_set: TokenSet,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
-        Box::pin(self.apply_tokens_inner(token_set))
+        Box::pin(self.apply_tokens_inner(token_set, false))
     }
 
-    async fn apply_tokens_inner(self: &Arc<Self>, token_set: TokenSet) {
+    /// Apply a token set produced by REFRESHING the current grant (proactive
+    /// timer, reactive 401, heartbeat recovery, manual `/oauth/refresh`).
+    /// Unlike [`Self::apply_tokens`], this refuses to commit when the grant
+    /// was discarded (disconnect / reset) after the refresh's network
+    /// exchange started: `disconnect()` clears the in-memory tokens under
+    /// the same `apply_lock`, so a refresh commit that acquires the lock
+    /// after a disconnect observes `tokens == None` and drops its result
+    /// instead of resurrecting the discarded grant on disk. Callback logins
+    /// (a NEW grant) must keep using `apply_tokens` — they legitimately
+    /// apply while no tokens exist.
+    pub fn apply_refreshed_tokens(
+        self: &Arc<Self>,
+        token_set: TokenSet,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+        Box::pin(self.apply_tokens_inner(token_set, true))
+    }
+
+    async fn apply_tokens_inner(self: &Arc<Self>, token_set: TokenSet, refresh_of_current: bool) {
         // Serialize the whole apply: callback, proactive refresh, and
         // reactive refresh may overlap, and interleaved applies could pair
         // the published adapter with another apply's fingerprint baseline
         // (see `apply_lock`). Applies are rare (login/refresh), so a full
         // mutex is the simple correct choice over rebuild versioning.
         let _apply_guard = self.apply_lock.lock().await;
+        if refresh_of_current && self.tokens.read().await.is_none() {
+            warn!(
+                "Dropping refreshed tokens: grant was discarded (disconnect/reset) while the refresh was in flight"
+            );
+            return;
+        }
         let endpoint = &self.config.endpoint_name;
 
         // 1. Persist to disk
@@ -1247,7 +1276,7 @@ impl OAuthAdapterInner {
                 match inner.do_token_refresh().await {
                     Ok(new_tokens) => {
                         // Recursively apply — this will schedule the next refresh
-                        inner.apply_tokens(new_tokens).await;
+                        inner.apply_refreshed_tokens(new_tokens).await;
                         // Defensive: if the recursive apply_tokens ever
                         // returns while still in `Refreshing`, surface a
                         // loud warn-log so a future regression is not
@@ -1276,7 +1305,7 @@ impl OAuthAdapterInner {
                         }
                         match inner.do_token_refresh().await {
                             Ok(new_tokens) => {
-                                inner.apply_tokens(new_tokens).await;
+                                inner.apply_refreshed_tokens(new_tokens).await;
                                 let state = inner.state.read().await.clone();
                                 if matches!(state, OAuthState::Refreshing) {
                                     warn!(
@@ -1351,8 +1380,21 @@ impl OAuthAdapterInner {
         *handle_guard = Some(join.abort_handle());
     }
 
-    /// Disconnect: abort refresh task, clear tokens, delete from disk, set Disconnected.
-    pub async fn disconnect(self: &Arc<Self>) {
+    /// Disconnect: abort refresh task, clear tokens, delete from disk, set
+    /// Disconnected. Returns `Err` when the persisted tokens could not be
+    /// deleted from disk — the grant then survives a restart, so callers
+    /// (revoke / reset) must surface the failure instead of reporting a
+    /// clean disconnect. DCR-record deletion failures are logged but do not
+    /// fail the disconnect: the record holds client credentials, not the
+    /// grant.
+    pub async fn disconnect(self: &Arc<Self>) -> Result<(), TokenError> {
+        // Serialize against a token apply: a refresh whose network exchange
+        // already succeeded commits (persist + rebuild) under this same
+        // lock, so acquiring it here means no refresh is mid-commit while
+        // we tear down — and a refresh commit that acquires it after us
+        // observes the cleared in-memory tokens and drops its result (see
+        // `apply_tokens_inner`) instead of resurrecting the grant.
+        let _apply_guard = self.apply_lock.lock().await;
         let endpoint = &self.config.endpoint_name;
 
         // Abort refresh task
@@ -1378,8 +1420,9 @@ impl OAuthAdapterInner {
         // Clear in-memory tokens
         *self.tokens.write().await = None;
 
-        // Delete tokens from disk
-        if let Err(e) = self.token_manager.delete(endpoint).await {
+        // Delete tokens from disk (propagated to the caller on failure)
+        let delete_result = self.token_manager.delete(endpoint).await;
+        if let Err(ref e) = delete_result {
             error!(error = %e, "Failed to delete tokens from disk");
         }
 
@@ -1391,6 +1434,8 @@ impl OAuthAdapterInner {
         // Set state
         self.transition_to(OAuthState::Disconnected, "user disconnected")
             .await;
+
+        delete_result
     }
 }
 
@@ -1527,7 +1572,7 @@ impl McpAdapter for OAuthAdapter {
                     *self.inner.tokens.write().await = Some(token_set);
                     match self.inner.do_token_refresh().await {
                         Ok(new_tokens) => {
-                            self.inner.apply_tokens(new_tokens).await;
+                            self.inner.apply_refreshed_tokens(new_tokens).await;
                         }
                         Err(e) => {
                             warn!(
@@ -1586,7 +1631,7 @@ impl McpAdapter for OAuthAdapter {
 
                             match self.inner.do_token_refresh().await {
                                 Ok(new_tokens) => {
-                                    self.inner.apply_tokens(new_tokens).await;
+                                    self.inner.apply_refreshed_tokens(new_tokens).await;
                                     // Retry with new token
                                     let guard = self.inner.inner_adapter.read().await;
                                     match guard.as_ref() {
@@ -1741,7 +1786,7 @@ impl McpAdapter for OAuthAdapter {
 
                 match refresh_result {
                     Ok(new_tokens) => {
-                        self.inner.apply_tokens(new_tokens).await;
+                        self.inner.apply_refreshed_tokens(new_tokens).await;
                         // Retry with new token — again in caller's span so
                         // the inner adapter sees the per-request scope.
                         let guard = self.inner.inner_adapter.read().await;
@@ -2338,7 +2383,7 @@ mod tests {
         assert_eq!(loaded.unwrap().access_token, "test-access");
 
         // Disconnect
-        adapter.inner.disconnect().await;
+        adapter.inner.disconnect().await.unwrap();
         assert_eq!(adapter.health(), HealthStatus::Stopped);
 
         // Verify tokens are deleted from disk
@@ -2348,6 +2393,74 @@ mod tests {
         // Verify in-memory tokens cleared
         let tokens = adapter.inner.tokens.read().await;
         assert!(tokens.is_none());
+    }
+
+    /// Reset-vs-refresh race (PR #145 review): a refresh whose network
+    /// exchange finished BEFORE the reset's disconnect must not commit its
+    /// tokens afterwards — `apply_refreshed_tokens` observes the cleared
+    /// in-memory tokens under the `apply_lock` and drops the result instead
+    /// of resurrecting the discarded grant on disk.
+    #[tokio::test]
+    async fn refreshed_tokens_dropped_after_disconnect() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let config = make_config();
+        let mut adapter = OAuthAdapter::new(config, tm.clone());
+        adapter.initialize().await.unwrap();
+
+        let token_set = TokenSet {
+            access_token: "old-access".to_string(),
+            refresh_token: Some("old-refresh".to_string()),
+            expires_at: None,
+            token_type: "Bearer".to_string(),
+            scope: None,
+            issued_at: None,
+        };
+        adapter.inner.apply_tokens(token_set).await;
+        assert!(tm.load("test").await.unwrap().is_some());
+
+        // The reset's disconnect lands first.
+        adapter.inner.disconnect().await.unwrap();
+        assert!(tm.load("test").await.unwrap().is_none());
+
+        // A refresh that raced the disconnect now tries to commit its
+        // result: it must be dropped, not persisted.
+        let refreshed = TokenSet {
+            access_token: "refreshed-access".to_string(),
+            refresh_token: Some("refreshed-refresh".to_string()),
+            expires_at: None,
+            token_type: "Bearer".to_string(),
+            scope: None,
+            issued_at: None,
+        };
+        adapter.inner.apply_refreshed_tokens(refreshed).await;
+
+        assert!(
+            tm.load("test").await.unwrap().is_none(),
+            "post-disconnect refresh commit must not resurrect the grant on disk"
+        );
+        assert!(adapter.inner.tokens.read().await.is_none());
+
+        // A NEW grant (callback login after the replacement start flow, which
+        // moves the endpoint back out of Disconnected) still applies from the
+        // clean slate.
+        adapter
+            .inner
+            .transition_to(OAuthState::NeedsLogin, "test: replacement start flow")
+            .await;
+        let new_grant = TokenSet {
+            access_token: "new-access".to_string(),
+            refresh_token: None,
+            expires_at: None,
+            token_type: "Bearer".to_string(),
+            scope: None,
+            issued_at: None,
+        };
+        adapter.inner.apply_tokens(new_grant).await;
+        assert_eq!(
+            tm.load("test").await.unwrap().unwrap().access_token,
+            "new-access"
+        );
     }
 
     #[test]

--- a/src/management.rs
+++ b/src/management.rs
@@ -2390,6 +2390,20 @@ async fn oauth_reset(
         }
     };
 
+    // Invalidate pending flows for this endpoint and bump its reset
+    // generation BEFORE disconnecting: an authorize URL handed out by a
+    // pre-reset `/oauth/start` stays valid for up to FLOW_MAX_AGE, and its
+    // late callback would otherwise complete after the disconnect and
+    // clobber the reset with the pre-reset grant. The generation bump also
+    // covers callbacks already consumed and mid token exchange — the
+    // callback handler refuses to commit a flow from a stale generation.
+    if let Some(ref flow_mgr) = state.oauth_flow_manager {
+        let removed = flow_mgr.invalidate_endpoint(&name).await;
+        if removed > 0 {
+            info!(endpoint = %name, removed, "Reset: invalidated pending OAuth flows");
+        }
+    }
+
     // Snapshot the client registration before disconnect: `disconnect()`
     // deletes the DCR record along with the tokens, but reset must only
     // discard the grant. Desktop-created DCR endpoints keep the

--- a/src/management.rs
+++ b/src/management.rs
@@ -1219,10 +1219,31 @@ struct OAuthRefreshResponse {
     refreshed_at: Option<u64>,
 }
 
+/// Optional query parameters for POST /api/endpoints/:name/oauth/start.
+#[derive(Deserialize, Default)]
+struct OAuthStartQuery {
+    /// When `true`, append `prompt=consent` to the authorize URL so the
+    /// provider re-shows its consent screen instead of silently reusing the
+    /// prior grant. Non-OIDC providers ignore unknown parameters, so this is
+    /// safe to send everywhere.
+    #[serde(default)]
+    force_consent: bool,
+}
+
 /// POST /api/endpoints/:name/oauth/start
 ///
 /// Generates a PKCE challenge, registers a pending flow, and returns the
 /// authorization URL that the user should open in a browser.
+async fn oauth_start(
+    State(state): State<ManagementState>,
+    Path(name): Path<String>,
+    Query(query): Query<OAuthStartQuery>,
+) -> impl IntoResponse {
+    oauth_start_inner(state, name, query.force_consent).await
+}
+
+/// Shared implementation of the auth-start flow, used by `oauth_start` and by
+/// `oauth_reset` (which forces consent).
 ///
 /// Resolution order:
 /// 1. If `oauth_server_url` is in config, derive endpoints from convention.
@@ -1231,10 +1252,13 @@ struct OAuthRefreshResponse {
 ///    credentials → if missing/expired + registration_endpoint available,
 ///    attempt dynamic client registration → if DCR fails/unavailable, return
 ///    `dcr_unsupported` so the UI can prompt for manual credentials.
-async fn oauth_start(
-    State(state): State<ManagementState>,
-    Path(name): Path<String>,
-) -> impl IntoResponse {
+///
+/// `force_consent` appends `prompt=consent` to the composed authorize URL.
+async fn oauth_start_inner(
+    state: ManagementState,
+    name: String,
+    force_consent: bool,
+) -> axum::response::Response {
     use crate::oauth::dcr;
     use crate::oauth::discovery;
 
@@ -1760,6 +1784,22 @@ async fn oauth_start(
         urlencoding(&code_challenge),
     );
 
+    // Forced consent ("Reset authorization"): `prompt=consent` makes OIDC
+    // providers re-show the consent screen instead of silently reusing the
+    // prior grant. Non-OIDC providers ignore unknown parameters, so this is
+    // safe to append unconditionally when requested.
+    if force_consent {
+        authorize_url.push_str("&prompt=consent");
+    }
+
+    // Google's authorization server only issues a refresh token when
+    // `access_type=offline` is requested — without it every grant is
+    // access-token-only and proactive refresh is impossible. Other providers
+    // ignore the unknown parameter, but scope it to Google to avoid noise.
+    if is_google_authorization_endpoint(&authorization_endpoint) {
+        authorize_url.push_str("&access_type=offline");
+    }
+
     // Scope accumulation for step-up authorization: union the scopes we'd
     // request today (config scopes) with any previously-granted scopes from a
     // persisted TokenSet, so re-authorizing for more access never drops scopes
@@ -2135,6 +2175,21 @@ fn urlencoding(s: &str) -> String {
     url::form_urlencoded::byte_serialize(s.as_bytes()).collect()
 }
 
+/// True when an authorize URL targets Google's authorization server
+/// (`accounts.google.com`), which requires `access_type=offline` for a
+/// refresh token to be issued (see `oauth_start_inner`). Host comparison
+/// only — a lookalike host like `accounts.google.com.evil.test` does not
+/// match.
+fn is_google_authorization_endpoint(authorization_endpoint: &str) -> bool {
+    url::Url::parse(authorization_endpoint)
+        .ok()
+        .and_then(|u| {
+            u.host_str()
+                .map(|h| h.eq_ignore_ascii_case("accounts.google.com"))
+        })
+        .unwrap_or(false)
+}
+
 /// GET /api/endpoints/:name/oauth/status
 ///
 /// Returns detailed OAuth status for the endpoint including token info.
@@ -2286,6 +2341,57 @@ async fn oauth_revoke(
         endpoint: name,
     })
     .into_response()
+}
+
+/// POST /api/endpoints/:name/oauth/reset
+///
+/// "Reset authorization": discard the old grant and force a fresh consent
+/// screen. Sequencing: disconnect the OAuth adapter first (best-effort
+/// upstream revocation + local token/DCR deletion — the same path as
+/// `/oauth/revoke`), then start a new authorization flow with
+/// `force_consent`, returning the composed `authorize_url`.
+async fn oauth_reset(
+    State(state): State<ManagementState>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    // Verify endpoint exists in registry
+    {
+        let entries = state.registry.entries().read().await;
+        if !entries.contains_key(&name) {
+            return endpoint_not_found(&name).into_response();
+        }
+    }
+
+    let Some(ref inners) = state.oauth_adapter_inners else {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "endpoint is not configured for OAuth",
+            Some("No OAuth adapter inners available"),
+        )
+        .into_response();
+    };
+
+    let inner = {
+        let inners_guard = inners.read().await;
+        match inners_guard.get(&name) {
+            Some(inner) => inner.clone(),
+            None => {
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    "endpoint is not configured for OAuth",
+                    Some(&format!("Endpoint '{}' is not an OAuth endpoint", name)),
+                )
+                .into_response();
+            }
+        }
+    };
+
+    // Discard the old grant (upstream revoke is best-effort inside
+    // disconnect) BEFORE composing the new authorize URL, so the start flow
+    // sees a clean slate.
+    inner.disconnect().await;
+
+    oauth_start_inner(state, name, true).await
 }
 
 /// POST /api/endpoints/:name/oauth/refresh
@@ -5532,6 +5638,7 @@ pub fn management_routes(state: ManagementState) -> Router {
         )
         .route("/api/endpoints/{name}/oauth/status", get(oauth_status))
         .route("/api/endpoints/{name}/oauth/revoke", post(oauth_revoke))
+        .route("/api/endpoints/{name}/oauth/reset", post(oauth_reset))
         .route("/api/endpoints/{name}/oauth/refresh", post(oauth_refresh))
         .route("/api/endpoints/{name}/oauth/metrics", get(oauth_metrics))
         // OAuth capability probe (add-time)
@@ -8817,6 +8924,126 @@ command = "echo"
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
+    /// Reset sequencing: disconnect (tokens deleted, state → Disconnected)
+    /// happens first, then a fresh start flow with forced consent returns an
+    /// authorize URL containing prompt=consent.
+    #[tokio::test]
+    async fn oauth_reset_disconnects_then_returns_consent_url() {
+        // Mock AS for the post-disconnect start flow.
+        async fn well_known(headers: axum::http::HeaderMap) -> Json<Value> {
+            let base = mock_issuer(&headers);
+            Json(serde_json::json!({
+                "issuer": base,
+                "authorization_endpoint": format!("{}/authorize", base),
+                "token_endpoint": format!("{}/token", base),
+                "code_challenge_methods_supported": ["S256"],
+            }))
+        }
+        let router =
+            Router::new().route("/.well-known/oauth-authorization-server", get(well_known));
+        let (base_url, _server) = spawn_mock_as(router).await;
+
+        // Config half: endpoint "oauth-ep" with oauth_server_url → mock AS.
+        let (start_state, _flow_mgr) = test_state_oauth_start("oauth-ep", &base_url, None);
+
+        // Adapter half: a live OAuth inner with persisted tokens.
+        let tmp = tempfile::tempdir().unwrap();
+        let token_manager = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let token_set = crate::token_manager::TokenSet {
+            access_token: "old-access".to_string(),
+            refresh_token: Some("old-refresh".to_string()),
+            expires_at: None,
+            token_type: "Bearer".to_string(),
+            scope: None,
+            issued_at: None,
+        };
+        token_manager.save("oauth-ep", &token_set).await.unwrap();
+        let adapter = OAuthAdapter::new(make_oauth_config("oauth-ep"), token_manager.clone());
+        let shared_inner = adapter.shared_inner();
+        *shared_inner.state.write().await = OAuthState::Authenticated;
+        let oauth_inners: OAuthAdapterInners =
+            Arc::new(RwLock::new(std::collections::HashMap::new()));
+        oauth_inners
+            .write()
+            .await
+            .insert("oauth-ep".to_string(), shared_inner.clone());
+        let registry = AdapterRegistry::new();
+        registry
+            .register(
+                "oauth-ep".to_string(),
+                Box::new(adapter),
+                "oauth".to_string(),
+                None,
+                None,
+            )
+            .await;
+
+        let state = ManagementState {
+            registry: Arc::new(registry),
+            oauth_adapter_inners: Some(oauth_inners),
+            token_manager: Some(token_manager.clone()),
+            ..start_state
+        };
+
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/oauth-ep/oauth/reset")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let authorize_url = body["authorize_url"].as_str().unwrap();
+        assert!(
+            authorize_url.contains("&prompt=consent"),
+            "reset must force consent, got: {}",
+            authorize_url
+        );
+
+        // Disconnect ran before the start flow: local tokens are gone and
+        // the adapter is Disconnected.
+        assert_eq!(*shared_inner.state.read().await, OAuthState::Disconnected);
+        assert!(token_manager.load("oauth-ep").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn oauth_reset_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (state, _inner) = test_state_with_oauth("oauth-ep", tmp.path()).await;
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/nonexistent/oauth/reset")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn oauth_reset_not_oauth_endpoint() {
+        // Non-OAuth endpoint with no adapter inners
+        let state = test_state(vec![("echo", MockAdapter::healthy_with_tools(vec![]))]).await;
+        let app = management_routes(state);
+
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/echo/oauth/reset")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+
     #[tokio::test]
     async fn oauth_refresh_needs_login_rejected() {
         let tmp = tempfile::tempdir().unwrap();
@@ -10980,6 +11207,155 @@ command = "echo"
         // No discovery metadata on the fallback path.
         assert!(body.get("discovery").is_none() || body["discovery"].is_null());
     }
+
+    #[test]
+    fn google_authorization_endpoint_detection() {
+        assert!(is_google_authorization_endpoint(
+            "https://accounts.google.com/o/oauth2/v2/auth"
+        ));
+        assert!(is_google_authorization_endpoint(
+            "https://ACCOUNTS.GOOGLE.COM/o/oauth2/v2/auth"
+        ));
+        // Lookalike hosts must not match.
+        assert!(!is_google_authorization_endpoint(
+            "https://accounts.google.com.evil.test/auth"
+        ));
+        assert!(!is_google_authorization_endpoint(
+            "https://auth.example.com/authorize"
+        ));
+        assert!(!is_google_authorization_endpoint("not a url"));
+    }
+
+    /// Mock AS whose metadata is served locally; the discovered
+    /// authorization_endpoint is NOT Google, so no access_type=offline.
+    async fn spawn_plain_as() -> (String, tokio::task::JoinHandle<()>) {
+        async fn well_known(headers: axum::http::HeaderMap) -> Json<Value> {
+            let base = mock_issuer(&headers);
+            Json(serde_json::json!({
+                "issuer": base,
+                "authorization_endpoint": format!("{}/authorize", base),
+                "token_endpoint": format!("{}/token", base),
+                "code_challenge_methods_supported": ["S256"],
+            }))
+        }
+        let router =
+            Router::new().route("/.well-known/oauth-authorization-server", get(well_known));
+        spawn_mock_as(router).await
+    }
+
+    #[tokio::test]
+    async fn oauth_start_force_consent_appends_prompt_consent() {
+        let (base_url, _server) = spawn_plain_as().await;
+        let (state, _flow_mgr) = test_state_oauth_start("ep1", &base_url, None);
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/ep1/oauth/start?force_consent=true")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let authorize_url = body["authorize_url"].as_str().unwrap();
+        assert!(
+            authorize_url.contains("&prompt=consent"),
+            "force_consent=true must append prompt=consent, got: {}",
+            authorize_url
+        );
+        // Non-Google AS: no access_type=offline.
+        assert!(
+            !authorize_url.contains("access_type=offline"),
+            "non-Google AS must not get access_type=offline, got: {}",
+            authorize_url
+        );
+    }
+
+    #[tokio::test]
+    async fn oauth_start_regular_has_no_prompt_consent() {
+        // Regular Authorize / Re-authorize is unchanged: no forced consent.
+        let (base_url, _server) = spawn_plain_as().await;
+        let (state, _flow_mgr) = test_state_oauth_start("ep1", &base_url, None);
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/ep1/oauth/start")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let authorize_url = body["authorize_url"].as_str().unwrap();
+        assert!(
+            !authorize_url.contains("prompt=consent"),
+            "regular start must not force consent, got: {}",
+            authorize_url
+        );
+    }
+
+    #[tokio::test]
+    async fn oauth_start_google_as_appends_access_type_offline() {
+        // Mock AS metadata pointing the authorization_endpoint at Google's
+        // AS: access_type=offline must be appended even WITHOUT
+        // force_consent, so Google issues a refresh token.
+        async fn well_known(headers: axum::http::HeaderMap) -> Json<Value> {
+            let base = mock_issuer(&headers);
+            Json(serde_json::json!({
+                "issuer": base,
+                "authorization_endpoint": "https://accounts.google.com/o/oauth2/v2/auth",
+                "token_endpoint": format!("{}/token", base),
+                "code_challenge_methods_supported": ["S256"],
+            }))
+        }
+        let router =
+            Router::new().route("/.well-known/oauth-authorization-server", get(well_known));
+        let (base_url, _server) = spawn_mock_as(router).await;
+
+        let (state, _flow_mgr) = test_state_oauth_start("ep1", &base_url, None);
+        let app = management_routes(state);
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/api/endpoints/ep1/oauth/start")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let authorize_url = body["authorize_url"].as_str().unwrap();
+        assert!(
+            authorize_url.starts_with("https://accounts.google.com/o/oauth2/v2/auth?"),
+            "expected Google authorization endpoint, got: {}",
+            authorize_url
+        );
+        assert!(
+            authorize_url.contains("&access_type=offline"),
+            "Google AS must get access_type=offline, got: {}",
+            authorize_url
+        );
+        assert!(!authorize_url.contains("prompt=consent"));
+
+        // With force_consent both parameters are present.
+        let resp = app
+            .oneshot(
+                Request::post("/api/endpoints/ep1/oauth/start?force_consent=true")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let authorize_url = body["authorize_url"].as_str().unwrap();
+        assert!(authorize_url.contains("&prompt=consent"));
+        assert!(authorize_url.contains("&access_type=offline"));
+    }
+
 
     #[tokio::test]
     async fn oauth_start_with_oauth_server_url_errors_on_transient_discovery_failure() {

--- a/src/management.rs
+++ b/src/management.rs
@@ -2346,10 +2346,14 @@ async fn oauth_revoke(
 /// POST /api/endpoints/:name/oauth/reset
 ///
 /// "Reset authorization": discard the old grant and force a fresh consent
-/// screen. Sequencing: disconnect the OAuth adapter first (best-effort
-/// upstream revocation + local token/DCR deletion — the same path as
-/// `/oauth/revoke`), then start a new authorization flow with
-/// `force_consent`, returning the composed `authorize_url`.
+/// screen. Sequencing: disconnect the OAuth adapter first (local token
+/// deletion via the same `disconnect()` path as `/oauth/revoke` — upstream
+/// RFC 7009 revocation rides along once `disconnect()` gains it), then start
+/// a new authorization flow with `force_consent`, returning the composed
+/// `authorize_url`. Unlike `/oauth/revoke`, the client registration (DCR
+/// record) is preserved across the reset: only the grant is discarded, so
+/// the follow-up start flow can reuse the registered client instead of
+/// losing a secret that exists nowhere else.
 async fn oauth_reset(
     State(state): State<ManagementState>,
     Path(name): Path<String>,
@@ -2386,10 +2390,27 @@ async fn oauth_reset(
         }
     };
 
-    // Discard the old grant (upstream revoke is best-effort inside
-    // disconnect) BEFORE composing the new authorize URL, so the start flow
-    // sees a clean slate.
+    // Snapshot the client registration before disconnect: `disconnect()`
+    // deletes the DCR record along with the tokens, but reset must only
+    // discard the grant. Desktop-created DCR endpoints keep the
+    // client_secret solely in that record, and manually supplied
+    // credentials live only there — losing it would break the one-step
+    // reset (no secret / `dcr_unsupported` on providers without DCR).
+    let preserved_dcr = match state.token_manager {
+        Some(ref tm) => tm.load_dcr(&name).await.ok().flatten(),
+        None => None,
+    };
+
+    // Discard the old grant BEFORE composing the new authorize URL, so the
+    // start flow sees a clean slate.
     inner.disconnect().await;
+
+    // Restore the client registration so the start flow reuses it.
+    if let (Some(tm), Some(ref creds)) = (state.token_manager.as_ref(), preserved_dcr.as_ref()) {
+        if let Err(e) = tm.save_dcr(&name, creds).await {
+            warn!(endpoint = %name, error = %e, "Reset: failed to restore client registration after disconnect");
+        }
+    }
 
     oauth_start_inner(state, name, true).await
 }
@@ -8944,7 +8965,11 @@ command = "echo"
         let (base_url, _server) = spawn_mock_as(router).await;
 
         // Config half: endpoint "oauth-ep" with oauth_server_url → mock AS.
+        // Clear the config client_id: the credentials live ONLY in the DCR
+        // record (the manually-supplied-credentials shape), so a reset that
+        // dropped the record would come back `dcr_unsupported`.
         let (start_state, _flow_mgr) = test_state_oauth_start("oauth-ep", &base_url, None);
+        start_state.config.write().await.endpoints[0].client_id = None;
 
         // Adapter half: a live OAuth inner with persisted tokens.
         let tmp = tempfile::tempdir().unwrap();
@@ -8958,6 +8983,18 @@ command = "echo"
             issued_at: None,
         };
         token_manager.save("oauth-ep", &token_set).await.unwrap();
+        // Manually supplied client credentials, stored only in the DCR
+        // record: reset must preserve them (only the grant is discarded).
+        let manual_creds = DcrCredentials {
+            client_id: "manual-client".to_string(),
+            client_secret: Some("manual-secret".to_string()),
+            registered_via_dcr: false,
+            ..Default::default()
+        };
+        token_manager
+            .save_dcr("oauth-ep", &manual_creds)
+            .await
+            .unwrap();
         let adapter = OAuthAdapter::new(make_oauth_config("oauth-ep"), token_manager.clone());
         let shared_inner = adapter.shared_inner();
         *shared_inner.state.write().await = OAuthState::Authenticated;
@@ -9007,6 +9044,21 @@ command = "echo"
         // the adapter is Disconnected.
         assert_eq!(*shared_inner.state.read().await, OAuthState::Disconnected);
         assert!(token_manager.load("oauth-ep").await.unwrap().is_none());
+
+        // ...but the client registration survives the reset, and the new
+        // authorize URL was built with the preserved client_id.
+        let creds = token_manager
+            .load_dcr("oauth-ep")
+            .await
+            .unwrap()
+            .expect("client registration must be preserved across reset");
+        assert_eq!(creds.client_id, "manual-client");
+        assert_eq!(creds.client_secret.as_deref(), Some("manual-secret"));
+        assert!(
+            authorize_url.contains("client_id=manual-client"),
+            "start flow must reuse the preserved client registration, got: {}",
+            authorize_url
+        );
     }
 
     #[tokio::test]

--- a/src/management.rs
+++ b/src/management.rs
@@ -2420,7 +2420,7 @@ async fn oauth_reset(
     inner.disconnect().await;
 
     // Restore the client registration so the start flow reuses it.
-    if let (Some(tm), Some(ref creds)) = (state.token_manager.as_ref(), preserved_dcr.as_ref()) {
+    if let (Some(tm), Some(creds)) = (state.token_manager.as_ref(), preserved_dcr.as_ref()) {
         if let Err(e) = tm.save_dcr(&name, creds).await {
             warn!(endpoint = %name, error = %e, "Reset: failed to restore client registration after disconnect");
         }
@@ -3251,6 +3251,14 @@ async fn oauth_setup(
                 urlencoding(&code_challenge),
             );
 
+            // Google only issues a refresh token when `access_type=offline`
+            // is requested (see `oauth_start_inner`); setup-created Google
+            // endpoints need it too or their very first grant is
+            // access-token-only.
+            if is_google_authorization_endpoint(&auth_endpoint) {
+                authorize_url.push_str("&access_type=offline");
+            }
+
             // Scope accumulation: union any previously-granted scopes (from a
             // persisted TokenSet for this name) with the requested scopes.
             let requested_scope = scopes_str.clone().unwrap_or_default();
@@ -3426,6 +3434,13 @@ async fn oauth_setup_credentials(
         urlencoding(&state_param),
         urlencoding(&code_challenge),
     );
+
+    // Google only issues a refresh token when `access_type=offline` is
+    // requested (see `oauth_start_inner`); the manual-credentials setup path
+    // needs it too or the very first grant is access-token-only.
+    if is_google_authorization_endpoint(&auth_endpoint) {
+        authorize_url.push_str("&access_type=offline");
+    }
 
     // Scope accumulation: union previously-granted scopes (from a persisted
     // TokenSet for this endpoint) with the requested scopes for step-up.
@@ -8988,12 +9003,15 @@ command = "echo"
         // Adapter half: a live OAuth inner with persisted tokens.
         let tmp = tempfile::tempdir().unwrap();
         let token_manager = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        // The old grant carries a scope: if the start half ran BEFORE the
+        // disconnect, scope accumulation would merge it into the new
+        // authorize URL — its absence below proves the ordering.
         let token_set = crate::token_manager::TokenSet {
             access_token: "old-access".to_string(),
             refresh_token: Some("old-refresh".to_string()),
             expires_at: None,
             token_type: "Bearer".to_string(),
-            scope: None,
+            scope: Some("pre-reset-scope".to_string()),
             issued_at: None,
         };
         token_manager.save("oauth-ep", &token_set).await.unwrap();
@@ -9058,6 +9076,15 @@ command = "echo"
         // the adapter is Disconnected.
         assert_eq!(*shared_inner.state.read().await, OAuthState::Disconnected);
         assert!(token_manager.load("oauth-ep").await.unwrap().is_none());
+
+        // Ordering proof: had the start half run before the disconnect,
+        // scope accumulation would have merged the old grant's scope into
+        // the new authorize URL.
+        assert!(
+            !authorize_url.contains("pre-reset-scope"),
+            "old grant's scope leaked into the reset URL — start ran before disconnect: {}",
+            authorize_url
+        );
 
         // ...but the client registration survives the reset, and the new
         // authorize URL was built with the preserved client_id.

--- a/src/management.rs
+++ b/src/management.rs
@@ -2390,6 +2390,23 @@ async fn oauth_reset(
         }
     };
 
+    // Serialize the whole discard (generation bump + disconnect + DCR
+    // restore) against the callback's commit phase: the callback holds this
+    // same per-endpoint lock from its post-exchange generation check through
+    // its token save / adapter apply, so a callback mid-commit either
+    // finishes before we bump (and its tokens are wiped by the disconnect
+    // below) or checks the generation after our bump and refuses to commit.
+    // Without it a callback that passed its check could persist the
+    // pre-reset grant AFTER our disconnect, undoing the reset.
+    let commit_guard = match state.oauth_flow_manager {
+        Some(ref flow_mgr) => Some(flow_mgr.commit_lock(&name).await),
+        None => None,
+    };
+    let _commit_guard = match commit_guard {
+        Some(ref lock) => Some(lock.lock().await),
+        None => None,
+    };
+
     // Invalidate pending flows for this endpoint and bump its reset
     // generation BEFORE disconnecting: an authorize URL handed out by a
     // pre-reset `/oauth/start` stays valid for up to FLOW_MAX_AGE, and its
@@ -2425,6 +2442,11 @@ async fn oauth_reset(
             warn!(endpoint = %name, error = %e, "Reset: failed to restore client registration after disconnect");
         }
     }
+
+    // Release before starting the replacement flow: `oauth_start_inner`
+    // performs discovery (network) and must not hold the commit lock.
+    drop(_commit_guard);
+    drop(commit_guard);
 
     oauth_start_inner(state, name, true).await
 }

--- a/src/management.rs
+++ b/src/management.rs
@@ -23,7 +23,9 @@ use crate::adapter::{FailedAdapter, HealthStatus, McpAdapter, StartingAdapter};
 use crate::config::{Config, ObservabilityConfig};
 use crate::events::ToolCallEventBus;
 use crate::oauth::client::{self, ClientRegistration};
-use crate::oauth::{OAuthFlowManager, OAuthSetupManager, PkceChallenge};
+use crate::oauth::{
+    append_google_authorize_params, OAuthFlowManager, OAuthSetupManager, PkceChallenge,
+};
 use crate::observability::payloads::StoredPayloads;
 use crate::observability::store::{AggregateBucket, CallRecord, QueryFilter};
 use crate::profile_registry::ProfileRegistry;
@@ -1814,13 +1816,9 @@ async fn oauth_start_inner(
         authorize_url.push_str("&prompt=consent");
     }
 
-    // Google's authorization server only issues a refresh token when
-    // `access_type=offline` is requested — without it every grant is
-    // access-token-only and proactive refresh is impossible. Other providers
-    // ignore the unknown parameter, but scope it to Google to avoid noise.
-    if is_google_authorization_endpoint(&authorization_endpoint) {
-        authorize_url.push_str("&access_type=offline");
-    }
+    // Google needs `access_type=offline` for a refresh token to be issued
+    // (shared helper — see `crate::oauth::append_google_authorize_params`).
+    append_google_authorize_params(&mut authorize_url, &authorization_endpoint);
 
     // Scope accumulation for step-up authorization: union the scopes we'd
     // request today (config scopes) with any previously-granted scopes from a
@@ -2197,21 +2195,6 @@ fn urlencoding(s: &str) -> String {
     url::form_urlencoded::byte_serialize(s.as_bytes()).collect()
 }
 
-/// True when an authorize URL targets Google's authorization server
-/// (`accounts.google.com`), which requires `access_type=offline` for a
-/// refresh token to be issued (see `oauth_start_inner`). Host comparison
-/// only — a lookalike host like `accounts.google.com.evil.test` does not
-/// match.
-fn is_google_authorization_endpoint(authorization_endpoint: &str) -> bool {
-    url::Url::parse(authorization_endpoint)
-        .ok()
-        .and_then(|u| {
-            u.host_str()
-                .map(|h| h.eq_ignore_ascii_case("accounts.google.com"))
-        })
-        .unwrap_or(false)
-}
-
 /// GET /api/endpoints/:name/oauth/status
 ///
 /// Returns detailed OAuth status for the endpoint including token info.
@@ -2356,7 +2339,17 @@ async fn oauth_revoke(
     drop(inners_guard);
 
     // Call disconnect (aborts refresh task, clears tokens, deletes from disk)
-    inner.disconnect().await;
+    if let Err(e) = inner.disconnect().await {
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to delete tokens from disk",
+            Some(&format!(
+                "The grant would survive a relay restart; retry the revoke. ({})",
+                e
+            )),
+        )
+        .into_response();
+    }
 
     Json(OAuthRevokeResponse {
         status: "disconnected".to_string(),
@@ -2455,8 +2448,20 @@ async fn oauth_reset(
     };
 
     // Discard the old grant BEFORE composing the new authorize URL, so the
-    // start flow sees a clean slate.
-    inner.disconnect().await;
+    // start flow sees a clean slate. A failed local deletion fails the
+    // whole reset: reporting success while the old token file survives on
+    // disk would silently restore the discarded grant on the next restart.
+    if let Err(e) = inner.disconnect().await {
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to delete tokens from disk",
+            Some(&format!(
+                "Reset aborted: the old grant would survive a relay restart; retry the reset. ({})",
+                e
+            )),
+        )
+        .into_response();
+    }
 
     // Restore the client registration so the start flow reuses it.
     if let (Some(tm), Some(creds)) = (state.token_manager.as_ref(), preserved_dcr.as_ref()) {
@@ -2534,7 +2539,7 @@ async fn oauth_refresh(
         Ok(new_tokens) => {
             let expires_at = new_tokens.expires_at;
             let refreshed_at = new_tokens.issued_at;
-            inner.apply_tokens(new_tokens).await;
+            inner.apply_refreshed_tokens(new_tokens).await;
 
             let status = {
                 let s = inner.state.read().await;
@@ -3295,13 +3300,10 @@ async fn oauth_setup(
                 urlencoding(&code_challenge),
             );
 
-            // Google only issues a refresh token when `access_type=offline`
-            // is requested (see `oauth_start_inner`); setup-created Google
-            // endpoints need it too or their very first grant is
-            // access-token-only.
-            if is_google_authorization_endpoint(&auth_endpoint) {
-                authorize_url.push_str("&access_type=offline");
-            }
+            // Google needs `access_type=offline` for a refresh token
+            // (shared helper); setup-created Google endpoints need it too or
+            // their very first grant is access-token-only.
+            append_google_authorize_params(&mut authorize_url, &auth_endpoint);
 
             // Scope accumulation: union any previously-granted scopes (from a
             // persisted TokenSet for this name) with the requested scopes.
@@ -3479,12 +3481,10 @@ async fn oauth_setup_credentials(
         urlencoding(&code_challenge),
     );
 
-    // Google only issues a refresh token when `access_type=offline` is
-    // requested (see `oauth_start_inner`); the manual-credentials setup path
-    // needs it too or the very first grant is access-token-only.
-    if is_google_authorization_endpoint(&auth_endpoint) {
-        authorize_url.push_str("&access_type=offline");
-    }
+    // Google needs `access_type=offline` for a refresh token (shared
+    // helper); the manual-credentials setup path needs it too or the very
+    // first grant is access-token-only.
+    append_google_authorize_params(&mut authorize_url, &auth_endpoint);
 
     // Scope accumulation: union previously-granted scopes (from a persisted
     // TokenSet for this endpoint) with the requested scopes for step-up.
@@ -6020,7 +6020,7 @@ async fn compose_org_sso_url(
     } else {
         '?'
     };
-    format!(
+    let mut authorize_url = format!(
         "{}{}response_type=code&client_id={}&redirect_uri={}&state={}&code_challenge={}&code_challenge_method=S256&scope={}",
         disc.authorization_endpoint,
         sep,
@@ -6029,7 +6029,11 @@ async fn compose_org_sso_url(
         urlencoding(&state_param),
         urlencoding(&code_challenge),
         urlencoding("openid offline_access"),
-    )
+    );
+    // Google needs `access_type=offline` for a refresh token (shared helper);
+    // a Google-fronted org SSO grant is access-token-only without it.
+    append_google_authorize_params(&mut authorize_url, &disc.authorization_endpoint);
+    authorize_url
 }
 
 /// Persist the updated organization list back to `config.toml`, preserving the
@@ -11346,6 +11350,7 @@ command = "echo"
 
     #[test]
     fn google_authorization_endpoint_detection() {
+        use crate::oauth::is_google_authorization_endpoint;
         assert!(is_google_authorization_endpoint(
             "https://accounts.google.com/o/oauth2/v2/auth"
         ));
@@ -11440,12 +11445,21 @@ command = "echo"
         // flow under the bumped generation and hand out an authorize URL
         // without the reset's prompt=consent. The start must fail with 409
         // superseded_by_reset and leave no pending flow behind.
+        // Two-step handshake, immune to lost wakeups on slow CI runners:
+        // `entered_tx` tells the test the discovery request ARRIVED (the
+        // start already sampled generation 0 — sampling precedes discovery),
+        // and `gate.notify_one()` stores a permit, so the release completes
+        // the handler's `notified().await` even if it parks afterwards.
         let gate = Arc::new(tokio::sync::Notify::new());
+        let (entered_tx, mut entered_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
         let gate_srv = gate.clone();
         let well_known = move |headers: axum::http::HeaderMap| {
             let gate = gate_srv.clone();
+            let entered_tx = entered_tx.clone();
             async move {
-                // Block discovery until the test has performed the reset.
+                // Signal arrival, then block discovery until the test has
+                // performed the reset.
+                let _ = entered_tx.send(());
                 gate.notified().await;
                 let base = mock_issuer(&headers);
                 Json(serde_json::json!({
@@ -11474,12 +11488,16 @@ command = "echo"
             .await
             .unwrap()
         });
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        // Wait until discovery is in flight (generation already sampled).
+        tokio::time::timeout(std::time::Duration::from_secs(30), entered_rx.recv())
+            .await
+            .expect("discovery request never arrived")
+            .expect("entered_tx dropped");
 
         // The reset lands mid-discovery: bump the generation (there is no
         // pending flow yet, so nothing is removed), then release discovery.
         assert_eq!(flow_mgr.invalidate_endpoint("ep1").await, 0);
-        gate.notify_waiters();
+        gate.notify_one();
 
         let resp = start_task.await.unwrap();
         assert_eq!(resp.status(), StatusCode::CONFLICT);

--- a/src/management.rs
+++ b/src/management.rs
@@ -9043,7 +9043,6 @@ command = "echo"
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
-
     #[tokio::test]
     async fn oauth_refresh_needs_login_rejected() {
         let tmp = tempfile::tempdir().unwrap();
@@ -11355,7 +11354,6 @@ command = "echo"
         assert!(authorize_url.contains("&prompt=consent"));
         assert!(authorize_url.contains("&access_type=offline"));
     }
-
 
     #[tokio::test]
     async fn oauth_start_with_oauth_server_url_errors_on_transient_discovery_failure() {

--- a/src/management.rs
+++ b/src/management.rs
@@ -1289,6 +1289,15 @@ async fn oauth_start_inner(
 
     let redirect_uri = format!("http://127.0.0.1:{}/oauth/callback", state.relay_port);
 
+    // Sample the endpoint's reset generation BEFORE the network-bound
+    // discovery/DCR work below. A "Reset authorization" that lands while
+    // this start is mid-discovery cannot invalidate it (no pending flow
+    // exists yet), so the flow registration at Step 3 re-checks this value
+    // and refuses the insert if a reset bumped it — otherwise this start
+    // would hand out a post-reset-valid authorize URL WITHOUT the reset's
+    // `prompt=consent`, silently reusing the old provider grant.
+    let start_generation = flow_mgr.generation(&name).await;
+
     // ── Step 1: Resolve OAuth server metadata ──────────────────────────
     let (
         authorization_endpoint,
@@ -1761,8 +1770,9 @@ async fn oauth_start_inner(
     let pkce = PkceChallenge::generate();
     let code_challenge = pkce.code_challenge.clone();
 
-    let state_param = flow_mgr
-        .start_flow(
+    let Some(state_param) = flow_mgr
+        .start_flow_if_current(
+            start_generation,
             &name,
             &token_endpoint,
             &client_id,
@@ -1772,7 +1782,19 @@ async fn oauth_start_inner(
             issuer.as_deref(),
             iss_supported,
         )
-        .await;
+        .await
+    else {
+        // A reset landed while this start was mid-discovery: this start
+        // predates the reset, so its URL must not be handed out (it lacks
+        // the reset's forced consent). The reset's own follow-up start is
+        // the authoritative one.
+        return error_response(
+            StatusCode::CONFLICT,
+            "superseded_by_reset",
+            Some("Authorization was reset while this start was in progress; use the reset's authorize URL or retry"),
+        )
+        .into_response();
+    };
 
     // ── Step 4: Build authorization URL ────────────────────────────────
     let mut authorize_url = format!(
@@ -11407,6 +11429,68 @@ command = "echo"
             !authorize_url.contains("prompt=consent"),
             "regular start must not force consent, got: {}",
             authorize_url
+        );
+    }
+
+    #[tokio::test]
+    async fn oauth_start_superseded_by_reset_during_discovery() {
+        // The discovery-phase race Copilot flagged: a /oauth/start that began
+        // BEFORE a reset is not pending yet while it does discovery, so
+        // invalidate_endpoint cannot remove it. It must not later register a
+        // flow under the bumped generation and hand out an authorize URL
+        // without the reset's prompt=consent. The start must fail with 409
+        // superseded_by_reset and leave no pending flow behind.
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let gate_srv = gate.clone();
+        let well_known = move |headers: axum::http::HeaderMap| {
+            let gate = gate_srv.clone();
+            async move {
+                // Block discovery until the test has performed the reset.
+                gate.notified().await;
+                let base = mock_issuer(&headers);
+                Json(serde_json::json!({
+                    "issuer": base,
+                    "authorization_endpoint": format!("{}/authorize", base),
+                    "token_endpoint": format!("{}/token", base),
+                    "code_challenge_methods_supported": ["S256"],
+                }))
+            }
+        };
+        let router =
+            Router::new().route("/.well-known/oauth-authorization-server", get(well_known));
+        let (base_url, _server) = spawn_mock_as(router).await;
+
+        let (state, flow_mgr) = test_state_oauth_start("ep1", &base_url, None);
+        let app = management_routes(state);
+
+        // Start the pre-reset /oauth/start; it samples generation 0 at entry
+        // and then parks inside discovery on the gate.
+        let start_task = tokio::spawn(async move {
+            app.oneshot(
+                Request::post("/api/endpoints/ep1/oauth/start")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // The reset lands mid-discovery: bump the generation (there is no
+        // pending flow yet, so nothing is removed), then release discovery.
+        assert_eq!(flow_mgr.invalidate_endpoint("ep1").await, 0);
+        gate.notify_waiters();
+
+        let resp = start_task.await.unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        let body = body_json(resp).await;
+        assert_eq!(body["error"], "superseded_by_reset");
+
+        // No flow was registered for the superseded start.
+        assert_eq!(
+            flow_mgr.invalidate_endpoint("ep1").await,
+            0,
+            "superseded start must not leave a pending flow"
         );
     }
 

--- a/src/oauth/mod.rs
+++ b/src/oauth/mod.rs
@@ -12,6 +12,7 @@ pub mod url_guard;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 use uuid::Uuid;
@@ -133,6 +134,11 @@ pub struct OAuthFlowManager {
     /// Per-endpoint reset generation counters (absent entry == generation 0).
     /// Bumped by [`invalidate_endpoint`](Self::invalidate_endpoint).
     generations: RwLock<HashMap<String, u64>>,
+    /// Per-endpoint commit locks serializing a callback's token commit
+    /// (post-exchange generation check + token save + adapter apply)
+    /// against a "Reset authorization" (generation bump + disconnect).
+    /// See [`commit_lock`](Self::commit_lock).
+    commit_locks: tokio::sync::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
 }
 
 impl OAuthFlowManager {
@@ -140,6 +146,7 @@ impl OAuthFlowManager {
         Self {
             pending: RwLock::new(HashMap::new()),
             generations: RwLock::new(HashMap::new()),
+            commit_locks: tokio::sync::Mutex::new(HashMap::new()),
         }
     }
 
@@ -160,6 +167,12 @@ impl OAuthFlowManager {
         iss_parameter_supported: bool,
     ) -> String {
         let state = generate_state();
+        // Hold the generations read lock through the pending insert so
+        // `invalidate_endpoint` (generations write → pending write) cannot
+        // bump the generation between sampling and insertion — that would
+        // hand the caller an authorize URL whose callback is guaranteed to
+        // be rejected as stale. Same lock order as `invalidate_endpoint`.
+        let generations = self.generations.read().await;
         let flow = PendingFlow {
             endpoint_name: endpoint_name.to_string(),
             code_verifier: pkce.code_verifier,
@@ -172,9 +185,10 @@ impl OAuthFlowManager {
             idp_issuer: None,
             idp_credential_key: None,
             created_at: Instant::now(),
-            generation: self.current_generation(endpoint_name).await,
+            generation: *generations.get(endpoint_name).unwrap_or(&0),
         };
         self.pending.write().await.insert(state.clone(), flow);
+        drop(generations);
         state
     }
 
@@ -208,6 +222,8 @@ impl OAuthFlowManager {
         idp_credential_key: &str,
     ) -> String {
         let state = generate_state();
+        // Generations read lock held through the insert — see `start_flow`.
+        let generations = self.generations.read().await;
         let flow = PendingFlow {
             endpoint_name: endpoint_name.to_string(),
             code_verifier: pkce.code_verifier,
@@ -220,9 +236,10 @@ impl OAuthFlowManager {
             idp_issuer: Some(idp_issuer.to_string()),
             idp_credential_key: Some(idp_credential_key.to_string()),
             created_at: Instant::now(),
-            generation: self.current_generation(endpoint_name).await,
+            generation: *generations.get(endpoint_name).unwrap_or(&0),
         };
         self.pending.write().await.insert(state.clone(), flow);
+        drop(generations);
         state
     }
 
@@ -272,6 +289,23 @@ impl OAuthFlowManager {
     /// a callback from a pre-reset flow cannot clobber the reset.
     pub async fn is_current(&self, flow: &PendingFlow) -> bool {
         flow.generation == self.current_generation(&flow.endpoint_name).await
+    }
+
+    /// The endpoint's commit lock. `/oauth/callback` holds it across its
+    /// post-exchange generation check AND the token save / adapter apply;
+    /// "Reset authorization" holds it across the generation bump +
+    /// disconnect. This closes the time-of-check/time-of-use window where a
+    /// reset lands after the callback's generation check but before its
+    /// commit finishes — with the lock, either the commit completes first
+    /// (and the reset then wipes the freshly saved tokens) or the reset
+    /// completes first (and the callback's check sees the stale generation).
+    pub async fn commit_lock(&self, endpoint_name: &str) -> Arc<tokio::sync::Mutex<()>> {
+        self.commit_locks
+            .lock()
+            .await
+            .entry(endpoint_name.to_string())
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
     }
 
     /// Test-only: re-insert a flow under a chosen state key, preserving its

--- a/src/oauth/mod.rs
+++ b/src/oauth/mod.rs
@@ -82,6 +82,34 @@ pub fn generate_state() -> String {
     URL_SAFE_NO_PAD.encode(bytes)
 }
 
+/// True when an authorize URL targets Google's authorization server
+/// (`accounts.google.com`), which requires `access_type=offline` for a
+/// refresh token to be issued. Host comparison only — a lookalike host like
+/// `accounts.google.com.evil.test` does not match.
+pub fn is_google_authorization_endpoint(authorization_endpoint: &str) -> bool {
+    url::Url::parse(authorization_endpoint)
+        .ok()
+        .and_then(|u| {
+            u.host_str()
+                .map(|h| h.eq_ignore_ascii_case("accounts.google.com"))
+        })
+        .unwrap_or(false)
+}
+
+/// Append Google-specific authorization parameters to a composed authorize
+/// URL. Google's authorization server only issues a refresh token when
+/// `access_type=offline` is requested — without it every grant is
+/// access-token-only and proactive refresh is impossible. Other providers
+/// ignore the unknown parameter, but it is scoped to Google to avoid noise.
+/// Shared by every authorize-URL builder (management start/setup, JIT, EMA
+/// IdP SSO, org SSO) so no path hands out a Google grant without it. The URL
+/// must already carry at least one query parameter (`&` separator).
+pub fn append_google_authorize_params(authorize_url: &mut String, authorization_endpoint: &str) {
+    if is_google_authorization_endpoint(authorization_endpoint) {
+        authorize_url.push_str("&access_type=offline");
+    }
+}
+
 /// Maximum age for a pending OAuth flow before it's considered stale.
 const FLOW_MAX_AGE: Duration = Duration::from_secs(600); // 10 minutes
 
@@ -740,6 +768,34 @@ mod tests {
         hasher.update(pkce.code_verifier.as_bytes());
         let expected = URL_SAFE_NO_PAD.encode(hasher.finalize());
         assert_eq!(pkce.code_challenge, expected);
+    }
+
+    #[test]
+    fn append_google_authorize_params_scoped_to_google_host() {
+        // Google host: access_type=offline appended (case-insensitive host).
+        let mut url = "https://accounts.google.com/o/oauth2/v2/auth?response_type=code".to_string();
+        append_google_authorize_params(&mut url, "https://accounts.google.com/o/oauth2/v2/auth");
+        assert!(url.ends_with("&access_type=offline"));
+
+        let mut url = "https://ACCOUNTS.GOOGLE.COM/auth?response_type=code".to_string();
+        append_google_authorize_params(&mut url, "https://ACCOUNTS.GOOGLE.COM/auth");
+        assert!(url.ends_with("&access_type=offline"));
+
+        // Non-Google and lookalike hosts: untouched.
+        for endpoint in [
+            "https://auth.example.com/authorize",
+            "https://accounts.google.com.evil.test/auth",
+            "not a url",
+        ] {
+            let mut url = format!("{}?response_type=code", endpoint);
+            let before = url.clone();
+            append_google_authorize_params(&mut url, endpoint);
+            assert_eq!(
+                url, before,
+                "non-Google endpoint must be untouched: {}",
+                endpoint
+            );
+        }
     }
 
     #[test]

--- a/src/oauth/mod.rs
+++ b/src/oauth/mod.rs
@@ -117,18 +117,29 @@ pub struct PendingFlow {
     /// falls back to `idp_issuer` as the key.
     pub idp_credential_key: Option<String>,
     pub created_at: Instant,
+    /// Per-endpoint reset generation this flow was started under. A
+    /// "Reset authorization" bumps the endpoint's generation (see
+    /// [`OAuthFlowManager::invalidate_endpoint`]); the `/oauth/callback`
+    /// commit path refuses flows from an older generation so a pre-reset
+    /// callback — even one already past `consume_flow` and mid token
+    /// exchange — cannot clobber the reset.
+    pub generation: u64,
 }
 
 /// In-memory map holding pending OAuth flows. One entry per in-progress login.
 /// Entries are created by `/oauth/start` and consumed by `/oauth/callback`.
 pub struct OAuthFlowManager {
     pending: RwLock<HashMap<String, PendingFlow>>,
+    /// Per-endpoint reset generation counters (absent entry == generation 0).
+    /// Bumped by [`invalidate_endpoint`](Self::invalidate_endpoint).
+    generations: RwLock<HashMap<String, u64>>,
 }
 
 impl OAuthFlowManager {
     pub fn new() -> Self {
         Self {
             pending: RwLock::new(HashMap::new()),
+            generations: RwLock::new(HashMap::new()),
         }
     }
 
@@ -161,6 +172,7 @@ impl OAuthFlowManager {
             idp_issuer: None,
             idp_credential_key: None,
             created_at: Instant::now(),
+            generation: self.current_generation(endpoint_name).await,
         };
         self.pending.write().await.insert(state.clone(), flow);
         state
@@ -208,6 +220,7 @@ impl OAuthFlowManager {
             idp_issuer: Some(idp_issuer.to_string()),
             idp_credential_key: Some(idp_credential_key.to_string()),
             created_at: Instant::now(),
+            generation: self.current_generation(endpoint_name).await,
         };
         self.pending.write().await.insert(state.clone(), flow);
         state
@@ -222,6 +235,50 @@ impl OAuthFlowManager {
             return None;
         }
         Some(flow)
+    }
+
+    /// The endpoint's current reset generation (0 until first invalidation).
+    async fn current_generation(&self, endpoint_name: &str) -> u64 {
+        *self
+            .generations
+            .read()
+            .await
+            .get(endpoint_name)
+            .unwrap_or(&0)
+    }
+
+    /// Invalidate every pending flow for `endpoint_name` and bump its reset
+    /// generation, so flows started before this call can neither be consumed
+    /// (removed here) nor committed if already consumed and mid token
+    /// exchange (their `generation` is now stale — see [`is_current`]).
+    /// Called by "Reset authorization" before it starts the replacement flow.
+    /// Returns the number of pending flows removed.
+    ///
+    /// [`is_current`]: Self::is_current
+    pub async fn invalidate_endpoint(&self, endpoint_name: &str) -> usize {
+        // Hold both locks across the bump+removal so a concurrent
+        // `start_flow` cannot interleave a flow stamped with the old
+        // generation after removal.
+        let mut generations = self.generations.write().await;
+        let mut pending = self.pending.write().await;
+        *generations.entry(endpoint_name.to_string()).or_insert(0) += 1;
+        let before = pending.len();
+        pending.retain(|_, f| f.endpoint_name != endpoint_name);
+        before - pending.len()
+    }
+
+    /// Whether `flow` was started under the endpoint's current reset
+    /// generation. `/oauth/callback` checks this before committing tokens so
+    /// a callback from a pre-reset flow cannot clobber the reset.
+    pub async fn is_current(&self, flow: &PendingFlow) -> bool {
+        flow.generation == self.current_generation(&flow.endpoint_name).await
+    }
+
+    /// Test-only: re-insert a flow under a chosen state key, preserving its
+    /// recorded `generation` (used to exercise the stale-generation guard).
+    #[cfg(test)]
+    pub(crate) async fn reinsert_flow_for_test(&self, state: &str, flow: PendingFlow) {
+        self.pending.write().await.insert(state.to_string(), flow);
     }
 
     /// Periodic cleanup of stale flows (call from a background task or on each access).
@@ -703,6 +760,56 @@ mod tests {
         mgr.cleanup_stale().await;
         let pending = mgr.pending.read().await;
         assert!(pending.is_empty());
+    }
+
+    async fn start_test_flow(mgr: &OAuthFlowManager, endpoint: &str) -> String {
+        mgr.start_flow(
+            endpoint,
+            "https://auth.example.com/token",
+            "cid",
+            None,
+            PkceChallenge::generate(),
+            "http://localhost/cb",
+            None,
+            false,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn invalidate_endpoint_removes_only_that_endpoints_flows() {
+        let mgr = OAuthFlowManager::new();
+        let state_a = start_test_flow(&mgr, "ep-a").await;
+        let state_a2 = start_test_flow(&mgr, "ep-a").await;
+        let state_b = start_test_flow(&mgr, "ep-b").await;
+
+        let removed = mgr.invalidate_endpoint("ep-a").await;
+        assert_eq!(removed, 2);
+
+        // ep-a flows are gone; ep-b's flow is untouched and still current.
+        assert!(mgr.consume_flow(&state_a).await.is_none());
+        assert!(mgr.consume_flow(&state_a2).await.is_none());
+        let flow_b = mgr.consume_flow(&state_b).await.unwrap();
+        assert!(mgr.is_current(&flow_b).await);
+    }
+
+    #[tokio::test]
+    async fn invalidate_endpoint_marks_consumed_flow_stale() {
+        // A callback consumed BEFORE the reset (mid token exchange) must be
+        // detectable as stale afterwards: is_current flips to false once the
+        // endpoint's generation is bumped.
+        let mgr = OAuthFlowManager::new();
+        let state = start_test_flow(&mgr, "ep").await;
+        let flow = mgr.consume_flow(&state).await.unwrap();
+        assert!(mgr.is_current(&flow).await);
+
+        mgr.invalidate_endpoint("ep").await;
+        assert!(!mgr.is_current(&flow).await);
+
+        // A flow started AFTER the reset carries the new generation.
+        let state2 = start_test_flow(&mgr, "ep").await;
+        let flow2 = mgr.consume_flow(&state2).await.unwrap();
+        assert!(mgr.is_current(&flow2).await);
     }
 
     #[test]

--- a/src/oauth/mod.rs
+++ b/src/oauth/mod.rs
@@ -137,8 +137,11 @@ pub struct OAuthFlowManager {
     /// Per-endpoint commit locks serializing a callback's token commit
     /// (post-exchange generation check + token save + adapter apply)
     /// against a "Reset authorization" (generation bump + disconnect).
-    /// See [`commit_lock`](Self::commit_lock).
-    commit_locks: tokio::sync::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+    /// Values are `Weak` so an entry lives only while a caller still holds
+    /// the `Arc` — dead entries are pruned on each acquisition, keeping the
+    /// map bounded even though setup callbacks use unique `setup:{uuid}`
+    /// keys. See [`commit_lock`](Self::commit_lock).
+    commit_locks: tokio::sync::Mutex<HashMap<String, std::sync::Weak<tokio::sync::Mutex<()>>>>,
 }
 
 impl OAuthFlowManager {
@@ -190,6 +193,58 @@ impl OAuthFlowManager {
         self.pending.write().await.insert(state.clone(), flow);
         drop(generations);
         state
+    }
+
+    /// Like [`start_flow`](Self::start_flow), but refuses the insert when the
+    /// endpoint's reset generation no longer equals `expected_generation`
+    /// (sampled by the caller via [`generation`](Self::generation) at
+    /// auth-start entry, BEFORE any network-bound discovery/DCR work).
+    ///
+    /// This closes the discovery-phase race: a `/oauth/start` that began
+    /// before a reset has no pending flow yet, so `invalidate_endpoint`
+    /// cannot remove it — without this check it would later insert a flow
+    /// stamped with the already-bumped generation and hand out an authorize
+    /// URL lacking the reset's `prompt=consent`, silently reusing the old
+    /// provider grant. Returns `None` when superseded; the caller must fail
+    /// the start rather than hand out a pre-reset URL.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn start_flow_if_current(
+        &self,
+        expected_generation: u64,
+        endpoint_name: &str,
+        token_endpoint: &str,
+        client_id: &str,
+        client_secret: Option<&str>,
+        pkce: PkceChallenge,
+        redirect_uri: &str,
+        issuer: Option<&str>,
+        iss_parameter_supported: bool,
+    ) -> Option<String> {
+        let state = generate_state();
+        // Same lock discipline as `start_flow`: hold the generations read
+        // lock through the pending insert so the check and the insert are
+        // atomic with respect to `invalidate_endpoint`.
+        let generations = self.generations.read().await;
+        if *generations.get(endpoint_name).unwrap_or(&0) != expected_generation {
+            return None;
+        }
+        let flow = PendingFlow {
+            endpoint_name: endpoint_name.to_string(),
+            code_verifier: pkce.code_verifier,
+            token_endpoint: token_endpoint.to_string(),
+            client_id: client_id.to_string(),
+            client_secret: client_secret.map(|s| s.to_string()),
+            redirect_uri: redirect_uri.to_string(),
+            issuer: issuer.map(|s| s.to_string()),
+            iss_parameter_supported,
+            idp_issuer: None,
+            idp_credential_key: None,
+            created_at: Instant::now(),
+            generation: expected_generation,
+        };
+        self.pending.write().await.insert(state.clone(), flow);
+        drop(generations);
+        Some(state)
     }
 
     /// Register a pending **EMA IdP SSO** flow (END-18 Step 1). Behaves exactly
@@ -255,6 +310,13 @@ impl OAuthFlowManager {
     }
 
     /// The endpoint's current reset generation (0 until first invalidation).
+    /// Sample this at auth-start entry (before discovery/DCR network work)
+    /// and pass it to [`start_flow_if_current`](Self::start_flow_if_current)
+    /// so a reset landing mid-discovery supersedes the start.
+    pub async fn generation(&self, endpoint_name: &str) -> u64 {
+        self.current_generation(endpoint_name).await
+    }
+
     async fn current_generation(&self, endpoint_name: &str) -> u64 {
         *self
             .generations
@@ -299,13 +361,30 @@ impl OAuthFlowManager {
     /// commit finishes — with the lock, either the commit completes first
     /// (and the reset then wipes the freshly saved tokens) or the reset
     /// completes first (and the callback's check sees the stale generation).
+    ///
+    /// The map stores `Weak` references and prunes dead entries on every
+    /// acquisition, so keys whose lock is no longer held anywhere (e.g. the
+    /// unique `setup:{uuid}` names from completed setup callbacks) do not
+    /// accumulate for the process lifetime. Concurrent callers for the same
+    /// key always get the same mutex: the upgrade-or-replace happens under
+    /// the outer map lock.
     pub async fn commit_lock(&self, endpoint_name: &str) -> Arc<tokio::sync::Mutex<()>> {
-        self.commit_locks
-            .lock()
-            .await
-            .entry(endpoint_name.to_string())
-            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
-            .clone()
+        let mut locks = self.commit_locks.lock().await;
+        locks.retain(|_, weak| weak.strong_count() > 0);
+        match locks.get(endpoint_name).and_then(std::sync::Weak::upgrade) {
+            Some(lock) => lock,
+            None => {
+                let lock = Arc::new(tokio::sync::Mutex::new(()));
+                locks.insert(endpoint_name.to_string(), Arc::downgrade(&lock));
+                lock
+            }
+        }
+    }
+
+    /// Test-only: number of live entries in the commit-lock map.
+    #[cfg(test)]
+    pub(crate) async fn commit_lock_count(&self) -> usize {
+        self.commit_locks.lock().await.len()
     }
 
     /// Test-only: re-insert a flow under a chosen state key, preserving its
@@ -844,6 +923,72 @@ mod tests {
         let state2 = start_test_flow(&mgr, "ep").await;
         let flow2 = mgr.consume_flow(&state2).await.unwrap();
         assert!(mgr.is_current(&flow2).await);
+    }
+
+    #[tokio::test]
+    async fn start_flow_if_current_rejects_when_generation_bumped() {
+        // The discovery-phase race: an auth-start samples the generation at
+        // entry, a reset lands mid-discovery, and the deferred flow insert
+        // must be refused — otherwise the start would register a flow under
+        // the NEW generation whose authorize URL lacks prompt=consent.
+        let mgr = OAuthFlowManager::new();
+        let g = mgr.generation("ep").await;
+        mgr.invalidate_endpoint("ep").await;
+
+        let pkce = PkceChallenge::generate();
+        let refused = mgr
+            .start_flow_if_current(
+                g,
+                "ep",
+                "https://auth.example.com/token",
+                "cid",
+                None,
+                pkce,
+                "http://localhost/cb",
+                None,
+                false,
+            )
+            .await;
+        assert!(refused.is_none(), "pre-reset start must be superseded");
+
+        // Sampling after the bump succeeds and the flow is current.
+        let g2 = mgr.generation("ep").await;
+        let pkce = PkceChallenge::generate();
+        let state = mgr
+            .start_flow_if_current(
+                g2,
+                "ep",
+                "https://auth.example.com/token",
+                "cid",
+                None,
+                pkce,
+                "http://localhost/cb",
+                None,
+                false,
+            )
+            .await
+            .expect("start sampled after the reset must succeed");
+        let flow = mgr.consume_flow(&state).await.unwrap();
+        assert!(mgr.is_current(&flow).await);
+    }
+
+    #[tokio::test]
+    async fn commit_lock_map_prunes_released_entries() {
+        // Unique setup:{uuid} keys must not accumulate forever: once no
+        // caller holds a lock's Arc, the entry is pruned on the next
+        // acquisition.
+        let mgr = OAuthFlowManager::new();
+        for i in 0..100 {
+            let lock = mgr.commit_lock(&format!("setup:{i}")).await;
+            let _guard = lock.lock().await;
+        }
+        // All 100 Arcs were dropped; acquiring a new key prunes them.
+        let _keep = mgr.commit_lock("ep").await;
+        assert_eq!(mgr.commit_lock_count().await, 1);
+
+        // Same key while held returns the SAME mutex (not a replacement).
+        let again = mgr.commit_lock("ep").await;
+        assert!(Arc::ptr_eq(&_keep, &again));
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -2215,6 +2215,15 @@ async fn oauth_callback(
         issued_at: Some(now_secs),
     };
 
+    // Commit phase: serialize against "Reset authorization" for this
+    // endpoint. The lock is held from the generation re-check below through
+    // every side effect (IdP credential save, token save, adapter apply), so
+    // a reset cannot land between the check and the commit and be undone by
+    // this callback persisting the pre-reset grant. The reset holds the same
+    // lock across its generation bump + disconnect.
+    let commit_lock = flow_mgr.commit_lock(&flow.endpoint_name).await;
+    let _commit_guard = commit_lock.lock().await;
+
     // Reset-generation re-check: the token exchange above is a network round
     // trip, so a reset can land while this callback is in flight (after the
     // pre-exchange check). Refuse to commit under a stale generation so the
@@ -6457,6 +6466,107 @@ mod tests {
             "error page must explain the flow was superseded by a reset: {body_str}"
         );
         assert!(tm.load(endpoint_name).await.unwrap().is_none());
+    }
+
+    /// Commit-lock serialization (post-check race): a reset that lands
+    /// AFTER the callback finished the token exchange but BEFORE its commit
+    /// must still win. The test holds the per-endpoint commit lock (as
+    /// `oauth_reset` does), lets the callback complete the exchange and
+    /// block on the lock, bumps the generation under the lock, then
+    /// releases it — the callback's post-exchange re-check must refuse the
+    /// commit even though its pre-exchange check passed.
+    #[tokio::test]
+    async fn oauth_callback_commit_blocked_by_reset_holding_commit_lock() {
+        use axum::body::to_bytes;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let token_hits = Arc::new(AtomicUsize::new(0));
+        let hits = token_hits.clone();
+        let router = axum::Router::new().route(
+            "/token",
+            axum::routing::post(move || {
+                let hits = hits.clone();
+                async move {
+                    hits.fetch_add(1, Ordering::SeqCst);
+                    "{\"access_token\":\"pre-reset\",\"token_type\":\"Bearer\",\"expires_in\":3600}"
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _server = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let token_endpoint = format!("http://127.0.0.1:{}/token", addr.port());
+
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let endpoint_name = "commit-lock-ep";
+
+        let flow_mgr = Arc::new(OAuthFlowManager::new());
+        let pkce = crate::oauth::PkceChallenge::generate();
+        let state_param = flow_mgr
+            .start_flow(
+                endpoint_name,
+                &token_endpoint,
+                "pre-reset-client",
+                None,
+                pkce,
+                "http://127.0.0.1:9400/oauth/callback",
+                None,
+                false,
+            )
+            .await;
+
+        let mut app_state = test_app_state();
+        app_state.oauth_flow_manager = Some(flow_mgr.clone());
+        app_state.token_manager = Some(tm.clone());
+
+        // Simulate a concurrent reset: grab the commit lock BEFORE the
+        // callback runs, so the callback exchanges tokens and then blocks
+        // at its commit phase.
+        let lock = flow_mgr.commit_lock(endpoint_name).await;
+        let guard = lock.lock().await;
+
+        let params = OAuthCallbackParams {
+            code: Some("authcode".to_string()),
+            state: Some(state_param),
+            error: None,
+            iss: None,
+        };
+        let callback = tokio::spawn(oauth_callback(State(app_state), Query(params)));
+
+        // Wait for the token exchange to complete (pre-exchange generation
+        // check passed, callback is now blocked on the commit lock).
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while token_hits.load(Ordering::SeqCst) == 0 {
+            assert!(Instant::now() < deadline, "token exchange never happened");
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            !callback.is_finished(),
+            "callback must block on the commit lock"
+        );
+
+        // The reset half, still under the lock: bump the generation.
+        flow_mgr.invalidate_endpoint(endpoint_name).await;
+        drop(guard);
+
+        // The callback resumes, re-checks the generation, and must refuse.
+        let resp = callback.await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            body_str.contains("superseded by a reset"),
+            "post-exchange commit must be refused under a stale generation: {body_str}"
+        );
+        assert!(
+            tm.load(endpoint_name).await.unwrap().is_none(),
+            "pre-reset grant must not be persisted after the reset"
+        );
     }
 
     /// After a successful interactive re-authorization the callback must

--- a/src/server.rs
+++ b/src/server.rs
@@ -1990,6 +1990,24 @@ async fn oauth_callback(
         }
     };
 
+    // Reset-generation guard: a "Reset authorization" invalidates the
+    // endpoint's pending flows and bumps its generation in the flow manager.
+    // `consume_flow` already misses flows removed by the invalidation; this
+    // check additionally covers a callback whose flow was consumed and mid
+    // token exchange when the reset landed (its recorded `generation` is now
+    // stale), so it cannot clobber the reset with the pre-reset grant.
+    if !flow_mgr.is_current(&flow).await {
+        warn!(
+            endpoint = %flow.endpoint_name,
+            flow_generation = flow.generation,
+            "Refusing OAuth callback from a flow superseded by a reset"
+        );
+        return oauth_html_response(
+            "<html><body><h1>OAuth Error</h1><p>This login session was superseded by a reset. Please click Authorize again.</p><p>You can close this window.</p></body></html>"
+                .to_string(),
+        );
+    }
+
     // RFC 9207 issuer (`iss`) validation: when we discovered the authorization
     // server's issuer, the callback MUST carry a matching `iss` (mix-up
     // defense). When no issuer was recorded (legacy convention-based config),
@@ -2196,6 +2214,22 @@ async fn oauth_callback(
         scope: token_json["scope"].as_str().map(|s| s.to_string()),
         issued_at: Some(now_secs),
     };
+
+    // Reset-generation re-check: the token exchange above is a network round
+    // trip, so a reset can land while this callback is in flight (after the
+    // pre-exchange check). Refuse to commit under a stale generation so the
+    // pre-reset grant cannot clobber the reset's clean slate.
+    if !flow_mgr.is_current(&flow).await {
+        warn!(
+            endpoint = %flow.endpoint_name,
+            flow_generation = flow.generation,
+            "Refusing to commit OAuth callback: flow superseded by a reset during token exchange"
+        );
+        return oauth_html_response(
+            "<html><body><h1>OAuth Error</h1><p>This login session was superseded by a reset. Please click Authorize again.</p><p>You can close this window.</p></body></html>"
+                .to_string(),
+        );
+    }
 
     // EMA Step 1 (END-18): when this authorization-code flow was an IdP SSO for
     // an EMA endpoint, capture the ID Token (plus the IdP refresh token and
@@ -6295,6 +6329,134 @@ mod tests {
         let loaded = tm.load_dcr(endpoint_name).await.unwrap().unwrap();
         assert_eq!(loaded.client_id, "operator-manual-client");
         assert!(!loaded.registered_via_dcr);
+    }
+
+    /// Reset-generation guard: a callback whose pending flow predates a
+    /// "Reset authorization" (`invalidate_endpoint`) must be rejected before
+    /// the token exchange, and must not save tokens — the reset's clean
+    /// slate wins over the pre-reset grant.
+    #[tokio::test]
+    async fn oauth_callback_rejects_flow_superseded_by_reset() {
+        use axum::body::to_bytes;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        // Token endpoint counts POSTs so we can assert it was never hit.
+        let token_hits = Arc::new(AtomicUsize::new(0));
+        let hits = token_hits.clone();
+        let router = axum::Router::new().route(
+            "/token",
+            axum::routing::post(move || {
+                let hits = hits.clone();
+                async move {
+                    hits.fetch_add(1, Ordering::SeqCst);
+                    "{\"access_token\":\"stale\",\"token_type\":\"Bearer\",\"expires_in\":3600}"
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _server = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let token_endpoint = format!("http://127.0.0.1:{}/token", addr.port());
+
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let endpoint_name = "reset-race-ep";
+
+        let flow_mgr = Arc::new(OAuthFlowManager::new());
+        let pkce = crate::oauth::PkceChallenge::generate();
+        let state_param = flow_mgr
+            .start_flow(
+                endpoint_name,
+                &token_endpoint,
+                "pre-reset-client",
+                None,
+                pkce,
+                "http://127.0.0.1:9400/oauth/callback",
+                None,
+                false,
+            )
+            .await;
+
+        // Simulate the pre-consume shape of the race: a reset lands after
+        // the authorize URL was handed out but before the callback arrives.
+        flow_mgr.invalidate_endpoint(endpoint_name).await;
+
+        let mut app_state = test_app_state();
+        app_state.oauth_flow_manager = Some(flow_mgr.clone());
+        app_state.token_manager = Some(tm.clone());
+
+        let params = OAuthCallbackParams {
+            code: Some("authcode".to_string()),
+            state: Some(state_param),
+            error: None,
+            iss: None,
+        };
+        let resp = oauth_callback(State(app_state.clone()), Query(params)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        // The pending flow was removed by the invalidation, so this rejects
+        // as an invalid/expired session without hitting the token endpoint.
+        assert_eq!(token_hits.load(Ordering::SeqCst), 0);
+        let body = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            body_str.contains("Invalid or expired"),
+            "pre-consume reset must invalidate the pending flow: {body_str}"
+        );
+        assert!(tm.load(endpoint_name).await.unwrap().is_none());
+
+        // Mid-exchange shape: the flow was consumed BEFORE the reset landed.
+        // Re-arm a pending flow, consume it manually (as the callback does),
+        // then reset — the generation guard must reject the commit.
+        let pkce = crate::oauth::PkceChallenge::generate();
+        let state_param2 = flow_mgr
+            .start_flow(
+                endpoint_name,
+                &token_endpoint,
+                "pre-reset-client",
+                None,
+                pkce,
+                "http://127.0.0.1:9400/oauth/callback",
+                None,
+                false,
+            )
+            .await;
+        let consumed = flow_mgr.consume_flow(&state_param2).await.unwrap();
+        flow_mgr.invalidate_endpoint(endpoint_name).await;
+        assert!(
+            !flow_mgr.is_current(&consumed).await,
+            "consumed flow must be stale after a reset"
+        );
+
+        // End-to-end: a state param whose flow is stamped with the old
+        // generation (re-inserted post-consume, pre-reset shape) is refused
+        // by the callback's generation guard before the token exchange.
+        let stale_state = "stale-generation-state".to_string();
+        flow_mgr
+            .reinsert_flow_for_test(&stale_state, consumed)
+            .await;
+        let params = OAuthCallbackParams {
+            code: Some("authcode".to_string()),
+            state: Some(stale_state),
+            error: None,
+            iss: None,
+        };
+        let resp = oauth_callback(State(app_state), Query(params)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            token_hits.load(Ordering::SeqCst),
+            0,
+            "generation guard must reject before POSTing to the token endpoint"
+        );
+        let body = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            body_str.contains("superseded by a reset"),
+            "error page must explain the flow was superseded by a reset: {body_str}"
+        );
+        assert!(tm.load(endpoint_name).await.unwrap().is_none());
     }
 
     /// After a successful interactive re-authorization the callback must


### PR DESCRIPTION
One in-app action that discards the old grant and forces the provider to show a fresh consent screen.

## Changes

- `POST /api/endpoints/{name}/oauth/start` now accepts an optional `?force_consent=true` query flag that appends `prompt=consent` to the authorize URL. OIDC providers re-show the consent screen; non-OIDC providers ignore unknown parameters, so this is safe unconditionally.
- Google authorization endpoints (`accounts.google.com`, host comparison only — lookalike hosts don't match) always get `access_type=offline` appended, so Google actually issues a refresh token. Previously none was requested, which is why proactive refresh was impossible on Google endpoints.
- New `POST /api/endpoints/{name}/oauth/reset` ("Reset authorization"): invalidates all pending OAuth flows for the endpoint (stale-callback protection, below), disconnects the OAuth adapter (local token deletion — the same `disconnect()` path as `/oauth/revoke`; best-effort upstream RFC 7009 revocation rides along automatically once the companion rfc7009-revoke work lands in `disconnect()`), then starts a new authorization flow with forced consent, returning the composed `authorize_url`. The client registration (DCR record) is preserved across the reset — only the grant is discarded — so desktop-created DCR secrets and manually supplied credentials survive and the follow-up start reuses the registered client.
- Stale-callback protection: `OAuthFlowManager` now tracks a per-endpoint reset generation. `oauth/reset` calls `invalidate_endpoint`, which removes every pending flow for the endpoint and bumps its generation atomically. A callback from a pre-reset `/oauth/start` therefore either misses `consume_flow` entirely, or — if it was already consumed and mid token exchange when the reset landed — fails the generation check the callback handler runs both before and after the token exchange. Either way the pre-reset grant cannot clobber the reset.

## Tests

- `google_authorization_endpoint_detection` — host matching incl. case-insensitivity and lookalike rejection
- `oauth_start_force_consent_appends_prompt_consent` — flag appends `prompt=consent`, no `access_type=offline` for non-Google AS
- `oauth_start_regular_has_no_prompt_consent` — regular start/re-authorize unchanged
- `oauth_start_google_as_appends_access_type_offline` — Google AS gets `access_type=offline` with and without `force_consent`
- `oauth_reset_disconnects_then_returns_consent_url` — sequencing: tokens deleted + adapter Disconnected before the consent URL is returned; client registration (manually-supplied shape, secret only in the DCR record) survives and the new authorize URL reuses the preserved client_id
- `oauth_reset_not_found` / `oauth_reset_not_oauth_endpoint` — error paths
- `invalidate_endpoint_removes_only_that_endpoints_flows` / `invalidate_endpoint_marks_consumed_flow_stale` — flow-manager invalidation + generation semantics
- `oauth_callback_rejects_flow_superseded_by_reset` — end-to-end: pre-consume and mid-exchange reset races both rejected; token endpoint never POSTed, no tokens saved

Full suite: 1399 passed, 0 failed.

Desktop side (Reset authorization button calling this route) is endara-ai/endara-desktop#154.
