### PR TITLE
fix: re-advertise tools after OAuth/HTTP endpoint recovery

### DIFF
--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -652,11 +652,18 @@ impl HttpAdapter {
     /// `health` write lock so they transition atomically with respect to
     /// [`Self::note_transport_failure`] — there is no interleaving that can
     /// leave the counter and health disagreeing.
+    ///
+    /// On an actual `Unhealthy` → `Healthy` flip (only — not on every
+    /// success) a `tools_changed` tick is emitted so the registry invalidates
+    /// any merged catalog rebuilt without this endpoint's tools during the
+    /// outage. Mirrors the SSE adapter's post-reconnect tick. `SendError`
+    /// (no subscribers) is harmless — drop it.
     async fn note_request_success(&self) {
         let mut health = self.health.write().await;
         self.transport_failures.store(0, Ordering::SeqCst);
         if matches!(*health, HealthStatus::Unhealthy(_)) {
             *health = HealthStatus::Healthy;
+            let _ = self.tools_changed_tx.send(());
         }
     }
 
@@ -2816,6 +2823,47 @@ mod tests {
             adapter.transport_failures.load(Ordering::SeqCst),
             0,
             "a successful request must reset the failure counter"
+        );
+
+        server.abort();
+    }
+
+    /// Reactive-health recovery must emit a `tools_changed` tick so the
+    /// registry invalidates the merged catalog that may have been rebuilt
+    /// without this endpoint's tools during the outage — and ONLY on the
+    /// actual Unhealthy→Healthy flip, not on every success.
+    #[tokio::test]
+    async fn recovery_flip_emits_tools_changed_tick_once() {
+        // GET 405 so the test doesn't depend on the SSE channel; POST returns ok.
+        let (url, server) = start_fake_http_server(true).await;
+        let adapter = HttpAdapter::new(HttpConfig::new(url));
+        let mut rx = adapter.subscribe_tools_changed().expect("Some receiver");
+        // Simulate a prior run of transport failures that demoted the adapter.
+        *adapter.health.write().await = HealthStatus::Unhealthy("upstream unreachable".into());
+        adapter.transport_failures.store(5, Ordering::SeqCst);
+
+        adapter
+            .call_tool("x", json!({}))
+            .await
+            .expect("live server should answer successfully");
+        assert_eq!(adapter.health(), HealthStatus::Healthy);
+        assert!(
+            rx.try_recv().is_ok(),
+            "Unhealthy→Healthy flip must emit a tools_changed tick"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "the flip must emit exactly one tick"
+        );
+
+        // A further success while already Healthy must NOT tick.
+        adapter
+            .call_tool("x", json!({}))
+            .await
+            .expect("live server should answer successfully");
+        assert!(
+            rx.try_recv().is_err(),
+            "a success while already Healthy must not emit a tick"
         );
 
         server.abort();

--- a/src/adapter/http.rs
+++ b/src/adapter/http.rs
@@ -656,13 +656,26 @@ impl HttpAdapter {
     /// On an actual `Unhealthy` → `Healthy` flip (only — not on every
     /// success) a `tools_changed` tick is emitted so the registry invalidates
     /// any merged catalog rebuilt without this endpoint's tools during the
-    /// outage. Mirrors the SSE adapter's post-reconnect tick. `SendError`
-    /// (no subscribers) is harmless — drop it.
+    /// outage. The tick is sent AFTER the statement-scoped write guard drops
+    /// (mirroring the SSE adapter's post-reconnect tick): [`Self::health`]
+    /// reads via `try_read` with a `Starting` fallback, so a catalog rebuild
+    /// racing a tick sent under the guard would mislabel the endpoint
+    /// UNAVAILABLE with no corrective tick to follow. A failure interleaving
+    /// between the drop and the send is benign — it just re-demotes health
+    /// and the next recovery flip ticks again. `SendError` (no subscribers)
+    /// is harmless — drop it.
     async fn note_request_success(&self) {
-        let mut health = self.health.write().await;
-        self.transport_failures.store(0, Ordering::SeqCst);
-        if matches!(*health, HealthStatus::Unhealthy(_)) {
-            *health = HealthStatus::Healthy;
+        let flipped = {
+            let mut health = self.health.write().await;
+            self.transport_failures.store(0, Ordering::SeqCst);
+            if matches!(*health, HealthStatus::Unhealthy(_)) {
+                *health = HealthStatus::Healthy;
+                true
+            } else {
+                false
+            }
+        };
+        if flipped {
             let _ = self.tools_changed_tx.send(());
         }
     }

--- a/src/adapter/oauth/heartbeat.rs
+++ b/src/adapter/oauth/heartbeat.rs
@@ -339,6 +339,16 @@ async fn apply_probe_action(
                 result = "unhealthy",
                 "heartbeat probe got 401, transitioning to AuthRequired"
             );
+            // Inside the state write critical section so the baseline
+            // clear is atomic with the degraded transition, matching the
+            // other state writers (`transition_to` /
+            // `transition_if_current`): while AuthRequired the registry
+            // may rebuild the merged catalog without this endpoint's
+            // tools, so the recovery apply must tick even when the
+            // re-probed tool set is unchanged.
+            adapter
+                .clear_fingerprint_on_degraded(&OAuthState::AuthRequired)
+                .await;
             *state = OAuthState::AuthRequired;
             // Keep the invariant "every state write bumps the generation
             // inside the write critical section" (see
@@ -956,7 +966,8 @@ mod tests {
     }
 
     /// Spawn a minimal MCP server so `apply_tokens` can re-init the inner
-    /// adapter and reach `Authenticated`.
+    /// adapter and reach `Authenticated`. Serves a FIXED tool set so the
+    /// fingerprint probe stores a stable `Some` baseline.
     async fn spawn_minimal_mcp_server() -> (String, tokio::task::JoinHandle<()>) {
         use axum::{routing::post, Json, Router};
         use serde_json::{json, Value};
@@ -964,8 +975,8 @@ mod tests {
         async fn handle(Json(body): Json<Value>) -> Json<Value> {
             let id = body.get("id").cloned().unwrap_or(Value::Null);
             let method = body.get("method").and_then(|m| m.as_str()).unwrap_or("");
-            if method == "initialize" {
-                Json(json!({
+            match method {
+                "initialize" => Json(json!({
                     "jsonrpc": "2.0",
                     "id": id,
                     "result": {
@@ -973,9 +984,19 @@ mod tests {
                         "capabilities": {},
                         "serverInfo": {"name": "test-server", "version": "0.0.1"},
                     },
-                }))
-            } else {
-                Json(json!({"jsonrpc": "2.0", "id": id, "result": {}}))
+                })),
+                "tools/list" => Json(json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {
+                        "tools": [{
+                            "name": "alpha",
+                            "description": "fixed tool",
+                            "inputSchema": {"type": "object", "properties": {}},
+                        }],
+                    },
+                })),
+                _ => Json(json!({"jsonrpc": "2.0", "id": id, "result": {}})),
             }
         }
 
@@ -1053,5 +1074,90 @@ mod tests {
             OAuthState::ConnectionFailed,
             "recovery must keep retrying without wedging"
         );
+    }
+
+    // -- Heartbeat-401 degradation → recovery-tick regression ---------------
+
+    fn make_tokens(access: &str) -> TokenSet {
+        TokenSet {
+            access_token: access.to_string(),
+            refresh_token: None,
+            expires_at: None,
+            token_type: "Bearer".to_string(),
+            scope: None,
+            issued_at: None,
+        }
+    }
+
+    /// Wait briefly for an outer tick. Returns whether one arrived.
+    async fn recv_outer_tick(
+        rx: &mut tokio::sync::broadcast::Receiver<()>,
+        timeout: Duration,
+    ) -> bool {
+        use tokio::sync::broadcast::error::RecvError;
+        matches!(
+            tokio::time::timeout(timeout, rx.recv()).await,
+            Ok(Ok(())) | Ok(Err(RecvError::Lagged(_)))
+        )
+    }
+
+    /// Drain any already-queued ticks so subsequent `recv` reflects new sends.
+    async fn drain_ticks(rx: &mut tokio::sync::broadcast::Receiver<()>) {
+        while recv_outer_tick(rx, Duration::from_millis(20)).await {}
+    }
+
+    /// Regression (PR #151 review): the heartbeat's AuthFailed arm writes
+    /// `AuthRequired` directly under the state write lock (bypassing
+    /// `transition_to`), so it must ALSO clear the tools-fingerprint
+    /// baseline — without the clear, a heartbeat-401 degradation followed
+    /// by a re-login reproducing the SAME tool set suppresses the recovery
+    /// tick (A==A comparison) and leaves the endpoint's tools missing from
+    /// the merged catalog until an unrelated invalidation.
+    #[tokio::test]
+    async fn heartbeat_401_degradation_clears_fingerprint_so_recovery_apply_ticks() {
+        use crate::adapter::McpAdapter as _;
+
+        let threshold = 3;
+        let (mcp_url, mcp_srv) = spawn_minimal_mcp_server().await;
+        let tmp = tempfile::tempdir().unwrap().keep();
+        let tm = Arc::new(TokenManager::new(tmp));
+        let mut config = make_test_config(threshold);
+        config.url = mcp_url;
+        let mut adapter = OAuthAdapter::new(config, tm);
+        adapter.initialize().await.unwrap();
+        let inner = adapter.shared_inner();
+        let mut outer_rx = adapter.subscribe_tools_changed().expect("outer rx");
+
+        // Baseline: apply with the server's fixed tool set → Authenticated
+        // with a stored fingerprint.
+        inner.apply_tokens(make_tokens("first")).await;
+        assert_eq!(*inner.state.read().await, OAuthState::Authenticated);
+        assert!(
+            inner.last_tools_fingerprint.read().await.is_some(),
+            "baseline fingerprint must be stored after a successful probe"
+        );
+        drain_ticks(&mut outer_rx).await;
+
+        // A heartbeat probe 401 lands through the real dispatch path,
+        // degrading to AuthRequired via the AuthFailed arm.
+        let mut failures = 0u32;
+        step_once(&inner, auth(), &mut failures, threshold).await;
+        assert_eq!(*inner.state.read().await, OAuthState::AuthRequired);
+        assert!(
+            inner.last_tools_fingerprint.read().await.is_none(),
+            "heartbeat 401 → AuthRequired must clear the fingerprint baseline"
+        );
+
+        // Recovery re-login reproducing the SAME tool set: the baseline is
+        // unknown, so the Some→Some swap must tick so the registry restores
+        // the endpoint's tools to the merged catalog.
+        inner.apply_tokens(make_tokens("second")).await;
+        assert!(
+            recv_outer_tick(&mut outer_rx, Duration::from_millis(500)).await,
+            "recovery apply after a heartbeat-401 degradation must tick even \
+             when the probed tool set is unchanged"
+        );
+
+        mcp_srv.abort();
     }
 }

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -325,8 +325,12 @@ pub struct OAuthAdapterInner {
     /// (`AuthRequired`/`ConnectionFailed`/`Disconnected` — the registry may
     /// rebuild the merged catalog without this endpoint's tools while
     /// degraded, so the recovery apply must tick even if the tool set is
-    /// unchanged; see `transition_to`). `Arc` so the forwarder task can
-    /// share it.
+    /// unchanged). Both state writers perform the degraded-state clear via
+    /// [`Self::clear_fingerprint_on_degraded`]: `transition_to`, and
+    /// `transition_if_current` AFTER its grant-epoch check passes — a
+    /// stale grant's refresh failure is skipped entirely and must not wipe
+    /// the CURRENT grant's baseline (that would make the next routine
+    /// refresh tick spuriously). `Arc` so the forwarder task can share it.
     last_tools_fingerprint: Arc<RwLock<Option<u64>>>,
     /// Serializes [`Self::apply_tokens`] end-to-end. The OAuth callback,
     /// proactive refresh, and reactive (401) refresh can all apply tokens
@@ -400,6 +404,31 @@ impl OAuthAdapterInner {
         Some(hasher.finish())
     }
 
+    /// Clear the tools-fingerprint baseline when `new_state` is degraded
+    /// (`AuthRequired`/`ConnectionFailed`/`Disconnected`). Entering a
+    /// degraded state means the registry may rebuild the merged catalog
+    /// without this endpoint's tools; clearing the baseline makes the next
+    /// successful `apply_tokens` hit the `(None, Some(_))` branch and tick
+    /// even when the tool set is unchanged. `Refreshing`/`Authenticated`
+    /// keep the baseline so routine refreshes stay silent (PR #140 review).
+    ///
+    /// Called by both state writers ([`Self::transition_to`] and
+    /// [`Self::transition_if_current`]) inside the `state` write critical
+    /// section — and, in `transition_if_current`, only AFTER the
+    /// grant-epoch check passes: a stale grant's refresh failure must not
+    /// wipe the current grant's baseline. Nothing holds the fingerprint
+    /// lock while acquiring the state lock (the forwarder task and
+    /// `apply_tokens_inner` take it in standalone statements), so taking
+    /// it under the state write lock is deadlock-free.
+    async fn clear_fingerprint_on_degraded(&self, new_state: &OAuthState) {
+        if matches!(
+            new_state,
+            OAuthState::AuthRequired | OAuthState::ConnectionFailed | OAuthState::Disconnected
+        ) {
+            *self.last_tools_fingerprint.write().await = None;
+        }
+    }
+
     /// Transition to a new `OAuthState`.
     ///
     /// This is the **single writer** of `self.state`. It acquires the state
@@ -407,19 +436,11 @@ impl OAuthAdapterInner {
     /// records it in the ring buffer, emits a tracing event, and updates
     /// the state.
     pub async fn transition_to(&self, new_state: OAuthState, reason: &str) {
-        // Entering a degraded state means the registry may rebuild the
-        // merged catalog without this endpoint's tools; clear the
-        // fingerprint baseline so the next successful `apply_tokens` hits
-        // the `(None, Some(_))` branch and ticks even when the tool set is
-        // unchanged. `Refreshing`/`Authenticated` keep the baseline so
-        // routine refreshes stay silent (PR #140 review).
-        if matches!(
-            new_state,
-            OAuthState::AuthRequired | OAuthState::ConnectionFailed | OAuthState::Disconnected
-        ) {
-            *self.last_tools_fingerprint.write().await = None;
-        }
         let mut state = self.state.write().await;
+        // Inside the state write critical section so the baseline clear is
+        // atomic with the transition itself (no window where the state is
+        // degraded but the baseline still holds, or vice versa).
+        self.clear_fingerprint_on_degraded(&new_state).await;
         let mut history = self.transition_history.write().await;
         let old = do_transition(&mut state, new_state.clone(), reason, &mut history);
         // Bumped inside the write critical section so "generation
@@ -475,6 +496,10 @@ impl OAuthAdapterInner {
             );
             return false;
         }
+        // Epoch check passed: this failure belongs to the CURRENT grant, so
+        // the degraded-state baseline clear applies (a stale grant's
+        // failure returns above without touching the baseline).
+        self.clear_fingerprint_on_degraded(&new_state).await;
         let mut history = self.transition_history.write().await;
         let old = do_transition(&mut state, new_state.clone(), reason, &mut history);
         // Bumped inside the write critical section like every other state
@@ -4755,9 +4780,10 @@ mod tests {
         );
         drain(&mut outer_rx).await;
 
-        // Simulate a refresh failure: the adapter degrades to AuthRequired
-        // (same transition `do_token_refresh` performs on a non-2xx token
-        // response).
+        // Degrade via the unconditional writer, `transition_to` (post-#148
+        // the production refresh-failure paths degrade via
+        // `transition_if_current` instead — that path is pinned by
+        // `epoch_guarded_degraded_transition_clears_fingerprint` below).
         adapter
             .inner
             .transition_to(OAuthState::AuthRequired, "test: refresh failure")
@@ -4775,6 +4801,102 @@ mod tests {
             recv_tick(&mut outer_rx, Duration::from_millis(500)).await,
             "recovery apply after a degraded state must tick even if the \
              probed set matches the pre-failure baseline"
+        );
+        server.abort();
+    }
+
+    /// Regression (PR #151 review): post-#148/#149 the production refresh
+    /// failure paths degrade via `transition_if_current`, which bypassed
+    /// the fingerprint clear that lived only in `transition_to` — so the
+    /// primary scenario (token refresh failed → AuthRequired → re-login
+    /// with an unchanged tool set) still suppressed the recovery tick.
+    /// Pins both halves of the epoch-guarded behavior: a CURRENT-epoch
+    /// degraded transition clears the baseline (recovery apply ticks), and
+    /// a STALE-epoch one is skipped without touching the current grant's
+    /// baseline (no spurious tick on the next routine refresh).
+    #[tokio::test]
+    async fn epoch_guarded_degraded_transition_clears_fingerprint() {
+        let tool_name = Arc::new(std::sync::RwLock::new("alpha".to_string()));
+        let (url, server) = spawn_mcp_server_with_mutable_tools(tool_name.clone()).await;
+        let mut config = make_config();
+        config.url = url;
+        let mut adapter = make_adapter(config);
+        adapter.initialize().await.unwrap();
+        let mut outer_rx = adapter.subscribe_tools_changed().expect("outer rx");
+
+        // Baseline: apply with tool set A → fingerprint stored.
+        adapter.inner.apply_tokens(make_token_set("first")).await;
+        assert!(
+            recv_tick(&mut outer_rx, Duration::from_millis(500)).await,
+            "None→Some must tick"
+        );
+        assert!(
+            adapter.inner.last_tools_fingerprint.read().await.is_some(),
+            "baseline fingerprint must be stored after a successful probe"
+        );
+        drain(&mut outer_rx).await;
+
+        // Refresh failure against the CURRENT grant: degrade through the
+        // epoch-guarded path exactly as `do_token_refresh` does on a
+        // non-2xx token response.
+        let current_epoch = adapter.inner.current_grant_epoch();
+        assert!(
+            adapter
+                .inner
+                .transition_if_current(
+                    current_epoch,
+                    OAuthState::AuthRequired,
+                    "test: refresh failure (current epoch)",
+                )
+                .await,
+            "current-epoch transition must be performed"
+        );
+        assert!(
+            adapter.inner.last_tools_fingerprint.read().await.is_none(),
+            "current-epoch degradation via transition_if_current must clear \
+             the fingerprint baseline"
+        );
+
+        // Recovery re-login reproducing the SAME tool set A must tick.
+        adapter.inner.apply_tokens(make_token_set("second")).await;
+        assert!(
+            recv_tick(&mut outer_rx, Duration::from_millis(500)).await,
+            "recovery apply after an epoch-guarded degradation must tick \
+             even if the probed set matches the pre-failure baseline"
+        );
+        drain(&mut outer_rx).await;
+        assert!(
+            adapter.inner.last_tools_fingerprint.read().await.is_some(),
+            "recovery apply must re-establish the fingerprint baseline"
+        );
+
+        // A STALE grant's refresh failure (epoch bumped by the re-login
+        // above) must be skipped entirely: no transition, and the CURRENT
+        // grant's baseline stays intact — wiping it would make the next
+        // routine refresh tick spuriously.
+        assert!(
+            !adapter
+                .inner
+                .transition_if_current(
+                    current_epoch,
+                    OAuthState::AuthRequired,
+                    "test: refresh failure (stale epoch)",
+                )
+                .await,
+            "stale-epoch transition must be skipped"
+        );
+        assert!(
+            adapter.inner.last_tools_fingerprint.read().await.is_some(),
+            "stale-epoch transition_if_current must NOT clear the current \
+             grant's fingerprint baseline"
+        );
+
+        // And the next routine unchanged-tool-set refresh stays silent.
+        adapter.inner.apply_tokens(make_token_set("third")).await;
+        assert!(
+            !recv_tick(&mut outer_rx, Duration::from_millis(200)).await,
+            "unchanged Some→Some swap after a skipped stale-epoch \
+             transition must not emit a spurious tick"
         );
         server.abort();
     }

--- a/src/adapter/oauth/mod.rs
+++ b/src/adapter/oauth/mod.rs
@@ -318,10 +318,15 @@ pub struct OAuthAdapterInner {
     /// (e.g. an OAuth callback re-login under a different account/scope, see
     /// PR #140 review) without spamming clients with `list_changed` on
     /// routine token refreshes. `None` until a probe succeeds; cleared when
-    /// the inner adapter is torn down AND whenever the forwarder relays an
+    /// the inner adapter is torn down, whenever the forwarder relays an
     /// inner `tools_changed` tick (the upstream drifted from the probed
     /// baseline, so the next Some→Some swap must tick to be safe — see
-    /// `swap_tools_forwarder`). `Arc` so the forwarder task can share it.
+    /// `swap_tools_forwarder`), AND on any transition into a degraded state
+    /// (`AuthRequired`/`ConnectionFailed`/`Disconnected` — the registry may
+    /// rebuild the merged catalog without this endpoint's tools while
+    /// degraded, so the recovery apply must tick even if the tool set is
+    /// unchanged; see `transition_to`). `Arc` so the forwarder task can
+    /// share it.
     last_tools_fingerprint: Arc<RwLock<Option<u64>>>,
     /// Serializes [`Self::apply_tokens`] end-to-end. The OAuth callback,
     /// proactive refresh, and reactive (401) refresh can all apply tokens
@@ -402,6 +407,18 @@ impl OAuthAdapterInner {
     /// records it in the ring buffer, emits a tracing event, and updates
     /// the state.
     pub async fn transition_to(&self, new_state: OAuthState, reason: &str) {
+        // Entering a degraded state means the registry may rebuild the
+        // merged catalog without this endpoint's tools; clear the
+        // fingerprint baseline so the next successful `apply_tokens` hits
+        // the `(None, Some(_))` branch and ticks even when the tool set is
+        // unchanged. `Refreshing`/`Authenticated` keep the baseline so
+        // routine refreshes stay silent (PR #140 review).
+        if matches!(
+            new_state,
+            OAuthState::AuthRequired | OAuthState::ConnectionFailed | OAuthState::Disconnected
+        ) {
+            *self.last_tools_fingerprint.write().await = None;
+        }
         let mut state = self.state.write().await;
         let mut history = self.transition_history.write().await;
         let old = do_transition(&mut state, new_state.clone(), reason, &mut history);
@@ -4707,6 +4724,59 @@ mod tests {
             recv_tick(&mut outer_rx, Duration::from_millis(500)).await,
             "Some→None inner readiness transition must emit a synthetic outer tick"
         );
+    }
+
+    /// Regression: a transition into a degraded state (e.g. a refresh
+    /// failure landing in `AuthRequired`) must clear the fingerprint
+    /// baseline. While degraded the registry may rebuild the merged catalog
+    /// without this endpoint's tools, so the recovery `apply_tokens` must
+    /// tick even when the probed tool set is UNCHANGED — without the clear,
+    /// the A==A comparison would suppress the tick and leave the endpoint's
+    /// tools missing from the catalog until an unrelated invalidation.
+    #[tokio::test]
+    async fn degraded_transition_clears_fingerprint_so_recovery_apply_ticks() {
+        let tool_name = Arc::new(std::sync::RwLock::new("alpha".to_string()));
+        let (url, server) = spawn_mcp_server_with_mutable_tools(tool_name.clone()).await;
+        let mut config = make_config();
+        config.url = url;
+        let mut adapter = make_adapter(config);
+        adapter.initialize().await.unwrap();
+        let mut outer_rx = adapter.subscribe_tools_changed().expect("outer rx");
+
+        // Baseline: apply with tool set A → fingerprint stored.
+        adapter.inner.apply_tokens(make_token_set("first")).await;
+        assert!(
+            recv_tick(&mut outer_rx, Duration::from_millis(500)).await,
+            "None→Some must tick"
+        );
+        assert!(
+            adapter.inner.last_tools_fingerprint.read().await.is_some(),
+            "baseline fingerprint must be stored after a successful probe"
+        );
+        drain(&mut outer_rx).await;
+
+        // Simulate a refresh failure: the adapter degrades to AuthRequired
+        // (same transition `do_token_refresh` performs on a non-2xx token
+        // response).
+        adapter
+            .inner
+            .transition_to(OAuthState::AuthRequired, "test: refresh failure")
+            .await;
+        assert!(
+            adapter.inner.last_tools_fingerprint.read().await.is_none(),
+            "degrading to AuthRequired must clear the fingerprint baseline"
+        );
+
+        // Recovery re-login reproducing the SAME tool set A: the baseline is
+        // unknown, so the Some→Some swap must tick so the registry restores
+        // the endpoint's tools to the merged catalog.
+        adapter.inner.apply_tokens(make_token_set("second")).await;
+        assert!(
+            recv_tick(&mut outer_rx, Duration::from_millis(500)).await,
+            "recovery apply after a degraded state must tick even if the \
+             probed set matches the pre-failure baseline"
+        );
+        server.abort();
     }
 
     /// Spawn an in-process MCP server that also answers `tools/list` with a


### PR DESCRIPTION
## Problem
After an OAuth endpoint recovers from an auth failure (token refresh failed -> AuthRequired -> re-login), clients keep seeing 0 tools for that endpoint until a manual Refresh in the desktop app. During the outage the merged-catalog rebuild omits the failing endpoint; on recovery, apply_tokens_inner suppresses the tools_changed tick because last_tools_fingerprint (the pre-outage baseline) matches the re-probed fingerprint - the tool set did not change, but the registry's cached catalog did.

The plain HTTP adapter has the same class of gap: reactive Unhealthy -> Healthy recovery in note_request_success emitted no tick.

## Fix
- oauth/mod.rs: transition_to now clears last_tools_fingerprint on transitions to AuthRequired / ConnectionFailed / Disconnected, so the next successful apply_tokens hits the existing (None, Some(_)) branch and emits the recovery tick. Refreshing / Authenticated transitions keep the baseline, so routine token refreshes stay silent (no list_changed spam - the intentional suppression from #140 is preserved).
- http.rs: note_request_success emits a tools_changed tick only on an actual Unhealthy -> Healthy flip, mirroring the SSE recovery precedent. Successes while already Healthy emit nothing.

stdio and SSE were audited and already tick on recovery - no changes needed.

## Tests
- New regression: degraded_transition_clears_fingerprint_so_recovery_apply_ticks (fingerprint cleared on degrade + tick on re-apply of an UNCHANGED tool set; both assertions fail without the fix).
- New regression: recovery_flip_emits_tools_changed_tick_once (exactly one tick on the recovery flip, none on subsequent successes).
- Full package suite green locally; adapter tests re-run green after rebase onto main (294 passed).