### PR TITLE
fix(sandbox): anchor readFile/writeFile beneath the write root to close the intermediate symlink-swap race

### DIFF
--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -1534,25 +1534,14 @@ fn read_file_native(_this: &JsValue, args: &[JsValue], context: &mut Context) ->
 
     // Only regular files are readable. Opening a FIFO blocks until a writer
     // appears, and reading a device or socket can block indefinitely, inside
-    // a native call the JS deadline cannot interrupt. Check the path first so
+    // a native call the JS deadline cannot interrupt. Check the type first so
     // the common case never opens such an entry at all — `O_NONBLOCK` below
     // covers FIFOs, but a device driver's open can still block or have side
     // effects — then re-validate the handle metadata for whatever inode was
-    // actually opened.
-    let path_meta = match std::fs::metadata(&source) {
-        Ok(meta) => meta,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return Err(JsNativeError::error()
-                .with_message(format!("readFile: '{}' does not exist", path_str))
-                .into())
-        }
-        Err(e) => {
-            return Err(JsNativeError::error()
-                .with_message(format!("readFile: failed to read '{}': {}", path_str, e))
-                .into())
-        }
-    };
-    reject_non_regular(&path_str, &path_meta)?;
+    // actually opened. On unix the pre-check is anchored beneath the root
+    // like the open, so it never stats (or leaks the existence of) anything
+    // a swapped-in symlink points at.
+    precheck_for_read(&path_str, &source, &matched_root)?;
 
     // Open once and derive metadata from the handle so the type/size checks
     // and the bounded read below all apply to the same inode, rather than
@@ -1693,6 +1682,45 @@ fn open_for_read(source: &Path, _root: &Path) -> std::io::Result<std::fs::File> 
     std::fs::OpenOptions::new().read(true).open(source)
 }
 
+/// Path-level type pre-check for `readFile`: rejects directories and
+/// non-regular entries (FIFOs, devices, sockets) before anything is opened.
+/// On unix the stat is anchored beneath `root` with the same containment as
+/// [`open_for_read`] — no symlink is followed at any component, and nothing
+/// outside the root is ever looked up — and it never opens the entry, so a
+/// device driver's `open` cannot run. Errors use the same messages as a
+/// failed open.
+#[cfg(unix)]
+fn precheck_for_read(path_str: &str, source: &Path, root: &Path) -> JsResult<()> {
+    let st = stat_for_read(source, root)
+        .map_err(|e| JsNativeError::error().with_message(open_error_message(path_str, &e)))?;
+    let kind = st.st_mode & libc::S_IFMT;
+    reject_non_regular_kind(path_str, kind == libc::S_IFDIR, kind == libc::S_IFREG)
+}
+
+/// Non-unix [`precheck_for_read`]: a plain `metadata` of the canonical path.
+#[cfg(not(unix))]
+fn precheck_for_read(path_str: &str, source: &Path, _root: &Path) -> JsResult<()> {
+    let meta = std::fs::metadata(source)
+        .map_err(|e| JsNativeError::error().with_message(open_error_message(path_str, &e)))?;
+    reject_non_regular(path_str, &meta)
+}
+
+/// Anchored `stat` of `source` beneath `root` (see [`open_for_read`] for the
+/// containment contract; this is its non-opening counterpart).
+#[cfg(unix)]
+fn stat_for_read(source: &Path, root: &Path) -> std::io::Result<libc::stat> {
+    use std::os::unix::io::AsFd as _;
+
+    let rel = source.strip_prefix(root).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "path escaped its matched write directory before the open",
+        )
+    })?;
+    let root_fd = open_beneath::open_root(root)?;
+    open_beneath::stat_beneath(root_fd.as_fd(), rel)
+}
+
 /// JS-facing message for a failed [`open_for_read`]. A missing file and, on
 /// unix, `ELOOP` get self-explanatory messages; everything else carries the
 /// OS error text. `ELOOP` is what the beneath-root open returns for a
@@ -1714,7 +1742,11 @@ fn open_error_message(path_str: &str, e: &std::io::Error) -> String {
 }
 
 fn reject_non_regular(path_str: &str, meta: &std::fs::Metadata) -> JsResult<()> {
-    if meta.is_dir() {
+    reject_non_regular_kind(path_str, meta.is_dir(), meta.is_file())
+}
+
+fn reject_non_regular_kind(path_str: &str, is_dir: bool, is_file: bool) -> JsResult<()> {
+    if is_dir {
         return Err(JsNativeError::error()
             .with_message(format!(
                 "readFile: '{}' is a directory, not a file",
@@ -1722,7 +1754,7 @@ fn reject_non_regular(path_str: &str, meta: &std::fs::Metadata) -> JsResult<()> 
             ))
             .into());
     }
-    if !meta.is_file() {
+    if !is_file {
         return Err(JsNativeError::error()
             .with_message(format!(
                 "readFile: '{}' is not a regular file (FIFOs, devices, and \
@@ -4257,12 +4289,24 @@ return {{ written: written, back: JSON.parse(readFile(written)) }};
                 rel,
                 msg
             );
+            // The type pre-check is anchored the same way: it must not stat
+            // through the swapped-in link either.
+            let err = stat_for_read(&source, root)
+                .expect_err("pre-check must refuse an intermediate symlink");
+            assert_eq!(err.raw_os_error(), Some(libc::ELOOP), "{}: {}", rel, err);
         }
 
         // Not beneath the matched root at all: refused without opening.
         let err = open_for_read(&outside.path().join("f.txt"), root)
             .expect_err("a path outside the root must be refused");
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput, "{}", err);
+        let err = stat_for_read(&outside.path().join("f.txt"), root)
+            .expect_err("a path outside the root must not be statted");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput, "{}", err);
+
+        // The genuine nested path pre-checks as a regular file.
+        let st = stat_for_read(&root.join("real/deep/f.txt"), root).unwrap();
+        assert_eq!(st.st_mode & libc::S_IFMT, libc::S_IFREG);
 
         // Sanity: the genuine (symlink-free) nested path still reads.
         let mut file = open_for_read(&root.join("real/deep/f.txt"), root).unwrap();

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -1304,9 +1304,14 @@ fn write_tmp_name(file_name: &std::ffi::OsStr) -> String {
 /// directory handle, and the publish is a `renameat` on that same handle.
 /// Because `dest` is canonical, any symlink met on the way is a
 /// post-validation swap and fails the write (`ELOOP`), as does a directory
-/// renamed out of the root while `openat2` resolves it (`EXDEV`) — nothing
-/// is created or written outside the root, no matter how the path is
-/// re-pointed concurrently. If the root itself was deleted
+/// renamed out of the root while `openat2` resolves it (`EXDEV`): no lookup
+/// here can be redirected through a symlink, on any tier. Containment is
+/// enforced while the directory handle is resolved, not afterwards — the
+/// handle is a capability, so if the destination directory itself is renamed
+/// out of the root between `open_dir_beneath_creating` returning and the
+/// `renameat`, the file lands wherever that directory now lives (a location
+/// the renaming actor could already write to; see the caveat in
+/// [`open_beneath`]). If the root itself was deleted
 /// after config resolution the write fails (the root handle cannot be
 /// opened); the "directories are never auto-created" stance in
 /// [`crate::config::resolve_write_roots`] only covers resolution time. On

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -1331,7 +1331,17 @@ fn write_atomic(dest: &Path, bytes: &[u8], root: &Path) -> Result<(), String> {
             e
         )
     };
-    let root_fd = open_beneath::open_root(root).map_err(parent_dirs_error)?;
+    let root_fd = open_beneath::open_root(root).map_err(|e| {
+        if e.raw_os_error() == Some(libc::ELOOP) {
+            return escaped();
+        }
+        format!(
+            "writeFile: configured write directory '{}' is not accessible: {} — recreate it \
+             or update [relay] write_dirs in ~/.endara/config.toml",
+            root.display(),
+            e
+        )
+    })?;
     let dir_fd = open_beneath::open_dir_beneath_creating(root_fd.as_fd(), rel_dir)
         .map_err(parent_dirs_error)?;
     let tmp = std::ffi::OsString::from(write_tmp_name(file_name));
@@ -3611,6 +3621,46 @@ mod tests {
             dir_entries(&root.join("keep/deep/fresh")),
             vec!["x.txt".to_string()]
         );
+    }
+
+    /// A root deleted after config resolution is not recreated (the anchor
+    /// cannot be opened), and the error names the root and the config knob
+    /// rather than blaming parent-directory creation. A root swapped for a
+    /// symlink is still reported as an escape.
+    #[cfg(unix)]
+    #[test]
+    fn test_write_atomic_reports_missing_root_distinctly() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let root = canonical_root(&dir).join("root");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::remove_dir(&root).unwrap();
+
+        let dest = root.join("a/b.txt");
+        let err = write_atomic(&dest, b"d", &root).unwrap_err();
+        assert!(
+            err.contains(&format!(
+                "configured write directory '{}' is not accessible",
+                root.display()
+            )) && err.contains("[relay] write_dirs"),
+            "unexpected error: {}",
+            err
+        );
+        assert!(
+            !err.contains("failed to create parent directories"),
+            "{}",
+            err
+        );
+        assert!(!root.exists(), "root must not be recreated");
+
+        std::os::unix::fs::symlink(outside.path(), &root).unwrap();
+        let err = write_atomic(&dest, b"d", &root).unwrap_err();
+        assert!(
+            err.contains("escaped the configured write directory during the write"),
+            "unexpected error: {}",
+            err
+        );
+        assert!(dir_entries(outside.path()).is_empty());
     }
 
     #[tokio::test]

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -1703,8 +1703,8 @@ fn open_for_read(source: &Path, _root: &Path) -> std::io::Result<std::fs::File> 
 /// Path-level type pre-check for `readFile`: rejects directories and
 /// non-regular entries (FIFOs, devices, sockets) before anything is opened.
 /// On unix the stat is anchored beneath `root` with the same containment as
-/// [`open_for_read`] — no symlink is followed at any component, and nothing
-/// outside the root is ever looked up — and it never opens the entry, so a
+/// [`open_for_read`] — no symlink is followed at any component, and no
+/// lookup is re-resolved from `/` — and it never opens the entry, so a
 /// device driver's `open` cannot run. Errors use the same messages as a
 /// failed open.
 #[cfg(unix)]

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -4792,13 +4792,18 @@ return errors;
         let sandbox = write_sandbox(vec![root.clone()]).await;
         let sub = root.join("sub");
         std::fs::create_dir(&sub).unwrap();
-        let script = format!("return readFile({});", js_quote(sub.to_str().unwrap()));
-        let err = sandbox.execute(&script).await.unwrap_err();
-        assert!(
-            format!("{}", err).contains("is a directory"),
-            "unexpected error: {}",
-            err
-        );
+        // A subdirectory and the allowlisted root itself (an empty relative
+        // path beneath the anchor) both report "is a directory".
+        for target in [&sub, &root] {
+            let script = format!("return readFile({});", js_quote(target.to_str().unwrap()));
+            let err = sandbox.execute(&script).await.unwrap_err();
+            assert!(
+                format!("{}", err).contains("is a directory"),
+                "{}: unexpected error: {}",
+                target.display(),
+                err
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -22,11 +22,8 @@ use tracing::Instrument;
 use crate::adapter::{AdapterError, ToolInfo};
 use crate::registry::MetaToolRegistry;
 
-// Beneath-root open primitives for readFile/writeFile. The call sites land
-// in follow-up changes; keep the allow until then so both targets stay
-// warning-clean under `clippy -D warnings`.
+// Beneath-root open primitives for readFile/writeFile.
 #[cfg(unix)]
-#[allow(dead_code)]
 mod open_beneath;
 
 // ---------------------------------------------------------------------------
@@ -1264,26 +1261,151 @@ fn write_dirs_rejection_message(op: &str, path_str: &str, write_roots: &[PathBuf
     msg
 }
 
-/// Write `bytes` to `dest` via a temp file in the destination directory plus
-/// an atomic rename, creating missing parent directories first. `dest` must
-/// already be validated by [`resolve_write_path`] against `root` (the
-/// allowlisted root it matched), so any directories created here sit inside
-/// that root. After `create_dir_all` the destination directory is
-/// re-canonicalized and containment is re-asserted, closing the
-/// validate→write window in which a checked directory could be swapped for
-/// a symlink pointing outside the root. If the root itself was deleted
-/// after config resolution, `create_dir_all` recreates it — still inside
-/// the allowed prefix; the "directories are never auto-created" stance in
-/// [`crate::config::resolve_write_roots`] only covers resolution time. On
-/// failure the temp file is removed — no partial destination file is ever
-/// observable.
-fn write_atomic(dest: &Path, bytes: &[u8], root: &Path) -> Result<(), String> {
+/// Split `dest` into its parent directory and file name for [`write_atomic`].
+fn split_write_dest(dest: &Path) -> Result<(&Path, &std::ffi::OsStr), String> {
     let dir = dest
         .parent()
         .ok_or_else(|| format!("writeFile: '{}' has no parent directory", dest.display()))?;
     let file_name = dest
         .file_name()
         .ok_or_else(|| format!("writeFile: '{}' does not name a file", dest.display()))?;
+    Ok((dir, file_name))
+}
+
+/// Unique temp-file name next to `file_name` for [`write_atomic`].
+fn write_tmp_name(file_name: &std::ffi::OsStr) -> String {
+    // Process-wide monotonic counter: concurrent writes to the same
+    // destination can observe the same SystemTime, so the timestamp alone
+    // does not make the temp name unique within this process.
+    static TMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!(
+        ".{}.{}.{}.{}.tmp",
+        file_name.to_string_lossy(),
+        std::process::id(),
+        unique,
+        seq
+    )
+}
+
+/// Write `bytes` to `dest` via a temp file in the destination directory plus
+/// an atomic rename, creating missing parent directories first. `dest` must
+/// already be validated by [`resolve_write_path`] against `root` (the
+/// allowlisted root it matched). Every filesystem step is anchored to a
+/// directory handle of `root`: missing parents are created with `mkdirat`
+/// along an `openat` walk that refuses to follow symlinks
+/// ([`open_beneath::open_dir_beneath_creating`]), the temp file is created
+/// with `openat(O_CREAT | O_EXCL)` on the destination directory handle, and
+/// the publish is a `renameat` on that same handle. Because `dest` is
+/// canonical, any symlink the walk meets is a post-validation swap and fails
+/// the write — nothing is created or written outside the root, no matter
+/// how the path is re-pointed concurrently. If the root itself was deleted
+/// after config resolution the write fails (the root handle cannot be
+/// opened); the "directories are never auto-created" stance in
+/// [`crate::config::resolve_write_roots`] only covers resolution time. On
+/// failure the temp file is removed — no partial destination file is ever
+/// observable.
+#[cfg(unix)]
+fn write_atomic(dest: &Path, bytes: &[u8], root: &Path) -> Result<(), String> {
+    use std::os::unix::io::{AsFd as _, AsRawFd as _};
+
+    let (dir, file_name) = split_write_dest(dest)?;
+    let escaped = || {
+        format!(
+            "writeFile: '{}' escaped the configured write directory during the write",
+            dest.display()
+        )
+    };
+    let rel_dir = dir.strip_prefix(root).map_err(|_| escaped())?;
+    let parent_dirs_error = |e: std::io::Error| {
+        if e.raw_os_error() == Some(libc::ELOOP) {
+            return escaped();
+        }
+        format!(
+            "writeFile: failed to create parent directories for '{}': {}",
+            dest.display(),
+            e
+        )
+    };
+    let root_fd = open_beneath::open_root(root).map_err(parent_dirs_error)?;
+    let dir_fd = open_beneath::open_dir_beneath_creating(root_fd.as_fd(), rel_dir)
+        .map_err(parent_dirs_error)?;
+    let tmp = std::ffi::OsString::from(write_tmp_name(file_name));
+    // O_EXCL guarantees this call exclusively owns the temp file even if the
+    // name somehow collides (e.g. across processes); 0o666 matches what
+    // `OpenOptions::create_new` would apply before the umask.
+    let write_result = open_beneath::openat(
+        dir_fd.as_raw_fd(),
+        &tmp,
+        libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_CLOEXEC,
+        0o666,
+    )
+    .map(std::fs::File::from)
+    .and_then(|mut f| std::io::Write::write_all(&mut f, bytes));
+    if let Err(e) = write_result {
+        let _ = unlinkat(dir_fd.as_raw_fd(), &tmp);
+        return Err(format!(
+            "writeFile: failed to write '{}': {}",
+            dest.display(),
+            e
+        ));
+    }
+    if let Err(e) = renameat(dir_fd.as_raw_fd(), &tmp, file_name) {
+        let _ = unlinkat(dir_fd.as_raw_fd(), &tmp);
+        return Err(format!(
+            "writeFile: failed to finalise '{}': {}",
+            dest.display(),
+            e
+        ));
+    }
+    Ok(())
+}
+
+/// `renameat(2)` of `from` to `to`, both relative to `dirfd`.
+#[cfg(unix)]
+fn renameat(
+    dirfd: libc::c_int,
+    from: &std::ffi::OsStr,
+    to: &std::ffi::OsStr,
+) -> std::io::Result<()> {
+    let c_from = open_beneath::c_string(from)?;
+    let c_to = open_beneath::c_string(to)?;
+    // SAFETY: `dirfd` is an open directory fd and both names are valid
+    // NUL-terminated strings that outlive the call.
+    let rc = unsafe { libc::renameat(dirfd, c_from.as_ptr(), dirfd, c_to.as_ptr()) };
+    if rc < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// `unlinkat(2)` of the file `name` relative to `dirfd`.
+#[cfg(unix)]
+fn unlinkat(dirfd: libc::c_int, name: &std::ffi::OsStr) -> std::io::Result<()> {
+    let c_name = open_beneath::c_string(name)?;
+    // SAFETY: `dirfd` is an open directory fd and `c_name` a valid
+    // NUL-terminated string that outlives the call.
+    let rc = unsafe { libc::unlinkat(dirfd, c_name.as_ptr(), 0) };
+    if rc < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Non-unix [`write_atomic`]: after `create_dir_all` the destination
+/// directory is re-canonicalized and containment is re-asserted, narrowing
+/// (but not closing — this platform has no beneath-root open) the
+/// validate→write window in which a checked directory could be swapped for
+/// a symlink pointing outside the root. If the root itself was deleted after
+/// config resolution, `create_dir_all` recreates it — still inside the
+/// allowed prefix.
+#[cfg(not(unix))]
+fn write_atomic(dest: &Path, bytes: &[u8], root: &Path) -> Result<(), String> {
+    let (dir, file_name) = split_write_dest(dest)?;
     std::fs::create_dir_all(dir).map_err(|e| {
         format!(
             "writeFile: failed to create parent directories for '{}': {}",
@@ -1300,22 +1422,7 @@ fn write_atomic(dest: &Path, bytes: &[u8], root: &Path) -> Result<(), String> {
         ));
     }
     let final_dest = canonical_dir.join(file_name);
-    // Process-wide monotonic counter: concurrent writes to the same
-    // destination can observe the same SystemTime, so the timestamp alone
-    // does not make the temp name unique within this process.
-    static TMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    let seq = TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let unique = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    let tmp = canonical_dir.join(format!(
-        ".{}.{}.{}.{}.tmp",
-        file_name.to_string_lossy(),
-        std::process::id(),
-        unique,
-        seq
-    ));
+    let tmp = canonical_dir.join(write_tmp_name(file_name));
     // create_new(true) guarantees this call exclusively owns the temp file
     // even if the name somehow collides (e.g. across processes).
     let write_result = std::fs::OpenOptions::new()
@@ -3388,6 +3495,70 @@ mod tests {
             msg
         );
         assert!(dir_entries(outside.path()).is_empty());
+    }
+
+    /// Simulates the validate→write race: `dest` is the canonical path
+    /// `resolve_write_path` produced, but by the time `write_atomic` runs an
+    /// intermediate component has been swapped for a symlink (out of the root,
+    /// and — separately — to a directory inside it). The dirfd-anchored walk
+    /// must reject the swap at every depth and create nothing anywhere: no
+    /// parents, no temp file, no destination.
+    #[cfg(unix)]
+    #[test]
+    fn test_write_atomic_rejects_intermediate_symlink_swap() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let root = canonical_root(&dir);
+        std::fs::create_dir_all(root.join("real")).unwrap();
+        std::fs::create_dir_all(root.join("keep/deep")).unwrap();
+        // "swapped" was validated as a real directory; now it is a link out.
+        std::os::unix::fs::symlink(outside.path(), root.join("swapped")).unwrap();
+        // A swap deeper in an existing chain.
+        std::os::unix::fs::symlink(outside.path(), root.join("keep/deep/out")).unwrap();
+        // A swap that stays inside the root is still a swap and still rejected.
+        std::os::unix::fs::symlink(root.join("real"), root.join("inner")).unwrap();
+
+        for rel in [
+            "swapped/x.txt",
+            "swapped/new/sub/x.txt",
+            "keep/deep/out/x.txt",
+            "keep/deep/out/new/x.txt",
+            "inner/x.txt",
+            "inner/new/x.txt",
+        ] {
+            let dest = root.join(rel);
+            let err = write_atomic(&dest, b"d", &root).unwrap_err();
+            assert!(
+                err.contains("escaped the configured write directory during the write"),
+                "{}: unexpected error: {}",
+                rel,
+                err
+            );
+        }
+        assert!(dir_entries(outside.path()).is_empty());
+        assert!(dir_entries(&root.join("real")).is_empty());
+        assert_eq!(
+            dir_entries(&root.join("keep/deep")),
+            vec!["out".to_string()]
+        );
+        assert_eq!(
+            dir_entries(&root),
+            vec![
+                "inner".to_string(),
+                "keep".to_string(),
+                "real".to_string(),
+                "swapped".to_string()
+            ]
+        );
+
+        // Sanity: a genuine (symlink-free) chain still gets created and written.
+        let ok_dest = root.join("keep/deep/fresh/x.txt");
+        write_atomic(&ok_dest, b"ok", &root).unwrap();
+        assert_eq!(std::fs::read(&ok_dest).unwrap(), b"ok");
+        assert_eq!(
+            dir_entries(&root.join("keep/deep/fresh")),
+            vec!["x.txt".to_string()]
+        );
     }
 
     #[tokio::test]

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -1529,7 +1529,7 @@ fn read_file_native(_this: &JsValue, args: &[JsValue], context: &mut Context) ->
             .into());
     }
 
-    let (source, _matched_root) = resolve_write_path("readFile", &path_str, &write_roots)
+    let (source, matched_root) = resolve_write_path("readFile", &path_str, &write_roots)
         .map_err(|msg| JsNativeError::error().with_message(msg))?;
 
     // Only regular files are readable. Opening a FIFO blocks until a writer
@@ -1558,10 +1558,11 @@ fn read_file_native(_this: &JsValue, args: &[JsValue], context: &mut Context) ->
     // and the bounded read below all apply to the same inode, rather than
     // to whatever the pathname resolves to on a second lookup. On unix the
     // open itself cannot block on a FIFO swapped in after the pre-check
-    // (`O_NONBLOCK`) and cannot follow a symlink swapped in for the
-    // canonicalized final component (`O_NOFOLLOW`); the fstat on the handle
+    // (`O_NONBLOCK`) and is anchored beneath the matched root, so a symlink
+    // swapped in for any component of the canonicalized path — not just the
+    // final one — is rejected rather than followed; the fstat on the handle
     // is authoritative.
-    let mut file = open_for_read(&source)
+    let mut file = open_for_read(&source, &matched_root)
         .map_err(|e| JsNativeError::error().with_message(open_error_message(&path_str, &e)))?;
     let meta = file.metadata().map_err(|e| {
         JsNativeError::error()
@@ -1650,34 +1651,53 @@ fn read_file_native(_this: &JsValue, args: &[JsValue], context: &mut Context) ->
     Ok(JsValue::from(boa_engine::js_string!(contents.as_str())))
 }
 
-/// Open `source` read-only for `readFile`. On unix the open carries
-/// `O_NONBLOCK`, so a FIFO with no writer returns a handle immediately
-/// instead of parking the sandbox thread (this is guaranteed for FIFOs only;
-/// a device driver's open may still block, which is why the caller keeps its
-/// path-level type pre-check); `O_NOFOLLOW`, so a
-/// symlink swapped in for the already-canonicalized final component fails
-/// with `ELOOP` rather than being followed; and `O_NOCTTY`, so a tty device
-/// node can never become the controlling terminal as a side effect of the
-/// open (std does not set it). The caller must still fstat the returned
+/// Open `source` read-only for `readFile`. `source` must already be
+/// validated by [`resolve_write_path`] against `root` (the allowlisted root
+/// it matched). The open is anchored to a directory handle of `root` and
+/// walks `source`'s path relative to it via [`open_beneath::open_beneath`],
+/// which refuses to follow a symlink at any component: because `source` is
+/// canonical, any symlink met is a post-validation swap and fails with
+/// `ELOOP` instead of being followed — possibly out of the root. The open
+/// also carries `O_NONBLOCK`, so a FIFO with no writer returns a handle
+/// immediately instead of parking the sandbox thread (this is guaranteed for
+/// FIFOs only; a device driver's open may still block, which is why the
+/// caller keeps its path-level type pre-check), and `O_NOCTTY`, so a tty
+/// device node can never become the controlling terminal as a side effect of
+/// the open (std does not set it). The caller must still fstat the returned
 /// handle and reject anything that is not a regular file; regular files are
 /// unaffected by these flags, so the bounded read that follows behaves
 /// exactly as a plain open would.
-fn open_for_read(source: &Path) -> std::io::Result<std::fs::File> {
-    let mut opts = std::fs::OpenOptions::new();
-    opts.read(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt as _;
-        opts.custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_NOCTTY);
-    }
-    opts.open(source)
+#[cfg(unix)]
+fn open_for_read(source: &Path, root: &Path) -> std::io::Result<std::fs::File> {
+    use std::os::unix::io::AsFd as _;
+
+    let rel = source.strip_prefix(root).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "path escaped its matched write directory before the open",
+        )
+    })?;
+    let root_fd = open_beneath::open_root(root)?;
+    open_beneath::open_beneath(
+        root_fd.as_fd(),
+        rel,
+        libc::O_RDONLY | libc::O_NONBLOCK | libc::O_NOCTTY,
+    )
+}
+
+/// Non-unix [`open_for_read`]: a plain read-only open of the canonical path.
+/// This platform has no beneath-root open, so the validate→open window is
+/// not closed here.
+#[cfg(not(unix))]
+fn open_for_read(source: &Path, _root: &Path) -> std::io::Result<std::fs::File> {
+    std::fs::OpenOptions::new().read(true).open(source)
 }
 
 /// JS-facing message for a failed [`open_for_read`]. A missing file and, on
 /// unix, `ELOOP` get self-explanatory messages; everything else carries the
-/// OS error text. `ELOOP` is returned both when `O_NOFOLLOW` rejects a
-/// symlink in the final component and when an intermediate component
-/// resolves through a symlink loop, so the message covers both.
+/// OS error text. `ELOOP` is what the beneath-root open returns for a
+/// symlink at any component of the path (final or intermediate) and what
+/// the kernel returns for a symlink loop, so the message covers all three.
 fn open_error_message(path_str: &str, e: &std::io::Error) -> String {
     if e.kind() == std::io::ErrorKind::NotFound {
         return format!("readFile: '{}' does not exist", path_str);
@@ -4125,9 +4145,10 @@ return {{ written: written, back: JSON.parse(readFile(written)) }};
             .expect("mkfifo must be available on unix");
         assert!(status.success(), "mkfifo failed: {:?}", status);
 
+        let root = dir.path().to_path_buf();
         let (tx, rx) = std::sync::mpsc::channel();
         std::thread::spawn(move || {
-            let _ = tx.send(open_for_read(&fifo).map(|f| f.metadata()));
+            let _ = tx.send(open_for_read(&fifo, &root).map(|f| f.metadata()));
         });
         let opened = rx
             .recv_timeout(Duration::from_secs(5))
@@ -4159,7 +4180,7 @@ return {{ written: written, back: JSON.parse(readFile(written)) }};
         let link = dir.path().join("link.txt");
         std::os::unix::fs::symlink(&target, &link).unwrap();
 
-        let err = open_for_read(&link).expect_err("O_NOFOLLOW must refuse a symlink");
+        let err = open_for_read(&link, dir.path()).expect_err("O_NOFOLLOW must refuse a symlink");
         assert_eq!(
             err.raw_os_error(),
             Some(libc::ELOOP),
@@ -4178,7 +4199,73 @@ return {{ written: written, back: JSON.parse(readFile(written)) }};
             msg
         );
 
-        let mut file = open_for_read(&target).unwrap();
+        let mut file = open_for_read(&target, dir.path()).unwrap();
+        assert!(file.metadata().unwrap().is_file());
+        let mut contents = String::new();
+        file.read_to_string(&mut contents).unwrap();
+        assert_eq!(contents, "plain");
+    }
+
+    /// The beneath-root open rejects a symlink swapped in for an
+    /// *intermediate* component of the already-canonicalized path — the case
+    /// a plain `open(2)` with `O_NOFOLLOW` would happily follow — whether the
+    /// link points out of the root or back inside it, and surfaces it through
+    /// the same friendly `ELOOP` message. A path that is not beneath the
+    /// matched root at all is refused before any handle is opened. (End to
+    /// end this arm is only reachable via the swap race: `resolve_write_path`
+    /// canonicalizes pre-existing symlinks away before the open.)
+    #[cfg(unix)]
+    #[test]
+    fn test_open_for_read_rejects_intermediate_symlink_swap() {
+        use std::io::Read as _;
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("f.txt"), "s3cr3t-content").unwrap();
+        std::fs::create_dir_all(root.join("real/deep")).unwrap();
+        std::fs::write(root.join("real/deep/f.txt"), "plain").unwrap();
+        // Out-of-root swap at the first component.
+        std::os::unix::fs::symlink(outside.path(), root.join("swapped")).unwrap();
+        // Out-of-root swap at a middle component.
+        std::os::unix::fs::symlink(outside.path(), root.join("real/out")).unwrap();
+        // In-root swap: still a post-canonicalize change, still rejected.
+        std::os::unix::fs::symlink(root.join("real"), root.join("inner")).unwrap();
+
+        for rel in ["swapped/f.txt", "real/out/f.txt", "inner/deep/f.txt"] {
+            let source = root.join(rel);
+            let err = match open_for_read(&source, root) {
+                Ok(_) => panic!("{}: intermediate symlink must be refused", rel),
+                Err(e) => e,
+            };
+            assert_eq!(
+                err.raw_os_error(),
+                Some(libc::ELOOP),
+                "{}: unexpected error: {}",
+                rel,
+                err
+            );
+            let msg = open_error_message(&format!("/root/{}", rel), &err);
+            assert!(
+                msg.contains("refers to a symbolic link or a path containing a symbolic link loop"),
+                "{}: unexpected message: {}",
+                rel,
+                msg
+            );
+            assert!(
+                !msg.contains("Too many levels") && !msg.contains("Not a directory"),
+                "{}: raw OS text must not leak: {}",
+                rel,
+                msg
+            );
+        }
+
+        // Not beneath the matched root at all: refused without opening.
+        let err = open_for_read(&outside.path().join("f.txt"), root)
+            .expect_err("a path outside the root must be refused");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput, "{}", err);
+
+        // Sanity: the genuine (symlink-free) nested path still reads.
+        let mut file = open_for_read(&root.join("real/deep/f.txt"), root).unwrap();
         assert!(file.metadata().unwrap().is_file());
         let mut contents = String::new();
         file.read_to_string(&mut contents).unwrap();

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -22,6 +22,13 @@ use tracing::Instrument;
 use crate::adapter::{AdapterError, ToolInfo};
 use crate::registry::MetaToolRegistry;
 
+// Beneath-root open primitives for readFile/writeFile. The call sites land
+// in follow-up changes; keep the allow until then so both targets stay
+// warning-clean under `clippy -D warnings`.
+#[cfg(unix)]
+#[allow(dead_code)]
+mod open_beneath;
+
 // ---------------------------------------------------------------------------
 // Retry tuning (Wave 3)
 // ---------------------------------------------------------------------------

--- a/src/js_sandbox.rs
+++ b/src/js_sandbox.rs
@@ -1297,13 +1297,16 @@ fn write_tmp_name(file_name: &std::ffi::OsStr) -> String {
 /// already be validated by [`resolve_write_path`] against `root` (the
 /// allowlisted root it matched). Every filesystem step is anchored to a
 /// directory handle of `root`: missing parents are created with `mkdirat`
-/// along an `openat` walk that refuses to follow symlinks
-/// ([`open_beneath::open_dir_beneath_creating`]), the temp file is created
-/// with `openat(O_CREAT | O_EXCL)` on the destination directory handle, and
-/// the publish is a `renameat` on that same handle. Because `dest` is
-/// canonical, any symlink the walk meets is a post-validation swap and fails
-/// the write — nothing is created or written outside the root, no matter
-/// how the path is re-pointed concurrently. If the root itself was deleted
+/// along a beneath-root open that refuses to follow symlinks
+/// ([`open_beneath::open_dir_beneath_creating`] — `openat2` re-resolving
+/// from the root at every step on Linux, an `openat` walk elsewhere), the
+/// temp file is created with `openat(O_CREAT | O_EXCL)` on the destination
+/// directory handle, and the publish is a `renameat` on that same handle.
+/// Because `dest` is canonical, any symlink met on the way is a
+/// post-validation swap and fails the write (`ELOOP`), as does a directory
+/// renamed out of the root while `openat2` resolves it (`EXDEV`) — nothing
+/// is created or written outside the root, no matter how the path is
+/// re-pointed concurrently. If the root itself was deleted
 /// after config resolution the write fails (the root handle cannot be
 /// opened); the "directories are never auto-created" stance in
 /// [`crate::config::resolve_write_roots`] only covers resolution time. On
@@ -1322,7 +1325,7 @@ fn write_atomic(dest: &Path, bytes: &[u8], root: &Path) -> Result<(), String> {
     };
     let rel_dir = dir.strip_prefix(root).map_err(|_| escaped())?;
     let parent_dirs_error = |e: std::io::Error| {
-        if e.raw_os_error() == Some(libc::ELOOP) {
+        if matches!(e.raw_os_error(), Some(libc::ELOOP) | Some(libc::EXDEV)) {
             return escaped();
         }
         format!(

--- a/src/js_sandbox/open_beneath.rs
+++ b/src/js_sandbox/open_beneath.rs
@@ -17,9 +17,14 @@
 //! - Everywhere else (macOS, old Linux): a component-by-component `openat(2)`
 //!   walk. Intermediates are opened `O_DIRECTORY | O_NOFOLLOW`, the final
 //!   component with the caller's flags plus `O_NOFOLLOW`, so a symlink at any
-//!   depth fails with `ELOOP`. Because every step is relative to the previous
-//!   directory handle, concurrent renames cannot re-point the walk outside the
-//!   root.
+//!   depth fails with `ELOOP`. Every step is relative to the previous
+//!   directory handle, so no lookup ever re-resolves an ancestor: a component
+//!   swapped for a symlink is caught, and `..`/absolute components never
+//!   reach the kernel. One caveat inherent to `openat` walks: a directory
+//!   that has already been opened and is then renamed out of the root stays
+//!   pinned, and the remaining components resolve inside it wherever it now
+//!   lives. `openat2` additionally detects that case (`EXDEV`); the walk
+//!   cannot, though it still never follows a symlink or a `..`.
 
 use std::ffi::{CString, OsStr};
 use std::fs::File;
@@ -59,19 +64,21 @@ pub(super) fn open_root(path: &Path) -> io::Result<OwnedFd> {
 /// `O_CREAT` is not supported — create files through the directory handle
 /// returned by [`open_dir_beneath_creating`] instead. A symlink component
 /// surfaces as `ELOOP`, on both the `openat2` and the walk paths.
-// `allow(dead_code)`: the readFile call site lands in a follow-up change;
-// keep the allow until then so both targets stay warning-clean under
-// `clippy -D warnings`.
-#[allow(dead_code)]
 pub(super) fn open_beneath(
     root: BorrowedFd<'_>,
     rel_path: &Path,
     final_flags: libc::c_int,
 ) -> io::Result<File> {
-    validated_open_components(rel_path, final_flags)?;
+    #[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
+    let components = validated_open_components(rel_path, final_flags)?;
     #[cfg(target_os = "linux")]
-    if let Some(result) = openat2::open(root, rel_path, final_flags) {
-        return result;
+    {
+        // Rebuild the path from the validated components so `openat2` sees
+        // exactly what the walk would (no trailing `/`, no `//`, no `./`).
+        let normalized: std::path::PathBuf = components.iter().collect();
+        if let Some(result) = openat2::open(root, &normalized, final_flags) {
+            return result;
+        }
     }
     open_beneath_walk(root, rel_path, final_flags)
 }
@@ -372,6 +379,14 @@ mod tests {
             assert_eq!(read_to_string(file), "nested", "{}", name);
             let top = opener(root.as_fd(), Path::new("top.txt"), READ_FLAGS).unwrap();
             assert_eq!(read_to_string(top), "top", "{}", name);
+            // Spellings `Path::components` normalizes away must behave the
+            // same on both openers (the openat2 path is rebuilt from the
+            // validated components rather than passed through verbatim).
+            for spelling in ["a/b/c.txt/", "a//b/c.txt", "a/./b/c.txt"] {
+                let file = opener(root.as_fd(), Path::new(spelling), READ_FLAGS)
+                    .unwrap_or_else(|e| panic!("{}: {:?}: {}", name, spelling, e));
+                assert_eq!(read_to_string(file), "nested", "{}: {:?}", name, spelling);
+            }
         }
     }
 

--- a/src/js_sandbox/open_beneath.rs
+++ b/src/js_sandbox/open_beneath.rs
@@ -59,6 +59,10 @@ pub(super) fn open_root(path: &Path) -> io::Result<OwnedFd> {
 /// `O_CREAT` is not supported — create files through the directory handle
 /// returned by [`open_dir_beneath_creating`] instead. A symlink component
 /// surfaces as `ELOOP`, on both the `openat2` and the walk paths.
+// `allow(dead_code)`: the readFile call site lands in a follow-up change;
+// keep the allow until then so both targets stay warning-clean under
+// `clippy -D warnings`.
+#[allow(dead_code)]
 pub(super) fn open_beneath(
     root: BorrowedFd<'_>,
     rel_path: &Path,
@@ -220,12 +224,14 @@ fn validated_components(rel_path: &Path) -> io::Result<Vec<&OsStr>> {
     Ok(out)
 }
 
-fn c_string(s: &OsStr) -> io::Result<CString> {
+pub(super) fn c_string(s: &OsStr) -> io::Result<CString> {
     CString::new(s.as_bytes())
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains a NUL byte"))
 }
 
-fn openat(
+/// `openat(2)` of `name` relative to `dirfd`; the caller supplies every flag
+/// (including `O_CLOEXEC`/`O_NOFOLLOW`) and the creation `mode`.
+pub(super) fn openat(
     dirfd: libc::c_int,
     name: &OsStr,
     flags: libc::c_int,

--- a/src/js_sandbox/open_beneath.rs
+++ b/src/js_sandbox/open_beneath.rs
@@ -12,8 +12,8 @@
 //! Two strategies share one contract:
 //! - Linux ≥ 5.6: a single `openat2(2)` with `RESOLVE_BENEATH |
 //!   RESOLVE_NO_SYMLINKS | RESOLVE_NO_MAGICLINKS`, enforced by the kernel.
-//!   `ENOSYS`/`EINVAL` (old kernel, seccomp) is remembered once and every
-//!   later call takes the walk.
+//!   `ENOSYS`/`EINVAL`/`EPERM` (old kernel, seccomp) is remembered once and
+//!   every later call takes the walk.
 //! - Everywhere else (macOS, old Linux): a component-by-component `openat(2)`
 //!   walk. Intermediates are opened `O_DIRECTORY | O_NOFOLLOW` (`O_PATH` on
 //!   Linux, `O_SEARCH` on Apple, so only search permission is needed), the final
@@ -132,10 +132,14 @@ pub(super) fn open_beneath_walk(
 /// the final one included — is `ELOOP`. Linux takes an `openat2(O_PATH)`
 /// and `fstat`s the handle; elsewhere (and on kernels without `openat2`)
 /// the walk ends in `fstatat(AT_SYMLINK_NOFOLLOW)` on the last directory
-/// handle.
+/// handle. An empty `rel_path` names `root` itself, which is stat'ed
+/// directly (the caller then reports it as a directory).
 pub(super) fn stat_beneath(root: BorrowedFd<'_>, rel_path: &Path) -> io::Result<libc::stat> {
     #[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
-    let components = validated_open_components(rel_path, 0)?;
+    let components = validated_components(rel_path)?;
+    if components.is_empty() {
+        return fstatat_nofollow(root.as_raw_fd(), OsStr::new("."));
+    }
     #[cfg(target_os = "linux")]
     {
         let normalized: std::path::PathBuf = components.iter().collect();
@@ -151,10 +155,10 @@ pub(super) fn stat_beneath(root: BorrowedFd<'_>, rel_path: &Path) -> io::Result<
 /// The portable walk behind [`stat_beneath`], exposed for the same reason
 /// as [`open_beneath_walk`].
 pub(super) fn stat_beneath_walk(root: BorrowedFd<'_>, rel_path: &Path) -> io::Result<libc::stat> {
-    let components = validated_open_components(rel_path, 0)?;
-    let (last, parents) = components
-        .split_last()
-        .expect("validated_open_components rejects empty paths");
+    let components = validated_components(rel_path)?;
+    let Some((last, parents)) = components.split_last() else {
+        return fstatat_nofollow(root.as_raw_fd(), OsStr::new("."));
+    };
     let dir = walk_parents(root, parents)?;
     let at = dir.as_ref().map_or(root.as_raw_fd(), |d| d.as_raw_fd());
     reject_symlink_stat(fstatat_nofollow(at, last)?)
@@ -359,8 +363,12 @@ mod openat2 {
         resolve: u64,
     }
 
-    /// Set once `openat2` reports `ENOSYS`/`EINVAL`, so the probe is paid
-    /// once per process and every later open goes straight to the walk.
+    /// Set once `openat2` reports `ENOSYS`/`EINVAL`/`EPERM`, so the probe is
+    /// paid once per process and every later open goes straight to the walk.
+    /// `EPERM` is how a seccomp default-deny profile answers an unlisted
+    /// syscall; nothing this module passes to `openat2` (no `O_NOATIME`, no
+    /// write modes) can earn a genuine per-file `EPERM`, and the walk would
+    /// surface one anyway.
     static UNSUPPORTED: AtomicBool = AtomicBool::new(false);
 
     /// `Some(result)` when `openat2` handled the open, `None` when the
@@ -399,7 +407,10 @@ mod openat2 {
         };
         if fd < 0 {
             let e = io::Error::last_os_error();
-            if matches!(e.raw_os_error(), Some(libc::ENOSYS) | Some(libc::EINVAL)) {
+            if matches!(
+                e.raw_os_error(),
+                Some(libc::ENOSYS) | Some(libc::EINVAL) | Some(libc::EPERM)
+            ) {
                 UNSUPPORTED.store(true, Ordering::Relaxed);
                 return None;
             }
@@ -660,6 +671,7 @@ mod tests {
             assert_eq!(kind("top.txt"), libc::S_IFREG, "{}", name);
             assert_eq!(kind("a/b"), libc::S_IFDIR, "{}", name);
             assert_eq!(kind("a/fifo"), libc::S_IFIFO, "{}", name);
+            assert_eq!(kind(""), libc::S_IFDIR, "{}: empty path is the root", name);
 
             let e = statter(root.as_fd(), Path::new("a/b/missing.txt")).unwrap_err();
             assert_eq!(e.kind(), io::ErrorKind::NotFound, "{}: {}", name, e);

--- a/src/js_sandbox/open_beneath.rs
+++ b/src/js_sandbox/open_beneath.rs
@@ -26,16 +26,23 @@
 //!   swapped for a symlink is caught, and `..`/absolute components never
 //!   reach the kernel.
 //!
-//! One caveat is inherent to `openat` walks and remains on the portable tier:
-//! a directory that has already been opened and is then renamed out of the
-//! root stays pinned, and the remaining components resolve inside it wherever
-//! it now lives. Moving it requires write permission on both its in-root
-//! parent and the destination parent (and `rename(2)` cannot cross a mount),
-//! so the walk can only be redirected into a directory the concurrent actor
-//! could already write to — never into an arbitrary location — and it still
-//! never follows a symlink or a `..`. `openat2` detects that case as well
-//! (`EXDEV` when the rename happens during resolution), which is why it is
-//! preferred wherever the kernel offers it. Closing it on macOS with
+//! One caveat is inherent to handle-based containment and applies to both
+//! tiers: a directory handle is a capability, and a directory that has
+//! already been opened and is then renamed out of the root stays pinned —
+//! whatever is done relative to that handle afterwards happens wherever the
+//! directory now lives. On the portable tier this covers the remaining
+//! components of the walk; on both tiers it covers the returned handle itself
+//! (e.g. the `openat`/`renameat` that `write_atomic` issues on the directory
+//! handle after `open_dir_beneath_creating` returns). `openat2` only enforces
+//! containment while it resolves a path (`EXDEV` if a component is renamed
+//! out mid-resolution, and every step of the creating open restarts from the
+//! root), which is why it is preferred where the kernel offers it, but it
+//! does not protect a handle once returned. Moving a directory requires write
+//! permission on both its in-root parent and the destination parent (and
+//! `rename(2)` cannot cross a mount), so on either tier the write can only be
+//! redirected into a directory the concurrent actor could already write to —
+//! never into an arbitrary location — and no lookup ever follows a symlink or
+//! a `..`. Narrowing the portable tier's walk residual on macOS with
 //! `O_RESOLVE_BENEATH | O_NOFOLLOW_ANY` is tracked in
 //! <https://github.com/endara-ai/endara-relay/issues/158>.
 

--- a/src/js_sandbox/open_beneath.rs
+++ b/src/js_sandbox/open_beneath.rs
@@ -1,0 +1,571 @@
+//! Beneath-root path opens for the sandbox file primitives (unix only).
+//!
+//! [`resolve_write_path`](super::resolve_write_path) canonicalizes a path up
+//! front, so by the time the sandbox touches the filesystem every existing
+//! component is known to be a real directory inside an allowlisted root. A
+//! plain `open(2)` of that canonical path still re-resolves each component,
+//! so a symlink swapped in for any of them between canonicalize and open
+//! would be followed — possibly out of the root. The helpers here anchor the
+//! open to a directory handle of the root and refuse to follow any symlink,
+//! which turns that swap into a hard error instead of an escape.
+//!
+//! Two strategies share one contract:
+//! - Linux ≥ 5.6: a single `openat2(2)` with `RESOLVE_BENEATH |
+//!   RESOLVE_NO_SYMLINKS | RESOLVE_NO_MAGICLINKS`, enforced by the kernel.
+//!   `ENOSYS`/`EINVAL` (old kernel, seccomp) is remembered once and every
+//!   later call takes the walk.
+//! - Everywhere else (macOS, old Linux): a component-by-component `openat(2)`
+//!   walk. Intermediates are opened `O_DIRECTORY | O_NOFOLLOW`, the final
+//!   component with the caller's flags plus `O_NOFOLLOW`, so a symlink at any
+//!   depth fails with `ELOOP`. Because every step is relative to the previous
+//!   directory handle, concurrent renames cannot re-point the walk outside the
+//!   root.
+
+use std::ffi::{CString, OsStr};
+use std::fs::File;
+use std::io;
+use std::os::unix::ffi::OsStrExt as _;
+use std::os::unix::io::{AsRawFd as _, BorrowedFd, FromRawFd as _, OwnedFd};
+use std::path::{Component, Path};
+
+/// `O_CLOEXEC` is always added so the handles never leak into spawned MCP
+/// server processes.
+const INTERMEDIATE_FLAGS: libc::c_int =
+    libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+
+/// Open the directory at `path` as an anchor for the beneath-root helpers.
+/// `path` is a trusted (canonical) allowlisted root.
+pub(super) fn open_root(path: &Path) -> io::Result<OwnedFd> {
+    let c_path = c_string(path.as_os_str())?;
+    // SAFETY: `c_path` is a valid NUL-terminated string that outlives the call.
+    let fd = unsafe {
+        libc::open(
+            c_path.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
+        )
+    };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: `fd` is a freshly opened descriptor exclusively owned here.
+    Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+}
+
+/// Open `rel_path` beneath `root`, refusing to follow a symlink at any
+/// component. `rel_path` must be a non-empty relative path made of plain
+/// components only (no `.`/`..`/root); anything else is rejected with
+/// `InvalidInput` before any syscall. `final_flags` are the `open(2)` flags
+/// for the last component (`O_CLOEXEC` and `O_NOFOLLOW` are always added);
+/// `O_CREAT` is not supported — create files through the directory handle
+/// returned by [`open_dir_beneath_creating`] instead. A symlink component
+/// surfaces as `ELOOP`, on both the `openat2` and the walk paths.
+pub(super) fn open_beneath(
+    root: BorrowedFd<'_>,
+    rel_path: &Path,
+    final_flags: libc::c_int,
+) -> io::Result<File> {
+    validated_open_components(rel_path, final_flags)?;
+    #[cfg(target_os = "linux")]
+    if let Some(result) = openat2::open(root, rel_path, final_flags) {
+        return result;
+    }
+    open_beneath_walk(root, rel_path, final_flags)
+}
+
+/// The portable `openat(2)` walk behind [`open_beneath`]. Exposed separately
+/// so the fallback is testable on kernels where `openat2` is available.
+pub(super) fn open_beneath_walk(
+    root: BorrowedFd<'_>,
+    rel_path: &Path,
+    final_flags: libc::c_int,
+) -> io::Result<File> {
+    let components = validated_open_components(rel_path, final_flags)?;
+    let (last, parents) = components
+        .split_last()
+        .expect("validated_open_components rejects empty paths");
+    let mut dir: Option<OwnedFd> = None;
+    for name in parents {
+        let at = dir.as_ref().map_or(root.as_raw_fd(), |d| d.as_raw_fd());
+        dir = Some(open_intermediate(at, name)?);
+    }
+    let at = dir.as_ref().map_or(root.as_raw_fd(), |d| d.as_raw_fd());
+    let fd = openat(
+        at,
+        last,
+        final_flags | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        0,
+    )?;
+    Ok(File::from(fd))
+}
+
+/// Open one intermediate component as a directory without following
+/// symlinks. Linux reports a symlink here as `ENOTDIR` (the link itself is
+/// not a directory once `O_NOFOLLOW` stops resolution); that case is
+/// normalised to `ELOOP` so callers see the same error the final component,
+/// `openat2`, and macOS produce.
+fn open_intermediate(dirfd: libc::c_int, name: &OsStr) -> io::Result<OwnedFd> {
+    match openat(dirfd, name, INTERMEDIATE_FLAGS, 0) {
+        Err(e) if e.raw_os_error() == Some(libc::ENOTDIR) && is_symlink_at(dirfd, name) => {
+            Err(io::Error::from_raw_os_error(libc::ELOOP))
+        }
+        other => other,
+    }
+}
+
+fn is_symlink_at(dirfd: libc::c_int, name: &OsStr) -> bool {
+    let Ok(c_name) = c_string(name) else {
+        return false;
+    };
+    let mut st = std::mem::MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: `dirfd` is an open descriptor, `c_name` a valid C string, and
+    // `st` is only read after fstatat reports success.
+    let rc = unsafe {
+        libc::fstatat(
+            dirfd,
+            c_name.as_ptr(),
+            st.as_mut_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    };
+    if rc != 0 {
+        return false;
+    }
+    // SAFETY: fstatat succeeded, so `st` is initialised.
+    let st = unsafe { st.assume_init() };
+    st.st_mode & libc::S_IFMT == libc::S_IFLNK
+}
+
+/// [`validated_components`] plus the file-open rules: the path must name at
+/// least one component and `final_flags` must not ask for `O_CREAT`.
+fn validated_open_components(rel_path: &Path, final_flags: libc::c_int) -> io::Result<Vec<&OsStr>> {
+    if final_flags & libc::O_CREAT != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "open_beneath does not support O_CREAT",
+        ));
+    }
+    let components = validated_components(rel_path)?;
+    if components.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "open_beneath requires a non-empty relative path",
+        ));
+    }
+    Ok(components)
+}
+
+/// Walk `rel_dir` beneath `root` like [`open_beneath_walk`], creating any
+/// missing directory with `mkdirat(2)` (mode `0o777`, subject to umask) and
+/// returning a handle to the final directory. `writeFile` creates its temp
+/// file and `renameat`s it relative to that handle, so nothing it does can
+/// land outside the root. An empty `rel_dir` returns a fresh handle to `root`
+/// itself. Pre-existing symlinks in the chain are rejected with `ELOOP`, so
+/// this always uses the walk (there is no create-parents `openat2`).
+pub(super) fn open_dir_beneath_creating(
+    root: BorrowedFd<'_>,
+    rel_dir: &Path,
+) -> io::Result<OwnedFd> {
+    let components = validated_components(rel_dir)?;
+    let mut dir = openat(root.as_raw_fd(), OsStr::new("."), INTERMEDIATE_FLAGS, 0)?;
+    for name in &components {
+        dir = match open_intermediate(dir.as_raw_fd(), name) {
+            Ok(fd) => fd,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                let c_name = c_string(name)?;
+                // SAFETY: `dir` is an open directory fd and `c_name` a valid C string.
+                let rc = unsafe { libc::mkdirat(dir.as_raw_fd(), c_name.as_ptr(), 0o777) };
+                if rc < 0 {
+                    let e = io::Error::last_os_error();
+                    // Lost a race with a concurrent creator: the open below
+                    // decides whether what appeared is an acceptable directory.
+                    if e.kind() != io::ErrorKind::AlreadyExists {
+                        return Err(e);
+                    }
+                }
+                open_intermediate(dir.as_raw_fd(), name)?
+            }
+            Err(e) => return Err(e),
+        };
+    }
+    Ok(dir)
+}
+
+/// Split `rel_path` into its plain components, rejecting absolute paths,
+/// `.`/`..`, and NUL bytes. Canonical paths from `resolve_write_path` never
+/// contain these; rejecting them here keeps the helper safe on its own.
+fn validated_components(rel_path: &Path) -> io::Result<Vec<&OsStr>> {
+    let mut out = Vec::new();
+    for component in rel_path.components() {
+        match component {
+            Component::Normal(name) => {
+                if name.as_bytes().contains(&0) {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "path component contains a NUL byte",
+                    ));
+                }
+                out.push(name);
+            }
+            other => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "path must be relative with plain components only, found {:?}",
+                        other.as_os_str()
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn c_string(s: &OsStr) -> io::Result<CString> {
+    CString::new(s.as_bytes())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains a NUL byte"))
+}
+
+fn openat(
+    dirfd: libc::c_int,
+    name: &OsStr,
+    flags: libc::c_int,
+    mode: libc::c_uint,
+) -> io::Result<OwnedFd> {
+    let c_name = c_string(name)?;
+    // SAFETY: `dirfd` is an open descriptor owned by the caller and `c_name`
+    // a valid NUL-terminated string that outlives the call.
+    let fd = unsafe { libc::openat(dirfd, c_name.as_ptr(), flags, mode) };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: `fd` is a freshly opened descriptor exclusively owned here.
+    Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+}
+
+#[cfg(target_os = "linux")]
+mod openat2 {
+    use std::fs::File;
+    use std::io;
+    use std::os::unix::io::{AsRawFd as _, BorrowedFd, FromRawFd as _};
+    use std::path::Path;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use super::c_string;
+
+    /// `struct open_how` from `linux/openat2.h`. Defined locally because
+    /// glibc has no `openat2` wrapper and libc's copy is `#[non_exhaustive]`.
+    #[repr(C)]
+    struct OpenHow {
+        flags: u64,
+        mode: u64,
+        resolve: u64,
+    }
+
+    /// Set once `openat2` reports `ENOSYS`/`EINVAL`, so the probe is paid
+    /// once per process and every later open goes straight to the walk.
+    static UNSUPPORTED: AtomicBool = AtomicBool::new(false);
+
+    /// `Some(result)` when `openat2` handled the open, `None` when the
+    /// syscall is unavailable and the caller must fall back to the walk.
+    pub(super) fn open(
+        root: BorrowedFd<'_>,
+        rel_path: &Path,
+        final_flags: libc::c_int,
+    ) -> Option<io::Result<File>> {
+        if UNSUPPORTED.load(Ordering::Relaxed) {
+            return None;
+        }
+        let c_path = match c_string(rel_path.as_os_str()) {
+            Ok(p) => p,
+            Err(e) => return Some(Err(e)),
+        };
+        let flags = final_flags | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+        let how = OpenHow {
+            flags: u64::from(flags as u32),
+            mode: 0,
+            resolve: libc::RESOLVE_BENEATH
+                | libc::RESOLVE_NO_SYMLINKS
+                | libc::RESOLVE_NO_MAGICLINKS,
+        };
+        // SAFETY: `root` is an open directory fd, `c_path` a valid C string and
+        // `how` a correctly sized, initialised `struct open_how`; all outlive
+        // the call.
+        let fd = unsafe {
+            libc::syscall(
+                libc::SYS_openat2,
+                root.as_raw_fd(),
+                c_path.as_ptr(),
+                &how as *const OpenHow,
+                std::mem::size_of::<OpenHow>(),
+            )
+        };
+        if fd < 0 {
+            let e = io::Error::last_os_error();
+            if matches!(e.raw_os_error(), Some(libc::ENOSYS) | Some(libc::EINVAL)) {
+                UNSUPPORTED.store(true, Ordering::Relaxed);
+                return None;
+            }
+            return Some(Err(e));
+        }
+        // SAFETY: `fd` is a freshly opened descriptor exclusively owned here.
+        Some(Ok(unsafe { File::from_raw_fd(fd as libc::c_int) }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read as _, Write as _};
+    use std::os::unix::fs::symlink;
+    use std::os::unix::io::AsFd as _;
+
+    const READ_FLAGS: libc::c_int = libc::O_RDONLY | libc::O_NONBLOCK | libc::O_NOCTTY;
+
+    type Opener = fn(BorrowedFd<'_>, &Path, libc::c_int) -> io::Result<File>;
+
+    /// Every open scenario is run through both the public entry point (which
+    /// takes `openat2` where the kernel offers it) and the walk directly, so
+    /// the fallback is covered even on kernels that never fall back.
+    const OPENERS: [(&str, Opener); 2] = [
+        ("open_beneath", open_beneath),
+        ("open_beneath_walk", open_beneath_walk),
+    ];
+
+    fn read_to_string(mut file: File) -> String {
+        let mut s = String::new();
+        file.read_to_string(&mut s).unwrap();
+        s
+    }
+
+    fn raw_os_error(name: &str, result: io::Result<File>) -> i32 {
+        match result {
+            Ok(_) => panic!("{}: expected an error, got a handle", name),
+            Err(e) => e
+                .raw_os_error()
+                .unwrap_or_else(|| panic!("{}: not an OS error: {}", name, e)),
+        }
+    }
+
+    /// Root containing `a/b/c.txt` (= "nested") and `top.txt` (= "top").
+    fn nested_root() -> (tempfile::TempDir, OwnedFd) {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("a/b")).unwrap();
+        std::fs::write(dir.path().join("a/b/c.txt"), "nested").unwrap();
+        std::fs::write(dir.path().join("top.txt"), "top").unwrap();
+        let root = open_root(dir.path()).unwrap();
+        (dir, root)
+    }
+
+    #[test]
+    fn test_open_beneath_opens_nested_regular_file() {
+        let (_dir, root) = nested_root();
+        for (name, opener) in OPENERS {
+            let file = opener(root.as_fd(), Path::new("a/b/c.txt"), READ_FLAGS)
+                .unwrap_or_else(|e| panic!("{}: {}", name, e));
+            assert!(file.metadata().unwrap().is_file(), "{}", name);
+            assert_eq!(read_to_string(file), "nested", "{}", name);
+            let top = opener(root.as_fd(), Path::new("top.txt"), READ_FLAGS).unwrap();
+            assert_eq!(read_to_string(top), "top", "{}", name);
+        }
+    }
+
+    #[test]
+    fn test_open_beneath_missing_file_is_not_found() {
+        let (_dir, root) = nested_root();
+        for (name, opener) in OPENERS {
+            let e = opener(root.as_fd(), Path::new("a/b/missing.txt"), READ_FLAGS).unwrap_err();
+            assert_eq!(e.kind(), io::ErrorKind::NotFound, "{}: {}", name, e);
+            let e = opener(root.as_fd(), Path::new("nope/c.txt"), READ_FLAGS).unwrap_err();
+            assert_eq!(e.kind(), io::ErrorKind::NotFound, "{}: {}", name, e);
+        }
+    }
+
+    /// A symlink as the FIRST component is rejected even when it points to a
+    /// directory inside the same root: the path was canonical, so any symlink
+    /// is a post-canonicalize swap.
+    #[test]
+    fn test_open_beneath_rejects_symlink_at_first_component() {
+        let (dir, root) = nested_root();
+        symlink(dir.path().join("a"), dir.path().join("link")).unwrap();
+        for (name, opener) in OPENERS {
+            let errno = raw_os_error(
+                name,
+                opener(root.as_fd(), Path::new("link/b/c.txt"), READ_FLAGS),
+            );
+            assert_eq!(errno, libc::ELOOP, "{}", name);
+        }
+    }
+
+    #[test]
+    fn test_open_beneath_rejects_symlink_at_middle_component() {
+        let (dir, root) = nested_root();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("c.txt"), "outside").unwrap();
+        symlink(outside.path(), dir.path().join("a/out")).unwrap();
+        for (name, opener) in OPENERS {
+            let errno = raw_os_error(
+                name,
+                opener(root.as_fd(), Path::new("a/out/c.txt"), READ_FLAGS),
+            );
+            assert_eq!(errno, libc::ELOOP, "{}", name);
+        }
+    }
+
+    #[test]
+    fn test_open_beneath_rejects_symlink_at_final_component() {
+        let (dir, root) = nested_root();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("secret"), "outside").unwrap();
+        symlink(
+            outside.path().join("secret"),
+            dir.path().join("a/b/escape.txt"),
+        )
+        .unwrap();
+        symlink("c.txt", dir.path().join("a/b/inside.txt")).unwrap();
+        symlink("dangling", dir.path().join("a/b/dangling.txt")).unwrap();
+        for (name, opener) in OPENERS {
+            for target in ["a/b/escape.txt", "a/b/inside.txt", "a/b/dangling.txt"] {
+                let errno = raw_os_error(name, opener(root.as_fd(), Path::new(target), READ_FLAGS));
+                assert_eq!(errno, libc::ELOOP, "{}: {}", name, target);
+            }
+        }
+    }
+
+    #[test]
+    fn test_open_beneath_rejects_non_plain_relative_paths() {
+        let (dir, root) = nested_root();
+        for (name, opener) in OPENERS {
+            for bad in [
+                "/etc/passwd",
+                "../a/b/c.txt",
+                "a/../top.txt",
+                "./top.txt",
+                "",
+            ] {
+                let e = opener(root.as_fd(), Path::new(bad), READ_FLAGS).unwrap_err();
+                assert_eq!(
+                    e.kind(),
+                    io::ErrorKind::InvalidInput,
+                    "{}: {:?}: {}",
+                    name,
+                    bad,
+                    e
+                );
+            }
+            let e = opener(
+                root.as_fd(),
+                Path::new("a/b/new.txt"),
+                READ_FLAGS | libc::O_CREAT,
+            )
+            .unwrap_err();
+            assert_eq!(e.kind(), io::ErrorKind::InvalidInput, "{}", name);
+            assert!(!dir.path().join("a/b/new.txt").exists(), "{}", name);
+        }
+    }
+
+    /// The walk stays anchored to the handle chain: a `..` smuggled in as a
+    /// raw component never reaches `openat` because validation rejects it,
+    /// and an absolute component (which `openat` would treat as absolute)
+    /// is likewise rejected up front.
+    #[test]
+    fn test_open_beneath_walk_rejects_paths_before_any_syscall() {
+        let (_dir, root) = nested_root();
+        let e = open_beneath_walk(
+            root.as_fd(),
+            Path::new("a/b/../../../etc/passwd"),
+            READ_FLAGS,
+        )
+        .unwrap_err();
+        assert_eq!(e.kind(), io::ErrorKind::InvalidInput);
+        let e = open_beneath_walk(root.as_fd(), Path::new("/"), READ_FLAGS).unwrap_err();
+        assert_eq!(e.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_openat2_fast_path_matches_walk_when_available() {
+        let (dir, root) = nested_root();
+        symlink(dir.path().join("a"), dir.path().join("link")).unwrap();
+        // `None` means a kernel without openat2: the fallback is what
+        // open_beneath uses and is exercised directly by the other tests.
+        if let Some(result) = openat2::open(root.as_fd(), Path::new("a/b/c.txt"), READ_FLAGS) {
+            assert_eq!(read_to_string(result.unwrap()), "nested");
+            let via_link = openat2::open(root.as_fd(), Path::new("link/b/c.txt"), READ_FLAGS)
+                .expect("openat2 still available")
+                .unwrap_err();
+            assert_eq!(via_link.raw_os_error(), Some(libc::ELOOP));
+        }
+    }
+
+    fn create_file_at(dir: &OwnedFd, name: &str, contents: &str) {
+        let fd = openat(
+            dir.as_raw_fd(),
+            OsStr::new(name),
+            libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_CLOEXEC,
+            0o644,
+        )
+        .unwrap();
+        File::from(fd).write_all(contents.as_bytes()).unwrap();
+    }
+
+    #[test]
+    fn test_open_dir_beneath_creating_creates_missing_chain_and_returns_usable_dirfd() {
+        let (dir, root) = nested_root();
+        let leaf = open_dir_beneath_creating(root.as_fd(), Path::new("a/new/deeper/leaf")).unwrap();
+        assert!(dir.path().join("a/new/deeper/leaf").is_dir());
+        create_file_at(&leaf, "f.txt", "via dirfd");
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("a/new/deeper/leaf/f.txt")).unwrap(),
+            "via dirfd"
+        );
+
+        // Second walk over the now-existing chain succeeds without recreating.
+        let again =
+            open_dir_beneath_creating(root.as_fd(), Path::new("a/new/deeper/leaf")).unwrap();
+        create_file_at(&again, "g.txt", "again");
+        assert!(dir.path().join("a/new/deeper/leaf/g.txt").is_file());
+    }
+
+    #[test]
+    fn test_open_dir_beneath_creating_empty_path_returns_root_handle() {
+        let (dir, root) = nested_root();
+        let handle = open_dir_beneath_creating(root.as_fd(), Path::new("")).unwrap();
+        create_file_at(&handle, "at_root.txt", "root");
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("at_root.txt")).unwrap(),
+            "root"
+        );
+    }
+
+    #[test]
+    fn test_open_dir_beneath_creating_rejects_symlink_components() {
+        let (dir, root) = nested_root();
+        let outside = tempfile::tempdir().unwrap();
+        symlink(outside.path(), dir.path().join("a/out")).unwrap();
+        symlink(outside.path(), dir.path().join("first")).unwrap();
+
+        for rel in ["a/out", "a/out/sub", "first/x/y"] {
+            let e = open_dir_beneath_creating(root.as_fd(), Path::new(rel)).unwrap_err();
+            assert_eq!(e.raw_os_error(), Some(libc::ELOOP), "{}: {}", rel, e);
+        }
+        assert!(!outside.path().join("sub").exists());
+        assert!(!outside.path().join("x").exists());
+    }
+
+    #[test]
+    fn test_open_dir_beneath_creating_rejects_non_plain_relative_paths() {
+        let (dir, root) = nested_root();
+        for bad in ["/tmp", "../x", "a/../x", "./a"] {
+            let e = open_dir_beneath_creating(root.as_fd(), Path::new(bad)).unwrap_err();
+            assert_eq!(e.kind(), io::ErrorKind::InvalidInput, "{:?}: {}", bad, e);
+        }
+        assert!(!dir.path().join("x").exists());
+    }
+
+    #[test]
+    fn test_open_dir_beneath_creating_fails_when_component_is_a_file() {
+        let (_dir, root) = nested_root();
+        let e = open_dir_beneath_creating(root.as_fd(), Path::new("top.txt/sub")).unwrap_err();
+        assert_eq!(e.raw_os_error(), Some(libc::ENOTDIR), "{}", e);
+    }
+}

--- a/src/js_sandbox/open_beneath.rs
+++ b/src/js_sandbox/open_beneath.rs
@@ -16,7 +16,7 @@
 //!   later call takes the walk.
 //! - Everywhere else (macOS, old Linux): a component-by-component `openat(2)`
 //!   walk. Intermediates are opened `O_DIRECTORY | O_NOFOLLOW` (`O_PATH` on
-//!   Linux, so only search permission is needed), the final
+//!   Linux, `O_SEARCH` on Apple, so only search permission is needed), the final
 //!   component with the caller's flags plus `O_NOFOLLOW`, so a symlink at any
 //!   depth fails with `ELOOP`. Every step is relative to the previous
 //!   directory handle, so no lookup ever re-resolves an ancestor: a component
@@ -34,18 +34,21 @@ use std::os::unix::ffi::OsStrExt as _;
 use std::os::unix::io::{AsRawFd as _, BorrowedFd, FromRawFd as _, OwnedFd};
 use std::path::{Component, Path};
 
-/// Flags for every directory anchor (the root and each intermediate). On
-/// Linux they are `O_PATH` handles: traversal then needs only search
-/// permission, as a normal pathname lookup does, whereas an `O_RDONLY`
-/// directory open would also demand read permission and fail with `EACCES`
-/// beneath an execute-only directory. Every use of these handles is an
-/// `*at(2)` call, which accepts `O_PATH` descriptors. Other unixes have no
-/// `O_PATH`, so `O_RDONLY` is used there. `O_CLOEXEC` is always added so the
-/// handles never leak into spawned MCP server processes.
+/// Flags for every directory anchor (the root and each intermediate).
+/// Traversal must need only search permission, as a normal pathname lookup
+/// does; an `O_RDONLY` directory open would also demand read permission and
+/// fail with `EACCES` beneath a `0o311` directory. Linux uses `O_PATH`;
+/// Apple has no `O_PATH` but `O_SEARCH` (`O_EXEC | O_DIRECTORY`), which XNU
+/// authorises as `KAUTH_VNODE_SEARCH` only. Every use of these handles is an
+/// `*at(2)` call, which accepts both kinds of descriptor. Other unixes fall
+/// back to `O_RDONLY`. `O_CLOEXEC` is always added so the handles never leak
+/// into spawned MCP server processes.
 #[cfg(target_os = "linux")]
 const DIR_ANCHOR_FLAGS: libc::c_int =
     libc::O_PATH | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_vendor = "apple")]
+const DIR_ANCHOR_FLAGS: libc::c_int = libc::O_SEARCH | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+#[cfg(not(any(target_os = "linux", target_vendor = "apple")))]
 const DIR_ANCHOR_FLAGS: libc::c_int =
     libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
 
@@ -676,13 +679,14 @@ mod tests {
         }
     }
 
-    /// Anchors are `O_PATH` on Linux, so a file beneath a directory without
-    /// read permission (search only — plus write, so creation can be
-    /// exercised too) stays reachable exactly as it is through a plain
-    /// pathname open, where an `O_RDONLY` directory anchor would fail with
-    /// `EACCES`. Root bypasses permission checks, so the test is skipped
-    /// there.
-    #[cfg(target_os = "linux")]
+    /// Anchors are `O_PATH` on Linux and `O_SEARCH` on Apple, so a file
+    /// beneath a directory without read permission (`0o311`: search plus
+    /// write, so creation can be exercised too) stays reachable exactly as it
+    /// is through a plain pathname open, where an `O_RDONLY` directory anchor
+    /// would fail with `EACCES`. Covers a `0o311` intermediate and a `0o311`
+    /// root, for both openers, both statters and the creating walk. Root
+    /// bypasses permission checks, so the test is skipped there.
+    #[cfg(any(target_os = "linux", target_vendor = "apple"))]
     #[test]
     fn test_anchors_traverse_execute_only_directories() {
         use std::os::unix::fs::PermissionsExt as _;
@@ -721,9 +725,18 @@ mod tests {
                 "ok"
             );
             let exec_only_root = open_root(&locked).unwrap();
-            let file =
-                open_beneath(exec_only_root.as_fd(), Path::new("c.txt"), READ_FLAGS).unwrap();
-            assert_eq!(read_to_string(file), "nested");
+            for (name, opener) in OPENERS {
+                let file = opener(exec_only_root.as_fd(), Path::new("c.txt"), READ_FLAGS)
+                    .unwrap_or_else(|e| panic!("{} via 0o311 root: {}", name, e));
+                assert_eq!(read_to_string(file), "nested", "{}", name);
+            }
+            let handle =
+                open_dir_beneath_creating(exec_only_root.as_fd(), Path::new("new")).unwrap();
+            create_file_at(&handle, "via_exec_only_root.txt", "ok");
+            assert_eq!(
+                std::fs::read_to_string(locked.join("new/via_exec_only_root.txt")).unwrap(),
+                "ok"
+            );
         }));
         restore();
         if let Err(panic) = outcome {

--- a/src/js_sandbox/open_beneath.rs
+++ b/src/js_sandbox/open_beneath.rs
@@ -276,18 +276,23 @@ fn validated_open_components(rel_path: &Path, final_flags: libc::c_int) -> io::R
 /// Open the directory `rel_dir` beneath `root`, creating any missing
 /// component with `mkdirat(2)` (mode `0o777`, subject to umask) and
 /// returning a handle to the final directory. `writeFile` creates its temp
-/// file and `renameat`s it relative to that handle, so nothing it does can
-/// land outside the root. An empty `rel_dir` returns a fresh handle to `root`
-/// itself. A pre-existing symlink anywhere in the chain is `ELOOP`.
+/// file and `renameat`s it relative to that handle, so none of its lookups
+/// can be redirected through a symlink or re-resolved from `/`. The handle is
+/// a capability: it was beneath the root when resolved, and the caller's
+/// later operations are anchored to it, not re-validated (see the module doc
+/// for the rename-out residual that leaves). An empty `rel_dir` returns a
+/// fresh handle to `root` itself. A pre-existing symlink anywhere in the
+/// chain is `ELOOP`.
 ///
 /// On Linux with `openat2`, every directory handle — including the one
 /// re-opened after each `mkdirat` — is resolved from `root` over the full
 /// accumulated relative path with `RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS`,
 /// never chained off the previous handle. The kernel therefore re-checks
 /// containment of the whole prefix at every step and reports an
-/// intermediate renamed out of the root during resolution as `EXDEV`, so the
-/// write fails closed instead of following the moved directory. Elsewhere
-/// the portable walk ([`open_dir_beneath_creating_walk`]) is used.
+/// intermediate renamed out of the root during resolution as `EXDEV`, so
+/// this function fails closed instead of following the moved directory
+/// while it is still resolving. Elsewhere the portable walk
+/// ([`open_dir_beneath_creating_walk`]) is used.
 pub(super) fn open_dir_beneath_creating(
     root: BorrowedFd<'_>,
     rel_dir: &Path,

--- a/src/js_sandbox/open_beneath.rs
+++ b/src/js_sandbox/open_beneath.rs
@@ -15,7 +15,8 @@
 //!   `ENOSYS`/`EINVAL` (old kernel, seccomp) is remembered once and every
 //!   later call takes the walk.
 //! - Everywhere else (macOS, old Linux): a component-by-component `openat(2)`
-//!   walk. Intermediates are opened `O_DIRECTORY | O_NOFOLLOW`, the final
+//!   walk. Intermediates are opened `O_DIRECTORY | O_NOFOLLOW` (`O_PATH` on
+//!   Linux, so only search permission is needed), the final
 //!   component with the caller's flags plus `O_NOFOLLOW`, so a symlink at any
 //!   depth fails with `ELOOP`. Every step is relative to the previous
 //!   directory handle, so no lookup ever re-resolves an ancestor: a component
@@ -33,9 +34,19 @@ use std::os::unix::ffi::OsStrExt as _;
 use std::os::unix::io::{AsRawFd as _, BorrowedFd, FromRawFd as _, OwnedFd};
 use std::path::{Component, Path};
 
-/// `O_CLOEXEC` is always added so the handles never leak into spawned MCP
-/// server processes.
-const INTERMEDIATE_FLAGS: libc::c_int =
+/// Flags for every directory anchor (the root and each intermediate). On
+/// Linux they are `O_PATH` handles: traversal then needs only search
+/// permission, as a normal pathname lookup does, whereas an `O_RDONLY`
+/// directory open would also demand read permission and fail with `EACCES`
+/// beneath an execute-only directory. Every use of these handles is an
+/// `*at(2)` call, which accepts `O_PATH` descriptors. Other unixes have no
+/// `O_PATH`, so `O_RDONLY` is used there. `O_CLOEXEC` is always added so the
+/// handles never leak into spawned MCP server processes.
+#[cfg(target_os = "linux")]
+const DIR_ANCHOR_FLAGS: libc::c_int =
+    libc::O_PATH | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+#[cfg(not(target_os = "linux"))]
+const DIR_ANCHOR_FLAGS: libc::c_int =
     libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
 
 /// Open the directory at `path` as an anchor for the beneath-root helpers.
@@ -48,12 +59,7 @@ const INTERMEDIATE_FLAGS: libc::c_int =
 pub(super) fn open_root(path: &Path) -> io::Result<OwnedFd> {
     let c_path = c_string(path.as_os_str())?;
     // SAFETY: `c_path` is a valid NUL-terminated string that outlives the call.
-    let fd = unsafe {
-        libc::open(
-            c_path.as_ptr(),
-            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
-        )
-    };
+    let fd = unsafe { libc::open(c_path.as_ptr(), DIR_ANCHOR_FLAGS) };
     if fd < 0 {
         let e = io::Error::last_os_error();
         // Same Linux ENOTDIR-for-a-symlink quirk as `open_intermediate`.
@@ -106,11 +112,7 @@ pub(super) fn open_beneath_walk(
     let (last, parents) = components
         .split_last()
         .expect("validated_open_components rejects empty paths");
-    let mut dir: Option<OwnedFd> = None;
-    for name in parents {
-        let at = dir.as_ref().map_or(root.as_raw_fd(), |d| d.as_raw_fd());
-        dir = Some(open_intermediate(at, name)?);
-    }
+    let dir = walk_parents(root, parents)?;
     let at = dir.as_ref().map_or(root.as_raw_fd(), |d| d.as_raw_fd());
     let fd = openat(
         at,
@@ -121,13 +123,66 @@ pub(super) fn open_beneath_walk(
     Ok(File::from(fd))
 }
 
+/// `stat(2)` information for `rel_path` beneath `root` with the same
+/// containment as [`open_beneath`] but without opening the entry itself, so
+/// a device node's driver `open` never runs. A symlink at any component —
+/// the final one included — is `ELOOP`. Linux takes an `openat2(O_PATH)`
+/// and `fstat`s the handle; elsewhere (and on kernels without `openat2`)
+/// the walk ends in `fstatat(AT_SYMLINK_NOFOLLOW)` on the last directory
+/// handle.
+pub(super) fn stat_beneath(root: BorrowedFd<'_>, rel_path: &Path) -> io::Result<libc::stat> {
+    #[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
+    let components = validated_open_components(rel_path, 0)?;
+    #[cfg(target_os = "linux")]
+    {
+        let normalized: std::path::PathBuf = components.iter().collect();
+        if let Some(result) = openat2::open(root, &normalized, libc::O_PATH) {
+            // With `O_PATH | O_NOFOLLOW`, openat2 hands back a handle to a
+            // trailing symlink instead of failing; normalise that to ELOOP.
+            return reject_symlink_stat(fstat(&result?)?);
+        }
+    }
+    stat_beneath_walk(root, rel_path)
+}
+
+/// The portable walk behind [`stat_beneath`], exposed for the same reason
+/// as [`open_beneath_walk`].
+pub(super) fn stat_beneath_walk(root: BorrowedFd<'_>, rel_path: &Path) -> io::Result<libc::stat> {
+    let components = validated_open_components(rel_path, 0)?;
+    let (last, parents) = components
+        .split_last()
+        .expect("validated_open_components rejects empty paths");
+    let dir = walk_parents(root, parents)?;
+    let at = dir.as_ref().map_or(root.as_raw_fd(), |d| d.as_raw_fd());
+    reject_symlink_stat(fstatat_nofollow(at, last)?)
+}
+
+fn reject_symlink_stat(st: libc::stat) -> io::Result<libc::stat> {
+    if st.st_mode & libc::S_IFMT == libc::S_IFLNK {
+        return Err(io::Error::from_raw_os_error(libc::ELOOP));
+    }
+    Ok(st)
+}
+
+/// Open each directory in `parents` relative to the previous handle (the
+/// first relative to `root`). `None` when there are no parents, i.e. the
+/// final component lives directly in `root`.
+fn walk_parents(root: BorrowedFd<'_>, parents: &[&OsStr]) -> io::Result<Option<OwnedFd>> {
+    let mut dir: Option<OwnedFd> = None;
+    for name in parents {
+        let at = dir.as_ref().map_or(root.as_raw_fd(), |d| d.as_raw_fd());
+        dir = Some(open_intermediate(at, name)?);
+    }
+    Ok(dir)
+}
+
 /// Open one intermediate component as a directory without following
 /// symlinks. Linux reports a symlink here as `ENOTDIR` (the link itself is
 /// not a directory once `O_NOFOLLOW` stops resolution); that case is
 /// normalised to `ELOOP` so callers see the same error the final component,
 /// `openat2`, and macOS produce.
 fn open_intermediate(dirfd: libc::c_int, name: &OsStr) -> io::Result<OwnedFd> {
-    match openat(dirfd, name, INTERMEDIATE_FLAGS, 0) {
+    match openat(dirfd, name, DIR_ANCHOR_FLAGS, 0) {
         Err(e) if e.raw_os_error() == Some(libc::ENOTDIR) && is_symlink_at(dirfd, name) => {
             Err(io::Error::from_raw_os_error(libc::ELOOP))
         }
@@ -136,9 +191,12 @@ fn open_intermediate(dirfd: libc::c_int, name: &OsStr) -> io::Result<OwnedFd> {
 }
 
 fn is_symlink_at(dirfd: libc::c_int, name: &OsStr) -> bool {
-    let Ok(c_name) = c_string(name) else {
-        return false;
-    };
+    fstatat_nofollow(dirfd, name).is_ok_and(|st| st.st_mode & libc::S_IFMT == libc::S_IFLNK)
+}
+
+/// `fstatat(2)` of `name` relative to `dirfd` with `AT_SYMLINK_NOFOLLOW`.
+fn fstatat_nofollow(dirfd: libc::c_int, name: &OsStr) -> io::Result<libc::stat> {
+    let c_name = c_string(name)?;
     let mut st = std::mem::MaybeUninit::<libc::stat>::uninit();
     // SAFETY: `dirfd` is an open descriptor, `c_name` a valid C string, and
     // `st` is only read after fstatat reports success.
@@ -151,11 +209,23 @@ fn is_symlink_at(dirfd: libc::c_int, name: &OsStr) -> bool {
         )
     };
     if rc != 0 {
-        return false;
+        return Err(io::Error::last_os_error());
     }
     // SAFETY: fstatat succeeded, so `st` is initialised.
-    let st = unsafe { st.assume_init() };
-    st.st_mode & libc::S_IFMT == libc::S_IFLNK
+    Ok(unsafe { st.assume_init() })
+}
+
+#[cfg(target_os = "linux")]
+fn fstat(file: &File) -> io::Result<libc::stat> {
+    let mut st = std::mem::MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: `file` holds an open descriptor and `st` is only read after
+    // fstat reports success.
+    let rc = unsafe { libc::fstat(file.as_raw_fd(), st.as_mut_ptr()) };
+    if rc != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: fstat succeeded, so `st` is initialised.
+    Ok(unsafe { st.assume_init() })
 }
 
 /// [`validated_components`] plus the file-open rules: the path must name at
@@ -189,7 +259,7 @@ pub(super) fn open_dir_beneath_creating(
     rel_dir: &Path,
 ) -> io::Result<OwnedFd> {
     let components = validated_components(rel_dir)?;
-    let mut dir = openat(root.as_raw_fd(), OsStr::new("."), INTERMEDIATE_FLAGS, 0)?;
+    let mut dir = openat(root.as_raw_fd(), OsStr::new("."), DIR_ANCHOR_FLAGS, 0)?;
     for name in &components {
         dir = match open_intermediate(dir.as_raw_fd(), name) {
             Ok(fd) => fd,
@@ -551,6 +621,113 @@ mod tests {
                 .expect("openat2 still available")
                 .unwrap_err();
             assert_eq!(via_link.raw_os_error(), Some(libc::ELOOP));
+        }
+    }
+
+    type Statter = fn(BorrowedFd<'_>, &Path) -> io::Result<libc::stat>;
+
+    const STATTERS: [(&str, Statter); 2] = [
+        ("stat_beneath", stat_beneath),
+        ("stat_beneath_walk", stat_beneath_walk),
+    ];
+
+    /// `stat_beneath` reports the entry type without opening it (a FIFO with
+    /// no writer is answered immediately) and, like the opens, treats a
+    /// symlink at any depth as a post-canonicalize swap.
+    #[test]
+    fn test_stat_beneath_reports_type_and_rejects_symlinks() {
+        let (dir, root) = nested_root();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("c.txt"), "outside").unwrap();
+        symlink(outside.path(), dir.path().join("a/out")).unwrap();
+        symlink(dir.path().join("a"), dir.path().join("link")).unwrap();
+        symlink(outside.path().join("c.txt"), dir.path().join("a/b/leaf")).unwrap();
+        let fifo = c_string(dir.path().join("a/fifo").as_os_str()).unwrap();
+        // SAFETY: `fifo` is a valid NUL-terminated path.
+        assert_eq!(unsafe { libc::mkfifo(fifo.as_ptr(), 0o600) }, 0);
+
+        for (name, statter) in STATTERS {
+            let kind = |rel: &str| {
+                statter(root.as_fd(), Path::new(rel))
+                    .unwrap_or_else(|e| panic!("{}: {}: {}", name, rel, e))
+                    .st_mode
+                    & libc::S_IFMT
+            };
+            assert_eq!(kind("a/b/c.txt"), libc::S_IFREG, "{}", name);
+            assert_eq!(kind("top.txt"), libc::S_IFREG, "{}", name);
+            assert_eq!(kind("a/b"), libc::S_IFDIR, "{}", name);
+            assert_eq!(kind("a/fifo"), libc::S_IFIFO, "{}", name);
+
+            let e = statter(root.as_fd(), Path::new("a/b/missing.txt")).unwrap_err();
+            assert_eq!(e.kind(), io::ErrorKind::NotFound, "{}: {}", name, e);
+            for rel in ["link/b/c.txt", "a/out/c.txt", "a/b/leaf"] {
+                let e = statter(root.as_fd(), Path::new(rel)).unwrap_err();
+                assert_eq!(
+                    e.raw_os_error(),
+                    Some(libc::ELOOP),
+                    "{}: {}: {}",
+                    name,
+                    rel,
+                    e
+                );
+            }
+            let e = statter(root.as_fd(), Path::new("../x")).unwrap_err();
+            assert_eq!(e.kind(), io::ErrorKind::InvalidInput, "{}: {}", name, e);
+        }
+    }
+
+    /// Anchors are `O_PATH` on Linux, so a file beneath a directory without
+    /// read permission (search only — plus write, so creation can be
+    /// exercised too) stays reachable exactly as it is through a plain
+    /// pathname open, where an `O_RDONLY` directory anchor would fail with
+    /// `EACCES`. Root bypasses permission checks, so the test is skipped
+    /// there.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_anchors_traverse_execute_only_directories() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        // SAFETY: geteuid has no preconditions.
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+        let (dir, root) = nested_root();
+        let locked = dir.path().join("a/b");
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o311)).unwrap();
+        let restore = || {
+            std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
+        };
+        assert_eq!(
+            std::fs::read_dir(&locked).map(|_| ()).unwrap_err().kind(),
+            io::ErrorKind::PermissionDenied,
+            "precondition: a/b must not be readable"
+        );
+
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            for (name, opener) in OPENERS {
+                let file = opener(root.as_fd(), Path::new("a/b/c.txt"), READ_FLAGS)
+                    .unwrap_or_else(|e| panic!("{}: {}", name, e));
+                assert_eq!(read_to_string(file), "nested", "{}", name);
+            }
+            for (name, statter) in STATTERS {
+                let st = statter(root.as_fd(), Path::new("a/b/c.txt"))
+                    .unwrap_or_else(|e| panic!("{}: {}", name, e));
+                assert_eq!(st.st_mode & libc::S_IFMT, libc::S_IFREG, "{}", name);
+            }
+            let handle = open_dir_beneath_creating(root.as_fd(), Path::new("a/b")).unwrap();
+            create_file_at(&handle, "via_exec_only.txt", "ok");
+            assert_eq!(
+                std::fs::read_to_string(locked.join("via_exec_only.txt")).unwrap(),
+                "ok"
+            );
+            let exec_only_root = open_root(&locked).unwrap();
+            let file =
+                open_beneath(exec_only_root.as_fd(), Path::new("c.txt"), READ_FLAGS).unwrap();
+            assert_eq!(read_to_string(file), "nested");
+        }));
+        restore();
+        if let Err(panic) = outcome {
+            std::panic::resume_unwind(panic);
         }
     }
 

--- a/src/js_sandbox/open_beneath.rs
+++ b/src/js_sandbox/open_beneath.rs
@@ -10,10 +10,13 @@
 //! which turns that swap into a hard error instead of an escape.
 //!
 //! Two strategies share one contract:
-//! - Linux ≥ 5.6: a single `openat2(2)` with `RESOLVE_BENEATH |
+//! - Linux ≥ 5.6: `openat2(2)` from the root handle with `RESOLVE_BENEATH |
 //!   RESOLVE_NO_SYMLINKS | RESOLVE_NO_MAGICLINKS`, enforced by the kernel.
-//!   `ENOSYS`/`EINVAL`/`EPERM` (old kernel, seccomp) is remembered once and
-//!   every later call takes the walk.
+//!   Opens and stats are a single call; the directory-creating open used by
+//!   `writeFile` re-resolves the whole accumulated prefix from the root after
+//!   every step, so containment is re-checked each time rather than inherited
+//!   from a previously opened handle. `ENOSYS`/`EINVAL`/`EPERM` (old kernel,
+//!   seccomp) is remembered once and every later call takes the walk.
 //! - Everywhere else (macOS, old Linux): a component-by-component `openat(2)`
 //!   walk. Intermediates are opened `O_DIRECTORY | O_NOFOLLOW` (`O_PATH` on
 //!   Linux, `O_SEARCH` on Apple, so only search permission is needed), the final
@@ -21,11 +24,18 @@
 //!   depth fails with `ELOOP`. Every step is relative to the previous
 //!   directory handle, so no lookup ever re-resolves an ancestor: a component
 //!   swapped for a symlink is caught, and `..`/absolute components never
-//!   reach the kernel. One caveat inherent to `openat` walks: a directory
-//!   that has already been opened and is then renamed out of the root stays
-//!   pinned, and the remaining components resolve inside it wherever it now
-//!   lives. `openat2` additionally detects that case (`EXDEV`); the walk
-//!   cannot, though it still never follows a symlink or a `..`.
+//!   reach the kernel.
+//!
+//! One caveat is inherent to `openat` walks and remains on the portable tier:
+//! a directory that has already been opened and is then renamed out of the
+//! root stays pinned, and the remaining components resolve inside it wherever
+//! it now lives. Moving it requires write permission on both its in-root
+//! parent and the destination parent (and `rename(2)` cannot cross a mount),
+//! so the walk can only be redirected into a directory the concurrent actor
+//! could already write to — never into an arbitrary location — and it still
+//! never follows a symlink or a `..`. `openat2` detects that case as well
+//! (`EXDEV` when the rename happens during resolution), which is why it is
+//! preferred wherever the kernel offers it.
 
 use std::ffi::{CString, OsStr};
 use std::fs::File;
@@ -254,14 +264,98 @@ fn validated_open_components(rel_path: &Path, final_flags: libc::c_int) -> io::R
     Ok(components)
 }
 
-/// Walk `rel_dir` beneath `root` like [`open_beneath_walk`], creating any
-/// missing directory with `mkdirat(2)` (mode `0o777`, subject to umask) and
+/// Open the directory `rel_dir` beneath `root`, creating any missing
+/// component with `mkdirat(2)` (mode `0o777`, subject to umask) and
 /// returning a handle to the final directory. `writeFile` creates its temp
 /// file and `renameat`s it relative to that handle, so nothing it does can
 /// land outside the root. An empty `rel_dir` returns a fresh handle to `root`
-/// itself. Pre-existing symlinks in the chain are rejected with `ELOOP`, so
-/// this always uses the walk (there is no create-parents `openat2`).
+/// itself. A pre-existing symlink anywhere in the chain is `ELOOP`.
+///
+/// On Linux with `openat2`, every directory handle — including the one
+/// re-opened after each `mkdirat` — is resolved from `root` over the full
+/// accumulated relative path with `RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS`,
+/// never chained off the previous handle. The kernel therefore re-checks
+/// containment of the whole prefix at every step and reports an
+/// intermediate renamed out of the root during resolution as `EXDEV`, so the
+/// write fails closed instead of following the moved directory. Elsewhere
+/// the portable walk ([`open_dir_beneath_creating_walk`]) is used.
 pub(super) fn open_dir_beneath_creating(
+    root: BorrowedFd<'_>,
+    rel_dir: &Path,
+) -> io::Result<OwnedFd> {
+    #[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
+    let components = validated_components(rel_dir)?;
+    #[cfg(target_os = "linux")]
+    {
+        if let Some(result) = open_dir_beneath_creating_openat2(root, &components) {
+            return result;
+        }
+    }
+    open_dir_beneath_creating_walk(root, rel_dir)
+}
+
+/// The `openat2` tier of [`open_dir_beneath_creating`]. `None` when the
+/// syscall is unavailable (nothing has been created yet in that case, since
+/// the probe is decided by the first call and latched process-wide).
+#[cfg(target_os = "linux")]
+fn open_dir_beneath_creating_openat2(
+    root: BorrowedFd<'_>,
+    components: &[&OsStr],
+) -> Option<io::Result<OwnedFd>> {
+    let mut so_far = std::path::PathBuf::new();
+    let mut dir = match openat(root.as_raw_fd(), OsStr::new("."), DIR_ANCHOR_FLAGS, 0) {
+        Ok(fd) => fd,
+        Err(e) => return Some(Err(e)),
+    };
+    for name in components {
+        so_far.push(name);
+        dir = match open_dir_beneath_openat2(root, dir.as_raw_fd(), name, &so_far)? {
+            Ok(fd) => fd,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                // `dir` was itself resolved beneath `root`; the re-open below
+                // re-resolves the whole prefix from `root`, so a directory that
+                // moved out in between is not followed.
+                if let Err(e) = mkdirat_tolerating_exists(dir.as_raw_fd(), name) {
+                    return Some(Err(e));
+                }
+                match open_dir_beneath_openat2(root, dir.as_raw_fd(), name, &so_far)? {
+                    Ok(fd) => fd,
+                    Err(e) => return Some(Err(e)),
+                }
+            }
+            Err(e) => return Some(Err(e)),
+        };
+    }
+    Some(Ok(dir))
+}
+
+/// `openat2(root, rel_dir)` as a directory anchor. `parent`/`name` identify
+/// the same entry relative to its already-opened parent, only used to
+/// normalise Linux's `ENOTDIR`-for-a-trailing-symlink to `ELOOP` (with
+/// `O_NOFOLLOW` the kernel does not resolve — and so does not reject — a
+/// trailing symlink; `O_DIRECTORY` then fails on it with `ENOTDIR`).
+#[cfg(target_os = "linux")]
+fn open_dir_beneath_openat2(
+    root: BorrowedFd<'_>,
+    parent: libc::c_int,
+    name: &OsStr,
+    rel_dir: &Path,
+) -> Option<io::Result<OwnedFd>> {
+    Some(match openat2::open(root, rel_dir, DIR_ANCHOR_FLAGS)? {
+        Ok(file) => Ok(OwnedFd::from(file)),
+        Err(e) if e.raw_os_error() == Some(libc::ENOTDIR) && is_symlink_at(parent, name) => {
+            Err(io::Error::from_raw_os_error(libc::ELOOP))
+        }
+        Err(e) => Err(e),
+    })
+}
+
+/// The portable `openat(2)`/`mkdirat(2)` walk behind
+/// [`open_dir_beneath_creating`]: each component is opened relative to the
+/// previous handle, so no ancestor is ever re-resolved and no symlink is
+/// followed. Exposed separately so it stays tested on kernels that take the
+/// `openat2` tier.
+pub(super) fn open_dir_beneath_creating_walk(
     root: BorrowedFd<'_>,
     rel_dir: &Path,
 ) -> io::Result<OwnedFd> {
@@ -271,23 +365,30 @@ pub(super) fn open_dir_beneath_creating(
         dir = match open_intermediate(dir.as_raw_fd(), name) {
             Ok(fd) => fd,
             Err(e) if e.kind() == io::ErrorKind::NotFound => {
-                let c_name = c_string(name)?;
-                // SAFETY: `dir` is an open directory fd and `c_name` a valid C string.
-                let rc = unsafe { libc::mkdirat(dir.as_raw_fd(), c_name.as_ptr(), 0o777) };
-                if rc < 0 {
-                    let e = io::Error::last_os_error();
-                    // Lost a race with a concurrent creator: the open below
-                    // decides whether what appeared is an acceptable directory.
-                    if e.kind() != io::ErrorKind::AlreadyExists {
-                        return Err(e);
-                    }
-                }
+                mkdirat_tolerating_exists(dir.as_raw_fd(), name)?;
                 open_intermediate(dir.as_raw_fd(), name)?
             }
             Err(e) => return Err(e),
         };
     }
     Ok(dir)
+}
+
+/// `mkdirat(2)` of `name` under `dirfd` (mode `0o777`, subject to umask).
+/// `EEXIST` is not an error: the caller lost a race with a concurrent
+/// creator and its following open decides whether what appeared is an
+/// acceptable directory.
+fn mkdirat_tolerating_exists(dirfd: libc::c_int, name: &OsStr) -> io::Result<()> {
+    let c_name = c_string(name)?;
+    // SAFETY: `dirfd` is an open directory fd and `c_name` a valid C string.
+    let rc = unsafe { libc::mkdirat(dirfd, c_name.as_ptr(), 0o777) };
+    if rc < 0 {
+        let e = io::Error::last_os_error();
+        if e.kind() != io::ErrorKind::AlreadyExists {
+            return Err(e);
+        }
+    }
+    Ok(())
 }
 
 /// Split `rel_path` into its plain components, rejecting absolute paths,
@@ -730,25 +831,29 @@ mod tests {
                     .unwrap_or_else(|e| panic!("{}: {}", name, e));
                 assert_eq!(st.st_mode & libc::S_IFMT, libc::S_IFREG, "{}", name);
             }
-            let handle = open_dir_beneath_creating(root.as_fd(), Path::new("a/b")).unwrap();
-            create_file_at(&handle, "via_exec_only.txt", "ok");
-            assert_eq!(
-                std::fs::read_to_string(locked.join("via_exec_only.txt")).unwrap(),
-                "ok"
-            );
+            for (name, creator) in CREATORS {
+                let handle = creator(root.as_fd(), Path::new("a/b"))
+                    .unwrap_or_else(|e| panic!("{}: {}", name, e));
+                let file = format!("via_exec_only_{}.txt", name);
+                create_file_at(&handle, &file, "ok");
+                assert_eq!(std::fs::read_to_string(locked.join(file)).unwrap(), "ok");
+            }
             let exec_only_root = open_root(&locked).unwrap();
             for (name, opener) in OPENERS {
                 let file = opener(exec_only_root.as_fd(), Path::new("c.txt"), READ_FLAGS)
                     .unwrap_or_else(|e| panic!("{} via 0o311 root: {}", name, e));
                 assert_eq!(read_to_string(file), "nested", "{}", name);
             }
-            let handle =
-                open_dir_beneath_creating(exec_only_root.as_fd(), Path::new("new")).unwrap();
-            create_file_at(&handle, "via_exec_only_root.txt", "ok");
-            assert_eq!(
-                std::fs::read_to_string(locked.join("new/via_exec_only_root.txt")).unwrap(),
-                "ok"
-            );
+            for (name, creator) in CREATORS {
+                let handle = creator(exec_only_root.as_fd(), Path::new(name))
+                    .unwrap_or_else(|e| panic!("{} via 0o311 root: {}", name, e));
+                create_file_at(&handle, "via_exec_only_root.txt", "ok");
+                assert_eq!(
+                    std::fs::read_to_string(locked.join(name).join("via_exec_only_root.txt"))
+                        .unwrap(),
+                    "ok"
+                );
+            }
         }));
         restore();
         if let Err(panic) = outcome {
@@ -767,64 +872,142 @@ mod tests {
         File::from(fd).write_all(contents.as_bytes()).unwrap();
     }
 
+    type Creator = fn(BorrowedFd<'_>, &Path) -> io::Result<OwnedFd>;
+
+    /// Like [`OPENERS`]: the public entry point (the `openat2` tier where the
+    /// kernel offers it) and the portable walk directly.
+    const CREATORS: [(&str, Creator); 2] = [
+        ("open_dir_beneath_creating", open_dir_beneath_creating),
+        (
+            "open_dir_beneath_creating_walk",
+            open_dir_beneath_creating_walk,
+        ),
+    ];
+
     #[test]
     fn test_open_dir_beneath_creating_creates_missing_chain_and_returns_usable_dirfd() {
-        let (dir, root) = nested_root();
-        let leaf = open_dir_beneath_creating(root.as_fd(), Path::new("a/new/deeper/leaf")).unwrap();
-        assert!(dir.path().join("a/new/deeper/leaf").is_dir());
-        create_file_at(&leaf, "f.txt", "via dirfd");
-        assert_eq!(
-            std::fs::read_to_string(dir.path().join("a/new/deeper/leaf/f.txt")).unwrap(),
-            "via dirfd"
-        );
+        for (name, creator) in CREATORS {
+            let (dir, root) = nested_root();
+            let leaf = creator(root.as_fd(), Path::new("a/new/deeper/leaf"))
+                .unwrap_or_else(|e| panic!("{}: {}", name, e));
+            assert!(dir.path().join("a/new/deeper/leaf").is_dir(), "{}", name);
+            create_file_at(&leaf, "f.txt", "via dirfd");
+            assert_eq!(
+                std::fs::read_to_string(dir.path().join("a/new/deeper/leaf/f.txt")).unwrap(),
+                "via dirfd",
+                "{}",
+                name
+            );
 
-        // Second walk over the now-existing chain succeeds without recreating.
-        let again =
-            open_dir_beneath_creating(root.as_fd(), Path::new("a/new/deeper/leaf")).unwrap();
-        create_file_at(&again, "g.txt", "again");
-        assert!(dir.path().join("a/new/deeper/leaf/g.txt").is_file());
+            // Second pass over the now-existing chain succeeds without recreating.
+            let again = creator(root.as_fd(), Path::new("a/new/deeper/leaf")).unwrap();
+            create_file_at(&again, "g.txt", "again");
+            assert!(
+                dir.path().join("a/new/deeper/leaf/g.txt").is_file(),
+                "{}",
+                name
+            );
+        }
     }
 
     #[test]
     fn test_open_dir_beneath_creating_empty_path_returns_root_handle() {
-        let (dir, root) = nested_root();
-        let handle = open_dir_beneath_creating(root.as_fd(), Path::new("")).unwrap();
-        create_file_at(&handle, "at_root.txt", "root");
-        assert_eq!(
-            std::fs::read_to_string(dir.path().join("at_root.txt")).unwrap(),
-            "root"
-        );
+        for (name, creator) in CREATORS {
+            let (dir, root) = nested_root();
+            let handle = creator(root.as_fd(), Path::new("")).unwrap();
+            create_file_at(&handle, "at_root.txt", "root");
+            assert_eq!(
+                std::fs::read_to_string(dir.path().join("at_root.txt")).unwrap(),
+                "root",
+                "{}",
+                name
+            );
+        }
     }
 
     #[test]
     fn test_open_dir_beneath_creating_rejects_symlink_components() {
-        let (dir, root) = nested_root();
-        let outside = tempfile::tempdir().unwrap();
-        symlink(outside.path(), dir.path().join("a/out")).unwrap();
-        symlink(outside.path(), dir.path().join("first")).unwrap();
+        for (name, creator) in CREATORS {
+            let (dir, root) = nested_root();
+            let outside = tempfile::tempdir().unwrap();
+            symlink(outside.path(), dir.path().join("a/out")).unwrap();
+            symlink(outside.path(), dir.path().join("first")).unwrap();
 
-        for rel in ["a/out", "a/out/sub", "first/x/y"] {
-            let e = open_dir_beneath_creating(root.as_fd(), Path::new(rel)).unwrap_err();
-            assert_eq!(e.raw_os_error(), Some(libc::ELOOP), "{}: {}", rel, e);
+            for rel in ["a/out", "a/out/sub", "first/x/y"] {
+                let e = creator(root.as_fd(), Path::new(rel)).unwrap_err();
+                assert_eq!(
+                    e.raw_os_error(),
+                    Some(libc::ELOOP),
+                    "{}: {}: {}",
+                    name,
+                    rel,
+                    e
+                );
+            }
+            assert!(!outside.path().join("sub").exists(), "{}", name);
+            assert!(!outside.path().join("x").exists(), "{}", name);
         }
-        assert!(!outside.path().join("sub").exists());
-        assert!(!outside.path().join("x").exists());
     }
 
     #[test]
     fn test_open_dir_beneath_creating_rejects_non_plain_relative_paths() {
-        let (dir, root) = nested_root();
-        for bad in ["/tmp", "../x", "a/../x", "./a"] {
-            let e = open_dir_beneath_creating(root.as_fd(), Path::new(bad)).unwrap_err();
-            assert_eq!(e.kind(), io::ErrorKind::InvalidInput, "{:?}: {}", bad, e);
+        for (name, creator) in CREATORS {
+            let (dir, root) = nested_root();
+            for bad in ["/tmp", "../x", "a/../x", "./a"] {
+                let e = creator(root.as_fd(), Path::new(bad)).unwrap_err();
+                assert_eq!(
+                    e.kind(),
+                    io::ErrorKind::InvalidInput,
+                    "{}: {:?}: {}",
+                    name,
+                    bad,
+                    e
+                );
+            }
+            assert!(!dir.path().join("x").exists(), "{}", name);
         }
-        assert!(!dir.path().join("x").exists());
     }
 
     #[test]
     fn test_open_dir_beneath_creating_fails_when_component_is_a_file() {
-        let (_dir, root) = nested_root();
-        let e = open_dir_beneath_creating(root.as_fd(), Path::new("top.txt/sub")).unwrap_err();
+        for (name, creator) in CREATORS {
+            let (_dir, root) = nested_root();
+            let e = creator(root.as_fd(), Path::new("top.txt/sub")).unwrap_err();
+            assert_eq!(e.raw_os_error(), Some(libc::ENOTDIR), "{}: {}", name, e);
+        }
+    }
+
+    /// The `openat2` tier is exercised directly (not only through the
+    /// `CREATORS` matrix, which takes it implicitly) so a kernel with
+    /// `openat2` is known to have run it: creation, the trailing-symlink
+    /// `ENOTDIR` → `ELOOP` normalisation, and the intermediate-symlink
+    /// rejection all match the walk. Skipped where `openat2` is unavailable.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_open_dir_beneath_creating_openat2_tier_matches_walk() {
+        let (dir, root) = nested_root();
+        let outside = tempfile::tempdir().unwrap();
+        symlink(outside.path(), dir.path().join("a/out")).unwrap();
+        let tier = |rel: &str| {
+            let components: Vec<&OsStr> = Path::new(rel).iter().collect();
+            open_dir_beneath_creating_openat2(root.as_fd(), &components)
+        };
+        let Some(created) = tier("a/new/deeper") else {
+            return;
+        };
+        create_file_at(&created.unwrap(), "f.txt", "openat2");
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("a/new/deeper/f.txt")).unwrap(),
+            "openat2"
+        );
+        for rel in ["a/out", "a/out/sub"] {
+            let e = tier(rel).expect("openat2 still available").unwrap_err();
+            assert_eq!(e.raw_os_error(), Some(libc::ELOOP), "{}: {}", rel, e);
+        }
+        assert!(!outside.path().join("sub").exists());
+        let e = tier("top.txt/sub")
+            .expect("openat2 still available")
+            .unwrap_err();
         assert_eq!(e.raw_os_error(), Some(libc::ENOTDIR), "{}", e);
     }
 }

--- a/src/js_sandbox/open_beneath.rs
+++ b/src/js_sandbox/open_beneath.rs
@@ -39,18 +39,30 @@ const INTERMEDIATE_FLAGS: libc::c_int =
     libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
 
 /// Open the directory at `path` as an anchor for the beneath-root helpers.
-/// `path` is a trusted (canonical) allowlisted root.
+/// `path` is a trusted (canonical) allowlisted root. The open is
+/// `O_NOFOLLOW`, so a symlink swapped in for the root's *final* component
+/// after config resolution is rejected with `ELOOP` rather than followed.
+/// The root's ancestors are still resolved by the kernel as for any absolute
+/// path — a swap above the root is outside this primitive's trusted-root
+/// contract and is not detected here.
 pub(super) fn open_root(path: &Path) -> io::Result<OwnedFd> {
     let c_path = c_string(path.as_os_str())?;
     // SAFETY: `c_path` is a valid NUL-terminated string that outlives the call.
     let fd = unsafe {
         libc::open(
             c_path.as_ptr(),
-            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
         )
     };
     if fd < 0 {
-        return Err(io::Error::last_os_error());
+        let e = io::Error::last_os_error();
+        // Same Linux ENOTDIR-for-a-symlink quirk as `open_intermediate`.
+        if e.raw_os_error() == Some(libc::ENOTDIR)
+            && is_symlink_at(libc::AT_FDCWD, path.as_os_str())
+        {
+            return Err(io::Error::from_raw_os_error(libc::ELOOP));
+        }
+        return Err(e);
     }
     // SAFETY: `fd` is a freshly opened descriptor exclusively owned here.
     Ok(unsafe { OwnedFd::from_raw_fd(fd) })
@@ -388,6 +400,30 @@ mod tests {
                 assert_eq!(read_to_string(file), "nested", "{}: {:?}", name, spelling);
             }
         }
+    }
+
+    /// The root path itself swapped for a symlink (to a directory inside or
+    /// outside the temp tree) is refused: `open_root` must never anchor the
+    /// helpers to a directory the link chose. A real directory still opens.
+    #[test]
+    fn test_open_root_rejects_symlink_at_root_final_component() {
+        let outer = tempfile::tempdir().unwrap();
+        let real = outer.path().join("real");
+        std::fs::create_dir(&real).unwrap();
+        std::fs::write(real.join("top.txt"), "top").unwrap();
+        let elsewhere = tempfile::tempdir().unwrap();
+        symlink(&real, outer.path().join("swapped_in")).unwrap();
+        symlink(elsewhere.path(), outer.path().join("swapped_out")).unwrap();
+        symlink("dangling", outer.path().join("swapped_dangling")).unwrap();
+
+        for name in ["swapped_in", "swapped_out", "swapped_dangling"] {
+            let e = open_root(&outer.path().join(name)).unwrap_err();
+            assert_eq!(e.raw_os_error(), Some(libc::ELOOP), "{}: {}", name, e);
+        }
+
+        let root = open_root(&real).unwrap();
+        let top = open_beneath(root.as_fd(), Path::new("top.txt"), READ_FLAGS).unwrap();
+        assert_eq!(read_to_string(top), "top");
     }
 
     #[test]

--- a/src/js_sandbox/open_beneath.rs
+++ b/src/js_sandbox/open_beneath.rs
@@ -35,7 +35,9 @@
 //! could already write to — never into an arbitrary location — and it still
 //! never follows a symlink or a `..`. `openat2` detects that case as well
 //! (`EXDEV` when the rename happens during resolution), which is why it is
-//! preferred wherever the kernel offers it.
+//! preferred wherever the kernel offers it. Closing it on macOS with
+//! `O_RESOLVE_BENEATH | O_NOFOLLOW_ANY` is tracked in
+//! <https://github.com/endara-ai/endara-relay/issues/158>.
 
 use std::ffi::{CString, OsStr};
 use std::fs::File;


### PR DESCRIPTION
## Motivation

`readFile` and `writeFile` validate a path with `resolve_write_path` (lexical checks + `canonicalize` + prefix check against `relay.write_dirs`) and then perform the I/O against that path string. Between validation and I/O, a concurrent actor with write access under the root can rename an in-root intermediate directory away and put a symlink to an outside location in its place; the subsequent `open`/`create_dir_all`/`rename` follows it. `O_NOFOLLOW` (added in #156) only protects the final component.

This was reviewed and accepted as a known limitation in #154 and #156:

- https://github.com/endara-ai/endara-relay/pull/154#discussion_r3921073054 (in-root parent replaced with a symlink after validation)
- https://github.com/endara-ai/endara-relay/pull/156#discussion_r3922010091 (`O_NOFOLLOW` protects only the final component)
- https://github.com/endara-ai/endara-relay/pull/156#discussion_r3922151684 (`ELOOP` from an intermediate component was indistinguishable from a final-component symlink)

This PR closes that race on unix by anchoring every filesystem operation to a directory handle of the matched root, so no path component can be re-pointed outside the root between validation and I/O.

## Design

- **`resolve_write_path` is unchanged.** Lexical checks and `canonicalize` still resolve pre-existing symlinks up front, so paths that legitimately traverse in-root symlinks keep working exactly as before. The canonical relative path is what gets opened.
- **New `js_sandbox/open_beneath.rs` (unix only).** `open_beneath(root_fd, rel, flags)` opens a canonical relative path anchored at the root dirfd and rejects *any* symlink encountered — since the path is already canonical, a symlink can only be a post-canonicalize swap.
  - Linux fast path: `openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS | RESOLVE_NO_MAGICLINKS)` via `libc::syscall(SYS_openat2)` with a local `open_how` definition (glibc has no wrapper). One syscall, kernel-enforced.
  - Portable fallback (macOS, kernels < 5.6, seccomp): once-detected on `ENOSYS`/`EINVAL`/`EPERM`, then a component-by-component `openat` walk — every directory anchor (root, intermediates, the creating walk's `"."` handle) shares `DIR_ANCHOR_FLAGS` — `O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC` on Linux, `O_SEARCH | O_NOFOLLOW | O_CLOEXEC` on Apple, `O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC` elsewhere — so traversal needs only search (`x`) permission, as a plain pathname lookup does; the final component opened with the caller's flags `| O_NOFOLLOW`. The Linux `ENOTDIR`-for-symlink quirk is normalised to `ELOOP`.
  - `open_dir_beneath_creating` (for `writeFile` parent creation) has the same two tiers. On Linux with `openat2`, every directory handle — including the one re-opened after each `mkdirat` — is resolved *from the root* over the full accumulated prefix with `RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS`, never chained off the previous handle, so containment is re-checked by the kernel at every step and a directory renamed out of the root during resolution fails closed (`EXDEV`, surfaced as the "escaped the configured write directory" error). The portable tier walks with `openat`/`mkdirat` off the previous handle.
  - Residual, inherent to handle-based containment and documented in the module doc: a directory handle is a capability, so a directory that was already opened and is then renamed out of the root stays pinned. On the portable tier that covers the remaining components of the walk; on both tiers it covers the returned destination handle — `openat2` enforces containment only while resolving a path, so if the destination directory is renamed out between `open_dir_beneath_creating` returning and the `renameat`, the file lands wherever the directory now lives. Doing that requires write permission on both the in-root parent and the destination parent, and `rename(2)` cannot cross a mount, so the write can only be redirected into a directory the concurrent actor could already write to — never an arbitrary location — and no lookup ever follows a symlink or `..`. Pre-PR code had a strictly larger race surface (the path string was re-resolved by the kernel from `/`, symlinks included). Narrowing the walk residual on macOS with `O_RESOLVE_BENEATH | O_NOFOLLOW_ANY` is tracked in #158.
  - `open_root` opens the trusted root with the same `DIR_ANCHOR_FLAGS`, so a symlink swapped in for the root path itself is rejected rather than followed.
- **`writeFile` (unix `write_atomic`).** Destination directory obtained via `open_dir_beneath_creating` (replacing `create_dir_all` + re-canonicalize + prefix re-check); temp file created with `openat(O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC)` on that dirfd; publish is `renameat(dirfd, tmp, dirfd, name)`; cleanup is `unlinkat`. On Linux the directory handle is `openat2`-validated beneath the root; elsewhere the fd chain guarantees no symlink or `..` is ever followed (see the portable-tier residual above). Return value and error messages are unchanged, except that a root that cannot be opened (deleted after config resolution) now reports `configured write directory '<root>' is not accessible: … — recreate it or update [relay] write_dirs …` instead of blaming parent creation.
- **`readFile` (unix).** Final open goes through `open_beneath` with the existing `O_RDONLY | O_NOFOLLOW | O_NONBLOCK | O_NOCTTY` flags; the type pre-check now uses `open_beneath::stat_beneath` (openat2 `O_PATH` + `fstat` on Linux; walk + `fstatat(AT_SYMLINK_NOFOLLOW)` elsewhere) so it can no longer be redirected by a mid-path swap; authoritative handle `fstat`, quota accounting and error messages are unchanged.
- **Non-unix (Windows) is untouched.** `cfg(not(unix))` keeps today's canonicalize + prefix re-check behaviour and the residual race remains documented as platform-specific. No dependency changes (`libc` was already a unix dependency).

## Deliberate behaviour changes (unix)

- A symlink present at any intermediate component *after* canonicalize is now rejected with a clear error instead of being followed. Pre-existing in-root symlinks still work because `canonicalize` resolves them first.
- A `write_dirs` root that is deleted after config resolution is no longer silently re-created by `writeFile`; the write fails with a message naming the root and `[relay] write_dirs`. (Roots are trusted config; auto-recreating them defeated the anchor.)
- A symlink at the root path's final component is rejected by `open_root` (`ELOOP`). Ancestor swaps above the root remain out of scope under the trusted-root contract; documented on `open_root`.

## Testing

- New unit tests in `open_beneath.rs`, each run against both the dispatcher (openat2 where available) and the walk fallback directly — for opens, stats and the creating open alike: nested regular-file open with equivalent spellings, openat2/walk parity (including the creating open's openat2 tier directly), symlink-component rejection at first/middle/final depth (`ELOOP`), non-plain relative path rejection before any syscall, `mkdirat` chain creation returning a usable dirfd, symlink and file-in-the-way rejection during creation, `stat_beneath` type reporting (empty path = the root), traversal through `0o311` directories, and `open_root` refusing a symlinked root.
- New `js_sandbox` tests: `test_write_atomic_rejects_intermediate_symlink_swap` and `test_open_for_read_rejects_intermediate_symlink_swap` (end-to-end swap after canonicalize; nothing created or read outside the root).
- Existing `js_sandbox` tests pass unchanged (legitimate-path UX preserved, including pre-existing in-root symlinks).
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` locally on Linux. Windows CI is the authoritative compile gate for the `cfg(not(unix))` branch — no local cross-check toolchain was available.

## Rollback

Single revert restores the canonicalize-based containment, which stays correct for everything except the swap race.


