### PR TITLE
fix: log isError tool results as failures and use effective server name in observability

### DIFF
--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -1431,14 +1431,22 @@ impl McpAdapter for HttpAdapter {
                     .await
                     .get(name)
                     .and_then(|v| v.as_ref().and_then(annotations_from_value));
+                // The overlay displays the event's `server_name`, so prefer
+                // the effective (override-aware) name over the raw
+                // upstream-derived one, matching the observability capture.
+                let server_type = self.server_type.read().await.clone();
+                let server_name = match server_type.clone() {
+                    Some(name) => Some(name),
+                    None => self.upstream_server_name.read().await.clone(),
+                };
                 bus.send(ToolCallEvent::Started {
                     request_id: request_id.clone(),
                     request_uid: span_ctx.request_uid.clone(),
                     ts: iso8601_now(),
                     endpoint: self.config.endpoint_name.clone(),
                     transport: "http".into(),
-                    server_type: self.server_type.read().await.clone(),
-                    server_name: self.upstream_server_name.read().await.clone(),
+                    server_type,
+                    server_name,
                     profile: span_ctx.profile.clone(),
                     tool: name.to_string(),
                     annotations,

--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -1457,15 +1457,28 @@ impl McpAdapter for HttpAdapter {
             // unless a JIT interceptor is attached (none are today).
             let result = self.maybe_intercept_401(result).await;
             let duration_ms = start.elapsed().as_millis();
+            // A transport-level `Ok` can still carry a tool-level error
+            // envelope (`{ content: [...], isError: true }`). Surface it as a
+            // failed call in the activity log, tracing line, and overlay
+            // events — mirroring the registry's durable capture — while
+            // forwarding the envelope to the client unchanged.
+            let tool_error = result
+                .as_ref()
+                .ok()
+                .and_then(crate::adapter::tool_result_error_message);
             let now = chrono::Utc::now()
                 .format("%Y-%m-%dT%H:%M:%S%.3fZ")
                 .to_string();
-            let log_line = match &result {
-                Ok(_) => format!(
+            let log_line = match (&result, &tool_error) {
+                (Ok(_), None) => format!(
                     "{}  INFO call_tool tool={} status=ok duration={}ms",
                     now, name, duration_ms
                 ),
-                Err(e) => format!(
+                (Ok(_), Some(msg)) => format!(
+                    "{}  WARN call_tool tool={} status=error duration={}ms error={}",
+                    now, name, duration_ms, msg
+                ),
+                (Err(e), _) => format!(
                     "{}  WARN call_tool tool={} status=error duration={}ms error={}",
                     now, name, duration_ms, e
                 ),
@@ -1481,8 +1494,8 @@ impl McpAdapter for HttpAdapter {
                 .as_ref()
                 .and_then(|c| c.version.clone())
                 .unwrap_or_default();
-            match &result {
-                Ok(_) => tracing::info!(
+            match (&result, &tool_error) {
+                (Ok(_), None) => tracing::info!(
                     tool = %name,
                     status = "ok",
                     duration_ms = duration_ms,
@@ -1490,7 +1503,16 @@ impl McpAdapter for HttpAdapter {
                     client_version = ?client_version,
                     "Tool call completed"
                 ),
-                Err(e) => tracing::warn!(
+                (Ok(_), Some(msg)) => tracing::warn!(
+                    tool = %name,
+                    status = "error",
+                    duration_ms = duration_ms,
+                    error = %msg,
+                    client_name = ?client_name,
+                    client_version = ?client_version,
+                    "Tool call failed"
+                ),
+                (Err(e), _) => tracing::warn!(
                     tool = %name,
                     status = "error",
                     duration_ms = duration_ms,
@@ -1503,14 +1525,21 @@ impl McpAdapter for HttpAdapter {
             if let Some(bus) = self.event_bus.get() {
                 let duration_ms_u64 = duration_ms as u64;
                 let ts = iso8601_now();
-                match &result {
-                    Ok(_) => bus.send(ToolCallEvent::Completed {
+                match (&result, &tool_error) {
+                    (Ok(_), None) => bus.send(ToolCallEvent::Completed {
                         request_id,
                         ts,
                         duration_ms: duration_ms_u64,
                         status: "ok".into(),
                     }),
-                    Err(e) => bus.send(ToolCallEvent::Failed {
+                    (Ok(_), Some(msg)) => bus.send(ToolCallEvent::Failed {
+                        request_id,
+                        ts,
+                        duration_ms: duration_ms_u64,
+                        status: "error".into(),
+                        error_message: msg.clone(),
+                    }),
+                    (Err(e), _) => bus.send(ToolCallEvent::Failed {
                         request_id,
                         ts,
                         duration_ms: duration_ms_u64,
@@ -2496,6 +2525,113 @@ mod tests {
         match result {
             Err(AdapterError::HttpError { status: 401, .. }) => {}
             other => panic!("expected HttpError {{ 401 }}, got {:?}", other),
+        }
+        server.abort();
+    }
+
+    // --- isError tool results surfaced as failures ---
+
+    /// Fixture whose `POST /mcp` answers every JSON-RPC request with the given
+    /// `result` payload. Minimal enough for direct `call_tool` tests — the
+    /// application/json response path does not validate the JSON-RPC id.
+    async fn spawn_fixed_result_fixture(
+        result: serde_json::Value,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        use axum::routing::post;
+        use axum::{Json, Router};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let base = format!("http://127.0.0.1:{}", addr.port());
+        let router = Router::new().route(
+            "/mcp",
+            post(move || {
+                let result = result.clone();
+                async move { Json(json!({"jsonrpc": "2.0", "result": result, "id": 1})) }
+            }),
+        );
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        (base, handle)
+    }
+
+    /// A transport-level `Ok` whose envelope carries `isError: true` must be
+    /// surfaced as a FAILED call: the activity log records `status=error` with
+    /// the captured message, and the event bus receives `Started` → `Failed`
+    /// (not `Completed`), matching the registry's durable capture. The
+    /// envelope itself is still forwarded unchanged.
+    #[tokio::test]
+    async fn call_tool_iserror_envelope_logs_error_and_emits_failed_event() {
+        let (base, server) = spawn_fixed_result_fixture(json!({
+            "content": [{"type": "text", "text": "invalid_grant"}],
+            "isError": true,
+        }))
+        .await;
+        let adapter = HttpAdapter::new(HttpConfig::new(format!("{}/mcp", base)));
+        let bus = ToolCallEventBus::with_default_capacity();
+        adapter.set_event_bus(bus.clone());
+        let mut rx = bus.subscribe();
+
+        let value = adapter
+            .call_tool("search", json!({}))
+            .await
+            .expect("isError envelope is still a transport-level Ok");
+        assert_eq!(value["isError"], true, "envelope forwarded unchanged");
+
+        let log = adapter.activity_log().await;
+        let line = log.last().expect("activity log line recorded");
+        assert!(line.contains("status=error"), "got: {line}");
+        assert!(line.contains("invalid_grant"), "got: {line}");
+
+        match rx.try_recv().expect("started event must be buffered") {
+            ToolCallEvent::Started { .. } => {}
+            other => panic!("expected Started, got {other:?}"),
+        }
+        match rx.try_recv().expect("terminal event must be buffered") {
+            ToolCallEvent::Failed {
+                status,
+                error_message,
+                ..
+            } => {
+                assert_eq!(status, "error");
+                assert_eq!(error_message, "invalid_grant");
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+        server.abort();
+    }
+
+    /// A plain success envelope (`isError` absent) keeps the pre-existing
+    /// behavior: `status=ok` activity-log line and a `Completed` event.
+    #[tokio::test]
+    async fn call_tool_success_envelope_logs_ok_and_emits_completed_event() {
+        let (base, server) = spawn_fixed_result_fixture(json!({
+            "content": [{"type": "text", "text": "all good"}],
+        }))
+        .await;
+        let adapter = HttpAdapter::new(HttpConfig::new(format!("{}/mcp", base)));
+        let bus = ToolCallEventBus::with_default_capacity();
+        adapter.set_event_bus(bus.clone());
+        let mut rx = bus.subscribe();
+
+        adapter
+            .call_tool("search", json!({}))
+            .await
+            .expect("success envelope");
+
+        let log = adapter.activity_log().await;
+        let line = log.last().expect("activity log line recorded");
+        assert!(line.contains("status=ok"), "got: {line}");
+
+        match rx.try_recv().expect("started event must be buffered") {
+            ToolCallEvent::Started { .. } => {}
+            other => panic!("expected Started, got {other:?}"),
+        }
+        match rx.try_recv().expect("terminal event must be buffered") {
+            ToolCallEvent::Completed { status, .. } => assert_eq!(status, "ok"),
+            other => panic!("expected Completed, got {other:?}"),
         }
         server.abort();
     }

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -43,6 +43,40 @@ pub(crate) fn merge_request_params(
     }
 }
 
+/// Upper bound on a captured tool-level `error_message`, in characters. Tool
+/// error envelopes are usually short, but a misbehaving server could return a
+/// large blob; cap it so the durable row stays bounded.
+pub(crate) const MAX_CAPTURED_ERROR_MESSAGE_CHARS: usize = 2048;
+
+/// Inspect a transport-level `Ok` `tools/call` result for a tool-level error
+/// envelope (`{ content: [...], isError: true }`). Returns the captured
+/// `error_message` (the first `content[].text` string, truncated) when the tool
+/// reported an error, or `None` for a normal success (`isError` absent/false).
+///
+/// Shared by the registry's durable capture (`registry.rs`) and the transport
+/// adapters' `call_tool` completion handling so an isError envelope is
+/// surfaced as a failed call consistently across the durable rows, the
+/// per-server logs, and the overlay event bus.
+pub(crate) fn tool_result_error_message(value: &Value) -> Option<String> {
+    if value.get("isError").and_then(|e| e.as_bool()) != Some(true) {
+        return None;
+    }
+    let text = value
+        .get("content")
+        .and_then(|c| c.as_array())
+        .and_then(|items| {
+            items
+                .iter()
+                .find_map(|item| item.get("text").and_then(|t| t.as_str()))
+        })
+        .unwrap_or("tool call returned an error result");
+    let truncated: String = text
+        .chars()
+        .take(MAX_CAPTURED_ERROR_MESSAGE_CHARS)
+        .collect();
+    Some(truncated)
+}
+
 /// Health status of an adapter.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum HealthStatus {
@@ -574,6 +608,52 @@ impl McpAdapter for StartingAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn tool_result_iserror_envelope_is_captured_as_failure() {
+        // A transport-level `Ok` carrying a tool-level error envelope must be
+        // recorded as a failed call with a non-empty error_message taken from
+        // the first text item in `content`.
+        let envelope = json!({
+            "content": [{ "type": "text", "text": "invalid_grant" }],
+            "isError": true,
+        });
+        let msg =
+            tool_result_error_message(&envelope).expect("isError envelope captured as failure");
+        assert_eq!(msg, "invalid_grant");
+    }
+
+    #[test]
+    fn tool_result_success_envelope_is_not_a_failure() {
+        // `isError` absent → success; explicit `isError: false` → success.
+        assert!(tool_result_error_message(&json!({ "content": [] })).is_none());
+        assert!(tool_result_error_message(&json!({
+            "content": [{ "type": "text", "text": "ok" }],
+            "isError": false,
+        }))
+        .is_none());
+    }
+
+    #[test]
+    fn tool_result_iserror_without_text_still_yields_message() {
+        // isError with no usable text content still produces a non-empty
+        // error_message so the durable row reflects the failure.
+        let msg = tool_result_error_message(&json!({ "isError": true, "content": [] }))
+            .expect("isError envelope captured as failure");
+        assert!(!msg.is_empty());
+    }
+
+    #[test]
+    fn tool_result_error_message_is_truncated() {
+        let long = "x".repeat(MAX_CAPTURED_ERROR_MESSAGE_CHARS + 500);
+        let msg = tool_result_error_message(&json!({
+            "isError": true,
+            "content": [{ "type": "text", "text": long }],
+        }))
+        .expect("isError envelope captured as failure");
+        assert_eq!(msg.chars().count(), MAX_CAPTURED_ERROR_MESSAGE_CHARS);
+    }
 
     /// A validation-failed endpoint registered as a `FailedAdapter` should
     /// still surface its configured `server_type_override` via

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -1058,14 +1058,22 @@ impl McpAdapter for SseAdapter {
                     .await
                     .get(name)
                     .and_then(|v| v.as_ref().and_then(annotations_from_value));
+                // The overlay displays the event's `server_name`, so prefer
+                // the effective (override-aware) name over the raw
+                // upstream-derived one, matching the observability capture.
+                let server_type = self.server_type.read().await.clone();
+                let server_name = match server_type.clone() {
+                    Some(name) => Some(name),
+                    None => self.upstream_server_name.read().await.clone(),
+                };
                 bus.send(ToolCallEvent::Started {
                     request_id: request_id.clone(),
                     request_uid: span_ctx.request_uid.clone(),
                     ts: iso8601_now(),
                     endpoint: self.config.endpoint_name.clone(),
                     transport: "sse".into(),
-                    server_type: self.server_type.read().await.clone(),
-                    server_name: self.upstream_server_name.read().await.clone(),
+                    server_type,
+                    server_name,
                     profile: span_ctx.profile.clone(),
                     tool: name.to_string(),
                     annotations,

--- a/src/adapter/sse.rs
+++ b/src/adapter/sse.rs
@@ -1080,15 +1080,28 @@ impl McpAdapter for SseAdapter {
             let start = Instant::now();
             let result = self.send_request("tools/call", Some(params)).await;
             let duration_ms = start.elapsed().as_millis();
+            // A transport-level `Ok` can still carry a tool-level error
+            // envelope (`{ content: [...], isError: true }`). Surface it as a
+            // failed call in the activity log, tracing line, and overlay
+            // events — mirroring the registry's durable capture — while
+            // forwarding the envelope to the client unchanged.
+            let tool_error = result
+                .as_ref()
+                .ok()
+                .and_then(crate::adapter::tool_result_error_message);
             let now = chrono::Utc::now()
                 .format("%Y-%m-%dT%H:%M:%S%.3fZ")
                 .to_string();
-            let log_line = match &result {
-                Ok(_) => format!(
+            let log_line = match (&result, &tool_error) {
+                (Ok(_), None) => format!(
                     "{}  INFO call_tool tool={} status=ok duration={}ms",
                     now, name, duration_ms
                 ),
-                Err(e) => format!(
+                (Ok(_), Some(msg)) => format!(
+                    "{}  WARN call_tool tool={} status=error duration={}ms error={}",
+                    now, name, duration_ms, msg
+                ),
+                (Err(e), _) => format!(
                     "{}  WARN call_tool tool={} status=error duration={}ms error={}",
                     now, name, duration_ms, e
                 ),
@@ -1104,8 +1117,8 @@ impl McpAdapter for SseAdapter {
                 .as_ref()
                 .and_then(|c| c.version.clone())
                 .unwrap_or_default();
-            match &result {
-                Ok(_) => tracing::info!(
+            match (&result, &tool_error) {
+                (Ok(_), None) => tracing::info!(
                     tool = %name,
                     status = "ok",
                     duration_ms = duration_ms,
@@ -1113,7 +1126,16 @@ impl McpAdapter for SseAdapter {
                     client_version = ?client_version,
                     "Tool call completed"
                 ),
-                Err(e) => tracing::warn!(
+                (Ok(_), Some(msg)) => tracing::warn!(
+                    tool = %name,
+                    status = "error",
+                    duration_ms = duration_ms,
+                    error = %msg,
+                    client_name = ?client_name,
+                    client_version = ?client_version,
+                    "Tool call failed"
+                ),
+                (Err(e), _) => tracing::warn!(
                     tool = %name,
                     status = "error",
                     duration_ms = duration_ms,
@@ -1126,14 +1148,21 @@ impl McpAdapter for SseAdapter {
             if let Some(bus) = self.event_bus.get() {
                 let duration_ms_u64 = duration_ms as u64;
                 let ts = iso8601_now();
-                match &result {
-                    Ok(_) => bus.send(ToolCallEvent::Completed {
+                match (&result, &tool_error) {
+                    (Ok(_), None) => bus.send(ToolCallEvent::Completed {
                         request_id,
                         ts,
                         duration_ms: duration_ms_u64,
                         status: "ok".into(),
                     }),
-                    Err(e) => bus.send(ToolCallEvent::Failed {
+                    (Ok(_), Some(msg)) => bus.send(ToolCallEvent::Failed {
+                        request_id,
+                        ts,
+                        duration_ms: duration_ms_u64,
+                        status: "error".into(),
+                        error_message: msg.clone(),
+                    }),
+                    (Err(e), _) => bus.send(ToolCallEvent::Failed {
                         request_id,
                         ts,
                         duration_ms: duration_ms_u64,
@@ -1361,6 +1390,9 @@ mod tests {
             /// When true, /message answers `server/discover` with a `2026-07-28`
             /// result (used to test the 2026 stateless version-gating path).
             discover_returns_2026: AtomicBool,
+            /// When true, /message answers `tools/call` with a tool-level error
+            /// envelope (`isError: true`) instead of the default success result.
+            tools_call_returns_iserror: AtomicBool,
             /// Bodies of every POST /message received, in arrival order.
             posts: std::sync::Mutex<Vec<Value>>,
         }
@@ -1480,6 +1512,16 @@ mod tests {
                     "result": {"tools": []},
                     "id": id,
                 }),
+                "tools/call" if app.fake.tools_call_returns_iserror.load(Ordering::SeqCst) => {
+                    json!({
+                        "jsonrpc": "2.0",
+                        "result": {
+                            "content": [{"type": "text", "text": "invalid_grant"}],
+                            "isError": true,
+                        },
+                        "id": id,
+                    })
+                }
                 _ => json!({
                     "jsonrpc": "2.0",
                     "result": {"content": [{"type": "text", "text": "ok"}]},
@@ -1743,6 +1785,86 @@ mod tests {
                 "call_tool took too long: {:?}",
                 elapsed
             );
+            adapter.shutdown().await.unwrap();
+        }
+
+        /// A transport-level `Ok` whose envelope carries `isError: true` must
+        /// be surfaced as a FAILED call: the activity log records
+        /// `status=error` with the captured message, and the event bus
+        /// receives `Started` → `Failed` (not `Completed`), matching the
+        /// registry's durable capture. The envelope itself is still forwarded
+        /// unchanged.
+        #[tokio::test]
+        async fn sse_call_tool_iserror_envelope_logs_error_and_emits_failed_event() {
+            let server = start_test_server().await;
+            server
+                .state
+                .tools_call_returns_iserror
+                .store(true, Ordering::SeqCst);
+
+            let mut adapter = build_adapter(&server.url, 5).await;
+            adapter.initialize().await.expect("initial connect");
+            let bus = ToolCallEventBus::with_default_capacity();
+            adapter.set_event_bus(bus.clone());
+            let mut rx = bus.subscribe();
+
+            let value = adapter
+                .call_tool("echo", json!({"message": "hi"}))
+                .await
+                .expect("isError envelope is still a transport-level Ok");
+            assert_eq!(value["isError"], true, "envelope forwarded unchanged");
+
+            let log = adapter.activity_log().await;
+            let line = log.last().expect("activity log line recorded");
+            assert!(line.contains("status=error"), "got: {line}");
+            assert!(line.contains("invalid_grant"), "got: {line}");
+
+            match rx.try_recv().expect("started event must be buffered") {
+                ToolCallEvent::Started { .. } => {}
+                other => panic!("expected Started, got {other:?}"),
+            }
+            match rx.try_recv().expect("terminal event must be buffered") {
+                ToolCallEvent::Failed {
+                    status,
+                    error_message,
+                    ..
+                } => {
+                    assert_eq!(status, "error");
+                    assert_eq!(error_message, "invalid_grant");
+                }
+                other => panic!("expected Failed, got {other:?}"),
+            }
+            adapter.shutdown().await.unwrap();
+        }
+
+        /// A plain success envelope (`isError` absent) keeps the pre-existing
+        /// behavior: `status=ok` activity-log line and a `Completed` event.
+        #[tokio::test]
+        async fn sse_call_tool_success_envelope_logs_ok_and_emits_completed_event() {
+            let server = start_test_server().await;
+            let mut adapter = build_adapter(&server.url, 5).await;
+            adapter.initialize().await.expect("initial connect");
+            let bus = ToolCallEventBus::with_default_capacity();
+            adapter.set_event_bus(bus.clone());
+            let mut rx = bus.subscribe();
+
+            adapter
+                .call_tool("echo", json!({"message": "hi"}))
+                .await
+                .expect("success envelope");
+
+            let log = adapter.activity_log().await;
+            let line = log.last().expect("activity log line recorded");
+            assert!(line.contains("status=ok"), "got: {line}");
+
+            match rx.try_recv().expect("started event must be buffered") {
+                ToolCallEvent::Started { .. } => {}
+                other => panic!("expected Started, got {other:?}"),
+            }
+            match rx.try_recv().expect("terminal event must be buffered") {
+                ToolCallEvent::Completed { status, .. } => assert_eq!(status, "ok"),
+                other => panic!("expected Completed, got {other:?}"),
+            }
             adapter.shutdown().await.unwrap();
         }
 

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -1610,6 +1610,15 @@ impl McpAdapter for StdioAdapter {
             let start = Instant::now();
             let result = self.send_external_request("tools/call", Some(params)).await;
             let duration_ms = start.elapsed().as_millis();
+            // A transport-level `Ok` can still carry a tool-level error
+            // envelope (`{ content: [...], isError: true }`). Surface it as a
+            // failed call in the tracing line and overlay events — mirroring
+            // the registry's durable capture — while forwarding the envelope
+            // to the client unchanged.
+            let tool_error = result
+                .as_ref()
+                .ok()
+                .and_then(crate::adapter::tool_result_error_message);
             let client_name = span_ctx
                 .client
                 .as_ref()
@@ -1620,8 +1629,8 @@ impl McpAdapter for StdioAdapter {
                 .as_ref()
                 .and_then(|c| c.version.clone())
                 .unwrap_or_default();
-            match &result {
-                Ok(_) => tracing::info!(
+            match (&result, &tool_error) {
+                (Ok(_), None) => tracing::info!(
                     tool = %name,
                     status = "ok",
                     duration_ms = duration_ms,
@@ -1629,7 +1638,16 @@ impl McpAdapter for StdioAdapter {
                     client_version = ?client_version,
                     "Tool call completed"
                 ),
-                Err(e) => tracing::warn!(
+                (Ok(_), Some(msg)) => tracing::warn!(
+                    tool = %name,
+                    status = "error",
+                    duration_ms = duration_ms,
+                    error = %msg,
+                    client_name = ?client_name,
+                    client_version = ?client_version,
+                    "Tool call failed"
+                ),
+                (Err(e), _) => tracing::warn!(
                     tool = %name,
                     status = "error",
                     duration_ms = duration_ms,
@@ -1642,14 +1660,21 @@ impl McpAdapter for StdioAdapter {
             if let Some(bus) = self.event_bus.get() {
                 let duration_ms_u64 = duration_ms as u64;
                 let ts = iso8601_now();
-                match &result {
-                    Ok(_) => bus.send(ToolCallEvent::Completed {
+                match (&result, &tool_error) {
+                    (Ok(_), None) => bus.send(ToolCallEvent::Completed {
                         request_id,
                         ts,
                         duration_ms: duration_ms_u64,
                         status: "ok".into(),
                     }),
-                    Err(e) => bus.send(ToolCallEvent::Failed {
+                    (Ok(_), Some(msg)) => bus.send(ToolCallEvent::Failed {
+                        request_id,
+                        ts,
+                        duration_ms: duration_ms_u64,
+                        status: "error".into(),
+                        error_message: msg.clone(),
+                    }),
+                    (Err(e), _) => bus.send(ToolCallEvent::Failed {
                         request_id,
                         ts,
                         duration_ms: duration_ms_u64,
@@ -3317,5 +3342,103 @@ with open(record_path, "w") as rec:
                 }
             });
         });
+    }
+
+    /// Create a StdioAdapter whose mock server answers `tools/call` with a
+    /// tool-level error envelope (`isError: true`) when the tool is named
+    /// `fail`, and a plain success envelope otherwise.
+    fn make_iserror_adapter() -> StdioAdapter {
+        let script = r#"
+import sys, json
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        req = json.loads(line)
+        if req.get("method") == "tools/call" and req.get("params", {}).get("name") == "fail":
+            result = {"content": [{"type": "text", "text": "invalid_grant"}], "isError": True}
+        else:
+            result = {"content": [{"type": "text", "text": "all good"}]}
+        resp = {"jsonrpc": "2.0", "result": result, "id": req.get("id")}
+        sys.stdout.write(json.dumps(resp) + "\n")
+        sys.stdout.flush()
+    except Exception:
+        pass
+"#;
+        StdioAdapter::new(StdioConfig {
+            command: "python3".to_string(),
+            args: vec!["-c".to_string(), script.to_string()],
+            env: HashMap::new(),
+            ..Default::default()
+        })
+    }
+
+    /// A transport-level `Ok` whose envelope carries `isError: true` must be
+    /// surfaced as a FAILED call: the event bus receives `Started` → `Failed`
+    /// (not `Completed`) with the captured message, matching the registry's
+    /// durable capture. The envelope itself is still forwarded unchanged.
+    #[tokio::test]
+    async fn call_tool_iserror_envelope_emits_failed_event() {
+        use crate::events::{ToolCallEvent, ToolCallEventBus};
+
+        let mut adapter = make_iserror_adapter();
+        adapter.spawn_process().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let bus = ToolCallEventBus::with_default_capacity();
+        adapter.set_event_bus(bus.clone());
+        let mut rx = bus.subscribe();
+
+        let value = adapter
+            .call_tool("fail", serde_json::json!({}))
+            .await
+            .expect("isError envelope is still a transport-level Ok");
+        assert_eq!(value["isError"], true, "envelope forwarded unchanged");
+
+        match rx.try_recv().expect("started event must be buffered") {
+            ToolCallEvent::Started { .. } => {}
+            other => panic!("expected Started, got {other:?}"),
+        }
+        match rx.try_recv().expect("terminal event must be buffered") {
+            ToolCallEvent::Failed {
+                status,
+                error_message,
+                ..
+            } => {
+                assert_eq!(status, "error");
+                assert_eq!(error_message, "invalid_grant");
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+        adapter.shutdown().await.unwrap();
+    }
+
+    /// A plain success envelope (`isError` absent) keeps the pre-existing
+    /// behavior: a `Completed` event with `status=ok`.
+    #[tokio::test]
+    async fn call_tool_success_envelope_emits_completed_event() {
+        use crate::events::{ToolCallEvent, ToolCallEventBus};
+
+        let mut adapter = make_iserror_adapter();
+        adapter.spawn_process().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let bus = ToolCallEventBus::with_default_capacity();
+        adapter.set_event_bus(bus.clone());
+        let mut rx = bus.subscribe();
+
+        adapter
+            .call_tool("echo", serde_json::json!({}))
+            .await
+            .expect("success envelope");
+
+        match rx.try_recv().expect("started event must be buffered") {
+            ToolCallEvent::Started { .. } => {}
+            other => panic!("expected Started, got {other:?}"),
+        }
+        match rx.try_recv().expect("terminal event must be buffered") {
+            ToolCallEvent::Completed { status, .. } => assert_eq!(status, "ok"),
+            other => panic!("expected Completed, got {other:?}"),
+        }
+        adapter.shutdown().await.unwrap();
     }
 }

--- a/src/adapter/stdio.rs
+++ b/src/adapter/stdio.rs
@@ -1588,14 +1588,22 @@ impl McpAdapter for StdioAdapter {
                     .await
                     .get(name)
                     .and_then(|v| v.as_ref().and_then(annotations_from_value));
+                // The overlay displays the event's `server_name`, so prefer
+                // the effective (override-aware) name over the raw
+                // upstream-derived one, matching the observability capture.
+                let server_type = self.server_type.read().await.clone();
+                let server_name = match server_type.clone() {
+                    Some(name) => Some(name),
+                    None => self.upstream_server_name.read().await.clone(),
+                };
                 bus.send(ToolCallEvent::Started {
                     request_id: request_id.clone(),
                     request_uid: span_ctx.request_uid.clone(),
                     ts: iso8601_now(),
                     endpoint: self.config.endpoint_name.clone(),
                     transport: "stdio".into(),
-                    server_type: self.server_type.read().await.clone(),
-                    server_name: self.upstream_server_name.read().await.clone(),
+                    server_type,
+                    server_name,
                     profile: span_ctx.profile.clone(),
                     tool: name.to_string(),
                     annotations,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -976,7 +976,13 @@ impl AdapterRegistry {
         let request_value = arguments.clone();
         let request_bytes = request_value.to_string().len() as i64;
         let server_type = entry.adapter.server_type();
-        let server_name = entry.adapter.upstream_server_name();
+        // Record the effective (override-aware) name so the Observability
+        // list/detail/filter honor a configured `server_type_override`,
+        // falling back to the raw upstream-derived name when the effective
+        // name is not yet known.
+        let server_name = server_type
+            .clone()
+            .or_else(|| entry.adapter.upstream_server_name());
         let transport = entry.transport.clone();
         let endpoint_name = endpoint.clone();
         let tool_name = tool.clone();
@@ -1596,6 +1602,10 @@ impl AdapterRegistry {
         if let Some(bus) = &self.event_bus {
             let span_ctx = current_request_context();
             let request_id = uuid::Uuid::new_v4().to_string();
+            // The overlay displays the event's `server_name`, so prefer the
+            // effective (override-aware) name over the raw upstream-derived
+            // one, matching the observability capture.
+            let server_name = server_type.clone().or(server_name);
             // Emit `Started` first so the overlay can spawn an in-flight
             // card before it sees `Failed`, matching the
             // adapter-side ordering.
@@ -1642,6 +1652,10 @@ impl AdapterRegistry {
         if let Some(bus) = &self.event_bus {
             let span_ctx = current_request_context();
             let request_id = uuid::Uuid::new_v4().to_string();
+            // The overlay displays the event's `server_name`, so prefer the
+            // effective (override-aware) name over the raw upstream-derived
+            // one, matching the observability capture.
+            let server_name = server_type.clone().or(server_name);
             // Emit `Started` first so the overlay spawns an in-flight card
             // before it sees `Failed`, matching the adapter-side ordering.
             bus.send(ToolCallEvent::Started {
@@ -2464,11 +2478,97 @@ mod tests {
         );
     }
 
+    /// Route one call through a registry wired with an in-memory
+    /// observability store and return the single captured row. Capture is
+    /// gated on an inbound `request` span carrying a `request_uid`, so the
+    /// call is instrumented the same way the inbound dispatch would.
+    async fn capture_one_call(adapter: MockAdapter) -> crate::observability::store::CallRecord {
+        use crate::config::ObservabilityConfig;
+        use crate::events::SpanFieldCaptureLayer;
+        use crate::observability::payloads::PayloadStore;
+        use crate::observability::store::{QueryFilter, Store};
+        use tracing::Instrument;
+        use tracing_subscriber::prelude::*;
+
+        let subscriber = tracing_subscriber::registry().with(SpanFieldCaptureLayer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let store = Arc::new(Store::open_in_memory().unwrap());
+        let payloads = Arc::new(PayloadStore::new(10, 128, 256 * 1024));
+        let config = ObservabilityConfig {
+            enabled: true,
+            ..ObservabilityConfig::default()
+        };
+        let obs = Observability::new(&config, Arc::clone(&store), Arc::clone(&payloads));
+        let registry = AdapterRegistry::new().with_observability(obs);
+        registry
+            .register(
+                "ep".into(),
+                Box::new(adapter),
+                "stdio".into(),
+                None,
+                Some("ep".into()),
+            )
+            .await;
+        registry
+            .route_tool_call("echo", json!({}))
+            .instrument(tracing::info_span!(
+                "request",
+                method = "tools/call",
+                request_uid = "test-uid",
+            ))
+            .await
+            .unwrap();
+
+        // Drain: poll until the row lands via the background consumer.
+        let mut rows = Vec::new();
+        for _ in 0..50 {
+            rows = store.query(&QueryFilter::default(), 10, None).unwrap();
+            if !rows.is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert_eq!(rows.len(), 1, "call captured");
+        rows.remove(0)
+    }
+
+    /// Bug 2 regression: the captured `server_name` prefers the effective
+    /// (override-aware) `server_type()` over the raw upstream-derived name so
+    /// the Observability list/detail/filter honor `server_type_override`.
+    #[tokio::test]
+    #[serial_test::serial(tracing)]
+    async fn captured_server_name_prefers_effective_name() {
+        crate::test_tracing::init_permissive_tracing();
+        let adapter = MockAdapter::healthy_with_names(
+            vec![make_tool("echo")],
+            Some("gmail"),
+            Some("statelessserver"),
+        );
+        let row = capture_one_call(adapter).await;
+        assert_eq!(row.server_name.as_deref(), Some("gmail"));
+        assert_eq!(row.server_type.as_deref(), Some("gmail"));
+    }
+
+    /// Without an effective name the capture falls back to the raw
+    /// upstream-derived name (unchanged pre-fix behavior).
+    #[tokio::test]
+    #[serial_test::serial(tracing)]
+    async fn captured_server_name_falls_back_to_upstream_name() {
+        crate::test_tracing::init_permissive_tracing();
+        let adapter =
+            MockAdapter::healthy_with_names(vec![make_tool("echo")], None, Some("statelessserver"));
+        let row = capture_one_call(adapter).await;
+        assert_eq!(row.server_name.as_deref(), Some("statelessserver"));
+        assert_eq!(row.server_type, None);
+    }
+
     /// A mock adapter for testing.
     struct MockAdapter {
         health: HealthStatus,
         tools: Vec<ToolInfo>,
         server_type_val: Option<String>,
+        upstream_name_val: Option<String>,
     }
 
     impl MockAdapter {
@@ -2477,6 +2577,7 @@ mod tests {
                 health: HealthStatus::Healthy,
                 tools,
                 server_type_val: None,
+                upstream_name_val: None,
             }
         }
 
@@ -2486,6 +2587,23 @@ mod tests {
                 health: HealthStatus::Healthy,
                 tools,
                 server_type_val: Some(st.to_string()),
+                upstream_name_val: None,
+            }
+        }
+
+        /// Healthy mock with independent effective (`server_type`) and raw
+        /// upstream (`upstream_server_name`) names, for the effective-name
+        /// preference tests.
+        fn healthy_with_names(
+            tools: Vec<ToolInfo>,
+            server_type: Option<&str>,
+            upstream_name: Option<&str>,
+        ) -> Self {
+            Self {
+                health: HealthStatus::Healthy,
+                tools,
+                server_type_val: server_type.map(str::to_string),
+                upstream_name_val: upstream_name.map(str::to_string),
             }
         }
 
@@ -2494,6 +2612,7 @@ mod tests {
                 health: HealthStatus::Unhealthy("test".into()),
                 tools: vec![],
                 server_type_val: None,
+                upstream_name_val: None,
             }
         }
 
@@ -2502,6 +2621,7 @@ mod tests {
                 health: HealthStatus::Unhealthy("test".into()),
                 tools,
                 server_type_val: None,
+                upstream_name_val: None,
             }
         }
     }
@@ -2526,6 +2646,9 @@ mod tests {
         }
         fn server_type(&self) -> Option<String> {
             self.server_type_val.clone()
+        }
+        fn upstream_server_name(&self) -> Option<String> {
+            self.upstream_name_val.clone()
         }
         async fn shutdown(&mut self) -> Result<(), AdapterError> {
             Ok(())

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,5 +1,5 @@
 use crate::adapter::stdio::iso8601_now;
-use crate::adapter::{AdapterError, HealthStatus, McpAdapter, ToolInfo};
+use crate::adapter::{tool_result_error_message, AdapterError, HealthStatus, McpAdapter, ToolInfo};
 use crate::events::{current_request_context, ToolCallEvent, ToolCallEventBus};
 use crate::observability::pipeline::{CaptureRecord, CapturedPayloads, Observability};
 use crate::observability::store::CallRecord;
@@ -1831,35 +1831,6 @@ fn compile_input_schema(prefixed_name: &str, schema: &serde_json::Value) -> Opti
     }
 }
 
-/// Upper bound on a captured tool-level `error_message`, in characters. Tool
-/// error envelopes are usually short, but a misbehaving server could return a
-/// large blob; cap it so the durable row stays bounded.
-const MAX_CAPTURED_ERROR_MESSAGE_CHARS: usize = 2048;
-
-/// Inspect a transport-level `Ok` `tools/call` result for a tool-level error
-/// envelope (`{ content: [...], isError: true }`). Returns the captured
-/// `error_message` (the first `content[].text` string, truncated) when the tool
-/// reported an error, or `None` for a normal success (`isError` absent/false).
-fn tool_result_error_message(value: &serde_json::Value) -> Option<String> {
-    if value.get("isError").and_then(|e| e.as_bool()) != Some(true) {
-        return None;
-    }
-    let text = value
-        .get("content")
-        .and_then(|c| c.as_array())
-        .and_then(|items| {
-            items
-                .iter()
-                .find_map(|item| item.get("text").and_then(|t| t.as_str()))
-        })
-        .unwrap_or("tool call returned an error result");
-    let truncated: String = text
-        .chars()
-        .take(MAX_CAPTURED_ERROR_MESSAGE_CHARS)
-        .collect();
-    Some(truncated)
-}
-
 /// Format the collected validation errors into the model-friendly MCP error
 /// text (spec §5.5). All errors from a single pass are listed together so the
 /// model can correct every field in one retry.
@@ -2400,51 +2371,6 @@ mod tests {
     use crate::adapter::StartingAdapter;
     use async_trait::async_trait;
     use serde_json::json;
-
-    #[test]
-    fn tool_result_iserror_envelope_is_captured_as_failure() {
-        // A transport-level `Ok` carrying a tool-level error envelope must be
-        // recorded as a failed call with a non-empty error_message taken from
-        // the first text item in `content`.
-        let envelope = json!({
-            "content": [{ "type": "text", "text": "invalid_grant" }],
-            "isError": true,
-        });
-        let msg =
-            tool_result_error_message(&envelope).expect("isError envelope captured as failure");
-        assert_eq!(msg, "invalid_grant");
-    }
-
-    #[test]
-    fn tool_result_success_envelope_is_not_a_failure() {
-        // `isError` absent → success; explicit `isError: false` → success.
-        assert!(tool_result_error_message(&json!({ "content": [] })).is_none());
-        assert!(tool_result_error_message(&json!({
-            "content": [{ "type": "text", "text": "ok" }],
-            "isError": false,
-        }))
-        .is_none());
-    }
-
-    #[test]
-    fn tool_result_iserror_without_text_still_yields_message() {
-        // isError with no usable text content still produces a non-empty
-        // error_message so the durable row reflects the failure.
-        let msg = tool_result_error_message(&json!({ "isError": true, "content": [] }))
-            .expect("isError envelope captured as failure");
-        assert!(!msg.is_empty());
-    }
-
-    #[test]
-    fn tool_result_error_message_is_truncated() {
-        let long = "x".repeat(MAX_CAPTURED_ERROR_MESSAGE_CHARS + 500);
-        let msg = tool_result_error_message(&json!({
-            "isError": true,
-            "content": [{ "type": "text", "text": long }],
-        }))
-        .expect("isError envelope captured as failure");
-        assert_eq!(msg.chars().count(), MAX_CAPTURED_ERROR_MESSAGE_CHARS);
-    }
 
     /// Regression: an `execute_tools` JS batch reuses one inbound
     /// `request_uid` across all its inner `tools/call`s. The observability


### PR DESCRIPTION
## Summary

Two observability fixes for MCP tool-call handling in the relay.

### Bug 1: `isError` tool results were logged as successes in adapter logs

**Symptom:** When an MCP server returned a tool result with `isError: true`, the Observability tab showed no error log for the call — the adapter log recorded it as a normal successful response, so failing tool calls were invisible when scanning for errors.

**Fix (d13c9e9):** The adapter logging path now inspects the `isError` flag on tool results and logs those responses as failures, so error-flagged tool results surface in adapter logs the same way transport/protocol errors do.

### Bug 2: `server_type_override` not reflected in observability server names

**Symptom:** When a server was configured with `server_type_override`, observability records and tool-call events still carried the original (pre-override) server name, so the Observability tab attributed traffic to the wrong server name.

**Fix (69899e1):** Observability records and tool-call events now use the effective (override-aware) server name, matching what the rest of the system reports.

## Verification

- `cargo fmt --check` clean
- Full test suite run and passing prior to opening this PR (1371 tests)
