### PR TITLE
fix(oauth): thread one epoch through refresh and commit

### DIFF
--- a/src/adapter/oauth/heartbeat.rs
+++ b/src/adapter/oauth/heartbeat.rs
@@ -160,7 +160,7 @@ fn classify_tick_action(state: &OAuthState) -> TickAction {
 /// the heartbeat interval, so there is no tight retry loop here.
 async fn attempt_recovery(adapter: &Arc<OAuthAdapterInner>) {
     let refresh_epoch = adapter.current_grant_epoch();
-    match adapter.do_token_refresh().await {
+    match adapter.do_token_refresh_with_epoch(refresh_epoch).await {
         Ok(tokens) => {
             adapter.apply_refreshed_tokens(tokens, refresh_epoch).await;
         }

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -581,13 +581,29 @@ impl OAuthAdapterInner {
     /// adapter transitions to `AuthRequired` (matching the pre-existing
     /// non-2xx behavior).
     pub async fn do_token_refresh(self: &Arc<Self>) -> Result<TokenSet, OAuthError> {
-        // Capture the grant epoch this refresh runs against. Every state
+        // Convenience entry for callers that do not commit the result via
+        // `apply_refreshed_tokens` (EMA startup acquisition, tests). Callers
+        // that DO commit must snapshot the epoch themselves and pass the
+        // same value to both `do_token_refresh_with_epoch` and
+        // `apply_refreshed_tokens`, so the refresh's transitions and its
+        // commit identify the same grant.
+        let refresh_epoch = self.current_grant_epoch();
+        self.do_token_refresh_with_epoch(refresh_epoch).await
+    }
+
+    pub async fn do_token_refresh_with_epoch(
+        self: &Arc<Self>,
+        refresh_epoch: u64,
+    ) -> Result<TokenSet, OAuthError> {
+        // `refresh_epoch` is the grant epoch this refresh runs against,
+        // snapshotted by the caller BEFORE the refresh began. Every state
         // transition below goes through `transition_if_current` with this
         // epoch, so a refresh that outlives its grant (reset/disconnect,
         // possibly followed by a replacement login) cannot perturb the
         // successor grant's state (PR #145 review). The result commit is
-        // epoch-guarded separately in `apply_refreshed_tokens`.
-        let refresh_epoch = self.current_grant_epoch();
+        // epoch-guarded separately in `apply_refreshed_tokens` — with the
+        // SAME epoch value, so the two guards cannot disagree about which
+        // grant the refresh belongs to.
 
         // EMA (END-18) endpoints mint/refresh their access token through the
         // ID-JAG chain (Steps 2+3, with a stored ID Token) instead of the
@@ -1460,7 +1476,7 @@ impl OAuthAdapterInner {
                     let _ = inner.refresh_task_handle.lock().await.take();
                 }
                 let refresh_epoch = inner.current_grant_epoch();
-                match inner.do_token_refresh().await {
+                match inner.do_token_refresh_with_epoch(refresh_epoch).await {
                     Ok(new_tokens) => {
                         // Recursively apply — this will schedule the next refresh
                         inner
@@ -1493,7 +1509,7 @@ impl OAuthAdapterInner {
                             let _ = inner.refresh_task_handle.lock().await.take();
                         }
                         let retry_epoch = inner.current_grant_epoch();
-                        match inner.do_token_refresh().await {
+                        match inner.do_token_refresh_with_epoch(retry_epoch).await {
                             Ok(new_tokens) => {
                                 inner.apply_refreshed_tokens(new_tokens, retry_epoch).await;
                                 let state = inner.state.read().await.clone();
@@ -1771,7 +1787,7 @@ impl McpAdapter for OAuthAdapter {
                     // Store expired tokens so refresh can use the refresh_token
                     *self.inner.tokens.write().await = Some(token_set);
                     let refresh_epoch = self.inner.current_grant_epoch();
-                    match self.inner.do_token_refresh().await {
+                    match self.inner.do_token_refresh_with_epoch(refresh_epoch).await {
                         Ok(new_tokens) => {
                             self.inner
                                 .apply_refreshed_tokens(new_tokens, refresh_epoch)
@@ -1837,7 +1853,7 @@ impl McpAdapter for OAuthAdapter {
                             info!("Got 401 on list_tools, attempting token refresh");
 
                             let refresh_epoch = self.inner.current_grant_epoch();
-                            match self.inner.do_token_refresh().await {
+                            match self.inner.do_token_refresh_with_epoch(refresh_epoch).await {
                                 Ok(new_tokens) => {
                                     self.inner
                                         .apply_refreshed_tokens(new_tokens, refresh_epoch)
@@ -1995,7 +2011,7 @@ impl McpAdapter for OAuthAdapter {
                 let refresh_epoch = self.inner.current_grant_epoch();
                 let refresh_result = async {
                     info!("Got 401, attempting token refresh");
-                    self.inner.do_token_refresh().await
+                    self.inner.do_token_refresh_with_epoch(refresh_epoch).await
                 }
                 .instrument(self.inner.span.clone())
                 .await;

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -904,6 +904,17 @@ impl OAuthAdapterInner {
             ema.client_secret.as_deref(),
             ema.resource_client_id.as_deref(),
             ema.resource_client_secret.as_deref(),
+            // Epoch-guard the chain's endpoint-token persistence: the save at
+            // the end of `ensure_access_token` happens under this same
+            // `apply_lock`/epoch pair that guards non-EMA refresh commits, so
+            // a disconnect or replacement grant landing mid-chain drops the
+            // minted token BEFORE it reaches disk (PR #149 review) — not just
+            // at the later `apply_refreshed_tokens`.
+            Some(ema::GrantGuard {
+                apply_lock: &self.apply_lock,
+                grant_epoch: &self.grant_epoch,
+                expected_epoch: refresh_epoch,
+            }),
         )
         .await
         {
@@ -915,6 +926,17 @@ impl OAuthAdapterInner {
                 *self.pending_authorize_url.write().await = None;
                 info!("EMA token exchange successful");
                 Ok(token_set)
+            }
+            Err(EmaError::StaleGrant) => {
+                // The grant this refresh ran against is gone (reset/disconnect
+                // or replacement login). Nothing was persisted; no state
+                // transition either — `transition_if_current` would be a no-op
+                // with the stale epoch, and the successor grant's state must
+                // not be perturbed. Mirrors the non-EMA abandon path.
+                info!("Abandoning EMA refresh: grant was discarded or replaced while the chain was in flight");
+                Err(OAuthError::StaleGrant {
+                    endpoint: self.config.endpoint_name.clone(),
+                })
             }
             Err(e) => {
                 self.metrics.inc_refresh_failure();

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -179,6 +179,18 @@ pub struct OAuthAdapterConfig {
     pub ema: Option<EmaConfig>,
 }
 
+/// Outcome of an epoch-guarded refresh commit
+/// ([`OAuthAdapterInner::apply_refreshed_tokens`]): either the token set was
+/// installed, or it was dropped because the grant the refresh began against
+/// was discarded or replaced (disconnect/reset/re-login) while the refresh
+/// was in flight. Callers that report success to a user must check for the
+/// dropped case instead of assuming a returned token set was committed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefreshCommitOutcome {
+    Committed,
+    DroppedStaleGrant,
+}
+
 /// Outcome of a single POST to the OAuth token endpoint. Returned by
 /// `OAuthAdapterInner::execute_token_post` so the caller can special-case
 /// HTTP 404 (which triggers the discovery fallback) without prematurely
@@ -638,26 +650,48 @@ impl OAuthAdapterInner {
         }
 
         let correlation_id = generate_correlation_id();
+        // Pair the epoch check with the refresh-token read under the
+        // `apply_lock`: epoch bumps and token installs happen under this
+        // same lock, so a replacement grant installed after the caller's
+        // snapshot but before this read is detected HERE — the stale
+        // attempt abandons instead of POSTing the NEW grant's refresh
+        // token, which a rotating provider would invalidate even though
+        // the epoch-guarded commit would drop the result. Lock order:
+        // `refresh_mutex` → `apply_lock` is safe because no `apply_lock`
+        // holder acquires the `refresh_mutex`. The guard is dropped before
+        // `transition_if_current` below (which re-acquires the
+        // `apply_lock` itself).
         let refresh_token = {
+            let _epoch_guard = self.apply_lock.lock().await;
+            if refresh_epoch != self.grant_epoch.load(Ordering::Acquire) {
+                info!(
+                    correlation_id = %correlation_id,
+                    "Abandoning refresh: grant was discarded or replaced before refresh inputs were read"
+                );
+                return Err(OAuthError::StaleGrant {
+                    endpoint: self.config.endpoint_name.clone(),
+                });
+            }
             let tokens = self.tokens.read().await;
-            match tokens.as_ref().and_then(|t| t.refresh_token.clone()) {
-                Some(rt) => rt,
-                None => {
-                    warn!(
-                        correlation_id = %correlation_id,
-                        "No refresh token available"
-                    );
-                    self.transition_if_current(
-                        refresh_epoch,
-                        OAuthState::AuthRequired,
-                        "no refresh token",
-                    )
-                    .await;
-                    self.metrics.inc_refresh_failure();
-                    return Err(OAuthError::NoRefreshToken {
-                        endpoint: self.config.endpoint_name.clone(),
-                    });
-                }
+            tokens.as_ref().and_then(|t| t.refresh_token.clone())
+        };
+        let refresh_token = match refresh_token {
+            Some(rt) => rt,
+            None => {
+                warn!(
+                    correlation_id = %correlation_id,
+                    "No refresh token available"
+                );
+                self.transition_if_current(
+                    refresh_epoch,
+                    OAuthState::AuthRequired,
+                    "no refresh token",
+                )
+                .await;
+                self.metrics.inc_refresh_failure();
+                return Err(OAuthError::NoRefreshToken {
+                    endpoint: self.config.endpoint_name.clone(),
+                });
             }
         };
 
@@ -1215,7 +1249,11 @@ impl OAuthAdapterInner {
         self: &Arc<Self>,
         token_set: TokenSet,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
-        Box::pin(self.apply_tokens_inner(token_set, None))
+        Box::pin(async move {
+            // NEW grants always commit; the outcome only matters for
+            // epoch-guarded refresh commits.
+            let _ = self.apply_tokens_inner(token_set, None).await;
+        })
     }
 
     /// Apply a token set produced by REFRESHING the current grant (proactive
@@ -1231,15 +1269,25 @@ impl OAuthAdapterInner {
     /// replacement grant installed by a post-reset login (a presence check
     /// on `tokens` alone would miss the latter). Callback logins (a NEW
     /// grant) must keep using `apply_tokens`.
+    ///
+    /// Returns whether the tokens were committed or dropped as stale, so
+    /// callers that report success to a user (manual `POST /oauth/refresh`)
+    /// can surface the drop instead of describing a token set that was
+    /// never installed.
     pub fn apply_refreshed_tokens(
         self: &Arc<Self>,
         token_set: TokenSet,
         refresh_epoch: u64,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = RefreshCommitOutcome> + Send + '_>>
+    {
         Box::pin(self.apply_tokens_inner(token_set, Some(refresh_epoch)))
     }
 
-    async fn apply_tokens_inner(self: &Arc<Self>, token_set: TokenSet, refresh_epoch: Option<u64>) {
+    async fn apply_tokens_inner(
+        self: &Arc<Self>,
+        token_set: TokenSet,
+        refresh_epoch: Option<u64>,
+    ) -> RefreshCommitOutcome {
         // Serialize the whole apply: callback, proactive refresh, and
         // reactive refresh may overlap, and interleaved applies could pair
         // the published adapter with another apply's fingerprint baseline
@@ -1251,7 +1299,7 @@ impl OAuthAdapterInner {
                 warn!(
                     "Dropping refreshed tokens: grant was discarded or replaced (disconnect/reset/re-login) while the refresh was in flight"
                 );
-                return;
+                return RefreshCommitOutcome::DroppedStaleGrant;
             }
             Some(_) => {}
             None => {
@@ -1551,6 +1599,8 @@ impl OAuthAdapterInner {
             let handle = tokio::spawn(fut.instrument(refresh_span));
             self.refresh_task_handle.lock().await.replace(handle);
         }
+
+        RefreshCommitOutcome::Committed
     }
 
     /// Abort any existing inner→outer tools-changed forwarder and, if `rx` is
@@ -2672,10 +2722,11 @@ mod tests {
             scope: None,
             issued_at: None,
         };
-        adapter
+        let outcome = adapter
             .inner
             .apply_refreshed_tokens(refreshed, refresh_epoch)
             .await;
+        assert_eq!(outcome, RefreshCommitOutcome::DroppedStaleGrant);
 
         assert!(
             tm.load("test").await.unwrap().is_none(),
@@ -2760,10 +2811,11 @@ mod tests {
             scope: None,
             issued_at: None,
         };
-        adapter
+        let outcome = adapter
             .inner
             .apply_refreshed_tokens(stale_result, stale_epoch)
             .await;
+        assert_eq!(outcome, RefreshCommitOutcome::DroppedStaleGrant);
         assert_eq!(
             tm.load("test").await.unwrap().unwrap().access_token,
             "new-access",
@@ -2805,14 +2857,105 @@ mod tests {
             scope: None,
             issued_at: None,
         };
-        adapter
+        let outcome = adapter
             .inner
             .apply_refreshed_tokens(fresh, current_epoch)
             .await;
+        assert_eq!(outcome, RefreshCommitOutcome::Committed);
         assert_eq!(
             tm.load("test").await.unwrap().unwrap().access_token,
             "new-access-2"
         );
+    }
+
+    /// PR #149 review: the epoch guard on the COMMIT is not enough when the
+    /// replacement grant lands between the caller's epoch snapshot and the
+    /// refresh's read of its inputs. Without a start-time check the stale
+    /// attempt would read grant B's refresh token from `self.tokens` and
+    /// POST it — a rotating provider then invalidates B's refresh token
+    /// even though the commit is dropped. The refresh must abandon with
+    /// `StaleGrant` BEFORE the network call: B's refresh token is neither
+    /// used nor invalidated, and B's state and tokens are untouched.
+    #[tokio::test]
+    async fn stale_refresh_abandons_before_using_replacement_grant_inputs() {
+        use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+        let token_posts = Arc::new(AtomicUsize::new(0));
+        let (token_url, token_server) = spawn_token_server_always_500(token_posts.clone()).await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let tm = Arc::new(TokenManager::new(tmp.path().to_path_buf()));
+        let mut config = make_config();
+        config.token_endpoint_url = token_url;
+        let mut adapter = OAuthAdapter::new(config, tm.clone());
+        adapter.initialize().await.unwrap();
+
+        let grant_a = TokenSet {
+            access_token: "a-access".to_string(),
+            refresh_token: Some("a-refresh".to_string()),
+            expires_at: None,
+            token_type: "Bearer".to_string(),
+            scope: None,
+            issued_at: None,
+        };
+        adapter.inner.apply_tokens(grant_a).await;
+
+        // A refresh driver snapshots epoch A...
+        let stale_epoch = adapter.inner.current_grant_epoch();
+
+        // ...but before it reads its inputs, a replacement login installs
+        // grant B (epoch bump under the apply_lock).
+        let grant_b = TokenSet {
+            access_token: "b-access".to_string(),
+            refresh_token: Some("b-refresh".to_string()),
+            expires_at: None,
+            token_type: "Bearer".to_string(),
+            scope: None,
+            issued_at: None,
+        };
+        adapter.inner.apply_tokens(grant_b).await;
+        let state_before = adapter.inner.state.read().await.clone();
+
+        // The stale attempt now proceeds: it must abandon without touching
+        // grant B's refresh token.
+        let err = adapter
+            .inner
+            .do_token_refresh_with_epoch(stale_epoch)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, OAuthError::StaleGrant { .. }),
+            "expected StaleGrant, got {err:?}"
+        );
+        assert_eq!(
+            token_posts.load(AtomicOrdering::SeqCst),
+            0,
+            "stale refresh must not POST the replacement grant's refresh token"
+        );
+
+        // Grant B is untouched: tokens (in memory and on disk) and state.
+        let tokens = adapter.inner.tokens.read().await.clone().unwrap();
+        assert_eq!(tokens.access_token, "b-access");
+        assert_eq!(tokens.refresh_token.as_deref(), Some("b-refresh"));
+        assert_eq!(
+            tm.load("test").await.unwrap().unwrap().access_token,
+            "b-access"
+        );
+        assert_eq!(*adapter.inner.state.read().await, state_before);
+
+        // Grant B's own refresh (current epoch) still reaches the network.
+        let current_epoch = adapter.inner.current_grant_epoch();
+        let _ = adapter
+            .inner
+            .do_token_refresh_with_epoch(current_epoch)
+            .await;
+        assert_eq!(
+            token_posts.load(AtomicOrdering::SeqCst),
+            1,
+            "current-epoch refresh must proceed to the token endpoint"
+        );
+
+        token_server.abort();
     }
 
     #[test]

--- a/src/management.rs
+++ b/src/management.rs
@@ -2536,7 +2536,7 @@ async fn oauth_refresh(
 
     // Attempt refresh
     let refresh_epoch = inner.current_grant_epoch();
-    match inner.do_token_refresh().await {
+    match inner.do_token_refresh_with_epoch(refresh_epoch).await {
         Ok(new_tokens) => {
             let expires_at = new_tokens.expires_at;
             let refreshed_at = new_tokens.issued_at;

--- a/src/management.rs
+++ b/src/management.rs
@@ -16,7 +16,7 @@ use tokio::sync::RwLock;
 use tracing::{info, warn};
 
 use crate::adapter::http::{HttpAdapter, HttpConfig};
-use crate::adapter::oauth::OAuthState;
+use crate::adapter::oauth::{OAuthState, RefreshCommitOutcome};
 use crate::adapter::sse::{SseAdapter, SseConfig};
 use crate::adapter::stdio::{StdioAdapter, StdioConfig};
 use crate::adapter::{FailedAdapter, HealthStatus, McpAdapter, StartingAdapter};
@@ -2540,9 +2540,23 @@ async fn oauth_refresh(
         Ok(new_tokens) => {
             let expires_at = new_tokens.expires_at;
             let refreshed_at = new_tokens.issued_at;
-            inner
+            let outcome = inner
                 .apply_refreshed_tokens(new_tokens, refresh_epoch)
                 .await;
+
+            // A successful token-endpoint response is not a committed
+            // refresh: the commit is dropped when the grant was discarded
+            // or replaced (disconnect/reset/re-login) while the refresh was
+            // in flight. Reporting 200 with the discarded set's metadata
+            // would falsely describe tokens that were never installed.
+            if outcome == RefreshCommitOutcome::DroppedStaleGrant {
+                return error_response(
+                    StatusCode::CONFLICT,
+                    "token refresh not committed",
+                    Some("the grant was discarded or replaced (disconnect/reset/re-login) while the refresh was in flight"),
+                )
+                .into_response();
+            }
 
             let status = {
                 let s = inner.state.read().await;
@@ -2556,6 +2570,14 @@ async fn oauth_refresh(
             })
             .into_response()
         }
+        // Same concurrent disconnect/replacement, caught before the token
+        // POST: not an upstream failure, so 409 rather than 502.
+        Err(e @ crate::oauth::OAuthError::StaleGrant { .. }) => error_response(
+            StatusCode::CONFLICT,
+            "token refresh not committed",
+            Some(&e.to_string()),
+        )
+        .into_response(),
         Err(e) => error_response(
             StatusCode::BAD_GATEWAY,
             "token refresh failed",

--- a/src/oauth/ema.rs
+++ b/src/oauth/ema.rs
@@ -13,6 +13,7 @@
 //! arrives over TLS from the IdP and the downstream AS verifies the signature
 //! in Step 3. This is a documented hardening follow-up.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
@@ -108,6 +109,35 @@ pub enum EmaError {
     /// persisting the resulting access token.
     #[error("token storage error: {0}")]
     Storage(String),
+
+    /// The grant this refresh ran against was discarded or replaced
+    /// (disconnect/reset or a new login) while the chain was in flight; the
+    /// minted token was NOT persisted (see [`GrantGuard`]).
+    #[error("grant discarded or replaced while EMA refresh was in flight")]
+    StaleGrant,
+}
+
+/// Epoch guard for the endpoint-token persistence at the end of
+/// [`ensure_access_token`].
+///
+/// The OAuth adapter's grant epoch is bumped (under its `apply_lock`) by both
+/// `disconnect()` (reset/revoke) and a NEW-grant token install, so a refresh
+/// that outlives its grant must not write its result to disk — that would
+/// resurrect a revoked grant after restart or overwrite the replacement
+/// grant's persisted tokens. When a guard is supplied, the save runs under
+/// `apply_lock` and only if `grant_epoch` still equals `expected_epoch`;
+/// otherwise the chain abandons with [`EmaError::StaleGrant`]. Epoch bumps
+/// happen under this same lock, so a bump ordered after the guarded save also
+/// cleans up or overwrites what it wrote — the disk can never end up holding
+/// a stale grant's token.
+pub struct GrantGuard<'a> {
+    /// The adapter's `apply_lock`: serializes token installs, disconnects,
+    /// and epoch bumps.
+    pub apply_lock: &'a Mutex<()>,
+    /// The adapter's grant epoch counter.
+    pub grant_epoch: &'a AtomicU64,
+    /// The caller's epoch snapshot, taken BEFORE the refresh began.
+    pub expected_epoch: u64,
 }
 
 /// Build the RFC 8693 token-exchange form body for the ID Token → ID-JAG leg
@@ -612,10 +642,16 @@ async fn refresh_and_persist_idp_token(
 ///    a single refresh-and-retry. A failed refresh ⇒ [`EmaError::ReauthRequired`]
 ///    (no silent loop); an [`EmaError::AuthorizationDenied`] propagates as-is (M5).
 /// 5. [`validate_id_jag`] (M6) then Step 3 (`redeem_id_jag`), persisting the
-///    resulting `TokenSet` via [`TokenManager::save`] (M8).
+///    resulting `TokenSet` via [`TokenManager::save`] (M8). With a
+///    [`GrantGuard`] the save runs under the adapter's `apply_lock` and only
+///    while the grant epoch still matches the caller's snapshot; a stale
+///    chain abandons with [`EmaError::StaleGrant`] instead of writing a
+///    discarded grant's token to disk.
 ///
 /// `refresh_mutex` is supplied by the caller (the OAuth adapter owns one per
 /// endpoint), mirroring the adapter's existing refresh-coalescing guard.
+/// `grant_guard` is `None` only for callers with no adapter grant lifecycle
+/// (unit tests); the adapter always passes `Some`.
 ///
 /// **Credential routing (R1).** `client_id`/`client_secret` are the *requesting*
 /// client credentials and are used only on the IdP-facing legs (Step 2 exchange
@@ -648,6 +684,7 @@ pub async fn ensure_access_token(
     client_secret: Option<&str>,
     resource_client_id: Option<&str>,
     resource_client_secret: Option<&str>,
+    grant_guard: Option<GrantGuard<'_>>,
 ) -> Result<TokenSet, EmaError> {
     // Fast path: a still-valid persisted token needs neither lock nor network.
     if let Some(ts) = load_token(token_manager, endpoint).await? {
@@ -750,10 +787,32 @@ pub async fn ensure_access_token(
         resource_client_secret,
     )
     .await?;
-    token_manager
-        .save(endpoint, &token_set)
-        .await
-        .map_err(|e| EmaError::Storage(e.to_string()))?;
+    // Persist the minted token — epoch-guarded when the caller has a grant
+    // lifecycle. The guard's `apply_lock` is the same lock under which the
+    // adapter bumps the epoch (disconnect / new-grant install), so a chain
+    // that outlived its grant is detected HERE, before its token reaches
+    // disk, instead of resurrecting a revoked grant after restart or
+    // overwriting a replacement grant's persisted tokens. Lock order:
+    // `refresh_mutex` → `apply_lock`, same as the non-EMA refresh path (no
+    // `apply_lock` holder acquires the `refresh_mutex`).
+    match grant_guard {
+        Some(guard) => {
+            let _apply = guard.apply_lock.lock().await;
+            if guard.expected_epoch != guard.grant_epoch.load(Ordering::Acquire) {
+                return Err(EmaError::StaleGrant);
+            }
+            token_manager
+                .save(endpoint, &token_set)
+                .await
+                .map_err(|e| EmaError::Storage(e.to_string()))?;
+        }
+        None => {
+            token_manager
+                .save(endpoint, &token_set)
+                .await
+                .map_err(|e| EmaError::Storage(e.to_string()))?;
+        }
+    }
     Ok(token_set)
 }
 
@@ -1404,6 +1463,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .expect("valid cached token must be returned");
@@ -1429,7 +1489,7 @@ mod tests {
 
         let ts = ensure_access_token(
             &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, None, true, None, None,
-            None, None,
+            None, None, None,
         )
         .await
         .expect("chain must succeed");
@@ -1469,7 +1529,7 @@ mod tests {
 
         let ts = ensure_access_token(
             &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, None, true, None, None,
-            None, None,
+            None, None, None,
         )
         .await
         .expect("refresh then chain must succeed");
@@ -1515,7 +1575,7 @@ mod tests {
 
         let ts = ensure_access_token(
             &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, None, true, None, None,
-            None, None,
+            None, None, None,
         )
         .await
         .expect("reactive refresh then retry must succeed");
@@ -1549,7 +1609,7 @@ mod tests {
 
         let err = ensure_access_token(
             &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, None, true, None, None,
-            None, None,
+            None, None, None,
         )
         .await
         .unwrap_err();
@@ -1586,6 +1646,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap_err();
@@ -1613,6 +1674,7 @@ mod tests {
             RESOURCE,
             None,
             true,
+            None,
             None,
             None,
             None,
@@ -1651,7 +1713,7 @@ mod tests {
             handles.push(tokio::spawn(async move {
                 ensure_access_token(
                     &mgr, &lock, "ep", IDP_ISS, &idp_ep, AS_ISS, &as_ep, RESOURCE, None, true,
-                    None, None, None, None,
+                    None, None, None, None, None,
                 )
                 .await
             }));
@@ -1668,6 +1730,119 @@ mod tests {
         );
         assert_eq!(c.redeem, 1, "coalesced: exactly one Step 3");
         drop(c);
+        server.abort();
+    }
+
+    /// A stale [`GrantGuard`] (epoch bumped mid-chain, e.g. disconnect or a
+    /// replacement login) abandons the chain with `StaleGrant` and leaves NO
+    /// endpoint token on disk — the minted token must not resurrect a revoked
+    /// grant or overwrite a replacement grant's persisted tokens.
+    #[tokio::test]
+    async fn stale_grant_guard_abandons_without_persisting() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        mgr.save_idp(
+            IDP_ISS,
+            &idp_creds("good-id-token", Some(now_unix() + 3600), None),
+        )
+        .await
+        .unwrap();
+        let (idp_ep, as_ep, counts, server) =
+            spawn_token_fixture(RefreshOutcome::Fail, "good-id-token", 0).await;
+        let lock = Mutex::new(());
+        let apply_lock = Mutex::new(());
+        let epoch = AtomicU64::new(0);
+
+        // Simulate a disconnect/replacement landing while the chain is in
+        // flight: the guard's snapshot (0) no longer matches the counter.
+        epoch.store(1, Ordering::Release);
+
+        let err = ensure_access_token(
+            &mgr,
+            &lock,
+            "ep",
+            IDP_ISS,
+            &idp_ep,
+            AS_ISS,
+            &as_ep,
+            RESOURCE,
+            None,
+            true,
+            None,
+            None,
+            None,
+            None,
+            Some(GrantGuard {
+                apply_lock: &apply_lock,
+                grant_epoch: &epoch,
+                expected_epoch: 0,
+            }),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, EmaError::StaleGrant), "got {err:?}");
+        // The chain ran (the guard fires only at persistence)…
+        {
+            let c = counts.lock().unwrap();
+            assert_eq!(c.exchange, 1, "Step 2 ran before the guard fired");
+            assert_eq!(c.redeem, 1, "Step 3 ran before the guard fired");
+        }
+        // …but nothing reached disk.
+        assert!(
+            mgr.load("ep").await.unwrap().is_none(),
+            "stale chain must not persist an endpoint token"
+        );
+        server.abort();
+    }
+
+    /// A current [`GrantGuard`] (epoch unchanged) persists and returns the
+    /// minted token exactly like the guard-less path.
+    #[tokio::test]
+    async fn current_grant_guard_persists_normally() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = TokenManager::new(tmp.path().to_path_buf());
+        mgr.save_idp(
+            IDP_ISS,
+            &idp_creds("good-id-token", Some(now_unix() + 3600), None),
+        )
+        .await
+        .unwrap();
+        let (idp_ep, as_ep, _counts, server) =
+            spawn_token_fixture(RefreshOutcome::Fail, "good-id-token", 0).await;
+        let lock = Mutex::new(());
+        let apply_lock = Mutex::new(());
+        let epoch = AtomicU64::new(7);
+
+        let ts = ensure_access_token(
+            &mgr,
+            &lock,
+            "ep",
+            IDP_ISS,
+            &idp_ep,
+            AS_ISS,
+            &as_ep,
+            RESOURCE,
+            None,
+            true,
+            None,
+            None,
+            None,
+            None,
+            Some(GrantGuard {
+                apply_lock: &apply_lock,
+                grant_epoch: &epoch,
+                expected_epoch: 7,
+            }),
+        )
+        .await
+        .expect("current-epoch chain must succeed");
+
+        assert_eq!(ts.access_token, "final-access-token");
+        assert!(
+            mgr.load("ep").await.unwrap().unwrap().is_valid(),
+            "current chain persists the minted token"
+        );
         server.abort();
     }
 
@@ -1782,6 +1957,7 @@ mod tests {
             Some("req-secret"),
             Some("res-client"),
             Some("res-secret"),
+            None,
         )
         .await
         .expect("chain must succeed");
@@ -1843,6 +2019,7 @@ mod tests {
             true,
             Some("req-client"),
             Some("req-secret"),
+            None,
             None,
             None,
         )

--- a/src/oauth/mod.rs
+++ b/src/oauth/mod.rs
@@ -48,6 +48,9 @@ pub enum OAuthError {
 
     #[error("EMA token exchange failed: {0}")]
     Ema(String),
+
+    #[error("Refresh abandoned for endpoint '{endpoint}': the grant it was started for was discarded or replaced")]
+    StaleGrant { endpoint: String },
 }
 
 /// PKCE (Proof Key for Code Exchange) challenge pair for OAuth 2.0 S256.


### PR DESCRIPTION
Follow-up to #148, addressing the [review comment](https://github.com/endara-ai/endara-relay/pull/148#discussion_r3844192147) that arrived after the merge queue picked the PR up.

## Problem

`do_token_refresh` took its own `grant_epoch` snapshot instead of using the one its caller captured. If a replacement grant is applied between the two loads, the refresh runs and transitions under epoch B while the caller commits with epoch A: `apply_refreshed_tokens` drops the *successful* result, leaving grant B stuck in `Refreshing` — and if the provider rotated the refresh token, the rotated token is discarded.

## Fix

Add `do_token_refresh_with_epoch(refresh_epoch)` and thread the caller's snapshot through every committing path (proactive timer + its 60s retry, reactive 401 on `list_tools`/`call_tool`, heartbeat recovery, manual `POST /oauth/refresh`, startup refresh), so the refresh's state transitions and its commit identify the same grant — one snapshot, both guards.

`do_token_refresh()` remains as a convenience entry that snapshots internally, documented as only for callers that do not commit via `apply_refreshed_tokens` (EMA startup acquisition commits via NEW-grant `apply_tokens`, tests).

## Tests

Full suite: 1422 passed, 0 failed; clippy and rustfmt clean. The existing epoch regression tests (`refreshed_tokens_dropped_after_disconnect`, `stale_refresh_does_not_overwrite_replacement_grant`) exercise the guard pair; this change removes the only window in which the two guards could observe different epochs.
