### PR TITLE
fix: open readFile targets with O_NONBLOCK|O_NOFOLLOW to close the FIFO swap race

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,6 +730,7 @@ dependencies = [
  "hyper-util",
  "if-addrs",
  "jsonschema",
+ "libc",
  "notify",
  "percent-encoding",
  "rand 0.10.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,6 @@ serial_test = "3.5.0"
 tempfile = "3.27.0"
 tokio = { version = "1", features = ["test-util"] }
 which = "7"
+
+[target."cfg(unix)".dependencies]
+libc = "0.2"

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -1560,9 +1560,10 @@ fn open_for_read(source: &Path) -> std::io::Result<std::fs::File> {
 }
 
 /// JS-facing message for a failed [`open_for_read`]. A missing file and, on
-/// unix, the `ELOOP` that `O_NOFOLLOW` returns for a symlink in the final
-/// component get self-explanatory messages; everything else carries the OS
-/// error text.
+/// unix, `ELOOP` get self-explanatory messages; everything else carries the
+/// OS error text. `ELOOP` is returned both when `O_NOFOLLOW` rejects a
+/// symlink in the final component and when an intermediate component
+/// resolves through a symlink loop, so the message covers both.
 fn open_error_message(path_str: &str, e: &std::io::Error) -> String {
     if e.kind() == std::io::ErrorKind::NotFound {
         return format!("readFile: '{}' does not exist", path_str);
@@ -1570,7 +1571,8 @@ fn open_error_message(path_str: &str, e: &std::io::Error) -> String {
     #[cfg(unix)]
     if e.raw_os_error() == Some(libc::ELOOP) {
         return format!(
-            "readFile: '{}' is a symbolic link and cannot be read",
+            "readFile: '{}' refers to a symbolic link or a path containing a \
+             symbolic link loop, which cannot be read",
             path_str
         );
     }
@@ -3989,7 +3991,8 @@ return {{ written: written, back: JSON.parse(readFile(written)) }};
         let msg = open_error_message("/root/link.txt", &err);
         assert_eq!(
             msg,
-            "readFile: '/root/link.txt' is a symbolic link and cannot be read"
+            "readFile: '/root/link.txt' refers to a symbolic link or a path \
+             containing a symbolic link loop, which cannot be read"
         );
         assert!(
             !msg.contains("Too many levels"),

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -1447,28 +1447,8 @@ fn read_file_native(_this: &JsValue, args: &[JsValue], context: &mut Context) ->
     // (`O_NONBLOCK`) and cannot follow a symlink swapped in for the
     // canonicalized final component (`O_NOFOLLOW`); the fstat on the handle
     // is authoritative.
-    let mut file = match open_for_read(&source) {
-        Ok(file) => file,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return Err(JsNativeError::error()
-                .with_message(format!("readFile: '{}' does not exist", path_str))
-                .into())
-        }
-        #[cfg(unix)]
-        Err(e) if e.raw_os_error() == Some(libc::ELOOP) => {
-            return Err(JsNativeError::error()
-                .with_message(format!(
-                    "readFile: '{}' is a symbolic link and cannot be read",
-                    path_str
-                ))
-                .into())
-        }
-        Err(e) => {
-            return Err(JsNativeError::error()
-                .with_message(format!("readFile: failed to read '{}': {}", path_str, e))
-                .into())
-        }
-    };
+    let mut file = open_for_read(&source)
+        .map_err(|e| JsNativeError::error().with_message(open_error_message(&path_str, &e)))?;
     let meta = file.metadata().map_err(|e| {
         JsNativeError::error()
             .with_message(format!("readFile: failed to read '{}': {}", path_str, e))
@@ -1577,6 +1557,24 @@ fn open_for_read(source: &Path) -> std::io::Result<std::fs::File> {
         opts.custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_NOCTTY);
     }
     opts.open(source)
+}
+
+/// JS-facing message for a failed [`open_for_read`]. A missing file and, on
+/// unix, the `ELOOP` that `O_NOFOLLOW` returns for a symlink in the final
+/// component get self-explanatory messages; everything else carries the OS
+/// error text.
+fn open_error_message(path_str: &str, e: &std::io::Error) -> String {
+    if e.kind() == std::io::ErrorKind::NotFound {
+        return format!("readFile: '{}' does not exist", path_str);
+    }
+    #[cfg(unix)]
+    if e.raw_os_error() == Some(libc::ELOOP) {
+        return format!(
+            "readFile: '{}' is a symbolic link and cannot be read",
+            path_str
+        );
+    }
+    format!("readFile: failed to read '{}': {}", path_str, e)
 }
 
 fn reject_non_regular(path_str: &str, meta: &std::fs::Metadata) -> JsResult<()> {
@@ -3965,8 +3963,12 @@ return {{ written: written, back: JSON.parse(readFile(written)) }};
     }
 
     /// `O_NOFOLLOW` still rejects a symlink in the final component at open
-    /// time — the swap-after-canonicalize case — while a regular file opened
-    /// with the same flags reads normally.
+    /// time — the swap-after-canonicalize case — and the `ELOOP` it returns
+    /// is surfaced as a self-explanatory symlink message rather than the raw
+    /// OS text, while a regular file opened with the same flags reads
+    /// normally. (End to end this arm is only reachable via the swap race:
+    /// `resolve_write_path` canonicalizes a pre-existing final-component
+    /// symlink away before the open.)
     #[cfg(unix)]
     #[test]
     fn test_open_for_read_rejects_final_component_symlink() {
@@ -3983,6 +3985,16 @@ return {{ written: written, back: JSON.parse(readFile(written)) }};
             Some(libc::ELOOP),
             "unexpected error: {}",
             err
+        );
+        let msg = open_error_message("/root/link.txt", &err);
+        assert_eq!(
+            msg,
+            "readFile: '/root/link.txt' is a symbolic link and cannot be read"
+        );
+        assert!(
+            !msg.contains("Too many levels"),
+            "raw ELOOP text must not leak: {}",
+            msg
         );
 
         let mut file = open_for_read(&target).unwrap();

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -1420,28 +1420,35 @@ fn read_file_native(_this: &JsValue, args: &[JsValue], context: &mut Context) ->
 
     // Only regular files are readable. Opening a FIFO blocks until a writer
     // appears, and reading a device or socket can block indefinitely, inside
-    // a native call the JS deadline cannot interrupt. Check the path first so
-    // the common case never opens such an entry at all; the handle metadata
+    // a native call the JS deadline cannot interrupt. Without a non-blocking
+    // open the only defence is a path-level type check, which leaves a
+    // regular-file→FIFO swap window before the open; the handle metadata
     // below re-validates whatever inode was actually opened.
-    let path_meta = match std::fs::metadata(&source) {
-        Ok(meta) => meta,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return Err(JsNativeError::error()
-                .with_message(format!("readFile: '{}' does not exist", path_str))
-                .into())
-        }
-        Err(e) => {
-            return Err(JsNativeError::error()
-                .with_message(format!("readFile: failed to read '{}': {}", path_str, e))
-                .into())
-        }
-    };
-    reject_non_regular(&path_str, &path_meta)?;
+    #[cfg(not(unix))]
+    {
+        let path_meta = match std::fs::metadata(&source) {
+            Ok(meta) => meta,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Err(JsNativeError::error()
+                    .with_message(format!("readFile: '{}' does not exist", path_str))
+                    .into())
+            }
+            Err(e) => {
+                return Err(JsNativeError::error()
+                    .with_message(format!("readFile: failed to read '{}': {}", path_str, e))
+                    .into())
+            }
+        };
+        reject_non_regular(&path_str, &path_meta)?;
+    }
 
     // Open once and derive metadata from the handle so the type/size checks
     // and the bounded read below all apply to the same inode, rather than
-    // to whatever the pathname resolves to on a second lookup.
-    let mut file = match std::fs::File::open(&source) {
+    // to whatever the pathname resolves to on a second lookup. On unix the
+    // open itself cannot block (`O_NONBLOCK`) and cannot follow a symlink
+    // swapped in for the canonicalized final component (`O_NOFOLLOW`), so no
+    // path-level pre-check is needed: the fstat on the handle is authoritative.
+    let mut file = match open_for_read(&source) {
         Ok(file) => file,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             return Err(JsNativeError::error()
@@ -1539,6 +1546,25 @@ fn read_file_native(_this: &JsValue, args: &[JsValue], context: &mut Context) ->
     };
 
     Ok(JsValue::from(boa_engine::js_string!(contents.as_str())))
+}
+
+/// Open `source` read-only for `readFile`. On unix the open carries
+/// `O_NONBLOCK`, so a FIFO with no writer (or a device) returns a handle
+/// immediately instead of parking the sandbox thread, and `O_NOFOLLOW`, so a
+/// symlink swapped in for the already-canonicalized final component fails
+/// with `ELOOP` rather than being followed. The caller must still fstat the
+/// returned handle and reject anything that is not a regular file; regular
+/// files are unaffected by `O_NONBLOCK`, so the bounded read that follows
+/// behaves exactly as a blocking open would.
+fn open_for_read(source: &Path) -> std::io::Result<std::fs::File> {
+    let mut opts = std::fs::OpenOptions::new();
+    opts.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        opts.custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    }
+    opts.open(source)
 }
 
 fn reject_non_regular(path_str: &str, meta: &std::fs::Metadata) -> JsResult<()> {
@@ -3878,8 +3904,10 @@ return {{ written: written, back: JSON.parse(readFile(written)) }};
             .expect("mkfifo must be available on unix");
         assert!(status.success(), "mkfifo failed: {:?}", status);
         let script = format!("return readFile({});", js_quote(fifo.to_str().unwrap()));
-        // With no writer attached, opening the FIFO for read would block
-        // forever — the rejection must happen before any read is attempted.
+        // With no writer attached, a blocking open of the FIFO would park the
+        // sandbox thread forever. On unix there is no path-level pre-check any
+        // more: the open is non-blocking and the handle fstat is what rejects
+        // it, before any read is attempted.
         let err = tokio::time::timeout(Duration::from_secs(5), sandbox.execute(&script))
             .await
             .expect("readFile on a FIFO must not block")
@@ -3890,6 +3918,66 @@ return {{ written: written, back: JSON.parse(readFile(written)) }};
             "unexpected error: {}",
             msg
         );
+    }
+
+    /// The handle path on its own: with `O_NONBLOCK` the open of a writer-less
+    /// FIFO returns a handle instead of blocking, and it is the fstat on that
+    /// handle — not a path-level check — that identifies it as non-regular.
+    /// This is the property that closes the regular-file→FIFO swap window.
+    #[cfg(unix)]
+    #[test]
+    fn test_open_for_read_fifo_returns_handle_and_fstat_rejects() {
+        let dir = tempfile::tempdir().unwrap();
+        let fifo = dir.path().join("pipe");
+        let status = std::process::Command::new("mkfifo")
+            .arg(&fifo)
+            .status()
+            .expect("mkfifo must be available on unix");
+        assert!(status.success(), "mkfifo failed: {:?}", status);
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(open_for_read(&fifo).map(|f| f.metadata()));
+        });
+        let opened = rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("open of a writer-less FIFO must not block")
+            .expect("O_NONBLOCK open of a FIFO must succeed");
+        let meta = opened.expect("fstat on the FIFO handle must succeed");
+        assert!(!meta.is_file(), "FIFO must not fstat as a regular file");
+        assert!(!meta.is_dir());
+        assert!(
+            reject_non_regular("pipe", &meta).is_err(),
+            "handle fstat must reject the FIFO"
+        );
+    }
+
+    /// `O_NOFOLLOW` still rejects a symlink in the final component at open
+    /// time — the swap-after-canonicalize case — while a regular file opened
+    /// with the same flags reads normally.
+    #[cfg(unix)]
+    #[test]
+    fn test_open_for_read_rejects_final_component_symlink() {
+        use std::io::Read as _;
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("real.txt");
+        std::fs::write(&target, "plain").unwrap();
+        let link = dir.path().join("link.txt");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let err = open_for_read(&link).expect_err("O_NOFOLLOW must refuse a symlink");
+        assert_eq!(
+            err.raw_os_error(),
+            Some(libc::ELOOP),
+            "unexpected error: {}",
+            err
+        );
+
+        let mut file = open_for_read(&target).unwrap();
+        assert!(file.metadata().unwrap().is_file());
+        let mut contents = String::new();
+        file.read_to_string(&mut contents).unwrap();
+        assert_eq!(contents, "plain");
     }
 
     #[tokio::test]

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -1549,19 +1549,21 @@ fn read_file_native(_this: &JsValue, args: &[JsValue], context: &mut Context) ->
 
 /// Open `source` read-only for `readFile`. On unix the open carries
 /// `O_NONBLOCK`, so a FIFO with no writer (or a device) returns a handle
-/// immediately instead of parking the sandbox thread, and `O_NOFOLLOW`, so a
+/// immediately instead of parking the sandbox thread; `O_NOFOLLOW`, so a
 /// symlink swapped in for the already-canonicalized final component fails
-/// with `ELOOP` rather than being followed. The caller must still fstat the
-/// returned handle and reject anything that is not a regular file; regular
-/// files are unaffected by `O_NONBLOCK`, so the bounded read that follows
-/// behaves exactly as a blocking open would.
+/// with `ELOOP` rather than being followed; and `O_NOCTTY`, so a tty device
+/// node can never become the controlling terminal as a side effect of the
+/// open (std does not set it). The caller must still fstat the returned
+/// handle and reject anything that is not a regular file; regular files are
+/// unaffected by these flags, so the bounded read that follows behaves
+/// exactly as a plain open would.
 fn open_for_read(source: &Path) -> std::io::Result<std::fs::File> {
     let mut opts = std::fs::OpenOptions::new();
     opts.read(true);
     #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt as _;
-        opts.custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+        opts.custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_NOCTTY);
     }
     opts.open(source)
 }

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -1420,34 +1420,33 @@ fn read_file_native(_this: &JsValue, args: &[JsValue], context: &mut Context) ->
 
     // Only regular files are readable. Opening a FIFO blocks until a writer
     // appears, and reading a device or socket can block indefinitely, inside
-    // a native call the JS deadline cannot interrupt. Without a non-blocking
-    // open the only defence is a path-level type check, which leaves a
-    // regular-file→FIFO swap window before the open; the handle metadata
-    // below re-validates whatever inode was actually opened.
-    #[cfg(not(unix))]
-    {
-        let path_meta = match std::fs::metadata(&source) {
-            Ok(meta) => meta,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                return Err(JsNativeError::error()
-                    .with_message(format!("readFile: '{}' does not exist", path_str))
-                    .into())
-            }
-            Err(e) => {
-                return Err(JsNativeError::error()
-                    .with_message(format!("readFile: failed to read '{}': {}", path_str, e))
-                    .into())
-            }
-        };
-        reject_non_regular(&path_str, &path_meta)?;
-    }
+    // a native call the JS deadline cannot interrupt. Check the path first so
+    // the common case never opens such an entry at all — `O_NONBLOCK` below
+    // covers FIFOs, but a device driver's open can still block or have side
+    // effects — then re-validate the handle metadata for whatever inode was
+    // actually opened.
+    let path_meta = match std::fs::metadata(&source) {
+        Ok(meta) => meta,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(JsNativeError::error()
+                .with_message(format!("readFile: '{}' does not exist", path_str))
+                .into())
+        }
+        Err(e) => {
+            return Err(JsNativeError::error()
+                .with_message(format!("readFile: failed to read '{}': {}", path_str, e))
+                .into())
+        }
+    };
+    reject_non_regular(&path_str, &path_meta)?;
 
     // Open once and derive metadata from the handle so the type/size checks
     // and the bounded read below all apply to the same inode, rather than
     // to whatever the pathname resolves to on a second lookup. On unix the
-    // open itself cannot block (`O_NONBLOCK`) and cannot follow a symlink
-    // swapped in for the canonicalized final component (`O_NOFOLLOW`), so no
-    // path-level pre-check is needed: the fstat on the handle is authoritative.
+    // open itself cannot block on a FIFO swapped in after the pre-check
+    // (`O_NONBLOCK`) and cannot follow a symlink swapped in for the
+    // canonicalized final component (`O_NOFOLLOW`); the fstat on the handle
+    // is authoritative.
     let mut file = match open_for_read(&source) {
         Ok(file) => file,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -3905,9 +3904,9 @@ return {{ written: written, back: JSON.parse(readFile(written)) }};
         assert!(status.success(), "mkfifo failed: {:?}", status);
         let script = format!("return readFile({});", js_quote(fifo.to_str().unwrap()));
         // With no writer attached, a blocking open of the FIFO would park the
-        // sandbox thread forever. On unix there is no path-level pre-check any
-        // more: the open is non-blocking and the handle fstat is what rejects
-        // it, before any read is attempted.
+        // sandbox thread forever — the rejection must happen before any read
+        // is attempted. The path-level pre-check catches this case; the
+        // handle-path test below covers a FIFO that reaches the open itself.
         let err = tokio::time::timeout(Duration::from_secs(5), sandbox.execute(&script))
             .await
             .expect("readFile on a FIFO must not block")

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -1454,6 +1454,15 @@ fn read_file_native(_this: &JsValue, args: &[JsValue], context: &mut Context) ->
                 .with_message(format!("readFile: '{}' does not exist", path_str))
                 .into())
         }
+        #[cfg(unix)]
+        Err(e) if e.raw_os_error() == Some(libc::ELOOP) => {
+            return Err(JsNativeError::error()
+                .with_message(format!(
+                    "readFile: '{}' is a symbolic link and cannot be read",
+                    path_str
+                ))
+                .into())
+        }
         Err(e) => {
             return Err(JsNativeError::error()
                 .with_message(format!("readFile: failed to read '{}': {}", path_str, e))
@@ -1548,8 +1557,10 @@ fn read_file_native(_this: &JsValue, args: &[JsValue], context: &mut Context) ->
 }
 
 /// Open `source` read-only for `readFile`. On unix the open carries
-/// `O_NONBLOCK`, so a FIFO with no writer (or a device) returns a handle
-/// immediately instead of parking the sandbox thread; `O_NOFOLLOW`, so a
+/// `O_NONBLOCK`, so a FIFO with no writer returns a handle immediately
+/// instead of parking the sandbox thread (this is guaranteed for FIFOs only;
+/// a device driver's open may still block, which is why the caller keeps its
+/// path-level type pre-check); `O_NOFOLLOW`, so a
 /// symlink swapped in for the already-canonicalized final component fails
 /// with `ELOOP` rather than being followed; and `O_NOCTTY`, so a tty device
 /// node can never become the controlling terminal as a side effect of the


### PR DESCRIPTION
Follow-up to #154, closing the caveat disclosed in its review threads: a regular file could be swapped for a FIFO between the path-level `metadata()` pre-check and `File::open`, and a blocking open of a writer-less FIFO would park the sandbox thread inside a native call the JS deadline cannot interrupt.

## What changed

- **Non-blocking, no-follow, no-ctty open on unix.** `readFile` now opens its target through a small `open_for_read` helper that sets `OpenOptions::custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_NOCTTY)`:
  - `O_NONBLOCK` — opening a FIFO with no writer returns a handle immediately instead of blocking. This is guaranteed for FIFOs only (a device driver's `open` may still block), which is why the path-level pre-check below is kept. Regular files are unaffected, so the bounded read that follows behaves exactly as before.
  - `O_NOFOLLOW` — the path handed to `open` is already canonicalized, so its final component is never a symlink at validation time; a symlink swapped in afterwards now fails the open with `ELOOP` instead of being followed. On unix that `ELOOP` is surfaced as `readFile: '<p>' is a symbolic link and cannot be read` rather than the raw OS message.
  - `O_NOCTTY` — a tty device node under a write root can never become the controlling terminal as a side effect of the open (std sets `O_CLOEXEC` but not `O_NOCTTY`). Note that Linux strips `O_NOCTTY` from `f_flags` at open time, so it is not observable in `/proc/self/fdinfo` even though it took effect.
- **Path-level pre-check kept on all platforms (defense in depth).** The `std::fs::metadata()` → `reject_non_regular` check before the open is unchanged and unconditional: an existing FIFO/device/socket/directory is rejected before `open_for_read` is ever called, so device nodes are never opened in the common case.
- **Handle fstat is authoritative.** The existing `file.metadata()` → `reject_non_regular` check on the opened handle rejects anything non-regular that reached the open. Because the open can no longer block on a FIFO and can no longer follow a swapped-in final-component symlink, the regular→FIFO swap window between the pre-check and the open is closed: the swap either happens before the open (nonblocking open returns a handle, fstat rejects it, nothing is read) or after it (the handle already refers to the regular file).
- **New dependency:** `libc = "0.2"` as a `[target."cfg(unix)".dependencies]` entry only (user-approved). `libc` was already in `Cargo.lock` transitively; the lock gains only the direct edge, no version change.
- **Known, out-of-scope limitation (unchanged from #154):** `O_NOFOLLOW` covers the final component only. An intermediate-directory→symlink swap after `resolve_write_path` is not closed here; the exposure is identical to the existing `writeFile` path, and fully closing it needs a beneath-root primitive (`openat2`/`RESOLVE_BENEATH` or a component-wise `openat` walk) applied to both `readFile` and `writeFile` as a separate change.

## Tests

- `test_read_file_rejects_fifo` (existing, unix) — end-to-end through the sandbox; a pre-existing FIFO is rejected by the path-level pre-check with no blocking.
- New `test_open_for_read_fifo_returns_handle_and_fstat_rejects` (unix): the handle path on its own — opens a writer-less FIFO on a helper thread with a 5 s timeout, asserts the open **succeeds** (non-blocking), and that the handle's fstat is non-regular and rejected by `reject_non_regular`. This is the property that closes the swap window.
- New `test_open_for_read_rejects_final_component_symlink` (unix): a symlink in the final component fails the open with `ELOOP`, while a regular file opened with the same flags reads normally.
- Symlink-escape, symlink-inside-root, quota and bounded-read regression tests are unchanged and pass.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test -p endara-relay` — all lib + integration tests passing, 0 failures
