### PR TITLE
feat: add opt-in listen_ips multi-IP MCP listener with eligibility classifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,6 +728,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "if-addrs",
  "jsonschema",
  "notify",
  "percent-encoding",
@@ -1446,6 +1447,16 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer 2.1.1",
  "icu_properties 2.1.2",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ getrandom = "0.2"
 hostname = "0.4.2"
 hyper = { version = "1", features = ["server", "http1", "http2"] }
 hyper-util = { version = "0.1", features = ["http1", "http2", "server", "server-auto", "tokio"] }
+if-addrs = "0.15.0"
 jsonschema = "0.46.5"
 notify = "7"
 percent-encoding = "2.3.2"

--- a/README.md
+++ b/README.md
@@ -132,6 +132,13 @@ write_dirs = ["/absolute/path/to/exports"]
                                   # sandbox scripts may write into via writeFile();
                                   # a leading ~/ is expanded to your home directory
                                   # (default: none — writing disabled). Hot-reloadable.
+listen_ips = ["100.101.102.103"]  # Optional — extra private-scope IPs the MCP TCP
+                                  # listener also binds on, alongside the always-bound
+                                  # 127.0.0.1 (default: none — loopback only). Only
+                                  # RFC 1918, CGNAT 100.64.0.0/10 (Tailscale), and
+                                  # IPv6 ULA fc00::/7 addresses are eligible; public
+                                  # IPs and wildcards (0.0.0.0 / ::) are refused.
+                                  # See "listen_ips and network exposure" below.
 
 # STDIO endpoint — spawns a child process
 [[endpoints]]
@@ -213,6 +220,20 @@ endpoints = ["filesystem"]
 js_execution = false
 toon_output = false
 ```
+
+### `listen_ips` and network exposure
+
+By default the relay's MCP listener binds only `127.0.0.1` — nothing on your network can reach it. `listen_ips` opts additional local IPs in, so other machines (e.g. peers on a Tailscale tailnet or your LAN) can use the relay. Loopback is always bound regardless; omitting the key or setting it to `[]` keeps the pre-existing loopback-only behavior.
+
+Only private-scope addresses are eligible:
+
+- IPv4 RFC 1918 — `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
+- IPv4 CGNAT / shared address space — `100.64.0.0/10` (Tailscale node addresses)
+- IPv6 unique-local — `fc00::/7`
+
+Wildcards (`0.0.0.0`, `::`), public, multicast, broadcast, and link-local addresses are **never bound**. Ineligible or unparseable entries are skipped with a startup warning rather than aborting startup, and duplicates are bound once. Entries are resolved when the listener binds at startup, so changing `listen_ips` requires a restart.
+
+> **⚠️ Security warning:** every IP you list exposes the full MCP endpoint — all aggregated tools, resources, and prompts — to anyone who can reach that address, with no authentication. Only list addresses on networks where you trust every host (e.g. your own tailnet). The management API is unaffected: it stays on the local Unix-domain socket / Named Pipe and is never reachable over TCP.
 
 ### Environment variable resolution
 
@@ -368,6 +389,7 @@ A curated subset of the API:
 | `POST` | `/api/endpoints/:name/disable` &nbsp;/ `enable` | Hide or restore an endpoint without removing it |
 | `GET` | `/api/config` | View current config (env values redacted) |
 | `POST` | `/api/config/reload` | Trigger a config reload |
+| `GET` | `/api/network-interfaces` | Detected private/CGNAT/ULA interface addresses eligible for `[relay] listen_ips`, plus the currently configured `listen_ips` |
 | `GET` | `/api/events/tool-calls` | Server-Sent Events stream of every tool call (in-flight, success, failure, duration, calling client) |
 | `GET` | `/api/observability/calls` | Query recorded tool calls (filter by endpoint, tool, status, time window) |
 | `GET` | `/api/observability/calls/:request_uid` | Full request/response payload for one recorded call |

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,6 +90,17 @@ pub struct RelayConfig {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub write_dirs: Option<Vec<PathBuf>>,
+    /// Extra IPs the MCP TCP listener additionally binds on. Loopback
+    /// (`127.0.0.1`) is always bound regardless. Only private-scope addresses
+    /// are eligible: IPv4 RFC 1918 (`10/8`, `172.16/12`, `192.168/16`), IPv4
+    /// CGNAT `100.64.0.0/10` (Tailscale), and IPv6 ULA `fc00::/7`. Wildcards
+    /// (`0.0.0.0` / `::`), public, multicast, broadcast, and link-local
+    /// entries are never bound — they are skipped with a startup warning (see
+    /// `crate::listen_ips`). `None`/empty means loopback only (the
+    /// pre-existing behavior).
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub listen_ips: Option<Vec<String>>,
 }
 
 impl Default for RelayConfig {
@@ -115,6 +126,7 @@ impl Default for RelayConfig {
             observability: ObservabilityConfig::default(),
             log_retention_days: None,
             write_dirs: None,
+            listen_ips: None,
         }
     }
 }
@@ -2007,6 +2019,7 @@ js_execution = false
                 observability: ObservabilityConfig::default(),
                 log_retention_days: None,
                 write_dirs: None,
+                listen_ips: None,
             },
             endpoints,
             profiles: None,
@@ -3369,6 +3382,64 @@ write_dirs = []
             parsed.relay.write_dirs,
             Some(vec![PathBuf::from("/tmp/media")])
         );
+    }
+
+    // --- listen_ips tests ---
+
+    #[test]
+    fn listen_ips_parses_under_relay_table() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+listen_ips = ["100.101.102.103", "192.168.1.5"]
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.relay.listen_ips,
+            Some(vec![
+                "100.101.102.103".to_string(),
+                "192.168.1.5".to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn listen_ips_omitted_is_none() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.relay.listen_ips, None);
+        assert_eq!(default_config().relay.listen_ips, None);
+    }
+
+    #[test]
+    fn listen_ips_empty_list_parses() {
+        let toml_str = r#"
+[relay]
+machine_name = "test"
+listen_ips = []
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.relay.listen_ips, Some(vec![]));
+    }
+
+    #[test]
+    fn listen_ips_round_trips() {
+        let config = Config {
+            relay: RelayConfig {
+                machine_name: "test".to_string(),
+                listen_ips: Some(vec!["10.0.0.7".to_string()]),
+                ..RelayConfig::default()
+            },
+            endpoints: vec![],
+            profiles: None,
+            organizations: Vec::new(),
+        };
+        let toml_str = toml::to_string_pretty(&config).unwrap();
+        let parsed: Config = toml::from_str(&toml_str).unwrap();
+        assert_eq!(parsed.relay.listen_ips, Some(vec!["10.0.0.7".to_string()]));
     }
 
     // --- resolve_write_roots tests ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod container_stats;
 pub mod events;
 pub mod js_sandbox;
 pub mod jsonrpc;
+pub mod listen_ips;
 pub mod local_network;
 pub mod management;
 pub mod management_listener;

--- a/src/listen_ips.rs
+++ b/src/listen_ips.rs
@@ -124,12 +124,23 @@ pub fn eligible_ip_kind(ip: IpAddr) -> Option<&'static str> {
 fn accepted_listen_ips(listen_ips: Option<&[String]>, warn_on_skip: bool) -> Vec<IpAddr> {
     let mut ips: Vec<IpAddr> = Vec::new();
     for entry in listen_ips.unwrap_or_default() {
-        let Ok(ip) = entry.trim().parse::<IpAddr>() else {
+        let Ok(mut ip) = entry.trim().parse::<IpAddr>() else {
             if warn_on_skip {
                 warn!(entry = %entry, "Ignoring unparseable [relay] listen_ips entry");
             }
             continue;
         };
+        // Normalize IPv4-mapped IPv6 (`::ffff:a.b.c.d`) to the embedded IPv4
+        // address before classification and dedup, matching how the
+        // classifier already treats mapped addresses. This makes the default
+        // `127.0.0.1` redundancy drop catch `::ffff:127.0.0.1`, collapses a
+        // mapped entry against its plain-v4 duplicate, and binds an AF_INET
+        // socket instead of a platform-dependent AF_INET6 mapped bind.
+        if let IpAddr::V6(v6) = ip {
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                ip = IpAddr::V4(v4);
+            }
+        }
         match classify_listen_ip(ip) {
             ListenIpClass::Ineligible(reason) => {
                 if warn_on_skip {
@@ -313,6 +324,27 @@ mod tests {
         );
     }
 
+    #[test]
+    fn ipv4_mapped_loopback_is_dropped_as_redundant() {
+        assert!(resolve(&["::ffff:127.0.0.1"], 9400).is_empty());
+    }
+
+    #[test]
+    fn ipv4_mapped_entries_normalize_to_plain_v4_binds() {
+        assert_eq!(
+            resolve(&["::ffff:192.168.1.10"], 9400),
+            vec!["192.168.1.10:9400".parse().unwrap()]
+        );
+    }
+
+    #[test]
+    fn ipv4_mapped_entries_dedupe_against_plain_v4_duplicates() {
+        assert_eq!(
+            resolve(&["::ffff:10.0.0.7", "10.0.0.7"], 9400),
+            vec!["10.0.0.7:9400".parse().unwrap()]
+        );
+    }
+
     fn canonical(entries: &[&str]) -> Vec<String> {
         let owned: Vec<String> = entries.iter().map(|s| s.to_string()).collect();
         canonical_listen_ips(Some(&owned))
@@ -345,6 +377,14 @@ mod tests {
     #[test]
     fn canonical_listen_ips_keeps_non_default_loopback_like_binding() {
         assert_eq!(canonical(&["::1"]), vec!["::1".to_string()]);
+    }
+
+    #[test]
+    fn canonical_listen_ips_normalizes_ipv4_mapped_to_plain_v4() {
+        assert_eq!(
+            canonical(&["::ffff:192.168.1.10", "::ffff:127.0.0.1"]),
+            vec!["192.168.1.10".to_string()]
+        );
     }
 
     #[test]

--- a/src/listen_ips.rs
+++ b/src/listen_ips.rs
@@ -115,6 +115,42 @@ pub fn eligible_ip_kind(ip: IpAddr) -> Option<&'static str> {
     })
 }
 
+/// Shared acceptance core for `[relay] listen_ips`: trim + parse each entry,
+/// drop unparseable and ineligible entries as well as the default
+/// `127.0.0.1`, and dedupe on the parsed `IpAddr` (so equivalent spellings
+/// like `fd12:0:0::1` and `fd12::1` collapse). `warn_on_skip` gates the
+/// startup warnings so read-only callers (the management API echo) stay
+/// silent.
+fn accepted_listen_ips(listen_ips: Option<&[String]>, warn_on_skip: bool) -> Vec<IpAddr> {
+    let mut ips: Vec<IpAddr> = Vec::new();
+    for entry in listen_ips.unwrap_or_default() {
+        let Ok(ip) = entry.trim().parse::<IpAddr>() else {
+            if warn_on_skip {
+                warn!(entry = %entry, "Ignoring unparseable [relay] listen_ips entry");
+            }
+            continue;
+        };
+        match classify_listen_ip(ip) {
+            ListenIpClass::Ineligible(reason) => {
+                if warn_on_skip {
+                    warn!(
+                        entry = %entry,
+                        reason,
+                        "Ignoring ineligible [relay] listen_ips entry; only RFC 1918, CGNAT (100.64.0.0/10), and IPv6 ULA (fc00::/7) addresses may be bound"
+                    );
+                }
+                continue;
+            }
+            ListenIpClass::Loopback if ip == IpAddr::V4(Ipv4Addr::LOCALHOST) => continue,
+            ListenIpClass::Loopback | ListenIpClass::Eligible => {}
+        }
+        if !ips.contains(&ip) {
+            ips.push(ip);
+        }
+    }
+    ips
+}
+
 /// Resolve `[relay] listen_ips` into the extra socket addresses to bind
 /// alongside the always-bound `127.0.0.1:port` listener.
 ///
@@ -123,30 +159,24 @@ pub fn eligible_ip_kind(ip: IpAddr) -> Option<&'static str> {
 /// address like `::1` is bound), but the default `127.0.0.1` itself and
 /// duplicate entries are dropped so no address is ever bound twice.
 pub fn resolve_extra_listen_addrs(listen_ips: Option<&[String]>, port: u16) -> Vec<SocketAddr> {
-    let mut addrs: Vec<SocketAddr> = Vec::new();
-    for entry in listen_ips.unwrap_or_default() {
-        let Ok(ip) = entry.trim().parse::<IpAddr>() else {
-            warn!(entry = %entry, "Ignoring unparseable [relay] listen_ips entry");
-            continue;
-        };
-        match classify_listen_ip(ip) {
-            ListenIpClass::Ineligible(reason) => {
-                warn!(
-                    entry = %entry,
-                    reason,
-                    "Ignoring ineligible [relay] listen_ips entry; only RFC 1918, CGNAT (100.64.0.0/10), and IPv6 ULA (fc00::/7) addresses may be bound"
-                );
-                continue;
-            }
-            ListenIpClass::Loopback if ip == IpAddr::V4(Ipv4Addr::LOCALHOST) => continue,
-            ListenIpClass::Loopback | ListenIpClass::Eligible => {}
-        }
-        let addr = SocketAddr::new(ip, port);
-        if !addrs.contains(&addr) {
-            addrs.push(addr);
-        }
-    }
-    addrs
+    accepted_listen_ips(listen_ips, true)
+        .into_iter()
+        .map(|ip| SocketAddr::new(ip, port))
+        .collect()
+}
+
+/// Canonicalize `[relay] listen_ips` for the management API's
+/// `GET /api/network-interfaces` toggle-state echo: the same acceptance
+/// rules as [`resolve_extra_listen_addrs`] (trim, parse, drop
+/// unparseable/ineligible entries and the default `127.0.0.1`, dedupe),
+/// rendered via `IpAddr`'s canonical `Display` so entries compare equal to
+/// the interface list's `ip` strings. Emits no warnings — this is a
+/// read-side view, not startup validation.
+pub fn canonical_listen_ips(listen_ips: Option<&[String]>) -> Vec<String> {
+    accepted_listen_ips(listen_ips, false)
+        .into_iter()
+        .map(|ip| ip.to_string())
+        .collect()
 }
 
 #[cfg(test)]
@@ -281,6 +311,53 @@ mod tests {
             resolve(&[" 10.0.0.7 ", "10.0.0.7"], 9400),
             vec!["10.0.0.7:9400".parse().unwrap()]
         );
+    }
+
+    fn canonical(entries: &[&str]) -> Vec<String> {
+        let owned: Vec<String> = entries.iter().map(|s| s.to_string()).collect();
+        canonical_listen_ips(Some(&owned))
+    }
+
+    #[test]
+    fn canonical_listen_ips_trims_and_canonicalizes() {
+        assert_eq!(
+            canonical(&[" fd12:0:0::1 ", " 10.0.0.7"]),
+            vec!["fd12::1".to_string(), "10.0.0.7".to_string()]
+        );
+    }
+
+    #[test]
+    fn canonical_listen_ips_dedupes_equivalent_spellings() {
+        assert_eq!(
+            canonical(&["fd12:0:0::1", "fd12::1", "fd12:0000::1"]),
+            vec!["fd12::1".to_string()]
+        );
+    }
+
+    #[test]
+    fn canonical_listen_ips_drops_what_binding_would_not_accept() {
+        assert_eq!(
+            canonical(&["8.8.8.8", "0.0.0.0", "not-an-ip", "127.0.0.1"]),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn canonical_listen_ips_keeps_non_default_loopback_like_binding() {
+        assert_eq!(canonical(&["::1"]), vec!["::1".to_string()]);
+    }
+
+    #[test]
+    fn canonical_listen_ips_matches_resolve_extra_listen_addrs() {
+        let entries: Vec<String> = [" fd12:0:0::1 ", "192.168.1.5", "8.8.8.8", "127.0.0.1"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let bound: Vec<String> = resolve_extra_listen_addrs(Some(&entries), 9400)
+            .iter()
+            .map(|a| a.ip().to_string())
+            .collect();
+        assert_eq!(canonical_listen_ips(Some(&entries)), bound);
     }
 
     fn kind(s: &str) -> Option<&'static str> {

--- a/src/listen_ips.rs
+++ b/src/listen_ips.rs
@@ -5,9 +5,10 @@
 //! private-scope addresses may be listed: IPv4 RFC 1918 (`10.0.0.0/8`,
 //! `172.16.0.0/12`, `192.168.0.0/16`), IPv4 CGNAT `100.64.0.0/10`
 //! (Tailscale), and IPv6 unique-local `fc00::/7`. Wildcards (`0.0.0.0`,
-//! `::`), public addresses, multicast, broadcast, and link-local addresses
-//! are never bound. Entries that fail the check are skipped with a warning
-//! instead of aborting startup — loopback remains the guaranteed listener.
+//! `::`), public addresses, multicast, broadcast, link-local, and loopback
+//! addresses are never bound (loopback is redundant with the always-bound
+//! listener). Entries that fail the check are skipped with a warning instead
+//! of aborting startup — loopback remains the guaranteed listener.
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use tracing::warn;
@@ -17,8 +18,8 @@ use tracing::warn;
 pub enum ListenIpClass {
     /// Private-scope address the relay may bind: RFC 1918, CGNAT, or ULA.
     Eligible,
-    /// Loopback — accepted, but redundant with the always-bound loopback
-    /// listener.
+    /// Loopback — never bound as an extra listener: redundant with the
+    /// always-bound `127.0.0.1` and outside the private/CGNAT/ULA allowlist.
     Loopback,
     /// Never bound; carries the reason for the startup warning.
     Ineligible(&'static str),
@@ -116,11 +117,11 @@ pub fn eligible_ip_kind(ip: IpAddr) -> Option<&'static str> {
 }
 
 /// Shared acceptance core for `[relay] listen_ips`: trim + parse each entry,
-/// drop unparseable and ineligible entries as well as the default
-/// `127.0.0.1`, and dedupe on the parsed `IpAddr` (so equivalent spellings
-/// like `fd12:0:0::1` and `fd12::1` collapse). `warn_on_skip` gates the
-/// startup warnings so read-only callers (the management API echo) stay
-/// silent.
+/// drop unparseable, ineligible, and loopback entries (loopback is redundant
+/// with the always-bound `127.0.0.1` listener), and dedupe on the parsed
+/// `IpAddr` (so equivalent spellings like `fd12:0:0::1` and `fd12::1`
+/// collapse). `warn_on_skip` gates the startup warnings so read-only callers
+/// (the management API echo) stay silent.
 fn accepted_listen_ips(listen_ips: Option<&[String]>, warn_on_skip: bool) -> Vec<IpAddr> {
     let mut ips: Vec<IpAddr> = Vec::new();
     for entry in listen_ips.unwrap_or_default() {
@@ -152,8 +153,16 @@ fn accepted_listen_ips(listen_ips: Option<&[String]>, warn_on_skip: bool) -> Vec
                 }
                 continue;
             }
-            ListenIpClass::Loopback if ip == IpAddr::V4(Ipv4Addr::LOCALHOST) => continue,
-            ListenIpClass::Loopback | ListenIpClass::Eligible => {}
+            ListenIpClass::Loopback => {
+                if warn_on_skip && ip != IpAddr::V4(Ipv4Addr::LOCALHOST) {
+                    warn!(
+                        entry = %entry,
+                        "Ignoring loopback [relay] listen_ips entry; 127.0.0.1 is always bound and only RFC 1918, CGNAT (100.64.0.0/10), and IPv6 ULA (fc00::/7) addresses may be added"
+                    );
+                }
+                continue;
+            }
+            ListenIpClass::Eligible => {}
         }
         if !ips.contains(&ip) {
             ips.push(ip);
@@ -165,10 +174,10 @@ fn accepted_listen_ips(listen_ips: Option<&[String]>, warn_on_skip: bool) -> Vec
 /// Resolve `[relay] listen_ips` into the extra socket addresses to bind
 /// alongside the always-bound `127.0.0.1:port` listener.
 ///
-/// Unparseable or ineligible entries are skipped with a `warn!` rather than
-/// aborting startup. Loopback entries are accepted (a non-default loopback
-/// address like `::1` is bound), but the default `127.0.0.1` itself and
-/// duplicate entries are dropped so no address is ever bound twice.
+/// Unparseable, ineligible, and loopback entries are skipped with a `warn!`
+/// rather than aborting startup (the default `127.0.0.1` is dropped
+/// silently — it is exactly what the primary listener binds), and duplicate
+/// entries are dropped so no address is ever bound twice.
 pub fn resolve_extra_listen_addrs(listen_ips: Option<&[String]>, port: u16) -> Vec<SocketAddr> {
     accepted_listen_ips(listen_ips, true)
         .into_iter()
@@ -179,10 +188,10 @@ pub fn resolve_extra_listen_addrs(listen_ips: Option<&[String]>, port: u16) -> V
 /// Canonicalize `[relay] listen_ips` for the management API's
 /// `GET /api/network-interfaces` toggle-state echo: the same acceptance
 /// rules as [`resolve_extra_listen_addrs`] (trim, parse, drop
-/// unparseable/ineligible entries and the default `127.0.0.1`, dedupe),
-/// rendered via `IpAddr`'s canonical `Display` so entries compare equal to
-/// the interface list's `ip` strings. Emits no warnings — this is a
-/// read-side view, not startup validation.
+/// unparseable/ineligible/loopback entries, dedupe), rendered via
+/// `IpAddr`'s canonical `Display` so entries compare equal to the interface
+/// list's `ip` strings. Emits no warnings — this is a read-side view, not
+/// startup validation.
 pub fn canonical_listen_ips(listen_ips: Option<&[String]>) -> Vec<String> {
     accepted_listen_ips(listen_ips, false)
         .into_iter()
@@ -312,8 +321,9 @@ mod tests {
     }
 
     #[test]
-    fn non_default_loopback_entry_is_accepted() {
-        assert_eq!(resolve(&["::1"], 9400), vec!["[::1]:9400".parse().unwrap()]);
+    fn all_loopback_entries_are_dropped() {
+        assert!(resolve(&["::1"], 9400).is_empty());
+        assert!(resolve(&["127.0.0.2"], 9400).is_empty());
     }
 
     #[test]
@@ -375,8 +385,8 @@ mod tests {
     }
 
     #[test]
-    fn canonical_listen_ips_keeps_non_default_loopback_like_binding() {
-        assert_eq!(canonical(&["::1"]), vec!["::1".to_string()]);
+    fn canonical_listen_ips_drops_loopback_like_binding() {
+        assert!(canonical(&["::1", "127.0.0.2"]).is_empty());
     }
 
     #[test]

--- a/src/listen_ips.rs
+++ b/src/listen_ips.rs
@@ -260,10 +260,7 @@ mod tests {
     #[test]
     fn ineligible_and_unparseable_entries_are_skipped() {
         assert_eq!(
-            resolve(
-                &["8.8.8.8", "0.0.0.0", "::", "not-an-ip", "10.1.2.3"],
-                9400
-            ),
+            resolve(&["8.8.8.8", "0.0.0.0", "::", "not-an-ip", "10.1.2.3"], 9400),
             vec!["10.1.2.3:9400".parse().unwrap()]
         );
     }

--- a/src/listen_ips.rs
+++ b/src/listen_ips.rs
@@ -1,0 +1,323 @@
+//! Eligibility rules for extra MCP listener bind addresses.
+//!
+//! `[relay] listen_ips` opts the relay into binding its MCP TCP listener on
+//! additional local IPs beyond the always-bound `127.0.0.1`. Only
+//! private-scope addresses may be listed: IPv4 RFC 1918 (`10.0.0.0/8`,
+//! `172.16.0.0/12`, `192.168.0.0/16`), IPv4 CGNAT `100.64.0.0/10`
+//! (Tailscale), and IPv6 unique-local `fc00::/7`. Wildcards (`0.0.0.0`,
+//! `::`), public addresses, multicast, broadcast, and link-local addresses
+//! are never bound. Entries that fail the check are skipped with a warning
+//! instead of aborting startup — loopback remains the guaranteed listener.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use tracing::warn;
+
+/// Classification of one candidate `listen_ips` entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ListenIpClass {
+    /// Private-scope address the relay may bind: RFC 1918, CGNAT, or ULA.
+    Eligible,
+    /// Loopback — accepted, but redundant with the always-bound loopback
+    /// listener.
+    Loopback,
+    /// Never bound; carries the reason for the startup warning.
+    Ineligible(&'static str),
+}
+
+/// Classify an IP against the `listen_ips` eligibility rules.
+pub fn classify_listen_ip(ip: IpAddr) -> ListenIpClass {
+    match ip {
+        IpAddr::V4(v4) => classify_v4(v4),
+        IpAddr::V6(v6) => classify_v6(v6),
+    }
+}
+
+fn classify_v4(ip: Ipv4Addr) -> ListenIpClass {
+    if ip.is_loopback() {
+        return ListenIpClass::Loopback;
+    }
+    if ip.is_unspecified() {
+        return ListenIpClass::Ineligible(
+            "unspecified address (0.0.0.0) would expose the relay on every interface",
+        );
+    }
+    if ip.is_broadcast() {
+        return ListenIpClass::Ineligible("broadcast address");
+    }
+    if ip.is_multicast() {
+        return ListenIpClass::Ineligible("multicast address");
+    }
+    if ip.is_link_local() {
+        return ListenIpClass::Ineligible("IPv4 link-local (169.254.0.0/16) is not supported");
+    }
+    if ip.is_private() || is_cgnat(ip) {
+        return ListenIpClass::Eligible;
+    }
+    ListenIpClass::Ineligible("public IPv4 address")
+}
+
+fn classify_v6(ip: Ipv6Addr) -> ListenIpClass {
+    // An IPv4-mapped address (`::ffff:a.b.c.d`) classifies as its embedded
+    // IPv4 address, mirroring `local_network.rs`.
+    if let Some(v4) = ip.to_ipv4_mapped() {
+        return classify_v4(v4);
+    }
+    if ip.is_loopback() {
+        return ListenIpClass::Loopback;
+    }
+    if ip.is_unspecified() {
+        return ListenIpClass::Ineligible(
+            "unspecified address (::) would expose the relay on every interface",
+        );
+    }
+    if ip.is_multicast() {
+        return ListenIpClass::Ineligible("multicast address");
+    }
+    let first = ip.segments()[0];
+    // Unique-local fc00::/7.
+    if (first & 0xfe00) == 0xfc00 {
+        return ListenIpClass::Eligible;
+    }
+    // Link-local fe80::/10.
+    if (first & 0xffc0) == 0xfe80 {
+        return ListenIpClass::Ineligible("IPv6 link-local (fe80::/10) is not supported");
+    }
+    ListenIpClass::Ineligible("public IPv6 address")
+}
+
+/// IPv4 CGNAT / shared address space `100.64.0.0/10` (RFC 6598), used by
+/// Tailscale for its per-node addresses.
+fn is_cgnat(ip: Ipv4Addr) -> bool {
+    let octets = ip.octets();
+    octets[0] == 100 && (octets[1] & 0b1100_0000) == 64
+}
+
+/// Sub-classification of an [`ListenIpClass::Eligible`] address for the
+/// management API's `GET /api/network-interfaces` payload: `"private"`
+/// (RFC 1918), `"cgnat"` (100.64.0.0/10), or `"ula"` (fc00::/7). Returns
+/// `None` for anything `classify_listen_ip` does not deem eligible
+/// (loopback, unspecified, link-local, public, ...), so those addresses can
+/// never surface through the API.
+pub fn eligible_ip_kind(ip: IpAddr) -> Option<&'static str> {
+    if classify_listen_ip(ip) != ListenIpClass::Eligible {
+        return None;
+    }
+    // An IPv4-mapped IPv6 address takes its embedded IPv4 kind, mirroring
+    // `classify_v6`.
+    let effective = match ip {
+        IpAddr::V6(v6) => v6.to_ipv4_mapped().map(IpAddr::V4).unwrap_or(ip),
+        v4 => v4,
+    };
+    Some(match effective {
+        IpAddr::V4(v4) if is_cgnat(v4) => "cgnat",
+        IpAddr::V4(_) => "private",
+        IpAddr::V6(_) => "ula",
+    })
+}
+
+/// Resolve `[relay] listen_ips` into the extra socket addresses to bind
+/// alongside the always-bound `127.0.0.1:port` listener.
+///
+/// Unparseable or ineligible entries are skipped with a `warn!` rather than
+/// aborting startup. Loopback entries are accepted (a non-default loopback
+/// address like `::1` is bound), but the default `127.0.0.1` itself and
+/// duplicate entries are dropped so no address is ever bound twice.
+pub fn resolve_extra_listen_addrs(listen_ips: Option<&[String]>, port: u16) -> Vec<SocketAddr> {
+    let mut addrs: Vec<SocketAddr> = Vec::new();
+    for entry in listen_ips.unwrap_or_default() {
+        let Ok(ip) = entry.trim().parse::<IpAddr>() else {
+            warn!(entry = %entry, "Ignoring unparseable [relay] listen_ips entry");
+            continue;
+        };
+        match classify_listen_ip(ip) {
+            ListenIpClass::Ineligible(reason) => {
+                warn!(
+                    entry = %entry,
+                    reason,
+                    "Ignoring ineligible [relay] listen_ips entry; only RFC 1918, CGNAT (100.64.0.0/10), and IPv6 ULA (fc00::/7) addresses may be bound"
+                );
+                continue;
+            }
+            ListenIpClass::Loopback if ip == IpAddr::V4(Ipv4Addr::LOCALHOST) => continue,
+            ListenIpClass::Loopback | ListenIpClass::Eligible => {}
+        }
+        let addr = SocketAddr::new(ip, port);
+        if !addrs.contains(&addr) {
+            addrs.push(addr);
+        }
+    }
+    addrs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn classify(s: &str) -> ListenIpClass {
+        classify_listen_ip(s.parse().unwrap())
+    }
+
+    fn is_eligible(s: &str) -> bool {
+        classify(s) == ListenIpClass::Eligible
+    }
+
+    fn is_ineligible(s: &str) -> bool {
+        matches!(classify(s), ListenIpClass::Ineligible(_))
+    }
+
+    #[test]
+    fn rfc1918_private_is_eligible() {
+        assert!(is_eligible("10.0.0.1"));
+        assert!(is_eligible("10.255.255.254"));
+        assert!(is_eligible("172.16.0.1"));
+        assert!(is_eligible("172.31.255.254"));
+        assert!(is_eligible("192.168.0.1"));
+        assert!(is_eligible("192.168.255.254"));
+    }
+
+    #[test]
+    fn cgnat_is_eligible_with_exact_bounds() {
+        assert!(is_eligible("100.64.0.0"));
+        assert!(is_eligible("100.101.102.103"));
+        assert!(is_eligible("100.127.255.255"));
+        // Just outside 100.64.0.0/10 is public.
+        assert!(is_ineligible("100.63.255.255"));
+        assert!(is_ineligible("100.128.0.0"));
+    }
+
+    #[test]
+    fn ipv6_ula_is_eligible() {
+        assert!(is_eligible("fc00::1"));
+        assert!(is_eligible("fd12:3456:789a::1"));
+        assert!(is_eligible("fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"));
+    }
+
+    #[test]
+    fn public_addresses_are_ineligible() {
+        assert!(is_ineligible("8.8.8.8"));
+        assert!(is_ineligible("172.32.0.1"));
+        assert!(is_ineligible("2001:db8::1"));
+        assert!(is_ineligible("2606:4700::1111"));
+    }
+
+    #[test]
+    fn unspecified_is_ineligible() {
+        assert!(is_ineligible("0.0.0.0"));
+        assert!(is_ineligible("::"));
+    }
+
+    #[test]
+    fn multicast_and_broadcast_are_ineligible() {
+        assert!(is_ineligible("224.0.0.1"));
+        assert!(is_ineligible("255.255.255.255"));
+        assert!(is_ineligible("ff02::1"));
+    }
+
+    #[test]
+    fn link_local_is_ineligible() {
+        assert!(is_ineligible("169.254.1.1"));
+        assert!(is_ineligible("fe80::1"));
+        assert!(is_ineligible("febf::1"));
+    }
+
+    #[test]
+    fn loopback_classifies_as_loopback() {
+        assert_eq!(classify("127.0.0.1"), ListenIpClass::Loopback);
+        assert_eq!(classify("127.0.0.2"), ListenIpClass::Loopback);
+        assert_eq!(classify("::1"), ListenIpClass::Loopback);
+    }
+
+    #[test]
+    fn ipv4_mapped_ipv6_classifies_as_embedded_ipv4() {
+        assert!(is_eligible("::ffff:192.168.1.10"));
+        assert!(is_eligible("::ffff:100.64.0.1"));
+        assert!(is_ineligible("::ffff:8.8.8.8"));
+        assert_eq!(classify("::ffff:127.0.0.1"), ListenIpClass::Loopback);
+    }
+
+    fn resolve(entries: &[&str], port: u16) -> Vec<SocketAddr> {
+        let owned: Vec<String> = entries.iter().map(|s| s.to_string()).collect();
+        resolve_extra_listen_addrs(Some(&owned), port)
+    }
+
+    #[test]
+    fn omitted_or_empty_resolves_to_no_extras() {
+        assert!(resolve_extra_listen_addrs(None, 9400).is_empty());
+        assert!(resolve(&[], 9400).is_empty());
+    }
+
+    #[test]
+    fn eligible_entries_bind_on_the_given_port() {
+        assert_eq!(
+            resolve(&["100.101.102.103", "192.168.1.5"], 9400),
+            vec![
+                "100.101.102.103:9400".parse().unwrap(),
+                "192.168.1.5:9400".parse().unwrap()
+            ]
+        );
+    }
+
+    #[test]
+    fn ineligible_and_unparseable_entries_are_skipped() {
+        assert_eq!(
+            resolve(
+                &["8.8.8.8", "0.0.0.0", "::", "not-an-ip", "10.1.2.3"],
+                9400
+            ),
+            vec!["10.1.2.3:9400".parse().unwrap()]
+        );
+    }
+
+    #[test]
+    fn default_loopback_entry_is_redundant_and_dropped() {
+        assert!(resolve(&["127.0.0.1"], 9400).is_empty());
+    }
+
+    #[test]
+    fn non_default_loopback_entry_is_accepted() {
+        assert_eq!(resolve(&["::1"], 9400), vec!["[::1]:9400".parse().unwrap()]);
+    }
+
+    #[test]
+    fn duplicates_are_deduped_and_whitespace_trimmed() {
+        assert_eq!(
+            resolve(&[" 10.0.0.7 ", "10.0.0.7"], 9400),
+            vec!["10.0.0.7:9400".parse().unwrap()]
+        );
+    }
+
+    fn kind(s: &str) -> Option<&'static str> {
+        eligible_ip_kind(s.parse().unwrap())
+    }
+
+    #[test]
+    fn eligible_ip_kind_subclassifies_eligible_ranges() {
+        assert_eq!(kind("10.0.0.1"), Some("private"));
+        assert_eq!(kind("172.16.0.1"), Some("private"));
+        assert_eq!(kind("192.168.1.5"), Some("private"));
+        assert_eq!(kind("100.101.102.103"), Some("cgnat"));
+        assert_eq!(kind("fd12:3456:789a::1"), Some("ula"));
+        // IPv4-mapped IPv6 takes its embedded IPv4 kind.
+        assert_eq!(kind("::ffff:192.168.1.10"), Some("private"));
+        assert_eq!(kind("::ffff:100.64.0.1"), Some("cgnat"));
+    }
+
+    #[test]
+    fn eligible_ip_kind_is_none_for_everything_else() {
+        for s in [
+            "127.0.0.1",
+            "::1",
+            "0.0.0.0",
+            "::",
+            "169.254.1.1",
+            "fe80::1",
+            "8.8.8.8",
+            "2001:db8::1",
+            "224.0.0.1",
+            "255.255.255.255",
+            "::ffff:8.8.8.8",
+        ] {
+            assert_eq!(kind(s), None, "expected no kind for {s}");
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ use js_sandbox::MetaToolHandler;
 use oauth::{OAuthFlowManager, OAuthSetupManager};
 use profile_registry::ProfileRegistry;
 use registry::AdapterRegistry;
-use server::{build_router, start_server, AppState};
+use server::{build_router, spawn_shutdown_coordinator, start_server, AppState};
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -960,6 +960,13 @@ async fn main() {
                 .relay
                 .startup_init_timeout_secs
                 .unwrap_or(config::DEFAULT_STARTUP_INIT_TIMEOUT_SECS);
+            // One persistent shutdown coordinator for the whole process: a
+            // single task owns the OS-signal receivers and flips a watch
+            // channel every listener observes. A signal that arrives at any
+            // point — during the startup wait, between the loopback bind and
+            // an extra bind, or later — is never missed by a listener bound
+            // after it, unlike per-listener one-shot signal futures.
+            let mut shutdown_rx = spawn_shutdown_coordinator();
             let mut shutdown_during_wait = false;
             if total_inits > 0 && timeout_secs > 0 {
                 let timeout = Duration::from_secs(timeout_secs);
@@ -976,7 +983,7 @@ async fn main() {
                     _ = tokio::time::sleep(timeout) => {
                         // Handles are dropped here; tasks keep running.
                     }
-                    _ = server::shutdown_signal() => {
+                    _ = shutdown_rx.wait_for(|v| *v) => {
                         shutdown_during_wait = true;
                     }
                 }
@@ -1036,24 +1043,31 @@ async fn main() {
             // Keep the management handle alive for the rest of the process.
             let _mgmt_handle = mgmt_handle;
 
-            match start_server(router.clone(), addr).await {
+            match start_server(router.clone(), addr, shutdown_rx.clone()).await {
                 Ok((bound_addr, handle)) => {
                     info!(addr = %bound_addr, "MCP server running");
 
                     // Resolve extras against the *bound* port (not the CLI
                     // value) so `--port 0` propagates the kernel-assigned
                     // port to every extra listener, and bind each one with
-                    // the same router. A bind failure here (e.g. interface
-                    // down) is non-fatal: loopback remains the guaranteed
-                    // listener. Handles are retained so shutdown awaits
-                    // every listener's graceful drain, not just loopback's.
+                    // the same router and the same shutdown watch channel.
+                    // A bind failure here (e.g. interface down) is
+                    // non-fatal: loopback remains the guaranteed listener.
+                    // Handles are retained so shutdown awaits every
+                    // listener's graceful drain, not just loopback's.
                     let extra_addrs = listen_ips::resolve_extra_listen_addrs(
                         cfg.relay.listen_ips.as_deref(),
                         bound_addr.port(),
                     );
                     let mut extra_handles = Vec::new();
                     for extra in extra_addrs {
-                        match start_server(router.clone(), extra).await {
+                        // Stop binding once shutdown has been signaled; the
+                        // already-bound listeners are draining.
+                        if *shutdown_rx.borrow() {
+                            info!(addr = %extra, "Shutdown already signaled; skipping extra listener bind");
+                            continue;
+                        }
+                        match start_server(router.clone(), extra, shutdown_rx.clone()).await {
                             Ok((extra_addr, extra_handle)) => {
                                 info!(addr = %extra_addr, "MCP server additionally listening");
                                 extra_handles.push(extra_handle);

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod advertise;
 mod container_runtime;
 mod container_stats;
 mod jsonrpc;
+mod listen_ips;
 mod local_network;
 mod prefix;
 mod profile_registry;
@@ -919,8 +920,12 @@ async fn main() {
             let router = build_router(state);
             let mgmt_router = management::management_routes(mgmt_state);
 
-            // Bind to loopback only; the relay is a local-only service.
+            // Always bind loopback; the relay is a local-only service unless
+            // `[relay] listen_ips` opts additional private-scope IPs in
+            // (ineligible entries are skipped with a warning, never bound).
             let addr: SocketAddr = ([127, 0, 0, 1], port).into();
+            let extra_addrs =
+                listen_ips::resolve_extra_listen_addrs(cfg.relay.listen_ips.as_deref(), port);
 
             // Start the management listener on its IPC path. We do this
             // *before* binding the MCP TCP listener so that callers observing
@@ -1030,9 +1035,25 @@ async fn main() {
             // Keep the management handle alive for the rest of the process.
             let _mgmt_handle = mgmt_handle;
 
-            match start_server(router, addr).await {
+            match start_server(router.clone(), addr).await {
                 Ok((bound_addr, handle)) => {
                     info!(addr = %bound_addr, "MCP server running");
+
+                    // Bind each opted-in extra listener with the same router.
+                    // A bind failure here (e.g. interface down) is non-fatal:
+                    // loopback remains the guaranteed listener. Dropping the
+                    // extra handle detaches the server task, which runs until
+                    // the shared graceful-shutdown signal fires.
+                    for extra in extra_addrs {
+                        match start_server(router.clone(), extra).await {
+                            Ok((extra_addr, _extra_handle)) => {
+                                info!(addr = %extra_addr, "MCP server additionally listening");
+                            }
+                            Err(e) => {
+                                warn!(addr = %extra, error = %e, "Failed to bind extra listen_ips address; continuing without it");
+                            }
+                        }
+                    }
 
                     // Spawn config file watcher for hot-reload
                     let _watcher_handle = ConfigWatcher::start(

--- a/src/main.rs
+++ b/src/main.rs
@@ -923,9 +923,10 @@ async fn main() {
             // Always bind loopback; the relay is a local-only service unless
             // `[relay] listen_ips` opts additional private-scope IPs in
             // (ineligible entries are skipped with a warning, never bound).
+            // Extra addresses are resolved after the loopback bind succeeds,
+            // against the port the kernel actually assigned, so `--port 0`
+            // keeps every listener on the same port.
             let addr: SocketAddr = ([127, 0, 0, 1], port).into();
-            let extra_addrs =
-                listen_ips::resolve_extra_listen_addrs(cfg.relay.listen_ips.as_deref(), port);
 
             // Start the management listener on its IPC path. We do this
             // *before* binding the MCP TCP listener so that callers observing
@@ -1039,15 +1040,23 @@ async fn main() {
                 Ok((bound_addr, handle)) => {
                     info!(addr = %bound_addr, "MCP server running");
 
-                    // Bind each opted-in extra listener with the same router.
-                    // A bind failure here (e.g. interface down) is non-fatal:
-                    // loopback remains the guaranteed listener. Dropping the
-                    // extra handle detaches the server task, which runs until
-                    // the shared graceful-shutdown signal fires.
+                    // Resolve extras against the *bound* port (not the CLI
+                    // value) so `--port 0` propagates the kernel-assigned
+                    // port to every extra listener, and bind each one with
+                    // the same router. A bind failure here (e.g. interface
+                    // down) is non-fatal: loopback remains the guaranteed
+                    // listener. Handles are retained so shutdown awaits
+                    // every listener's graceful drain, not just loopback's.
+                    let extra_addrs = listen_ips::resolve_extra_listen_addrs(
+                        cfg.relay.listen_ips.as_deref(),
+                        bound_addr.port(),
+                    );
+                    let mut extra_handles = Vec::new();
                     for extra in extra_addrs {
                         match start_server(router.clone(), extra).await {
-                            Ok((extra_addr, _extra_handle)) => {
+                            Ok((extra_addr, extra_handle)) => {
                                 info!(addr = %extra_addr, "MCP server additionally listening");
+                                extra_handles.push(extra_handle);
                             }
                             Err(e) => {
                                 warn!(addr = %extra, error = %e, "Failed to bind extra listen_ips address; continuing without it");
@@ -1072,6 +1081,13 @@ async fn main() {
                     );
 
                     handle.await.ok();
+                    // Each extra listener shares the same graceful-shutdown
+                    // signal; await its drain too before tearing down
+                    // adapters so in-flight requests on extra listeners are
+                    // not interrupted.
+                    for extra_handle in extra_handles {
+                        extra_handle.await.ok();
+                    }
 
                     // Shut down all adapters gracefully (kills STDIO child processes, etc.)
                     info!("Shutting down all adapters");

--- a/src/management.rs
+++ b/src/management.rs
@@ -660,7 +660,10 @@ pub fn filter_network_interfaces(
 /// configured `[relay] listen_ips` for toggle state.
 async fn get_network_interfaces(State(state): State<ManagementState>) -> impl IntoResponse {
     let candidates: Vec<(String, std::net::IpAddr)> = match if_addrs::get_if_addrs() {
-        Ok(ifaces) => ifaces.into_iter().map(|i| (i.name.clone(), i.ip())).collect(),
+        Ok(ifaces) => ifaces
+            .into_iter()
+            .map(|i| (i.name.clone(), i.ip()))
+            .collect(),
         Err(e) => {
             warn!(error = %e, "Failed to enumerate network interfaces");
             Vec::new()
@@ -7623,10 +7626,7 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         let body = body_json(resp).await;
-        assert_eq!(
-            body["listen_ips"],
-            serde_json::json!(["100.101.102.103"])
-        );
+        assert_eq!(body["listen_ips"], serde_json::json!(["100.101.102.103"]));
         // Interface content is machine-dependent, but the filtering invariant
         // is not: no loopback/unspecified/link-local/public address may
         // appear, and every entry re-classifies as eligible.

--- a/src/management.rs
+++ b/src/management.rs
@@ -625,6 +625,12 @@ struct NetworkInterfacesResponse {
     /// entry compares equal to an interface `ip` string and no malformed or
     /// non-bindable configured value leaks into the payload.
     listen_ips: Vec<String>,
+    /// Present only when interface enumeration itself failed, so the UI can
+    /// distinguish "couldn't detect interfaces" from "no eligible
+    /// interfaces on this host" (both carry `interfaces: []`). Omitted on
+    /// success to keep the payload backward compatible.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
 }
 
 /// Filter raw `(interface name, address)` candidates down to the addresses
@@ -657,30 +663,50 @@ pub fn filter_network_interfaces(
     out
 }
 
+/// Build the `GET /api/network-interfaces` payload from an enumeration
+/// outcome: `Ok(candidates)` filters to eligible addresses; `Err(msg)`
+/// yields an empty interface list with the failure surfaced in `error`.
+fn network_interfaces_response(
+    candidates: Result<Vec<(String, std::net::IpAddr)>, String>,
+    listen_ips: Vec<String>,
+) -> NetworkInterfacesResponse {
+    match candidates {
+        Ok(candidates) => NetworkInterfacesResponse {
+            interfaces: filter_network_interfaces(&candidates),
+            listen_ips,
+            error: None,
+        },
+        Err(e) => NetworkInterfacesResponse {
+            interfaces: Vec::new(),
+            listen_ips,
+            error: Some(e),
+        },
+    }
+}
+
 /// GET /api/network-interfaces
 ///
 /// Detected candidate interfaces for the desktop "Network exposure" UI,
 /// filtered to `listen_ips`-eligible addresses only, plus the currently
-/// configured `[relay] listen_ips` for toggle state.
+/// configured `[relay] listen_ips` for toggle state. An enumeration failure
+/// still returns 200 with `interfaces: []` but carries an `error` field so
+/// the UI can distinguish it from a host with no eligible interfaces.
 async fn get_network_interfaces(State(state): State<ManagementState>) -> impl IntoResponse {
-    let candidates: Vec<(String, std::net::IpAddr)> = match if_addrs::get_if_addrs() {
-        Ok(ifaces) => ifaces
-            .into_iter()
-            .map(|i| (i.name.clone(), i.ip()))
-            .collect(),
-        Err(e) => {
+    let candidates: Result<Vec<(String, std::net::IpAddr)>, String> = if_addrs::get_if_addrs()
+        .map(|ifaces| {
+            ifaces
+                .into_iter()
+                .map(|i| (i.name.clone(), i.ip()))
+                .collect()
+        })
+        .map_err(|e| {
             warn!(error = %e, "Failed to enumerate network interfaces");
-            Vec::new()
-        }
-    };
-    let interfaces = filter_network_interfaces(&candidates);
+            format!("failed to enumerate network interfaces: {e}")
+        });
     let listen_ips = crate::listen_ips::canonical_listen_ips(
         state.config.read().await.relay.listen_ips.as_deref(),
     );
-    Json(NetworkInterfacesResponse {
-        interfaces,
-        listen_ips,
-    })
+    Json(network_interfaces_response(candidates, listen_ips))
 }
 
 #[derive(Serialize)]
@@ -698,6 +724,12 @@ struct SanitizedRelay {
     /// the desktop Settings tab can render the Observability section; contains
     /// no secrets, so it is surfaced verbatim.
     observability: ObservabilityConfig,
+    /// `[relay] listen_ips` as configured (no secrets), surfaced verbatim so
+    /// the sanitized config view reflects the full non-secret `[relay]`
+    /// surface. The canonicalized toggle-state view lives at
+    /// `GET /api/network-interfaces`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    listen_ips: Option<Vec<String>>,
 }
 
 #[derive(Serialize)]
@@ -720,6 +752,7 @@ fn sanitize_config(config: &Config) -> SanitizedConfig {
             machine_name: config.relay.machine_name.clone(),
             local_js_execution: config.relay.local_js_execution,
             observability: config.relay.observability.clone(),
+            listen_ips: config.relay.listen_ips.clone(),
         },
         endpoints: config
             .endpoints
@@ -7552,18 +7585,63 @@ mod tests {
     #[tokio::test]
     async fn management_config_sanitized() {
         let state = test_state(vec![]).await;
+        let config = state.config.clone();
         let app = management_routes(state);
         let resp = app
+            .clone()
             .oneshot(Request::get("/api/config").body(Body::empty()).unwrap())
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         let body = body_json(resp).await;
         assert_eq!(body["relay"]["machine_name"], "test-machine");
+        // listen_ips is omitted while unset (backward-compatible payload).
+        assert!(body["relay"].get("listen_ips").is_none());
         let ep = &body["endpoints"][0];
         assert_eq!(ep["name"], "echo");
         // env values should be redacted
         assert_eq!(ep["env"]["SECRET"], "***");
+
+        // Once configured, the sanitized view surfaces [relay] listen_ips
+        // verbatim (it contains no secrets).
+        {
+            let mut cfg = config.write().await;
+            cfg.relay.listen_ips = Some(vec!["100.101.102.103".to_string()]);
+        }
+        let resp = app
+            .oneshot(Request::get("/api/config").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(
+            body["relay"]["listen_ips"],
+            serde_json::json!(["100.101.102.103"])
+        );
+    }
+
+    #[test]
+    fn network_interfaces_response_surfaces_enumeration_failure() {
+        let resp = network_interfaces_response(
+            Err("boom".to_string()),
+            vec!["100.101.102.103".to_string()],
+        );
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["error"], "boom");
+        assert_eq!(json["interfaces"], serde_json::json!([]));
+        // The rest of the payload keeps its shape so the UI stays compatible.
+        assert_eq!(json["listen_ips"], serde_json::json!(["100.101.102.103"]));
+    }
+
+    #[test]
+    fn network_interfaces_response_omits_error_on_success() {
+        let candidates = vec![("eth0".to_string(), "192.168.1.5".parse().unwrap())];
+        let resp = network_interfaces_response(Ok(candidates), Vec::new());
+        let json = serde_json::to_value(&resp).unwrap();
+        // No `error` key at all on success — an empty interface list from a
+        // successful enumeration stays distinguishable from a failure.
+        assert!(json.as_object().unwrap().get("error").is_none());
+        assert_eq!(json["interfaces"][0]["ip"], "192.168.1.5");
     }
 
     #[test]

--- a/src/management.rs
+++ b/src/management.rs
@@ -603,6 +603,84 @@ async fn get_config(State(state): State<ManagementState>) -> impl IntoResponse {
     Json(sanitized).into_response()
 }
 
+/// One detected interface address eligible for `[relay] listen_ips`.
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct NetworkInterfaceInfo {
+    /// OS interface name (e.g. `eth0`, `tailscale0`).
+    pub name: String,
+    /// The address as an IP literal.
+    pub ip: String,
+    /// `"v4"` or `"v6"`.
+    pub family: &'static str,
+    /// `"private"` (RFC 1918), `"cgnat"` (100.64.0.0/10), or `"ula"` (fc00::/7).
+    pub kind: &'static str,
+}
+
+#[derive(Serialize)]
+struct NetworkInterfacesResponse {
+    interfaces: Vec<NetworkInterfaceInfo>,
+    /// Echo of `[relay] listen_ips` so the UI can render toggle state.
+    listen_ips: Vec<String>,
+}
+
+/// Filter raw `(interface name, address)` candidates down to the addresses
+/// the relay may bind, using the same eligibility classifier as
+/// `[relay] listen_ips` (`crate::listen_ips`). Loopback, unspecified
+/// (0.0.0.0 / ::), link-local, and public addresses never pass; exact
+/// duplicates are dropped.
+pub fn filter_network_interfaces(
+    candidates: &[(String, std::net::IpAddr)],
+) -> Vec<NetworkInterfaceInfo> {
+    let mut out: Vec<NetworkInterfaceInfo> = Vec::new();
+    for (name, ip) in candidates {
+        let Some(kind) = crate::listen_ips::eligible_ip_kind(*ip) else {
+            continue;
+        };
+        let family = match ip {
+            std::net::IpAddr::V4(_) => "v4",
+            std::net::IpAddr::V6(_) => "v6",
+        };
+        let info = NetworkInterfaceInfo {
+            name: name.clone(),
+            ip: ip.to_string(),
+            family,
+            kind,
+        };
+        if !out.contains(&info) {
+            out.push(info);
+        }
+    }
+    out
+}
+
+/// GET /api/network-interfaces
+///
+/// Detected candidate interfaces for the desktop "Network exposure" UI,
+/// filtered to `listen_ips`-eligible addresses only, plus the currently
+/// configured `[relay] listen_ips` for toggle state.
+async fn get_network_interfaces(State(state): State<ManagementState>) -> impl IntoResponse {
+    let candidates: Vec<(String, std::net::IpAddr)> = match if_addrs::get_if_addrs() {
+        Ok(ifaces) => ifaces.into_iter().map(|i| (i.name.clone(), i.ip())).collect(),
+        Err(e) => {
+            warn!(error = %e, "Failed to enumerate network interfaces");
+            Vec::new()
+        }
+    };
+    let interfaces = filter_network_interfaces(&candidates);
+    let listen_ips = state
+        .config
+        .read()
+        .await
+        .relay
+        .listen_ips
+        .clone()
+        .unwrap_or_default();
+    Json(NetworkInterfacesResponse {
+        interfaces,
+        listen_ips,
+    })
+}
+
 #[derive(Serialize)]
 struct SanitizedConfig {
     relay: SanitizedRelay,
@@ -5749,6 +5827,7 @@ pub fn management_routes(state: ManagementState) -> Router {
         .route("/api/catalog", get(get_catalog))
         .route("/api/config", get(get_config))
         .route("/api/config/reload", post(reload_config))
+        .route("/api/network-interfaces", get(get_network_interfaces))
         .route("/api/test-connection", post(test_connection))
         // Profile CRUD (R4.A) — spec §8.1, §8.2.
         .route("/api/profiles", get(list_profiles).post(create_profile))
@@ -7136,6 +7215,7 @@ mod tests {
                 observability: crate::config::ObservabilityConfig::default(),
                 log_retention_days: None,
                 write_dirs: None,
+                listen_ips: None,
             },
             endpoints: vec![EndpointConfig {
                 name: "echo".to_string(),
@@ -7482,6 +7562,87 @@ mod tests {
         assert_eq!(ep["name"], "echo");
         // env values should be redacted
         assert_eq!(ep["env"]["SECRET"], "***");
+    }
+
+    #[test]
+    fn filter_network_interfaces_keeps_only_eligible_addresses() {
+        let candidates: Vec<(String, std::net::IpAddr)> = [
+            ("lo", "127.0.0.1"),
+            ("lo", "::1"),
+            ("any", "0.0.0.0"),
+            ("any6", "::"),
+            ("ll", "169.254.1.1"),
+            ("ll6", "fe80::1"),
+            ("wan", "8.8.8.8"),
+            ("wan6", "2001:db8::1"),
+            ("eth0", "192.168.1.5"),
+            ("tailscale0", "100.101.102.103"),
+            ("ula0", "fd12:3456:789a::1"),
+        ]
+        .iter()
+        .map(|(n, ip)| (n.to_string(), ip.parse().unwrap()))
+        .collect();
+
+        let out = filter_network_interfaces(&candidates);
+        let summary: Vec<(&str, &str, &str, &str)> = out
+            .iter()
+            .map(|i| (i.name.as_str(), i.ip.as_str(), i.family, i.kind))
+            .collect();
+        assert_eq!(
+            summary,
+            vec![
+                ("eth0", "192.168.1.5", "v4", "private"),
+                ("tailscale0", "100.101.102.103", "v4", "cgnat"),
+                ("ula0", "fd12:3456:789a::1", "v6", "ula"),
+            ]
+        );
+    }
+
+    #[test]
+    fn filter_network_interfaces_dedupes_exact_duplicates() {
+        let ip: std::net::IpAddr = "10.0.0.7".parse().unwrap();
+        let candidates = vec![("eth0".to_string(), ip), ("eth0".to_string(), ip)];
+        assert_eq!(filter_network_interfaces(&candidates).len(), 1);
+    }
+
+    #[tokio::test]
+    async fn management_network_interfaces_echoes_listen_ips_and_filters() {
+        let state = test_state(vec![]).await;
+        {
+            let mut cfg = state.config.write().await;
+            cfg.relay.listen_ips = Some(vec!["100.101.102.103".to_string()]);
+        }
+        let app = management_routes(state);
+        let resp = app
+            .oneshot(
+                Request::get("/api/network-interfaces")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(
+            body["listen_ips"],
+            serde_json::json!(["100.101.102.103"])
+        );
+        // Interface content is machine-dependent, but the filtering invariant
+        // is not: no loopback/unspecified/link-local/public address may
+        // appear, and every entry re-classifies as eligible.
+        for iface in body["interfaces"].as_array().unwrap() {
+            let ip: std::net::IpAddr = iface["ip"].as_str().unwrap().parse().unwrap();
+            assert_eq!(
+                crate::listen_ips::classify_listen_ip(ip),
+                crate::listen_ips::ListenIpClass::Eligible,
+                "route returned ineligible address {ip}"
+            );
+            assert!(matches!(iface["family"].as_str().unwrap(), "v4" | "v6"));
+            assert!(matches!(
+                iface["kind"].as_str().unwrap(),
+                "private" | "cgnat" | "ula"
+            ));
+        }
     }
 
     #[tokio::test]
@@ -10582,6 +10743,7 @@ command = "echo"
                 observability: crate::config::ObservabilityConfig::default(),
                 log_retention_days: None,
                 write_dirs: None,
+                listen_ips: None,
             },
             endpoints: vec![EndpointConfig {
                 name: name.to_string(),
@@ -11128,6 +11290,7 @@ command = "echo"
                 observability: crate::config::ObservabilityConfig::default(),
                 log_retention_days: None,
                 write_dirs: None,
+                listen_ips: None,
             },
             endpoints: vec![EndpointConfig {
                 name: name.to_string(),
@@ -12920,6 +13083,7 @@ command = "echo"
                 observability: crate::config::ObservabilityConfig::default(),
                 log_retention_days: None,
                 write_dirs: None,
+                listen_ips: None,
             },
             endpoints: vec![EndpointConfig {
                 name: name.to_string(),
@@ -13047,6 +13211,7 @@ client_id = "client123"
                 observability: crate::config::ObservabilityConfig::default(),
                 log_retention_days: None,
                 write_dirs: None,
+                listen_ips: None,
             },
             endpoints: vec![],
             profiles: None,
@@ -13114,6 +13279,7 @@ client_id = "client123"
                 observability: crate::config::ObservabilityConfig::default(),
                 log_retention_days: None,
                 write_dirs: None,
+                listen_ips: None,
             },
             endpoints: endpoint_names
                 .iter()
@@ -13679,6 +13845,7 @@ client_id = "client123"
                 observability: crate::config::ObservabilityConfig::default(),
                 log_retention_days: None,
                 write_dirs: None,
+                listen_ips: None,
             },
             endpoints: vec![EndpointConfig {
                 name: "existing".to_string(),

--- a/src/management.rs
+++ b/src/management.rs
@@ -619,7 +619,11 @@ pub struct NetworkInterfaceInfo {
 #[derive(Serialize)]
 struct NetworkInterfacesResponse {
     interfaces: Vec<NetworkInterfaceInfo>,
-    /// Echo of `[relay] listen_ips` so the UI can render toggle state.
+    /// Canonicalized echo of `[relay] listen_ips` so the UI can render
+    /// toggle state: parsed, eligibility-filtered, and deduplicated with the
+    /// same rules the relay uses to bind (`canonical_listen_ips`), so every
+    /// entry compares equal to an interface `ip` string and no malformed or
+    /// non-bindable configured value leaks into the payload.
     listen_ips: Vec<String>,
 }
 
@@ -670,14 +674,9 @@ async fn get_network_interfaces(State(state): State<ManagementState>) -> impl In
         }
     };
     let interfaces = filter_network_interfaces(&candidates);
-    let listen_ips = state
-        .config
-        .read()
-        .await
-        .relay
-        .listen_ips
-        .clone()
-        .unwrap_or_default();
+    let listen_ips = crate::listen_ips::canonical_listen_ips(
+        state.config.read().await.relay.listen_ips.as_deref(),
+    );
     Json(NetworkInterfacesResponse {
         interfaces,
         listen_ips,
@@ -7613,7 +7612,18 @@ mod tests {
         let state = test_state(vec![]).await;
         {
             let mut cfg = state.config.write().await;
-            cfg.relay.listen_ips = Some(vec!["100.101.102.103".to_string()]);
+            // Deliberately messy: whitespace, a non-canonical IPv6 spelling
+            // plus its canonical duplicate, a public address, an unparseable
+            // entry, and the default loopback. The echo must apply the same
+            // parse/filter/canonicalize/dedupe rules used for binding.
+            cfg.relay.listen_ips = Some(vec![
+                " fd12:0:0::1 ".to_string(),
+                "fd12::1".to_string(),
+                "8.8.8.8".to_string(),
+                "not-an-ip".to_string(),
+                "100.101.102.103".to_string(),
+                "127.0.0.1".to_string(),
+            ]);
         }
         let app = management_routes(state);
         let resp = app
@@ -7626,7 +7636,10 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         let body = body_json(resp).await;
-        assert_eq!(body["listen_ips"], serde_json::json!(["100.101.102.103"]));
+        assert_eq!(
+            body["listen_ips"],
+            serde_json::json!(["fd12::1", "100.101.102.103"])
+        );
         // Interface content is machine-dependent, but the filtering invariant
         // is not: no loopback/unspecified/link-local/public address may
         // appear, and every entry re-classifies as eligible.

--- a/src/server.rs
+++ b/src/server.rs
@@ -2772,11 +2772,31 @@ pub(crate) async fn shutdown_signal() {
     }
 }
 
+/// Spawn the process-wide shutdown coordinator: a single task that waits for
+/// an OS shutdown signal (SIGINT/SIGTERM/SIGHUP) and flips the returned watch
+/// channel to `true`. Every listener observes the same channel, so a signal
+/// arriving before a listener is bound is still seen by it — unlike
+/// per-listener one-shot signal receivers, which miss signals delivered
+/// before they were installed.
+pub fn spawn_shutdown_coordinator() -> tokio::sync::watch::Receiver<bool> {
+    let (tx, rx) = tokio::sync::watch::channel(false);
+    tokio::spawn(async move {
+        shutdown_signal().await;
+        let _ = tx.send(true);
+    });
+    rx
+}
+
 /// Start the HTTP server and return the bound address.
-/// The server runs until the provided shutdown signal completes.
+/// The server runs until the shutdown watch channel flips to `true`
+/// (see [`spawn_shutdown_coordinator`]); a channel already at `true`
+/// shuts the server down immediately. If the sender is dropped without
+/// ever signaling (e.g. tests that never shut down), the server keeps
+/// running, matching the old never-fired signal behavior.
 pub async fn start_server(
     router: Router,
     addr: SocketAddr,
+    mut shutdown: tokio::sync::watch::Receiver<bool>,
 ) -> std::io::Result<(SocketAddr, tokio::task::JoinHandle<()>)> {
     let listener = TcpListener::bind(addr).await?;
     let local_addr = listener.local_addr()?;
@@ -2784,7 +2804,13 @@ pub async fn start_server(
 
     let handle = tokio::spawn(async move {
         axum::serve(listener, router)
-            .with_graceful_shutdown(shutdown_signal())
+            .with_graceful_shutdown(async move {
+                // `wait_for` resolves immediately if the channel is already
+                // `true`, so a listener bound after the signal still drains.
+                if shutdown.wait_for(|v| *v).await.is_err() {
+                    std::future::pending::<()>().await;
+                }
+            })
             .await
             .ok();
     });
@@ -2985,6 +3011,35 @@ mod tests {
         assert_eq!(merged.version.as_deref(), Some("0.1.0"));
         assert_eq!(merged.user_agent.as_deref(), Some("claude-desktop/0.7"));
         assert_eq!(merged.origin.as_deref(), Some("https://claude.ai"));
+    }
+
+    #[tokio::test]
+    async fn start_server_drains_when_shutdown_flips_after_bind() {
+        let (tx, rx) = tokio::sync::watch::channel(false);
+        let (_addr, handle) = start_server(Router::new(), "127.0.0.1:0".parse().unwrap(), rx)
+            .await
+            .unwrap();
+        tx.send(true).unwrap();
+        tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("server did not drain after shutdown was signaled")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn start_server_bound_after_shutdown_signal_still_drains() {
+        // Regression: a listener bound *after* the shutdown signal fired must
+        // still observe it. With per-listener one-shot signal receivers it
+        // would wait forever; the shared watch channel resolves immediately.
+        let (tx, rx) = tokio::sync::watch::channel(false);
+        tx.send(true).unwrap();
+        let (_addr, handle) = start_server(Router::new(), "127.0.0.1:0".parse().unwrap(), rx)
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("late-bound server did not observe pre-existing shutdown signal")
+            .unwrap();
     }
 
     #[tokio::test]

--- a/tests/health_endpoint_integration.rs
+++ b/tests/health_endpoint_integration.rs
@@ -34,7 +34,7 @@ async fn setup_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
     };
     let router = build_router(state);
     let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
-    let (bound_addr, handle) = start_server(router, addr)
+    let (bound_addr, handle) = start_server(router, addr, tokio::sync::watch::channel(false).1)
         .await
         .expect("server start failed");
     (bound_addr, handle)

--- a/tests/hot_reload_integration.rs
+++ b/tests/hot_reload_integration.rs
@@ -71,6 +71,7 @@ async fn test_config_diff_add_endpoint() {
             observability: config::ObservabilityConfig::default(),
             log_retention_days: None,
             write_dirs: None,
+            listen_ips: None,
         },
         endpoints: vec![config::EndpointConfig {
             name: "echo-ep".to_string(),
@@ -112,6 +113,7 @@ async fn test_config_diff_add_endpoint() {
             observability: config::ObservabilityConfig::default(),
             log_retention_days: None,
             write_dirs: None,
+            listen_ips: None,
         },
         endpoints: vec![
             config::EndpointConfig {
@@ -267,6 +269,7 @@ async fn test_config_diff_remove_endpoint() {
             observability: config::ObservabilityConfig::default(),
             log_retention_days: None,
             write_dirs: None,
+            listen_ips: None,
         },
         endpoints: vec![
             config::EndpointConfig {
@@ -333,6 +336,7 @@ async fn test_config_diff_remove_endpoint() {
             observability: config::ObservabilityConfig::default(),
             log_retention_days: None,
             write_dirs: None,
+            listen_ips: None,
         },
         endpoints: vec![config::EndpointConfig {
             name: "echo-ep".to_string(),

--- a/tests/js_execution_integration.rs
+++ b/tests/js_execution_integration.rs
@@ -66,7 +66,7 @@ async fn setup_js_server(js_mode: bool) -> (SocketAddr, tokio::task::JoinHandle<
     };
     let router = build_router(state);
     let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
-    let (bound_addr, handle) = start_server(router, addr)
+    let (bound_addr, handle) = start_server(router, addr, tokio::sync::watch::channel(false).1)
         .await
         .expect("server start failed");
     (bound_addr, handle)

--- a/tests/management_api_integration.rs
+++ b/tests/management_api_integration.rs
@@ -97,6 +97,7 @@ fn test_config() -> Config {
             observability: ObservabilityConfig::default(),
             log_retention_days: None,
             write_dirs: None,
+            listen_ips: None,
         },
         endpoints: vec![EndpointConfig {
             name: "echo".to_string(),
@@ -321,6 +322,48 @@ async fn test_management_api_config() {
     assert_eq!(endpoints.len(), 1);
     assert_eq!(endpoints[0]["name"], "echo");
     assert_eq!(endpoints[0]["transport"], "stdio");
+}
+
+#[tokio::test]
+async fn test_management_api_network_interfaces() {
+    let (addr, _handle) =
+        start_management_server(vec![("echo-ep", MockAdapter::healthy_with_tools(vec![]))]).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!("http://{}/api/network-interfaces", addr))
+        .send()
+        .await
+        .expect("request failed");
+    assert!(resp.status().is_success());
+    let body: Value = resp.json().await.unwrap();
+
+    // test_config() has listen_ips: None → echoed as an empty list.
+    assert_eq!(body["listen_ips"], json!([]));
+
+    // The interface list is machine-dependent, but the filtering invariants
+    // are not: every entry has the documented shape and re-classifies as
+    // eligible (never loopback, unspecified, link-local, or public).
+    let interfaces = body["interfaces"].as_array().expect("interfaces array");
+    for iface in interfaces {
+        assert!(iface["name"].as_str().is_some());
+        let ip_str = iface["ip"].as_str().expect("ip string");
+        let ip: std::net::IpAddr = ip_str.parse().expect("valid IP literal");
+        assert_eq!(
+            endara_relay::listen_ips::classify_listen_ip(ip),
+            endara_relay::listen_ips::ListenIpClass::Eligible,
+            "route returned ineligible address {ip}"
+        );
+        assert!(!ip.is_loopback());
+        assert!(!ip.is_unspecified());
+        let family = iface["family"].as_str().unwrap();
+        assert!(matches!(family, "v4" | "v6"));
+        assert_eq!(family == "v4", ip.is_ipv4());
+        assert!(matches!(
+            iface["kind"].as_str().unwrap(),
+            "private" | "cgnat" | "ula"
+        ));
+    }
 }
 
 async fn start_management_server_with_config(

--- a/tests/mcp_server_integration.rs
+++ b/tests/mcp_server_integration.rs
@@ -66,7 +66,7 @@ async fn setup_server() -> (SocketAddr, AdapterRegistry, tokio::task::JoinHandle
     let router = build_router(state);
     // Bind to port 0 to get a random available port
     let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
-    let (bound_addr, handle) = start_server(router, addr)
+    let (bound_addr, handle) = start_server(router, addr, tokio::sync::watch::channel(false).1)
         .await
         .expect("server start failed");
 
@@ -256,7 +256,7 @@ async fn setup_native_toon_server(toon_enabled: bool) -> (SocketAddr, tokio::tas
     };
     let router = build_router(state);
     let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
-    let (bound_addr, handle) = start_server(router, addr)
+    let (bound_addr, handle) = start_server(router, addr, tokio::sync::watch::channel(false).1)
         .await
         .expect("server start failed");
     (bound_addr, handle)
@@ -430,7 +430,7 @@ async fn profile_tools_list_excludes_out_of_profile_tools() {
     };
     let router = build_router(state);
     let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
-    let (addr, _handle) = start_server(router, addr)
+    let (addr, _handle) = start_server(router, addr, tokio::sync::watch::channel(false).1)
         .await
         .expect("server start failed");
 
@@ -618,7 +618,7 @@ async fn oauth_login_heals_stale_empty_tools_list() {
     };
     let router = build_router(state);
     let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
-    let (addr, _handle) = start_server(router, addr)
+    let (addr, _handle) = start_server(router, addr, tokio::sync::watch::channel(false).1)
         .await
         .expect("server start failed");
     let client = reqwest::Client::new();

--- a/tests/multi_endpoint_integration.rs
+++ b/tests/multi_endpoint_integration.rs
@@ -100,7 +100,7 @@ async fn setup_multi_endpoint_server() -> (SocketAddr, AdapterRegistry, tokio::t
     };
     let router = build_router(state);
     let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
-    let (bound_addr, handle) = start_server(router, addr)
+    let (bound_addr, handle) = start_server(router, addr, tokio::sync::watch::channel(false).1)
         .await
         .expect("server start failed");
 
@@ -253,7 +253,7 @@ async fn test_multi_endpoint_overlapping_tool_names() {
     };
     let router = build_router(state);
     let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
-    let (bound_addr, _handle) = start_server(router, addr)
+    let (bound_addr, _handle) = start_server(router, addr, tokio::sync::watch::channel(false).1)
         .await
         .expect("server start failed");
 

--- a/tests/oauth_setup_integration.rs
+++ b/tests/oauth_setup_integration.rs
@@ -32,6 +32,7 @@ fn empty_config() -> Config {
             observability: ObservabilityConfig::default(),
             log_retention_days: None,
             write_dirs: None,
+            listen_ips: None,
         },
         endpoints: vec![EndpointConfig {
             name: "echo".to_string(),

--- a/tests/prompts_e2e_integration.rs
+++ b/tests/prompts_e2e_integration.rs
@@ -174,7 +174,9 @@ async fn setup_two_endpoint_server() -> (
     };
     let router = build_router(state);
     let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
-    let (bound, handle) = start_server(router, addr).await.expect("server start");
+    let (bound, handle) = start_server(router, addr, tokio::sync::watch::channel(false).1)
+        .await
+        .expect("server start");
 
     (
         bound,

--- a/tests/write_file_integration.rs
+++ b/tests/write_file_integration.rs
@@ -85,7 +85,7 @@ async fn setup_server(write_roots: Vec<PathBuf>) -> (SocketAddr, tokio::task::Jo
     };
     let router = build_router(state);
     let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
-    let (bound_addr, handle) = start_server(router, addr)
+    let (bound_addr, handle) = start_server(router, addr, tokio::sync::watch::channel(false).1)
         .await
         .expect("server start failed");
     (bound_addr, handle)


### PR DESCRIPTION
## Summary
Adds an opt-in list of extra listen IPs for the MCP endpoint. By default (omitted or empty relay.listen_ips), behavior is unchanged: the relay binds 127.0.0.1 only.

- New relay.listen_ips config key (TOML string array under [relay])
- New src/listen_ips.rs eligibility classifier: eligible = RFC 1918 private, CGNAT 100.64.0.0/10 (Tailscale IPv4), IPv6 ULA fc00::/7. Unspecified (0.0.0.0 / ::), public, multicast, broadcast, and link-local addresses are refused — skipped with a warning, never bound and never fatal.
- 127.0.0.1 is ALWAYS bound; configured eligible IPs are bound additionally on the same port. Extra-bind failures (e.g. interface down) are non-fatal warnings.
- New management route GET /api/network-interfaces: enumerates host interfaces (if-addrs) filtered through the same classifier, plus the currently configured listen_ips — used by the desktop Settings UI. Loopback/unspecified/link-local/public addresses can never appear in the payload.
- README: config reference, a network-exposure security warning section, and the API table row.

## Security
Enabling a non-loopback IP exposes the unauthenticated MCP endpoint to other devices on that network. The classifier makes wildcard and public binds impossible; the management API remains IPC-only.

## Testing
- cargo test: all green (17 classifier tests, config parse/round-trip tests, route unit tests, integration test asserting the payload invariant)
- cargo clippy --all-targets -- -D warnings: clean

Companion desktop PR: endara-ai/endara-desktop (Network Exposure settings UI).